### PR TITLE
GD-27: Cleanup `GdUnitInspector` and move filesystem dock code into `EditorFileSystemControls`

### DIFF
--- a/addons/gdUnit4/src/GdUnitTestSuite.gd
+++ b/addons/gdUnit4/src/GdUnitTestSuite.gd
@@ -14,6 +14,8 @@
 class_name GdUnitTestSuite
 extends Node
 
+@icon("res://addons/gdUnit4/src/ui/assets/TestSuite.svg")
+
 const NO_ARG = GdUnitConstants.NO_ARG
 
 # This function is called before a test suite starts

--- a/addons/gdUnit4/src/ui/EditorFileSystemControls.gd
+++ b/addons/gdUnit4/src/ui/EditorFileSystemControls.gd
@@ -1,0 +1,46 @@
+# A tool to provide extended filesystem editor functionallity
+class_name EditorFileSystemControls
+extends RefCounted
+
+
+# Returns the EditorInterface instance
+static func editor_interface() -> EditorInterface:
+	if not Engine.has_meta("GdUnitEditorPlugin"):
+		return null
+	var plugin :EditorPlugin = Engine.get_meta("GdUnitEditorPlugin")
+	return plugin.get_editor_interface()
+
+
+# Returns the FileSystemDock instance
+static func filesystem_dock() -> FileSystemDock:
+	return editor_interface().get_file_system_dock()
+
+
+# Register the given context menu to the filesystem dock
+# Is called when the plugin is activated
+# The filesystem popup is connected to the EditorFileSystemContextMenuHandler
+static func register_context_menu(menu :Array[GdUnitContextMenuItem]) -> void:
+	EditorFileSystemContextMenuHandler.create(_file_tree(), _menu_popup(), menu)
+
+
+# Unregisteres all registerend context menus and gives the EditorFileSystemContextMenuHandler> free
+# Is called when the plugin is deactivated
+static func unregister_context_menu() -> void:
+	EditorFileSystemContextMenuHandler.release(_menu_popup())
+
+
+static func _file_tree() -> Tree:
+	return GdObjects.find_nodes_by_class(filesystem_dock(), "Tree", true)[-1]
+
+
+static func _menu_popup() -> PopupMenu:
+	return GdObjects.find_nodes_by_class(filesystem_dock(), "PopupMenu")[-1]
+
+
+static func _print_menu(popup :PopupMenu):
+	for itemIndex in popup.item_count:
+		prints( "get_item_id", popup.get_item_id(itemIndex))
+		prints( "get_item_accelerator", popup.get_item_accelerator(itemIndex))
+		prints( "get_item_shortcut", popup.get_item_shortcut(itemIndex))
+		prints( "get_item_text", popup.get_item_text(itemIndex))
+		prints()

--- a/addons/gdUnit4/src/ui/GdUnitInspector.gd
+++ b/addons/gdUnit4/src/ui/GdUnitInspector.gd
@@ -2,54 +2,8 @@
 class_name GdUnitInspecor
 extends Panel
 
-
 signal gdunit_runner_start()
 signal gdunit_runner_stop()
-
-#https://github.com/godotengine/godot/blob/3.2/editor/plugins/script_editor_plugin.h
-enum EDITOR_ACTIONS {
-		FILE_NEW,
-		FILE_NEW_TEXTFILE,
-		FILE_OPEN,
-		FILE_REOPEN_CLOSED,
-		FILE_OPEN_RECENT,
-		FILE_SAVE,
-		FILE_SAVE_AS,
-		FILE_SAVE_ALL,
-		FILE_THEME,
-		FILE_RUN,
-		FILE_CLOSE,
-		CLOSE_DOCS,
-		CLOSE_ALL,
-		CLOSE_OTHER_TABS,
-		TOGGLE_SCRIPTS_PANEL,
-		SHOW_IN_FILE_SYSTEM,
-		FILE_COPY_PATH,
-		FILE_TOOL_RELOAD,
-		FILE_TOOL_RELOAD_SOFT,
-		DEBUG_NEXT,
-		DEBUG_STEP,
-		DEBUG_BREAK,
-		DEBUG_CONTINUE,
-		DEBUG_KEEP_DEBUGGER_OPEN,
-		DEBUG_WITH_EXTERNAL_EDITOR,
-		SEARCH_IN_FILES,
-		SEARCH_HELP,
-		SEARCH_WEBSITE,
-		HELP_SEARCH_FIND,
-		HELP_SEARCH_FIND_NEXT,
-		HELP_SEARCH_FIND_PREVIOUS,
-		WINDOW_MOVE_UP,
-		WINDOW_MOVE_DOWN,
-		WINDOW_NEXT,
-		WINDOW_PREV,
-		WINDOW_SORT,
-		WINDOW_SELECT_BASE = 100
-	}
-
-const MENU_ID_TEST_RUN    := GdUnitContextMenuItem.MENU_ID.TEST_RUN
-const MENU_ID_TEST_DEBUG  := GdUnitContextMenuItem.MENU_ID.TEST_DEBUG
-const MENU_ID_CREATE_TEST := GdUnitContextMenuItem.MENU_ID.CREATE_TEST
 
 # header
 @onready var _runButton :Button = $VBoxContainer/Header/ToolBar/Tools/run
@@ -69,6 +23,7 @@ var _editor_interface :EditorInterface
 # the current test runner config
 var _runner_config := GdUnitRunnerConfig.new()
 
+
 func _ready():
 	GdUnitSignals.gdunit_client_connected.connect(Callable(self, "_on_client_connected"))
 	GdUnitSignals.gdunit_client_disconnected.connect(Callable(self, "_on_client_disconnected"))
@@ -76,7 +31,6 @@ func _ready():
 	
 	if Engine.is_editor_hint():
 		_getEditorThemes(_editor_interface)
-		add_file_system_dock_context_menu()
 	# preload previous test execution
 	_runner_config.load()
 
@@ -84,14 +38,18 @@ func _ready():
 func _enter_tree():
 	if Engine.is_editor_hint():
 		add_script_editor_context_menu()
+		add_file_system_dock_context_menu()
 
 
 func _exit_tree():
-	ScriptEditorControls.unregister_context_menu()
+	if Engine.is_editor_hint():
+		ScriptEditorControls.unregister_context_menu()
+		EditorFileSystemControls.unregister_context_menu()
 
 
 func _process(_delta):
 	_check_test_run_stopped_manually()
+
 
 # is checking if the user has press the editor stop scene 
 func _check_test_run_stopped_manually():
@@ -100,18 +58,20 @@ func _check_test_run_stopped_manually():
 			push_warning("Test Runner scene was stopped manually, force stopping the current test run!")
 		_gdUnit_stop(_client_id)
 
+
 func _is_test_running_but_stop_pressed():
 	return _editor_interface and _running_debug_mode and _is_running and not _editor_interface.is_playing_scene()
 
+
 func set_editor_interface(editor_interface :EditorInterface) -> void:
 	_editor_interface = editor_interface
+
 
 func _getEditorThemes(interface :EditorInterface) -> void:
 	if interface == null:
 		return
 		# example to access current theme
 	var editiorTheme := interface.get_base_control().theme
-
 	# setup inspector button icons
 	#var stylebox_types :PackedStringArray = editiorTheme.get_stylebox_type_list()
 	#for stylebox_type in stylebox_types:
@@ -125,40 +85,22 @@ func _getEditorThemes(interface :EditorInterface) -> void:
 	#status_label.add_theme_color_override("font_color", get_color("contrast_color_2", "Editor"))
 	#no_sessions_label.add_theme_color_override("font_color", get_color("contrast_color_2", "Editor"))
 
+
 # Context menu registrations ----------------------------------------------------------------------
 func add_file_system_dock_context_menu() -> void:
-	if _editor_interface == null:
-		return
-	var filesystem_dock = _editor_interface.get_file_system_dock()
-	var popups := GdObjects.find_nodes_by_class(filesystem_dock, "PopupMenu")
-	var file_tree := GdObjects.find_nodes_by_class(filesystem_dock, "Tree", true)
-	var context_menu :PopupMenu = popups[-1]
-	context_menu.connect("about_to_popup", Callable(self, "_on_file_system_dock_context_menu_show").bind(context_menu))
-	context_menu.connect("id_pressed", Callable(self, "_on_file_system_dock_context_menu_pressed").bind(file_tree[-1]))
-
-func _on_file_system_dock_context_menu_show(context_menu :PopupMenu) -> void:
-	context_menu.add_separator()
-	# save menu entry index
-	var current_index := context_menu.get_item_count()
-	context_menu.add_item("Run Tests", MENU_ID_TEST_RUN)
-	context_menu.add_item("Debug Tests", MENU_ID_TEST_DEBUG)
-	# deactivate menu enties if currently a run in progress
-	context_menu.set_item_disabled(current_index+0, _runButton.disabled)
-	context_menu.set_item_disabled(current_index+1, _runButton.disabled)
-
-func _on_file_system_dock_context_menu_pressed(id :int, file_tree :Tree) -> void:
-	if id != MENU_ID_TEST_RUN && id != MENU_ID_TEST_DEBUG:
-		return
-	var selected_item := file_tree.get_selected()
-	if selected_item == null:
-		prints("no resource selected")
-		return
-	var selected_test_suites := Array()
-	while selected_item:
-		selected_test_suites.append(selected_item.get_metadata(0))
-		selected_item = file_tree.get_next_selected(selected_item)
-	var debug = id == MENU_ID_TEST_DEBUG
-	run_test_suites(selected_test_suites, debug)
+	var is_test_suite := func is_visible(script :GDScript, is_test_suite :bool):
+		if script == null:
+			return true
+		return GdObjects.is_test_suite(script) == is_test_suite
+	var is_enabled := func is_enabled(script :GDScript):
+		return !_runButton.disabled
+	var run_test := func run_test(resource_paths :PackedStringArray, debug :bool):
+		run_test_suites(resource_paths, debug)
+	var menu := [
+		GdUnitContextMenuItem.new(GdUnitContextMenuItem.MENU_ID.TEST_RUN, "Run Tests", is_test_suite.bind(true), is_enabled, run_test.bind(false)),
+		GdUnitContextMenuItem.new(GdUnitContextMenuItem.MENU_ID.TEST_DEBUG, "Debug Tests", is_test_suite.bind(true), is_enabled, run_test.bind(true)),
+	]
+	EditorFileSystemControls.register_context_menu(menu)
 
 
 func add_script_editor_context_menu():
@@ -199,7 +141,7 @@ func add_script_editor_context_menu():
 	ScriptEditorControls.register_context_menu(menu)
 
 
-func run_test_suites(test_suite_paths :Array, debug :bool, rerun :bool=false) -> void:
+func run_test_suites(test_suite_paths :PackedStringArray, debug :bool, rerun :bool=false) -> void:
 	# create new runner runner_config for fresh run otherwise use saved one
 	if not rerun:
 		var result := _runner_config.clear()\
@@ -209,6 +151,7 @@ func run_test_suites(test_suite_paths :Array, debug :bool, rerun :bool=false) ->
 			push_error(result.error_message())
 			return
 	_gdUnit_run(debug)
+
 
 func run_test_case(test_suite_resource_path :String, test_case :String, debug :bool, rerun := false) -> void:
 	# create new runner config for fresh run otherwise use saved one
@@ -240,7 +183,6 @@ func _gdUnit_run(debug :bool) -> void:
 	ScriptEditorControls.save_all_open_script()
 	# wait until all changes are saved
 	await get_tree().process_frame
-
 	gdunit_runner_start.emit()
 	if debug:
 		_editor_interface.play_custom_scene("res://addons/gdUnit4/src/core/GdUnitRunner.tscn")
@@ -257,6 +199,7 @@ func _gdUnit_run(debug :bool) -> void:
 	# prints("execute ", OS.get_executable_path(), arguments)
 	_current_runner_process_id = OS.execute(OS.get_executable_path(), arguments, output, false, false);
 	_is_running = true
+
 
 func _gdUnit_stop(client_id :int) -> void:
 	# don't stop if is already stopped
@@ -281,25 +224,31 @@ func _on_event(event :GdUnitEvent):
 	if event.type() == GdUnitEvent.STOP:
 		_gdUnit_stop(_client_id)
 
+
 ################################################################################
 # Inspector signal receiver
 ################################################################################
 func _on_ToolBar_run_pressed(debug :bool = false):
 	_gdUnit_run(debug)
 
+
 func _on_ToolBar_stop_pressed():
 	_gdUnit_stop(_client_id)
+
 
 func _on_MainPanel_run_testsuite(test_suite_paths :Array, debug :bool):
 	run_test_suites(test_suite_paths, debug)
 
+
 func _on_MainPanel_run_testcase(resource_path :String, test_case :String, debug :bool):
 	run_test_case(resource_path, test_case, debug)
+
 
 ##########################################################################
 # Network stuff
 func _on_client_connected(client_id :int) -> void:
 	_client_id = client_id
+
 
 func _on_client_disconnected(client_id :int) -> void:
 	# only stops is not in debug mode running and the current client

--- a/addons/gdUnit4/src/ui/menu/EditorFileSystemContextMenuHandler.gd
+++ b/addons/gdUnit4/src/ui/menu/EditorFileSystemContextMenuHandler.gd
@@ -1,0 +1,78 @@
+class_name EditorFileSystemContextMenuHandler
+extends Node
+
+
+var _context_menus := Dictionary()
+
+
+func _init(context_menus :Array[GdUnitContextMenuItem]):
+	set_name("EditorFileSystemContextMenuHandler")
+	for menu in context_menus:
+		_context_menus[menu.id] = menu
+
+
+static func create(file_tree :Tree, popup : PopupMenu, context_menus :Array[GdUnitContextMenuItem]) -> EditorFileSystemContextMenuHandler:
+	var handler := EditorFileSystemContextMenuHandler.new(context_menus)
+	popup.connect("about_to_popup", Callable(handler, "on_context_menu_show").bind(popup, file_tree))
+	popup.connect("id_pressed", Callable(handler, "on_context_menu_pressed").bind(file_tree))
+	Engine.get_main_loop().root.call_deferred("add_child", handler, true)
+	return handler
+
+
+static func release(popup : PopupMenu):
+	var handler = Engine.get_main_loop().root.find_child("EditorFileSystemContextMenuHandler*", false, false)
+	if handler:
+		if popup.is_connected("about_to_popup", Callable(handler, "on_context_menu_show")):
+			popup.disconnect("about_to_popup", Callable(handler, "on_context_menu_show"))
+		if popup.is_connected("id_pressed", Callable(handler, "on_context_menu_pressed")):
+			popup.disconnect("id_pressed", Callable(handler, "on_context_menu_pressed"))
+		handler.queue_free()
+
+func on_context_menu_show(context_menu :PopupMenu, file_tree :Tree) -> void:
+	context_menu.add_separator()
+	var current_index := context_menu.get_item_count()
+	var selected_test_suites := collect_testsuites(_context_menus.values()[0], file_tree)
+	
+	for menu_id in _context_menus.keys():
+		var menu_item :GdUnitContextMenuItem = _context_menus[menu_id]
+		if selected_test_suites.size() != 0:
+			context_menu.add_item(menu_item.name, menu_id)
+			context_menu.set_item_disabled(current_index, !menu_item.is_enabled(null))
+			current_index += 1
+
+
+func on_context_menu_pressed(id :int, file_tree :Tree) -> void:
+	#prints("on_context_menu_pressed", id)
+	if !_context_menus.has(id):
+		return
+	var menu_item :GdUnitContextMenuItem = _context_menus[id]
+	var selected_test_suites := collect_testsuites(menu_item, file_tree)
+	menu_item.execute([selected_test_suites])
+
+
+func collect_testsuites(menu_item :GdUnitContextMenuItem, file_tree :Tree) -> PackedStringArray:
+	var file_system := editor_interface().get_resource_filesystem()
+	var selected_item := file_tree.get_selected()
+	var selected_test_suites := PackedStringArray()
+	while selected_item:
+		var resource_path :String = selected_item.get_metadata(0)
+		var file_type := file_system.get_file_type(resource_path)
+		var is_dir := DirAccess.dir_exists_absolute(resource_path)
+		if is_dir:
+			selected_test_suites.append(resource_path)
+		elif is_dir or file_type == "GDScript":
+			# find a performant way to check if the selected item a testsuite
+			#var resource := ResourceLoader.load(resource_path, "GDScript", ResourceLoader.CACHE_MODE_REUSE)
+			#prints("loaded", resource)
+			#if resource is GDScript and menu_item.is_visible(resource):
+			selected_test_suites.append(resource_path)
+		selected_item = file_tree.get_next_selected(selected_item)
+	return selected_test_suites
+
+
+# Returns the EditorInterface instance
+static func editor_interface() -> EditorInterface:
+	if not Engine.has_meta("GdUnitEditorPlugin"):
+		return null
+	var plugin :EditorPlugin = Engine.get_meta("GdUnitEditorPlugin")
+	return plugin.get_editor_interface()

--- a/project.godot
+++ b/project.godot
@@ -209,6 +209,16 @@ _global_script_classes=[{
 "language": &"GDScript",
 "path": "res://addons/gdUnit4/src/asserts/DefaultValueProvider.gd"
 }, {
+"base": "Node",
+"class": &"EditorFileSystemContextMenuHandler",
+"language": &"GDScript",
+"path": "res://addons/gdUnit4/src/ui/menu/EditorFileSystemContextMenuHandler.gd"
+}, {
+"base": "RefCounted",
+"class": &"EditorFileSystemControls",
+"language": &"GDScript",
+"path": "res://addons/gdUnit4/src/ui/EditorFileSystemControls.gd"
+}, {
 "base": "GdUnitArgumentMatcher",
 "class": &"EqualsArgumentMatcher",
 "language": &"GDScript",
@@ -1255,6 +1265,8 @@ _global_script_class_icons={
 "CustomResourceTestClass": "",
 "DeepStubTestClass": "",
 "DefaultValueProvider": "",
+"EditorFileSystemContextMenuHandler": "",
+"EditorFileSystemControls": "",
 "EqualsArgumentMatcher": "",
 "ExtendedTest": "",
 "Fuzzer": "",
@@ -1388,7 +1400,7 @@ _global_script_class_icons={
 "GdUnitTestCaseReport": "",
 "GdUnitTestResourceLoader": "",
 "GdUnitTestResourceLoaderTest": "",
-"GdUnitTestSuite": "",
+"GdUnitTestSuite": "res://addons/gdUnit4/src/ui/assets/TestSuite.svg",
 "GdUnitTestSuiteBuilder": "",
 "GdUnitTestSuiteBuilderTest": "",
 "GdUnitTestSuiteDefaultTemplate": "",


### PR DESCRIPTION


- move all context menu related stuff into new tools `EditorFileSystemControls`
- cleanup `GdUnitInspector`
- add testsuite icon to testsuite