### PR TITLE
GD-7, GD-22: Fix create a testcase via context menu

### DIFF
--- a/addons/gdUnit4/src/core/GdUnitTestSuiteBuilder.gd
+++ b/addons/gdUnit4/src/core/GdUnitTestSuiteBuilder.gd
@@ -1,26 +1,12 @@
 class_name GdUnitTestSuiteBuilder
-extends Resource
-
-#https://github.com/godotengine/godot/blob/3.2/editor/plugins/script_editor_plugin.h
-enum EDITOR_ACTIONS {
-		FILE_NEW,
-		FILE_NEW_TEXTFILE,
-		FILE_OPEN,
-		FILE_REOPEN_CLOSED,
-		FILE_OPEN_RECENT,
-		FILE_SAVE,
-		FILE_SAVE_AS,
-		FILE_SAVE_ALL,
-		FILE_THEME,
-		FILE_RUN,
-		FILE_CLOSE,
-		CLOSE_DOCS
-}
+extends RefCounted
 
 
-func create(source :Script, line_number :int) -> Result:
+static func create(source :Script, line_number :int) -> Result:
 	var test_suite_path := _TestSuiteScanner.resolve_test_suite_path(source.resource_path, GdUnitSettings.test_root_folder())
-	_save_and_close_script(test_suite_path)
+	# we need to save and close the testsuite and source if is current opened before modify
+	ScriptEditorControls.save_an_open_script(source.resource_path)
+	ScriptEditorControls.save_an_open_script(test_suite_path, true)
 	
 	if GdObjects.is_cs_script(source):
 		return GdUnit3MonoAPI.create_test_suite(source.resource_path, line_number+1, test_suite_path)
@@ -32,26 +18,3 @@ func create(source :Script, line_number :int) -> Result:
 	if func_name.is_empty():
 		return Result.error("No function found at line: %d." % line_number)
 	return _TestSuiteScanner.create_test_case(test_suite_path, func_name, source.resource_path)
-
-
-static func _save_and_close_script(script_path :String):
-	if not Engine.has_meta("GdUnitEditorPlugin"):
-		return
-	var plugin :EditorPlugin = Engine.get_meta("GdUnitEditorPlugin")
-	var script_editor :ScriptEditor = plugin.get_editor_interface().get_script_editor()
-	# is already opened?
-	var open_file_index = 0
-	for open_script in script_editor.get_open_scripts():
-		if open_script.resource_path == script_path:
-			# select the script in the editor
-			script_editor._script_selected(open_file_index)
-			
-			# seams to be the save is async and collidates with external changes
-			# https://github.com/godotengine/godot/issues/50163
-			if not script_path.ends_with(".cs"):
-				# needs to be saved first to store current editor changes
-				script_editor._menu_option(EDITOR_ACTIONS.FILE_SAVE)
-			# finally needs to be closed to can modify and reload
-			script_editor._menu_option(EDITOR_ACTIONS.FILE_CLOSE)
-			return
-		open_file_index += 1

--- a/addons/gdUnit4/src/core/_TestSuiteScanner.gd
+++ b/addons/gdUnit4/src/core/_TestSuiteScanner.gd
@@ -213,25 +213,27 @@ static func get_test_case_line_number(resource_path :String, func_name :String) 
 				return line_number
 	return -1
 
+
 static func add_test_case(resource_path :String, func_name :String)  -> Result:
-	var file := FileAccess.open(resource_path, FileAccess.READ)
-	if file == null:
-		return Result.error("Can't access test suite : %s. Error code %s" % [resource_path, FileAccess.get_open_error()])
-	var line_number := 0
-	while not file.eof_reached():
-		file.get_line()
-		line_number += 1
 	var script := load(resource_path) as GDScript
+	# count all exiting lines and add two as space to add new test case
+	var line_number := count_lines(script) + 2
 	script.source_code +=\
 """
+
 func test_${func_name}() -> void:
-	# remove_at this line and complete your test
+	# remove this line and complete your test
 	assert_not_yet_implemented()
 """.replace("${func_name}", func_name)
 	var error := ResourceSaver.save(script, resource_path)
 	if error != OK:
 		return Result.error("Can't add test case at: %s to '%s'. Error code %s" % [func_name, resource_path, error])
 	return Result.success({ "path" : resource_path, "line" : line_number})
+
+
+static func count_lines(script : GDScript) -> int:
+	return script.source_code.split("\n").size()
+
 
 static func test_suite_exists(test_suite_path :String) -> bool:
 	return FileAccess.file_exists(test_suite_path)

--- a/addons/gdUnit4/src/ui/ScriptEditorControls.gd
+++ b/addons/gdUnit4/src/ui/ScriptEditorControls.gd
@@ -1,0 +1,108 @@
+# A tool to provide extended script editor functionallity
+class_name ScriptEditorControls
+extends RefCounted
+
+# https://github.com/godotengine/godot/blob/master/editor/plugins/script_editor_plugin.h
+# the Editor menu popup items
+enum {
+	FILE_NEW,
+	FILE_NEW_TEXTFILE,
+	FILE_OPEN,
+	FILE_REOPEN_CLOSED,
+	FILE_OPEN_RECENT,
+	FILE_SAVE,
+	FILE_SAVE_AS,
+	FILE_SAVE_ALL,
+	FILE_THEME,
+	FILE_RUN,
+	FILE_CLOSE,
+	CLOSE_DOCS,
+	CLOSE_ALL,
+	CLOSE_OTHER_TABS,
+	TOGGLE_SCRIPTS_PANEL,
+	SHOW_IN_FILE_SYSTEM,
+	FILE_COPY_PATH,
+	FILE_TOOL_RELOAD_SOFT,
+	SEARCH_IN_FILES,
+	REPLACE_IN_FILES,
+	SEARCH_HELP,
+	SEARCH_WEBSITE,
+	HELP_SEARCH_FIND,
+	HELP_SEARCH_FIND_NEXT,
+	HELP_SEARCH_FIND_PREVIOUS,
+	WINDOW_MOVE_UP,
+	WINDOW_MOVE_DOWN,
+	WINDOW_NEXT,
+	WINDOW_PREV,
+	WINDOW_SORT,
+	WINDOW_SELECT_BASE = 100
+}
+
+
+# Returns the EditorInterface instance
+static func editor_interface() -> EditorInterface:
+	if not Engine.has_meta("GdUnitEditorPlugin"):
+		return null
+	var plugin :EditorPlugin = Engine.get_meta("GdUnitEditorPlugin")
+	return plugin.get_editor_interface()
+
+
+# Returns the ScriptEditor instance
+static func script_editor() -> ScriptEditor:
+	return editor_interface().get_script_editor()
+
+
+# Saves the given script and closes if requested by <close=true>
+# The script is saved when is opened in the editor.
+# The script is closed when <close> is set to true.
+static func save_an_open_script(script_path :String, close := false) -> bool:
+	var editor_interface := editor_interface()
+	var script_editor := script_editor()
+	var editor_popup := _menu_popup()
+	var open_file_index = 0
+	# search for the script in all opened editor scrips
+	for open_script in script_editor.get_open_scripts():
+		if open_script.resource_path == script_path:
+			# select the script in the editor
+			#var e: ScriptEditorBase = script_editor.get_open_script_editors()[open_file_index]
+			editor_interface.edit_script(open_script, 0);
+			# save and close
+			editor_popup.emit_signal("id_pressed", FILE_SAVE)
+			if close:
+				editor_popup.emit_signal("id_pressed", FILE_CLOSE)
+			return true
+		open_file_index +=1
+	return false
+
+
+# Saves all opened script
+static func save_all_open_script() -> void:
+	_menu_popup().emit_signal("id_pressed", FILE_SAVE_ALL)
+
+
+# Edits the given script.
+# The script is openend in the current editor and selected in the file system dock.
+# The line and column on which to open the script can also be specified.
+# The script will be open with the user-configured editor for the script's language which may be an external editor.
+static func edit_script(script_path :String, line_number :int = -1):
+	var editor_interface := editor_interface()
+	var file_system := editor_interface.get_resource_filesystem()
+	file_system.update_file(script_path)
+	var file_system_dock := editor_interface.get_file_system_dock()
+	file_system_dock.navigate_to_path(script_path)
+	editor_interface.select_file(script_path)
+	var script = load(script_path)
+	editor_interface.edit_script(script, line_number)
+
+
+static func _menu_popup() -> PopupMenu:
+	return script_editor().get_child(0).get_child(0).get_child(0).get_popup()
+
+
+static func _print_menu(popup :PopupMenu):
+	for itemIndex in popup.item_count:
+		prints( "get_item_id", popup.get_item_id(itemIndex))
+		prints( "get_item_accelerator", popup.get_item_accelerator(itemIndex))
+		prints( "get_item_shortcut", popup.get_item_shortcut(itemIndex))
+		prints( "get_item_text", popup.get_item_text(itemIndex))
+		prints()

--- a/project.godot
+++ b/project.godot
@@ -874,7 +874,7 @@ _global_script_classes=[{
 "language": &"GDScript",
 "path": "res://addons/gdUnit4/src/GdUnitTestSuite.gd"
 }, {
-"base": "Resource",
+"base": "RefCounted",
 "class": &"GdUnitTestSuiteBuilder",
 "language": &"GDScript",
 "path": "res://addons/gdUnit4/src/core/GdUnitTestSuiteBuilder.gd"
@@ -1113,6 +1113,11 @@ _global_script_classes=[{
 "class": &"ResultTest",
 "language": &"GDScript",
 "path": "res://addons/gdUnit4/test/core/ResultTest.gd"
+}, {
+"base": "RefCounted",
+"class": &"ScriptEditorControls",
+"language": &"GDScript",
+"path": "res://addons/gdUnit4/src/ui/ScriptEditorControls.gd"
 }, {
 "base": "Resource",
 "class": &"ScriptWithClassName",
@@ -1421,6 +1426,7 @@ _global_script_class_icons={
 "RPCMessage": "",
 "Result": "",
 "ResultTest": "",
+"ScriptEditorControls": "",
 "ScriptWithClassName": "",
 "SnakeCaseWithClassName": "",
 "Spell": "",


### PR DESCRIPTION
The creation of a test case was broken and ends up in an error dialog

Fixes:
- refactor editor interactions and extract it to a external class
- fix save open scripts
- save current edited script before build the test case
- save, close reopen the testsuite on test creation to avoid script code inconsitency