### PR TITLE
GD-32: Create test case use configured text ident settings

### DIFF
--- a/addons/gdUnit4/bin/GdUnitCmdTool.gd
+++ b/addons/gdUnit4/bin/GdUnitCmdTool.gd
@@ -203,13 +203,12 @@ class CLIRunner extends Node:
 		var test_suites_to_process = Array()
 		var to_execute := config.to_execute()
 		# scan for the requested test suites
-		var _scanner := _TestSuiteScanner.new()
+		var _scanner := GdUnitTestSuiteScanner.new()
 		for resource_path in to_execute.keys():
 			var selected_tests :Array = to_execute.get(resource_path)
 			var scaned_suites = _scanner.scan(resource_path)
 			skip_test_case(scaned_suites, selected_tests)
 			test_suites_to_process += scaned_suites
-		_scanner.free()
 		skip_suites(test_suites_to_process, config)
 		return test_suites_to_process
 

--- a/addons/gdUnit4/src/core/GdUnitRunner.gd
+++ b/addons/gdUnit4/src/core/GdUnitRunner.gd
@@ -95,13 +95,12 @@ func load_test_suits() -> Array:
 		return []
 	# scan for the requested test suites
 	var test_suites := Array()
-	var _scanner := _TestSuiteScanner.new()
+	var _scanner := GdUnitTestSuiteScanner.new()
 	for resource_path in to_execute.keys():
 		var selected_tests :Array[StringName] = to_execute.get(resource_path)
 		var scaned_suites := _scanner.scan(resource_path)
 		_filter_test_case(scaned_suites, selected_tests)
 		test_suites += scaned_suites
-	_scanner.free()
 	return test_suites
 
 func gdUnitInit() -> void:

--- a/addons/gdUnit4/src/core/GdUnitTestSuiteBuilder.gd
+++ b/addons/gdUnit4/src/core/GdUnitTestSuiteBuilder.gd
@@ -3,7 +3,7 @@ extends RefCounted
 
 
 static func create(source :Script, line_number :int) -> Result:
-	var test_suite_path := _TestSuiteScanner.resolve_test_suite_path(source.resource_path, GdUnitSettings.test_root_folder())
+	var test_suite_path := GdUnitTestSuiteScanner.resolve_test_suite_path(source.resource_path, GdUnitSettings.test_root_folder())
 	# we need to save and close the testsuite and source if is current opened before modify
 	ScriptEditorControls.save_an_open_script(source.resource_path)
 	ScriptEditorControls.save_an_open_script(test_suite_path, true)
@@ -17,4 +17,4 @@ static func create(source :Script, line_number :int) -> Result:
 	var func_name := parser.parse_func_name(current_line)
 	if func_name.is_empty():
 		return Result.error("No function found at line: %d." % line_number)
-	return _TestSuiteScanner.create_test_case(test_suite_path, func_name, source.resource_path)
+	return GdUnitTestSuiteScanner.create_test_case(test_suite_path, func_name, source.resource_path)

--- a/addons/gdUnit4/src/core/GdUnitTestSuiteScanner.gd
+++ b/addons/gdUnit4/src/core/GdUnitTestSuiteScanner.gd
@@ -1,9 +1,16 @@
-class_name _TestSuiteScanner
-extends Node
+class_name GdUnitTestSuiteScanner
+extends RefCounted
 
+const TEST_FUNC_TEMPLATE ="""
+
+func test_${func_name}() -> void:
+	# remove this line and complete your test
+	assert_not_yet_implemented()
+"""
 
 var _script_parser := GdScriptParser.new()
 var _extends_test_suite_classes := Array()
+
 
 func scan_testsuite_classes() -> void:
 	# scan and cache extends GdUnitTestSuite by class name an resource paths
@@ -14,6 +21,7 @@ func scan_testsuite_classes() -> void:
 			var script_meta = element as Dictionary
 			if script_meta["base"] == "GdUnitTestSuite":
 				_extends_test_suite_classes.append(script_meta["class"])
+
 
 func scan(resource_path :String) -> Array:
 	scan_testsuite_classes()
@@ -27,6 +35,7 @@ func scan(resource_path :String) -> Array:
 			prints("Given directory or file does not exists:", resource_path)
 			return []
 	return _scan_test_suites(base_dir, [])
+
 
 func _scan_test_suites(dir :DirAccess, collected_suites :Array) -> Array:
 	prints("Scanning for test suites in:", dir.get_current_dir())
@@ -45,11 +54,13 @@ func _scan_test_suites(dir :DirAccess, collected_suites :Array) -> Array:
 		file_name = dir.get_next()
 	return collected_suites
 
+
 static func _file(dir :DirAccess, file_name :String) -> String:
 	var current_dir := dir.get_current_dir()
 	if current_dir.ends_with("/"):
 		return current_dir + file_name
 	return current_dir + "/" + file_name
+
 
 func _parse_is_test_suite(resource_path :String) -> Node:
 	if not _is_script_format_supported(resource_path):
@@ -63,11 +74,13 @@ func _parse_is_test_suite(resource_path :String) -> Node:
 		return _parse_test_suite(script)
 	return null
 
+
 static func _is_script_format_supported(resource_path :String) -> bool:
 	var ext := resource_path.get_extension()
 	if ext == "gd":
 		return true
 	return GdUnit3MonoAPI.is_csharp_file(resource_path)
+
 
 func _parse_test_suite(script :GDScript) -> GdUnitTestSuite:
 	var test_suite = script.new()
@@ -87,6 +100,7 @@ func _parse_test_suite(script :GDScript) -> GdUnitTestSuite:
 			base_script = base_script.get_base_script()
 	return test_suite
 
+
 func _extract_test_case_names(script :GDScript) -> PackedStringArray:
 	var names := PackedStringArray()
 	for method in script.get_script_method_list():
@@ -97,8 +111,10 @@ func _extract_test_case_names(script :GDScript) -> PackedStringArray:
 			names.append(funcName)
 	return names
 
+
 static func parse_test_suite_name(script :Script) -> String:
 	return script.resource_path.get_file().replace(".gd", "")
+
 
 func _parse_and_add_test_cases(test_suite, script :GDScript, test_case_names :PackedStringArray):
 	var test_cases_to_find = Array(test_case_names)
@@ -138,6 +154,7 @@ func _parse_and_add_test_cases(test_suite, script :GDScript, test_case_names :Pa
 					test.skip(true, error)
 				test.set_test_parameters(test_paramaters)
 
+
 # converts given file name by configured naming convention
 static func _to_naming_convention(file_name :String) -> String:
 	var nc :int = GdUnitSettings.get_setting(GdUnitSettings.TEST_SITE_NAMING_CONVENTION, 0)
@@ -152,6 +169,7 @@ static func _to_naming_convention(file_name :String) -> String:
 			return GdObjects.to_pascal_case(file_name + "Test")
 	push_error("Unexpected case")
 	return "-<Unexpected>-"
+
 
 static func resolve_test_suite_path(source_script_path :String, test_root_folder :String = "test") -> String:
 	var file_extension := source_script_path.get_extension()
@@ -183,6 +201,7 @@ static func resolve_test_suite_path(source_script_path :String, test_root_folder
 				test_suite_path += "/" + paths[index]
 	return test_suite_path.replace(file_name, suite_name)
 
+
 static func create_test_suite(test_suite_path :String, source_path :String) -> Result:
 	# create directory if not exists
 	if not DirAccess.dir_exists_absolute(test_suite_path.get_base_dir()):
@@ -196,6 +215,7 @@ static func create_test_suite(test_suite_path :String, source_path :String) -> R
 	if error != OK:
 		return Result.error("Can't create test suite at: %s. Error code %s" % [test_suite_path, error])
 	return Result.success(test_suite_path)
+
 
 static func get_test_case_line_number(resource_path :String, func_name :String) -> int:
 	var file := FileAccess.open(resource_path, FileAccess.READ)
@@ -218,13 +238,16 @@ static func add_test_case(resource_path :String, func_name :String)  -> Result:
 	var script := load(resource_path) as GDScript
 	# count all exiting lines and add two as space to add new test case
 	var line_number := count_lines(script) + 2
-	script.source_code +=\
-"""
-
-func test_${func_name}() -> void:
-	# remove this line and complete your test
-	assert_not_yet_implemented()
-""".replace("${func_name}", func_name)
+	var func_body := TEST_FUNC_TEMPLATE.replace("${func_name}", func_name)
+	if Engine.is_editor_hint():
+		var ep := EditorPlugin.new()
+		var settings := ep.get_editor_interface().get_editor_settings()
+		ep.free()
+		var ident_type :int = settings.get_setting("text_editor/behavior/indent/type")
+		var ident_size :int = settings.get_setting("text_editor/behavior/indent/size")
+		if ident_type == 1:
+			func_body = func_body.replace("	", "".lpad(ident_size, " "))
+	script.source_code += func_body
 	var error := ResourceSaver.save(script, resource_path)
 	if error != OK:
 		return Result.error("Can't add test case at: %s to '%s'. Error code %s" % [func_name, resource_path, error])

--- a/addons/gdUnit4/test/GdUnitTestResourceLoader.gd
+++ b/addons/gdUnit4/test/GdUnitTestResourceLoader.gd
@@ -29,11 +29,10 @@ static func load_test_suite_gd(resource_path :String) -> GdUnitTestSuite:
 	var test_suite :GdUnitTestSuite = script.new()
 	test_suite.set_name(new_resource_path.get_file().replace(".gd", ""))
 	# complete test suite wiht parsed test cases
-	var suite_parser := _TestSuiteScanner.new()
-	var test_case_names := suite_parser._extract_test_case_names(script)
+	var suite_scanner := GdUnitTestSuiteScanner.new()
+	var test_case_names := suite_scanner._extract_test_case_names(script)
 	# add test cases to test suite and parse test case line nummber
-	suite_parser._parse_and_add_test_cases(test_suite, script, test_case_names)
-	suite_parser.free()
+	suite_scanner._parse_and_add_test_cases(test_suite, script, test_case_names)
 	GdUnitTools.delete_directory("res://addons/gdUnit4/.tmp")
 	return test_suite
 
@@ -43,12 +42,11 @@ static func load_test_suite_gd_(resource_path :String) -> GdUnitTestSuite:
 	var test_suite :GdUnitTestSuite = script.new()
 	test_suite.set_name(resource_path.get_file().replace(".resource", "").replace(".gd", ""))
 	# complete test suite wiht parsed test cases
-	var suite_parser := _TestSuiteScanner.new()
-	var test_case_names := suite_parser._extract_test_case_names(script)
+	var suite_scanner := GdUnitTestSuiteScanner.new()
+	var test_case_names := suite_scanner._extract_test_case_names(script)
 	# add test cases to test suite and parse test case line nummber
 	script.resource_path = resource_path
-	suite_parser._parse_and_add_test_cases(test_suite, script, test_case_names)
-	suite_parser.free()
+	suite_scanner._parse_and_add_test_cases(test_suite, script, test_case_names)
 	return test_suite
 
 

--- a/addons/gdUnit4/test/core/GdUnitTestSuiteScannerTest.gd
+++ b/addons/gdUnit4/test/core/GdUnitTestSuiteScannerTest.gd
@@ -5,17 +5,20 @@ class_name TestSuiteScannerTest
 extends GdUnitTestSuite
 
 # TestSuite generated from
-const __source = 'res://addons/gdUnit4/src/core/_TestSuiteScanner.gd'
+const __source = 'res://addons/gdUnit4/src/core/GdUnitTestSuiteScanner.gd'
 
 func before_test():
 	ProjectSettings.set_setting(GdUnitSettings.TEST_SITE_NAMING_CONVENTION, GdUnitSettings.NAMING_CONVENTIONS.AUTO_DETECT)
 	GdUnitTools.clear_tmp()
 
+
 func after():
 	GdUnitTools.clear_tmp()
 
+
 func resolve_path(source_file :String) -> String:
-	return _TestSuiteScanner.resolve_test_suite_path(source_file, "_test_")
+	return GdUnitTestSuiteScanner.resolve_test_suite_path(source_file, "_test_")
+
 
 func test_resolve_test_suite_path_project() -> void:
 	# if no `src` folder found use test folder as root
@@ -25,75 +28,80 @@ func test_resolve_test_suite_path_project() -> void:
 	assert_str(resolve_path("res://src/foo.gd")).is_equal("res://_test_/foo_test.gd")
 	assert_str(resolve_path("res://project_name/src/foo.gd")).is_equal("res://project_name/_test_/foo_test.gd")
 	assert_str(resolve_path("res://project_name/src/module/foo.gd")).is_equal("res://project_name/_test_/module/foo_test.gd")
-	
+
+
 func test_resolve_test_suite_path_plugins() -> void:
 	assert_str(resolve_path("res://addons/plugin_a/foo.gd")).is_equal("res://addons/plugin_a/_test_/foo_test.gd")
 	assert_str(resolve_path("res://addons/plugin_a/src/foo.gd")).is_equal("res://addons/plugin_a/_test_/foo_test.gd")
 
 
-
 func test_resolve_test_suite_path__no_test_root():
 	# from a project path
-	assert_str(_TestSuiteScanner.resolve_test_suite_path("res://project/src/models/events/ModelChangedEvent.gd", ""))\
+	assert_str(GdUnitTestSuiteScanner.resolve_test_suite_path("res://project/src/models/events/ModelChangedEvent.gd", ""))\
 		.is_equal("res://project/src/models/events/ModelChangedEventTest.gd")
 	# from a plugin path
-	assert_str(_TestSuiteScanner.resolve_test_suite_path("res://addons/MyPlugin/src/models/events/ModelChangedEvent.gd", ""))\
+	assert_str(GdUnitTestSuiteScanner.resolve_test_suite_path("res://addons/MyPlugin/src/models/events/ModelChangedEvent.gd", ""))\
 		.is_equal("res://addons/MyPlugin/src/models/events/ModelChangedEventTest.gd")
 	# located in user path
-	assert_str(_TestSuiteScanner.resolve_test_suite_path("user://project/src/models/events/ModelChangedEvent.gd", ""))\
+	assert_str(GdUnitTestSuiteScanner.resolve_test_suite_path("user://project/src/models/events/ModelChangedEvent.gd", ""))\
 		.is_equal("user://project/src/models/events/ModelChangedEventTest.gd")
+
 
 func test_resolve_test_suite_path__path_contains_src_folder():
 	# from a project path
-	assert_str(_TestSuiteScanner.resolve_test_suite_path("res://project/src/models/events/ModelChangedEvent.gd"))\
+	assert_str(GdUnitTestSuiteScanner.resolve_test_suite_path("res://project/src/models/events/ModelChangedEvent.gd"))\
 		.is_equal("res://project/test/models/events/ModelChangedEventTest.gd")
-	assert_str(_TestSuiteScanner.resolve_test_suite_path("res://project/src/models/events/ModelChangedEvent.gd", "custom_test"))\
+	assert_str(GdUnitTestSuiteScanner.resolve_test_suite_path("res://project/src/models/events/ModelChangedEvent.gd", "custom_test"))\
 		.is_equal("res://project/custom_test/models/events/ModelChangedEventTest.gd")
 	# from a plugin path
-	assert_str(_TestSuiteScanner.resolve_test_suite_path("res://addons/MyPlugin/src/models/events/ModelChangedEvent.gd"))\
+	assert_str(GdUnitTestSuiteScanner.resolve_test_suite_path("res://addons/MyPlugin/src/models/events/ModelChangedEvent.gd"))\
 		.is_equal("res://addons/MyPlugin/test/models/events/ModelChangedEventTest.gd")
-	assert_str(_TestSuiteScanner.resolve_test_suite_path("res://addons/MyPlugin/src/models/events/ModelChangedEvent.gd", "custom_test"))\
+	assert_str(GdUnitTestSuiteScanner.resolve_test_suite_path("res://addons/MyPlugin/src/models/events/ModelChangedEvent.gd", "custom_test"))\
 		.is_equal("res://addons/MyPlugin/custom_test/models/events/ModelChangedEventTest.gd")
 	# located in user path
-	assert_str(_TestSuiteScanner.resolve_test_suite_path("user://project/src/models/events/ModelChangedEvent.gd"))\
+	assert_str(GdUnitTestSuiteScanner.resolve_test_suite_path("user://project/src/models/events/ModelChangedEvent.gd"))\
 		.is_equal("user://project/test/models/events/ModelChangedEventTest.gd")
-	assert_str(_TestSuiteScanner.resolve_test_suite_path("user://project/src/models/events/ModelChangedEvent.gd", "custom_test"))\
+	assert_str(GdUnitTestSuiteScanner.resolve_test_suite_path("user://project/src/models/events/ModelChangedEvent.gd", "custom_test"))\
 		.is_equal("user://project/custom_test/models/events/ModelChangedEventTest.gd")
-		
+
+
 func test_resolve_test_suite_path__path_not_contains_src_folder():
 	# from a project path
-	assert_str(_TestSuiteScanner.resolve_test_suite_path("res://project/models/events/ModelChangedEvent.gd"))\
+	assert_str(GdUnitTestSuiteScanner.resolve_test_suite_path("res://project/models/events/ModelChangedEvent.gd"))\
 		.is_equal("res://test/project/models/events/ModelChangedEventTest.gd")
-	assert_str(_TestSuiteScanner.resolve_test_suite_path("res://project/models/events/ModelChangedEvent.gd", "custom_test"))\
+	assert_str(GdUnitTestSuiteScanner.resolve_test_suite_path("res://project/models/events/ModelChangedEvent.gd", "custom_test"))\
 		.is_equal("res://custom_test/project/models/events/ModelChangedEventTest.gd")
 	# from a plugin path
-	assert_str(_TestSuiteScanner.resolve_test_suite_path("res://addons/MyPlugin/models/events/ModelChangedEvent.gd"))\
+	assert_str(GdUnitTestSuiteScanner.resolve_test_suite_path("res://addons/MyPlugin/models/events/ModelChangedEvent.gd"))\
 		.is_equal("res://addons/MyPlugin/test/models/events/ModelChangedEventTest.gd")
-	assert_str(_TestSuiteScanner.resolve_test_suite_path("res://addons/MyPlugin/models/events/ModelChangedEvent.gd", "custom_test"))\
+	assert_str(GdUnitTestSuiteScanner.resolve_test_suite_path("res://addons/MyPlugin/models/events/ModelChangedEvent.gd", "custom_test"))\
 		.is_equal("res://addons/MyPlugin/custom_test/models/events/ModelChangedEventTest.gd")
 	# located in user path
-	assert_str(_TestSuiteScanner.resolve_test_suite_path("user://project/models/events/ModelChangedEvent.gd"))\
+	assert_str(GdUnitTestSuiteScanner.resolve_test_suite_path("user://project/models/events/ModelChangedEvent.gd"))\
 		.is_equal("user://test/project/models/events/ModelChangedEventTest.gd")
-	assert_str(_TestSuiteScanner.resolve_test_suite_path("user://project/models/events/ModelChangedEvent.gd", "custom_test"))\
+	assert_str(GdUnitTestSuiteScanner.resolve_test_suite_path("user://project/models/events/ModelChangedEvent.gd", "custom_test"))\
 		.is_equal("user://custom_test/project/models/events/ModelChangedEventTest.gd")
+
 
 func test_test_suite_exists():
 	var path_exists := "res://addons/gdUnit4/test/resources/core/GeneratedPersonTest.gd"
 	var path_not_exists := "res://addons/gdUnit4/test/resources/core/FamilyTest.gd"
-	assert_that(_TestSuiteScanner.test_suite_exists(path_exists)).is_true()
-	assert_that(_TestSuiteScanner.test_suite_exists(path_not_exists)).is_false()
+	assert_that(GdUnitTestSuiteScanner.test_suite_exists(path_exists)).is_true()
+	assert_that(GdUnitTestSuiteScanner.test_suite_exists(path_not_exists)).is_false()
+
 
 func test_test_case_exists():
 	var test_suite_path := "res://addons/gdUnit4/test/resources/core/GeneratedPersonTest.gd"
-	assert_that(_TestSuiteScanner.test_case_exists(test_suite_path, "name")).is_true()
-	assert_that(_TestSuiteScanner.test_case_exists(test_suite_path, "last_name")).is_false()
+	assert_that(GdUnitTestSuiteScanner.test_case_exists(test_suite_path, "name")).is_true()
+	assert_that(GdUnitTestSuiteScanner.test_case_exists(test_suite_path, "last_name")).is_false()
+
 
 func test_create_test_suite_pascal_case_path():
 	var temp_dir := GdUnitTools.create_temp_dir("TestSuiteScannerTest")
 	# checked source with class_name is set
 	var source_path := "res://addons/gdUnit4/test/core/resources/naming_conventions/PascalCaseWithClassName.gd"
 	var suite_path := temp_dir + "/test/MyClassTest1.gd"
-	var result := _TestSuiteScanner.create_test_suite(suite_path, source_path)
+	var result := GdUnitTestSuiteScanner.create_test_suite(suite_path, source_path)
 	assert_that(result.is_success()).is_true()
 	assert_str(result.value()).is_equal(suite_path)
 	assert_file(result.value()).exists()\
@@ -112,7 +120,7 @@ func test_create_test_suite_pascal_case_path():
 	# checked source with class_name is NOT set
 	source_path = "res://addons/gdUnit4/test/core/resources/naming_conventions/PascalCaseWithoutClassName.gd"
 	suite_path = temp_dir + "/test/MyClassTest2.gd"
-	result = _TestSuiteScanner.create_test_suite(suite_path, source_path)
+	result = GdUnitTestSuiteScanner.create_test_suite(suite_path, source_path)
 	assert_that(result.is_success()).is_true()
 	assert_str(result.value()).is_equal(suite_path)
 	assert_file(result.value()).exists()\
@@ -129,12 +137,13 @@ func test_create_test_suite_pascal_case_path():
 			"const __source = '%s'" % source_path,
 			""])
 
+
 func test_create_test_suite_snake_case_path():
 	var temp_dir := GdUnitTools.create_temp_dir("TestSuiteScannerTest")
 	# checked source with class_name is set
 	var source_path :="res://addons/gdUnit4/test/core/resources/naming_conventions/snake_case_with_class_name.gd"
 	var suite_path := temp_dir + "/test/my_class_test1.gd"
-	var result := _TestSuiteScanner.create_test_suite(suite_path, source_path)
+	var result := GdUnitTestSuiteScanner.create_test_suite(suite_path, source_path)
 	assert_that(result.is_success()).is_true()
 	assert_str(result.value()).is_equal(suite_path)
 	assert_file(result.value()).exists()\
@@ -153,7 +162,7 @@ func test_create_test_suite_snake_case_path():
 	# checked source with class_name is NOT set
 	source_path ="res://addons/gdUnit4/test/core/resources/naming_conventions/snake_case_without_class_name.gd"
 	suite_path = temp_dir + "/test/my_class_test2.gd"
-	result = _TestSuiteScanner.create_test_suite(suite_path, source_path)
+	result = GdUnitTestSuiteScanner.create_test_suite(suite_path, source_path)
 	assert_that(result.is_success()).is_true()
 	assert_str(result.value()).is_equal(suite_path)
 	assert_file(result.value()).exists()\
@@ -170,13 +179,14 @@ func test_create_test_suite_snake_case_path():
 			"const __source = '%s'" % source_path,
 			""])
 
+
 func test_create_test_case():
 	# store test class checked temp dir
 	var tmp_path := GdUnitTools.create_temp_dir("TestSuiteScannerTest")
 	var source_path := "res://addons/gdUnit4/test/resources/core/Person.gd"
 	# generate new test suite with test 'test_last_name()'
 	var test_suite_path = tmp_path + "/test/PersonTest.gd"
-	var result := _TestSuiteScanner.create_test_case(test_suite_path, "last_name", source_path)
+	var result := GdUnitTestSuiteScanner.create_test_case(test_suite_path, "last_name", source_path)
 	assert_that(result.is_success()).is_true()
 	var info :Dictionary = result.value()
 	assert_int(info.get("line")).is_equal(11)
@@ -199,37 +209,39 @@ func test_create_test_case():
 			"	assert_not_yet_implemented()",
 			""])
 	# try to add again
-	result = _TestSuiteScanner.create_test_case(test_suite_path, "last_name", source_path)
+	result = GdUnitTestSuiteScanner.create_test_case(test_suite_path, "last_name", source_path)
 	assert_that(result.is_success()).is_true()
 	assert_that(result.value()).is_equal({"line" : 11, "path": test_suite_path})
+
 
 # https://github.com/MikeSchulze/gdUnit4/issues/25
 func test_build_test_suite_path() -> void:
 	# checked project root
-	assert_str(_TestSuiteScanner.resolve_test_suite_path("res://new_script.gd")).is_equal("res://test/new_script_test.gd")
+	assert_str(GdUnitTestSuiteScanner.resolve_test_suite_path("res://new_script.gd")).is_equal("res://test/new_script_test.gd")
 	
 	# checked project without src folder
-	assert_str(_TestSuiteScanner.resolve_test_suite_path("res://foo/bar/new_script.gd")).is_equal("res://test/foo/bar/new_script_test.gd")
+	assert_str(GdUnitTestSuiteScanner.resolve_test_suite_path("res://foo/bar/new_script.gd")).is_equal("res://test/foo/bar/new_script_test.gd")
 	
 	# project code structured by 'src'
-	assert_str(_TestSuiteScanner.resolve_test_suite_path("res://src/new_script.gd")).is_equal("res://test/new_script_test.gd")
-	assert_str(_TestSuiteScanner.resolve_test_suite_path("res://src/foo/bar/new_script.gd")).is_equal("res://test/foo/bar/new_script_test.gd")
+	assert_str(GdUnitTestSuiteScanner.resolve_test_suite_path("res://src/new_script.gd")).is_equal("res://test/new_script_test.gd")
+	assert_str(GdUnitTestSuiteScanner.resolve_test_suite_path("res://src/foo/bar/new_script.gd")).is_equal("res://test/foo/bar/new_script_test.gd")
 	# folder name contains 'src' in name
-	assert_str(_TestSuiteScanner.resolve_test_suite_path("res://foo/srcare/new_script.gd")).is_equal("res://test/foo/srcare/new_script_test.gd")
+	assert_str(GdUnitTestSuiteScanner.resolve_test_suite_path("res://foo/srcare/new_script.gd")).is_equal("res://test/foo/srcare/new_script_test.gd")
 	
 	# checked plugins without src folder
-	assert_str(_TestSuiteScanner.resolve_test_suite_path("res://addons/plugin/foo/bar/new_script.gd")).is_equal("res://addons/plugin/test/foo/bar/new_script_test.gd")
+	assert_str(GdUnitTestSuiteScanner.resolve_test_suite_path("res://addons/plugin/foo/bar/new_script.gd")).is_equal("res://addons/plugin/test/foo/bar/new_script_test.gd")
 	# plugin code structured by 'src'
-	assert_str(_TestSuiteScanner.resolve_test_suite_path("res://addons/plugin/src/foo/bar/new_script.gd")).is_equal("res://addons/plugin/test/foo/bar/new_script_test.gd")
+	assert_str(GdUnitTestSuiteScanner.resolve_test_suite_path("res://addons/plugin/src/foo/bar/new_script.gd")).is_equal("res://addons/plugin/test/foo/bar/new_script_test.gd")
 	
 	# checked user temp folder
 	var tmp_path := GdUnitTools.create_temp_dir("projectX/entity")
 	var source_path := tmp_path + "/Person.gd"
-	assert_str(_TestSuiteScanner.resolve_test_suite_path(source_path)).is_equal("user://tmp/test/projectX/entity/PersonTest.gd")
+	assert_str(GdUnitTestSuiteScanner.resolve_test_suite_path(source_path)).is_equal("user://tmp/test/projectX/entity/PersonTest.gd")
+
 
 func test_parse_and_add_test_cases() -> void:
 	var default_time := GdUnitSettings.test_timeout()
-	var scanner :_TestSuiteScanner = auto_free(_TestSuiteScanner.new())
+	var scanner :GdUnitTestSuiteScanner = auto_free(GdUnitTestSuiteScanner.new())
 	# fake a test suite
 	var test_suite :GdUnitTestSuite = auto_free(GdUnitTestSuite.new())
 	var script := GDScript.new()
@@ -267,8 +279,9 @@ func test_parse_and_add_test_cases() -> void:
 				GdFunctionArgument.new("fuzzer_b", GdObjects.TYPE_FUZZER, "Fuzzers.rangei(23,42)")], 33)
 			])
 
+
 func test_scan_by_inheritance_class_name() -> void:
-	var scanner :_TestSuiteScanner = auto_free(_TestSuiteScanner.new())
+	var scanner :GdUnitTestSuiteScanner = auto_free(GdUnitTestSuiteScanner.new())
 	var test_suites := scanner.scan("res://addons/gdUnit4/test/core/resources/scan_testsuite_inheritance/by_class_name/")
 	
 	assert_array(test_suites).extractv(extr("get_name"), extr("get_script.get_path"), extr("get_children.get_name"))\
@@ -281,8 +294,9 @@ func test_scan_by_inheritance_class_name() -> void:
 	for ts in test_suites:
 		ts.free()
 
+
 func test_scan_by_inheritance_class_path() -> void:
-	var scanner :_TestSuiteScanner = auto_free(_TestSuiteScanner.new())
+	var scanner :GdUnitTestSuiteScanner = auto_free(GdUnitTestSuiteScanner.new())
 	var test_suites := scanner.scan("res://addons/gdUnit4/test/core/resources/scan_testsuite_inheritance/by_class_path/")
 	
 	assert_array(test_suites).extractv(extr("get_name"), extr("get_script.get_path"), extr("get_children.get_name"))\
@@ -295,35 +309,39 @@ func test_scan_by_inheritance_class_path() -> void:
 	for ts in test_suites:
 		ts.free()
 
+
 func test_get_test_case_line_number() -> void:
-	assert_int(_TestSuiteScanner.get_test_case_line_number("res://addons/gdUnit4/test/core/TestSuiteScannerTest.gd", "get_test_case_line_number")).is_equal(298)
-	assert_int(_TestSuiteScanner.get_test_case_line_number("res://addons/gdUnit4/test/core/TestSuiteScannerTest.gd", "unknown")).is_equal(-1)
+	assert_int(GdUnitTestSuiteScanner.get_test_case_line_number("res://addons/gdUnit4/test/core/GdUnitTestSuiteScannerTest.gd", "get_test_case_line_number")).is_equal(313)
+	assert_int(GdUnitTestSuiteScanner.get_test_case_line_number("res://addons/gdUnit4/test/core/GdUnitTestSuiteScannerTest.gd", "unknown")).is_equal(-1)
+
 
 func test__to_naming_convention() -> void:
 	ProjectSettings.set_setting(GdUnitSettings.TEST_SITE_NAMING_CONVENTION, GdUnitSettings.NAMING_CONVENTIONS.AUTO_DETECT)
-	assert_str(_TestSuiteScanner._to_naming_convention("MyClass")).is_equal("MyClassTest")
-	assert_str(_TestSuiteScanner._to_naming_convention("my_class")).is_equal("my_class_test")
-	assert_str(_TestSuiteScanner._to_naming_convention("myclass")).is_equal("myclass_test")
+	assert_str(GdUnitTestSuiteScanner._to_naming_convention("MyClass")).is_equal("MyClassTest")
+	assert_str(GdUnitTestSuiteScanner._to_naming_convention("my_class")).is_equal("my_class_test")
+	assert_str(GdUnitTestSuiteScanner._to_naming_convention("myclass")).is_equal("myclass_test")
 	
 	ProjectSettings.set_setting(GdUnitSettings.TEST_SITE_NAMING_CONVENTION, GdUnitSettings.NAMING_CONVENTIONS.SNAKE_CASE)
-	assert_str(_TestSuiteScanner._to_naming_convention("MyClass")).is_equal("my_class_test")
-	assert_str(_TestSuiteScanner._to_naming_convention("my_class")).is_equal("my_class_test")
-	assert_str(_TestSuiteScanner._to_naming_convention("myclass")).is_equal("myclass_test")
+	assert_str(GdUnitTestSuiteScanner._to_naming_convention("MyClass")).is_equal("my_class_test")
+	assert_str(GdUnitTestSuiteScanner._to_naming_convention("my_class")).is_equal("my_class_test")
+	assert_str(GdUnitTestSuiteScanner._to_naming_convention("myclass")).is_equal("myclass_test")
 	
 	ProjectSettings.set_setting(GdUnitSettings.TEST_SITE_NAMING_CONVENTION, GdUnitSettings.NAMING_CONVENTIONS.PASCAL_CASE)
-	assert_str(_TestSuiteScanner._to_naming_convention("MyClass")).is_equal("MyClassTest")
-	assert_str(_TestSuiteScanner._to_naming_convention("my_class")).is_equal("MyClassTest")
-	assert_str(_TestSuiteScanner._to_naming_convention("myclass")).is_equal("MyclassTest")
+	assert_str(GdUnitTestSuiteScanner._to_naming_convention("MyClass")).is_equal("MyClassTest")
+	assert_str(GdUnitTestSuiteScanner._to_naming_convention("my_class")).is_equal("MyClassTest")
+	assert_str(GdUnitTestSuiteScanner._to_naming_convention("myclass")).is_equal("MyclassTest")
+
 
 func test_is_script_format_supported() -> void:
-	assert_bool(_TestSuiteScanner._is_script_format_supported("res://exampe.gd")).is_true()
+	assert_bool(GdUnitTestSuiteScanner._is_script_format_supported("res://exampe.gd")).is_true()
 	if GdUnitTools.is_mono_supported():
-		assert_bool(_TestSuiteScanner._is_script_format_supported("res://exampe.cs")).is_true()
+		assert_bool(GdUnitTestSuiteScanner._is_script_format_supported("res://exampe.cs")).is_true()
 	else:
-		assert_bool(_TestSuiteScanner._is_script_format_supported("res://exampe.cs")).is_false()
-	assert_bool(_TestSuiteScanner._is_script_format_supported("res://exampe.gdns")).is_false()
-	assert_bool(_TestSuiteScanner._is_script_format_supported("res://exampe.vs")).is_false()
-	assert_bool(_TestSuiteScanner._is_script_format_supported("res://exampe.tres")).is_false()
+		assert_bool(GdUnitTestSuiteScanner._is_script_format_supported("res://exampe.cs")).is_false()
+	assert_bool(GdUnitTestSuiteScanner._is_script_format_supported("res://exampe.gdns")).is_false()
+	assert_bool(GdUnitTestSuiteScanner._is_script_format_supported("res://exampe.vs")).is_false()
+	assert_bool(GdUnitTestSuiteScanner._is_script_format_supported("res://exampe.tres")).is_false()
+
 
 func test_load_parameterized_test_suite():
 	var test_suite :GdUnitTestSuite = auto_free(GdUnitTestResourceLoader.load_test_suite("res://addons/gdUnit4/test/core/resources/testsuites/TestSuiteInvalidParameterizedTests.resource"))

--- a/addons/gdUnit4/test/mono/GdUnit3MonoAPITest.gd
+++ b/addons/gdUnit4/test/mono/GdUnit3MonoAPITest.gd
@@ -19,7 +19,7 @@ func test_create_test_suite() -> void:
 		# ignore this test checked none mono installations
 		return
 	var source := load(_example_source_cs)
-	var test_suite_path := _TestSuiteScanner.resolve_test_suite_path(source.resource_path, "test")
+	var test_suite_path := GdUnitTestSuiteScanner.resolve_test_suite_path(source.resource_path, "test")
 	var result := GdUnit3MonoAPI.create_test_suite(source.resource_path, 18, test_suite_path)
 
 	assert_result(result).is_success()

--- a/project.godot
+++ b/project.godot
@@ -915,6 +915,11 @@ _global_script_classes=[{
 "path": "res://addons/gdUnit4/src/report/GdUnitTestSuiteReport.gd"
 }, {
 "base": "RefCounted",
+"class": &"GdUnitTestSuiteScanner",
+"language": &"GDScript",
+"path": "res://addons/gdUnit4/src/core/GdUnitTestSuiteScanner.gd"
+}, {
+"base": "RefCounted",
 "class": &"GdUnitTestSuiteTemplate",
 "language": &"GDScript",
 "path": "res://addons/gdUnit4/src/core/templates/test_suite/GdUnitTestSuiteTemplate.gd"
@@ -1172,7 +1177,7 @@ _global_script_classes=[{
 "base": "GdUnitTestSuite",
 "class": &"TestSuiteScannerTest",
 "language": &"GDScript",
-"path": "res://addons/gdUnit4/test/core/TestSuiteScannerTest.gd"
+"path": "res://addons/gdUnit4/test/core/GdUnitTestSuiteScannerTest.gd"
 }, {
 "base": "GdUnitTestSuite",
 "class": &"TestSuiteTemplateTest",
@@ -1213,11 +1218,6 @@ _global_script_classes=[{
 "class": &"_TestCase",
 "language": &"GDScript",
 "path": "res://addons/gdUnit4/src/core/_TestCase.gd"
-}, {
-"base": "Node",
-"class": &"_TestSuiteScanner",
-"language": &"GDScript",
-"path": "res://addons/gdUnit4/src/core/_TestSuiteScanner.gd"
 }, {
 "base": "RefCounted",
 "class": &"snake_case_class_name",
@@ -1406,6 +1406,7 @@ _global_script_class_icons={
 "GdUnitTestSuiteDefaultTemplate": "",
 "GdUnitTestSuiteDto": "",
 "GdUnitTestSuiteReport": "",
+"GdUnitTestSuiteScanner": "",
 "GdUnitTestSuiteTemplate": "",
 "GdUnitTestSuiteTemplateTest": "",
 "GdUnitTestSuiteTest": "",
@@ -1466,7 +1467,6 @@ _global_script_class_icons={
 "XmlElement": "",
 "XmlElementTest": "",
 "_TestCase": "",
-"_TestSuiteScanner": "",
 "snake_case_class_name": ""
 }
 
@@ -1497,7 +1497,6 @@ enabled=PackedStringArray("res://addons/gdUnit4/plugin.cfg")
 
 settings/common/update_notification_enabled=false
 report/assert/verbose_errors=false
-report/assert/verbose_warnings=false
 
 [network]
 


### PR DESCRIPTION
# Why
A user can change the texteditor setting to use custom ident.
e.i. Tabs vs Spaces

# What
Use the editor settings to format the test function to expected ident,