### PR TITLE
GD-30: Fix run tests in release mode

### DIFF
--- a/addons/gdUnit4/src/core/GdUnitRunner.gd
+++ b/addons/gdUnit4/src/core/GdUnitRunner.gd
@@ -24,8 +24,10 @@ var _result :Result
 func _init():
 	# minimize scene window checked debug mode
 	if OS.get_cmdline_args().size() == 1:
-		DisplayServer.window_set_title("GdUnit3 Runner (Debug)")
-		DisplayServer.window_set_mode(DisplayServer.WINDOW_MODE_MINIMIZED)
+		DisplayServer.window_set_title("GdUnit3 Runner (Debug Mode)")
+	else:
+		DisplayServer.window_set_title("GdUnit3 Runner (Release Mode)")
+	DisplayServer.window_set_mode(DisplayServer.WINDOW_MODE_MINIMIZED)
 	# store current runner instance to engine meta data to can be access in as a singleton
 	Engine.set_meta(GDUNIT_RUNNER, self)
 	_cs_executor = GdUnit3MonoAPI.create_executor(self)

--- a/addons/gdUnit4/src/ui/GdUnitInspector.gd
+++ b/addons/gdUnit4/src/ui/GdUnitInspector.gd
@@ -190,14 +190,8 @@ func _gdUnit_run(debug :bool) -> void:
 		return
 	var arguments := Array()
 	arguments.append("--no-window")
-	#arguments.append("-d")
-	#arguments.append("-s")
 	arguments.append("res://addons/gdUnit4/src/core/GdUnitRunner.tscn")
-	#prints("arguments", arguments)
-	var output = []
-#	_running_debug_mode = false
-	# prints("execute ", OS.get_executable_path(), arguments)
-	_current_runner_process_id = OS.execute(OS.get_executable_path(), arguments, output, false, false);
+	_current_runner_process_id = OS.create_process(OS.get_executable_path(), arguments, false);
 	_is_running = true
 
 


### PR DESCRIPTION
#Why
The OS.execute was changed in Godot4 and the flag `blocking` was removed where results in a blocking thread and the editor was blocked 


#What
Fixed by use the new provided function `create_process` to spwan a new thread and run the scene into