### PR TITLE
GD-39: Fix unreadable failure report for `assert_dict` and improve failure messages for `assert_array`

### DIFF
--- a/addons/gdUnit4/src/asserts/GdUnitArrayAssertImpl.gd
+++ b/addons/gdUnit4/src/asserts/GdUnitArrayAssertImpl.gd
@@ -8,8 +8,14 @@ func _init(caller :Object, current, expect_result: int):
 	if not __validate_value_type(current):
 		report_error("GdUnitArrayAssert inital error, unexpected type <%s>" % GdObjects.typeof_as_string(current))
 
+
 func __validate_value_type(value) -> bool:
-	return value is ValueProvider or value == null or GdObjects.is_array_type(value)
+	return (
+		value is ValueProvider
+		or value == null
+		or GdObjects.is_array_type(value)
+	)
+
 
 func __current() -> Variant:
 	var current = _base.__current()
@@ -17,115 +23,40 @@ func __current() -> Variant:
 		return current
 	return Array(current)
 
+
 func __expected(expected) -> Variant:
 	if typeof(expected) == TYPE_ARRAY:
 		return expected
 	return Array(expected)
 
-func report_success() -> GdUnitArrayAssert:
-	_base.report_success()
-	return self
 
-func report_error(error :String) -> GdUnitArrayAssert:
-	_base.report_error(error)
-	return self
+func _array_equals_div(current :Array, expected :Array, case_sensitive :bool = false) -> Array:
+	var current_ := PackedStringArray(current)
+	var expected_ := PackedStringArray(expected)
+	var index_report_ := Array()
+	for index in current_.size():
+		var c := current_[index]
+		if index < expected_.size():
+			var e := expected_[index]
+			if not GdObjects.equals(c, e, case_sensitive):
+				var length := GdUnitTools.max_length(c, e)
+				current_[index] = GdAssertMessages.format_invalid(c.lpad(length))
+				expected_[index] = e.lpad(length)
+				index_report_.push_back({"index" : index, "current" :c, "expected": e})
+		else:
+			current_[index] = GdAssertMessages.format_invalid(c)
+			index_report_.push_back({"index" : index, "current" :c, "expected": "<N/A>"})
+	
+	for index in range(current.size(), expected.size()):
+		var value := expected_[index]
+		expected_[index] = GdAssertMessages.format_invalid(value)
+		index_report_.push_back({"index" : index, "current" : "<N/A>", "expected": value})
+	return [current_, expected_, index_report_]
 
-# -------- Base Assert wrapping ------------------------------------------------
-func has_failure_message(expected: String) -> GdUnitArrayAssert:
-	# normalize text to get rid of windows vs unix line formatting
-	_base.has_failure_message(GdUnitTools.normalize_text(expected))
-	return self
 
-func starts_with_failure_message(expected: String) -> GdUnitArrayAssert:
-	_base.starts_with_failure_message(expected)
-	return self
-
-func override_failure_message(message :String) -> GdUnitArrayAssert:
-	_base.override_failure_message(message)
-	return self
-
-func _notification(event):
-	if event == NOTIFICATION_PREDELETE:
-		if _base != null:
-			_base.notification(event)
-			_base = null
-#-------------------------------------------------------------------------------
-
-func is_null() -> GdUnitArrayAssert:
-	_base.is_null()
-	return self
-
-func is_not_null() -> GdUnitArrayAssert:
-	_base.is_not_null()
-	return self
-
-# Verifies that the current String is equal to the given one.
-func is_equal(expected) -> GdUnitArrayAssert:
-	var current_ = __current()
-	var expected_ = __expected(expected)
-	if current_ == null and expected_ != null:
-		return report_error(GdAssertMessages.error_equal(null, expected_))
-	if not GdObjects.equals(current_, expected_):
-		var diff := _array_equals_div(current_, expected_)
-		var expected_as_list := GdObjects.array_to_string(diff[0], ", ", 32)
-		var current_as_list := GdObjects.array_to_string(diff[1], ", ", 32)
-		var index_report = diff[2]
-		return report_error(GdAssertMessages.error_equal(expected_as_list, current_as_list, index_report))
-	return report_success()
-
-# Verifies that the current Array is equal to the given one, ignoring case considerations.
-func is_equal_ignoring_case(expected) -> GdUnitArrayAssert:
-	var current_ = __current()
-	var expected_ = __expected(expected)
-	if current_ == null and expected_ != null:
-		return report_error(GdAssertMessages.error_equal(null, expected_))
-	if not GdObjects.equals(current_, expected_, true):
-		var diff := _array_equals_div(current_, expected_, true)
-		var expected_as_list := GdObjects.array_to_string(diff[0], ", ", 32)
-		var current_as_list := GdObjects.array_to_string(diff[1], ", ", 32)
-		var index_report = diff[2]
-		return report_error(GdAssertMessages.error_equal(expected_as_list, current_as_list, index_report))
-	return report_success()
-
-func is_not_equal(expected) -> GdUnitArrayAssert:
-	var current_ = __current()
-	var expected_ = __expected(expected)
-	if GdObjects.equals(current_, expected_):
-		return report_error(GdAssertMessages.error_not_equal(current_, expected_))
-	return report_success()
-
-func is_not_equal_ignoring_case(expected) -> GdUnitArrayAssert:
-	var current_ = __current()
-	var expected_ = __expected(expected)
-	if GdObjects.equals(current_, expected_, true):
-		return report_error(GdAssertMessages.error_not_equal(current_, expected_))
-	return report_success()
-
-# Verifies that the current Array is empty, it has a size of 0.
-func is_empty() -> GdUnitArrayAssert:
-	var current_ = __current()
-	if current_ == null or current_.size() > 0:
-		return report_error(GdAssertMessages.error_is_empty(current_))
-	return report_success()
-
-# Verifies that the current Array is not empty, it has a size of minimum 1.
-func is_not_empty() -> GdUnitArrayAssert:
-	var current_ = __current()
-	if current_ != null and current_.size() == 0:
-		return report_error(GdAssertMessages.error_is_not_empty())
-	return report_success()
-
-# Verifies that the current Array has a size of given value.
-func has_size(expected: int) -> GdUnitArrayAssert:
-	var current_ = __current()
-	if current_== null or current_.size() != expected:
-		return report_error(GdAssertMessages.error_has_size(current_, expected))
-	return report_success()
-
-func array_div(left :Array, right :Array, same_order := false) -> Array:
+func _array_div(left :Array, right :Array, same_order := false) -> Array:
 	var not_expect := left.duplicate(true)
 	var not_found := right.duplicate(true)
-	
 	for index_c in left.size():
 		var c = left[index_c]
 		for index_e in right.size():
@@ -136,96 +67,192 @@ func array_div(left :Array, right :Array, same_order := false) -> Array:
 				break
 	return [not_expect, not_found]
 
-func _array_equals_div(current :Array, expected :Array, case_sensitive :bool = false) -> Array:
-	var current_ := current.duplicate(true)
-	var expected_ := expected.duplicate(true)
-	var index_report_ := Array()
-	for index in current.size():
-		var c = current[index]
-		if index < expected_.size():
-			var e = expected_[index]
-			if not GdObjects.equals(c, e, case_sensitive):
-				var lenght := GdUnitTools.max_length(c, e)
-				current_[index] = GdDiffTool.as_invalid(GdUnitTools.expand_value(c, lenght))
-				expected_[index] = GdUnitTools.expand_value(e, lenght)
-				index_report_.push_back({"index" : index, "current" :c, "expected": e})
-		else:
-			current_[index] = GdDiffTool.as_invalid(GdUnitTools.expand_value(c, str(c).length()))
-			index_report_.push_back({"index" : index, "current" :c, "expected": "<N/A>"})
-	
-	for index in range(current.size(), expected.size()):
-		var value = expected_[index]
-		expected_[index] = GdDiffTool.as_invalid(GdUnitTools.expand_value(value, str(value).length()))
-		index_report_.push_back({"index" : index, "current" : "<N/A>", "expected": value})
-	return [current_, expected_, index_report_]
+
+func report_success() -> GdUnitArrayAssert:
+	_base.report_success()
+	return self
+
+
+func report_error(error :String) -> GdUnitArrayAssert:
+	_base.report_error(error)
+	return self
+
+
+# -------- Base Assert wrapping ------------------------------------------------
+func has_failure_message(expected: String) -> GdUnitArrayAssert:
+	# normalize text to get rid of windows vs unix line formatting
+	_base.has_failure_message(GdUnitTools.normalize_text(expected))
+	return self
+
+
+func starts_with_failure_message(expected: String) -> GdUnitArrayAssert:
+	_base.starts_with_failure_message(expected)
+	return self
+
+
+func override_failure_message(message :String) -> GdUnitArrayAssert:
+	_base.override_failure_message(message)
+	return self
+
+
+func _notification(event):
+	if event == NOTIFICATION_PREDELETE:
+		if _base != null:
+			_base.notification(event)
+			_base = null
+#-------------------------------------------------------------------------------
+
+
+func is_null() -> GdUnitArrayAssert:
+	_base.is_null()
+	return self
+
+
+func is_not_null() -> GdUnitArrayAssert:
+	_base.is_not_null()
+	return self
+
+
+# Verifies that the current String is equal to the given one.
+func is_equal(expected) -> GdUnitArrayAssert:
+	var current_ = __current()
+	var expected_ = __expected(expected)
+	if current_ == null and expected_ != null:
+		return report_error(GdAssertMessages.error_equal(null, GdObjects.array_to_string(expected_, ", ", 32)))
+	if not GdObjects.equals(current_, expected_):
+		var diff := _array_equals_div(current_, expected_)
+		var expected_as_list := GdObjects.array_to_string(diff[0], ", ", 32)
+		var current_as_list := GdObjects.array_to_string(diff[1], ", ", 32)
+		var index_report = diff[2]
+		return report_error(GdAssertMessages.error_equal(expected_as_list, current_as_list, index_report))
+	return report_success()
+
+
+# Verifies that the current Array is equal to the given one, ignoring case considerations.
+func is_equal_ignoring_case(expected) -> GdUnitArrayAssert:
+	var current_ = __current()
+	var expected_ = __expected(expected)
+	if current_ == null and expected_ != null:
+		return report_error(GdAssertMessages.error_equal(null, GdObjects.array_to_string(expected_, ", ", 32)))
+	if not GdObjects.equals(current_, expected_, true):
+		var diff := _array_equals_div(current_, expected_, true)
+		var expected_as_list := GdObjects.array_to_string(diff[0], ", ", 32)
+		var current_as_list := GdObjects.array_to_string(diff[1], ", ", 32)
+		var index_report = diff[2]
+		return report_error(GdAssertMessages.error_equal(expected_as_list, current_as_list, index_report))
+	return report_success()
+
+
+func is_not_equal(expected) -> GdUnitArrayAssert:
+	var current_ = __current()
+	var expected_ = __expected(expected)
+	if GdObjects.equals(current_, expected_):
+		var c := GdObjects.array_to_string(current_, ", ", 32)
+		var e := GdObjects.array_to_string(expected_, ", ", 32)
+		return report_error(GdAssertMessages.error_not_equal(c, e))
+	return report_success()
+
+
+func is_not_equal_ignoring_case(expected) -> GdUnitArrayAssert:
+	var current_ = __current()
+	var expected_ = __expected(expected)
+	if GdObjects.equals(current_, expected_, true):
+		var c := GdObjects.array_to_string(current_, ", ", 32)
+		var e := GdObjects.array_to_string(expected_, ", ", 32)
+		return report_error(GdAssertMessages.error_not_equal_case_insensetiv(c, e))
+	return report_success()
+
+
+# Verifies that the current Array is empty, it has a size of 0.
+func is_empty() -> GdUnitArrayAssert:
+	var current_ = __current()
+	if current_ == null or current_.size() > 0:
+		return report_error(GdAssertMessages.error_is_empty(current_))
+	return report_success()
+
+
+# Verifies that the current Array is not empty, it has a size of minimum 1.
+func is_not_empty() -> GdUnitArrayAssert:
+	var current_ = __current()
+	if current_ != null and current_.size() == 0:
+		return report_error(GdAssertMessages.error_is_not_empty())
+	return report_success()
+
+
+# Verifies that the current Array has a size of given value.
+func has_size(expected: int) -> GdUnitArrayAssert:
+	var current_ = __current()
+	if current_ == null or current_.size() != expected:
+		return report_error(GdAssertMessages.error_has_size(current_, expected))
+	return report_success()
+
 
 # Verifies that the current Array contains the given values, in any order.
 func contains(expected) -> GdUnitArrayAssert:
 	var current_ = __current()
 	var expected_ = __expected(expected)
-	
 	if current_ == null:
 		return report_error(GdAssertMessages.error_arr_contains(current_, expected_, [], expected_))
-	
-	var diffs := array_div(current_, expected_)
+	var diffs := _array_div(current_, expected_)
 	var not_expect := diffs[0] as Array
 	var not_found := diffs[1] as Array
 	if not not_found.is_empty():
 		return report_error(GdAssertMessages.error_arr_contains(current_, expected_, [], not_found))
 	return report_success()
 
+
 # Verifies that the current Array contains only the given values and nothing else, in order.
 func contains_exactly(expected :Array) -> GdUnitArrayAssert:
 	var current_ = __current()
 	var expected_ = __expected(expected)
-	
 	if current_ == null:
 		return report_error(GdAssertMessages.error_arr_contains_exactly(current_, expected_, [], expected_))
-	
 	# has same content in same order
 	if GdObjects.equals(current_, expected_):
 		return report_success()
 	# check has same elements but in different order
-	
 	if GdObjects.equals_sorted(current_, expected_):
 		return report_error(GdAssertMessages.error_arr_contains_exactly(current_, expected_, [], []))
 	# find the difference
-	var diffs := array_div(current_, expected_, true)
+	var diffs := _array_div(current_, expected_, true)
 	var not_expect := diffs[0] as Array
 	var not_found := diffs[1] as Array
 	return report_error(GdAssertMessages.error_arr_contains_exactly(current_, expected_, not_expect, not_found))
+
 
 # Verifies that the current Array contains exactly only the given values and nothing else, in any order.
 func contains_exactly_in_any_order(expected) -> GdUnitArrayAssert:
 	var current_ = __current()
 	var expected_ = __expected(expected)
-	
 	if current_ == null:
 		return report_error(GdAssertMessages.error_arr_contains_exactly_in_any_order(current_, expected_, [], expected_))
-	
 	# find the difference
-	var diffs := array_div(current_, expected_, false)
+	var diffs := _array_div(current_, expected_, false)
 	var not_expect := diffs[0] as Array
 	var not_found := diffs[1] as Array
 	if not_expect.is_empty() and not_found.is_empty():
 		return report_success()
 	return report_error(GdAssertMessages.error_arr_contains_exactly_in_any_order(current_, expected_, not_expect, not_found))
 
+
 func is_same(expected) -> GdUnitAssert:
 	_base.is_same(expected)
 	return self
+
 
 func is_not_same(expected) -> GdUnitAssert:
 	_base.is_not_same(expected)
 	return self
 
+
 func is_instanceof(expected) -> GdUnitAssert:
 	_base.is_instanceof(expected)
 	return self
 
+
 # extracts all values by given function name or null if not exists
 func extract(func_name :String, args := Array()) -> GdUnitArrayAssert:
-	var extracted_elements: = Array()
+	var extracted_elements := Array()
 	var extractor := GdUnitFuncValueExtractor.new(func_name, args)
 	var current = __current()
 	if current == null:
@@ -235,6 +262,7 @@ func extract(func_name :String, args := Array()) -> GdUnitArrayAssert:
 			extracted_elements.append(extractor.extract_value(element))
 	_base._current_value_provider = DefaultValueProvider.new(extracted_elements)
 	return self
+
 
 # Extracts all values by given extractors into a new ArrayAssert
 func extractv(
@@ -249,7 +277,7 @@ func extractv(
 	extr8 :GdUnitValueExtractor = null,
 	extr9 :GdUnitValueExtractor = null) -> GdUnitArrayAssert:
 	var extractors := GdObjects.array_filter_value([extr0, extr1, extr2, extr3, extr4, extr5, extr6, extr7, extr8, extr9], null)
-	var extracted_elements: = Array()
+	var extracted_elements := Array()
 	var current = __current()
 	if current == null:
 		extracted_elements.append(null)

--- a/addons/gdUnit4/src/asserts/GdUnitAssertImpl.gd
+++ b/addons/gdUnit4/src/asserts/GdUnitAssertImpl.gd
@@ -81,7 +81,7 @@ func has_failure_message(expected :String):
 	if current_error != expected:
 		_expect_fail = false
 		var diffs := GdDiffTool.string_diff(current_error, expected)
-		var current := GdAssertMessages.colorDiff(diffs[1])
+		var current := GdAssertMessages._colored_array_div(diffs[1])
 		report_error(GdAssertMessages.error_not_same_error(current, expected))
 	return self
 
@@ -90,7 +90,7 @@ func starts_with_failure_message(expected :String):
 	if current_error.find(expected) != 0:
 		_expect_fail = false
 		var diffs := GdDiffTool.string_diff(current_error, expected)
-		var current := GdAssertMessages.colorDiff(diffs[1])
+		var current := GdAssertMessages._colored_array_div(diffs[1])
 		report_error(GdAssertMessages.error_not_same_error(current, expected))
 	return self
 

--- a/addons/gdUnit4/src/asserts/GdUnitDictionaryAssertImpl.gd
+++ b/addons/gdUnit4/src/asserts/GdUnitDictionaryAssertImpl.gd
@@ -3,77 +3,89 @@ extends GdUnitDictionaryAssert
 
 var _base :GdUnitAssert
 
-func _init(caller :Object,current,expect_result: int):
+
+func _init(caller :Object, current, expect_result: int):
 	_base = GdUnitAssertImpl.new(caller, current, expect_result)
 	if not _base.__validate_value_type(current, TYPE_DICTIONARY):
 		report_error("GdUnitDictionaryAssert inital error, unexpected type <%s>" % GdObjects.typeof_as_string(current))
 
+
 func __current() -> Variant:
 	return _base.__current()
 
+
 func __expected(expected) -> Variant:
 	return expected
+
 
 func report_success() -> GdUnitDictionaryAssert:
 	_base.report_success()
 	return self
 
+
 func report_error(error :String) -> GdUnitDictionaryAssert:
 	_base.report_error(error)
 	return self
+
 
 # -------- Base Assert wrapping ------------------------------------------------
 func has_failure_message(expected: String) -> GdUnitDictionaryAssert:
 	_base.has_failure_message(expected)
 	return self
 
+
 func starts_with_failure_message(expected: String) -> GdUnitDictionaryAssert:
 	_base.starts_with_failure_message(expected)
 	return self
 
+
 func override_failure_message(message :String) -> GdUnitDictionaryAssert:
 	_base.override_failure_message(message)
 	return self
+
 
 func _notification(event):
 	if event == NOTIFICATION_PREDELETE:
 		if _base != null:
 			_base.notification(event)
 			_base = null
+
+
 #-------------------------------------------------------------------------------
 # Verifies that the current value is null.
 func is_null() -> GdUnitDictionaryAssert:
 	_base.is_null()
 	return self
 
+
 # Verifies that the current value is not null.
 func is_not_null() -> GdUnitDictionaryAssert:
 	_base.is_not_null()
 	return self
+
 
 # Verifies that the current dictionary is equal to the given one.
 func is_equal(expected) -> GdUnitDictionaryAssert:
 	var current = __current()
 	expected = __expected(expected)
 	if current == null:
-		return report_error(GdAssertMessages.error_equal(null, expected))
+		return report_error(GdAssertMessages.error_equal(null, GdAssertMessages._format_dict(expected)))
 	if not GdObjects.equals(current, expected):
-		var c = var_to_str(current)
-		var e = var_to_str(expected)
+		var c := GdAssertMessages._format_dict(current)
+		var e := GdAssertMessages._format_dict(expected)
 		var diff := GdDiffTool.string_diff(c, e)
-		return report_error(GdAssertMessages.error_equal(diff[1], diff[0]))
+		return report_error(GdAssertMessages.error_equal(diff[1], e))
 	return report_success()
+
 
 # Verifies that the current dictionary is not equal to the given one.
 func is_not_equal(expected) -> GdUnitDictionaryAssert:
 	var current = __current()
 	expected = __expected(expected)
 	if GdObjects.equals(current, expected):
-		var c = var_to_str(current)
-		var e = var_to_str(expected)
-		var diff := GdDiffTool.string_diff(c, e)
-		return report_error(GdAssertMessages.error_equal(diff[1], diff[0]))
+		return report_error(GdAssertMessages.error_not_equal(current, expected))
 	return report_success()
+
 
 # Verifies that the current dictionary is empty, it has a size of 0.
 func is_empty() -> GdUnitDictionaryAssert:
@@ -82,12 +94,14 @@ func is_empty() -> GdUnitDictionaryAssert:
 		return report_error(GdAssertMessages.error_is_empty(current))
 	return report_success()
 
+
 # Verifies that the current dictionary is not empty, it has a size of minimum 1.
 func is_not_empty() -> GdUnitDictionaryAssert:
 	var current = __current()
 	if current == null or current.is_empty():
 		return report_error(GdAssertMessages.error_is_not_empty())
 	return report_success()
+
 
 # Verifies that the current dictionary has a size of given value.
 func has_size(expected: int) -> GdUnitDictionaryAssert:
@@ -98,44 +112,42 @@ func has_size(expected: int) -> GdUnitDictionaryAssert:
 		return report_error(GdAssertMessages.error_has_size(current, expected))
 	return report_success()
 
+
 # Verifies that the current dictionary contains the given key(s).
 func contains_keys(expected :Array) -> GdUnitDictionaryAssert:
 	var current = __current()
 	if current == null:
 		return report_error(GdAssertMessages.error_is_not_null())
-	
 	# find expected keys
 	var keys_not_found := expected.duplicate()
 	for key in current.keys():
 		keys_not_found.erase(key)
-		
 	if not keys_not_found.is_empty():
 		return report_error(GdAssertMessages.error_contains_keys(current.keys(), expected, keys_not_found))
 	return report_success()
+
 
 # Verifies that the current dictionary not contains the given key(s).
 func contains_not_keys(expected :Array) -> GdUnitDictionaryAssert:
 	var current = __current()
 	if current == null:
 		return report_error(GdAssertMessages.error_is_not_null())
-	
 	# find not expected keys
 	var keys_found := Array()
 	var current_keys = current.keys()
 	for do_not_contain_key in expected:
 		if current_keys.has(do_not_contain_key):
 			keys_found.append(do_not_contain_key)
-		
 	if not keys_found.is_empty():
 		return report_error(GdAssertMessages.error_not_contains_keys(current.keys(), expected, keys_found))
 	return report_success()
+
 
 # Verifies that the current dictionary contains the given key and value.
 func contains_key_value(key, value) -> GdUnitDictionaryAssert:
 	var current = __current()
 	if current == null:
 		return report_error(GdAssertMessages.error_is_not_null())
-	
 	if not current.has(key):
 		return report_error(GdAssertMessages.error_contains_keys(current.keys(), [key], [key]))
 	if not GdObjects.equals(current[key], value):

--- a/addons/gdUnit4/src/asserts/GdUnitFuncAssertImpl.gd
+++ b/addons/gdUnit4/src/asserts/GdUnitFuncAssertImpl.gd
@@ -50,7 +50,7 @@ func has_failure_message(expected: String) -> GdUnitFuncAssert:
 	if current_error != expected:
 		_expect_fail = false
 		var diffs := GdDiffTool.string_diff(current_error, expected)
-		var current := GdAssertMessages.colorDiff(diffs[1])
+		var current := GdAssertMessages._colored_array_div(diffs[1])
 		_custom_failure_message = ""
 		report_error(GdAssertMessages.error_not_same_error(current, expected))
 	return self
@@ -60,7 +60,7 @@ func starts_with_failure_message(expected: String) -> GdUnitFuncAssert:
 	if not current_error.begins_with(expected):
 		_expect_fail = false
 		var diffs := GdDiffTool.string_diff(current_error, expected)
-		var current := GdAssertMessages.colorDiff(diffs[1])
+		var current := GdAssertMessages._colored_array_div(diffs[1])
 		_custom_failure_message = ""
 		report_error(GdAssertMessages.error_not_same_error(current, expected))
 	return self

--- a/addons/gdUnit4/src/asserts/GdUnitSignalAssertImpl.gd
+++ b/addons/gdUnit4/src/asserts/GdUnitSignalAssertImpl.gd
@@ -142,7 +142,7 @@ func has_failure_message(expected: String) -> GdUnitSignalAssert:
 	if current_error != expected:
 		_expect_fail = false
 		var diffs := GdDiffTool.string_diff(current_error, expected)
-		var current := GdAssertMessages.colorDiff(diffs[1])
+		var current := GdAssertMessages._colored_array_div(diffs[1])
 		_custom_failure_message = ""
 		report_error(GdAssertMessages.error_not_same_error(current, expected))
 	return self
@@ -152,7 +152,7 @@ func starts_with_failure_message(expected: String) -> GdUnitSignalAssert:
 	if not current_error.begins_with(expected):
 		_expect_fail = false
 		var diffs := GdDiffTool.string_diff(current_error, expected)
-		var current := GdAssertMessages.colorDiff(diffs[1])
+		var current := GdAssertMessages._colored_array_div(diffs[1])
 		_custom_failure_message = ""
 		report_error(GdAssertMessages.error_not_same_error(current, expected))
 	return self

--- a/addons/gdUnit4/src/asserts/GdUnitStringAssertImpl.gd
+++ b/addons/gdUnit4/src/asserts/GdUnitStringAssertImpl.gd
@@ -57,7 +57,7 @@ func is_equal(expected) -> GdUnitStringAssert:
 		return report_error(GdAssertMessages.error_equal(current, expected))
 	if not GdObjects.equals(current, expected):
 		var diffs := GdDiffTool.string_diff(current, expected)
-		var formatted_current := GdAssertMessages.colorDiff(diffs[1])
+		var formatted_current := GdAssertMessages._colored_array_div(diffs[1])
 		return report_error(GdAssertMessages.error_equal(formatted_current, expected))
 	return report_success()
 
@@ -67,7 +67,7 @@ func is_equal_ignoring_case(expected) -> GdUnitStringAssert:
 		return report_error(GdAssertMessages.error_equal_ignoring_case(current, expected))
 	if not GdObjects.equals(current, expected, true):
 		var diffs := GdDiffTool.string_diff(current, expected)
-		var formatted_current := GdAssertMessages.colorDiff(diffs[1])
+		var formatted_current := GdAssertMessages._colored_array_div(diffs[1])
 		return report_error(GdAssertMessages.error_equal_ignoring_case(formatted_current, expected))
 	return report_success()
 

--- a/addons/gdUnit4/src/core/GdDiffTool.gd
+++ b/addons/gdUnit4/src/core/GdDiffTool.gd
@@ -2,8 +2,10 @@
 class_name GdDiffTool
 extends RefCounted
 
-const DIV_ADD :int = 14
-const DIV_SUB :int = 15
+
+const DIV_ADD :int = 214
+const DIV_SUB :int = 215
+
 
 static func _diff(lb: PackedByteArray, rb: PackedByteArray, lookup: Array, ldiff: Array, rdiff: Array):
 	var loffset = lb.size()
@@ -35,15 +37,17 @@ static func _diff(lb: PackedByteArray, rb: PackedByteArray, lookup: Array, ldiff
 			continue
 		break
 
+
 # lookup[i][j] stores the length of LCS of substring X[0..i-1], Y[0..j-1]
 static func _createLookUp(lb: PackedByteArray, rb: PackedByteArray) -> Array:
-	var lookup:Array = Array()
+	var lookup := Array()
 	lookup.resize(lb.size() + 1)
 	for i in lookup.size():
 		var x = []
 		x.resize(rb.size() + 1)
 		lookup[i] = x
 	return lookup
+
 
 static func _buildLookup(lb: PackedByteArray, rb: PackedByteArray) -> Array:
 	var lookup := _createLookUp(lb, rb)
@@ -65,21 +69,16 @@ static func _buildLookup(lb: PackedByteArray, rb: PackedByteArray) -> Array:
 				lookup[i][j] = max(lookup[i - 1][j], lookup[i][j - 1]);
 	return lookup
 
+
 static func string_diff(left, right) -> Array[PackedByteArray]:
 	var lb := PackedByteArray() if left == null else str(left).to_ascii_buffer()
 	var rb := PackedByteArray() if right == null else str(right).to_ascii_buffer()
 	var ldiff := Array()
 	var rdiff := Array()
-	var lookup =  _buildLookup(lb, rb);
+	var lookup := _buildLookup(lb, rb);
 	_diff(lb, rb, lookup, ldiff, rdiff)
 	return [PackedByteArray(ldiff), PackedByteArray(rdiff)]
 
-static func as_invalid(value) -> String:
-	var x := PackedByteArray()
-	for c in str(value).to_ascii_buffer():
-		x.append(DIV_SUB)
-		x.append(c)
-	return x.get_string_from_utf8()
 
 # prototype
 static func longestCommonSubsequence(text1 :String, text2 :String) -> PackedStringArray:
@@ -114,6 +113,7 @@ static func longestCommonSubsequence(text1 :String, text2 :String) -> PackedStri
 		else:
 			j += 1
 	return lcsResultList
+
 
 static func markTextDifferences(text1 :String, text2 :String, lcsList :PackedStringArray, insertColor :Color, deleteColor:Color) -> String:
 	var stringBuffer = ""

--- a/addons/gdUnit4/src/core/GdUnitTools.gd
+++ b/addons/gdUnit4/src/core/GdUnitTools.gd
@@ -220,14 +220,12 @@ static func resource_as_string(resource_path :String) -> String:
 static func normalize_text(text :String) -> String:
 	return text.replace("\r", "");
 
+
 static func max_length(left, right) -> int:
 	var ls = str(left).length()
 	var rs = str(right).length()
 	return rs if ls < rs else ls
 
-static func expand_value(value, length :int) -> String:
-	var format := "%+"+ str(length)+"s"
-	return format % str(value)
 
 static func free_instance(instance :Variant) -> void:
 	# is instance already freed?

--- a/addons/gdUnit4/test/asserts/GdUnitArrayAssertImplTest.gd
+++ b/addons/gdUnit4/test/asserts/GdUnitArrayAssertImplTest.gd
@@ -1,9 +1,9 @@
 # GdUnit generated TestSuite
-class_name GdUnitArrayAssertImplTest
 extends GdUnitTestSuite
 
 # TestSuite generated from
 const __source = 'res://addons/gdUnit4/src/asserts/GdUnitArrayAssertImpl.gd'
+
 
 func test_is_null():
 	assert_array(null).is_null()
@@ -12,12 +12,14 @@ func test_is_null():
 		.is_null()\
 		.has_failure_message("Expecting: '<null>' but was empty")
 
+
 func test_is_not_null():
 	assert_array([]).is_not_null()
 	# should fail because the array is null
 	assert_array(null, GdUnitAssert.EXPECT_FAIL) \
 		.is_not_null()\
 		.has_failure_message("Expecting: not to be '<null>'")
+
 
 func test_is_equal():
 	assert_array([1, 2, 3, 4, 2, 5]).is_equal([1, 2, 3, 4, 2, 5])
@@ -28,30 +30,37 @@ func test_is_equal():
 		.is_equal([1, 2, 3, 4])
 	# current array is bigger than expected
 	assert_array([1, 2222, 3, 4, 5, 6], GdUnitAssert.EXPECT_FAIL).is_equal([1, 2, 3, 4])\
-		.has_failure_message("""Expecting:
- '1,    2, 3, 4'
- but was
- '1, 2222, 3, 4, 5, 6'
-
-Differences found:
-Index	Current	Expected	1	2222	2	4	5	<N/A>	5	6	<N/A>	""")
+		.has_failure_message("""
+			Expecting:
+			 '1,    2, 3, 4'
+			 but was
+			 '1, 2222, 3, 4, 5, 6'
+			
+			Differences found:
+			Index	Current	Expected	1	2222	2	4	5	<N/A>	5	6	<N/A>	"""
+			.dedent().trim_prefix("\n"))
 	
 	# expected array is bigger than current
 	assert_array([1, 222, 3, 4], GdUnitAssert.EXPECT_FAIL).is_equal([1, 2, 3, 4, 5, 6])\
-		.has_failure_message("""Expecting:
- '1,   2, 3, 4, 5, 6'
- but was
- '1, 222, 3, 4'
-
-Differences found:
-Index	Current	Expected	1	222	2	4	<N/A>	5	5	<N/A>	6	""")
+		.has_failure_message("""
+			Expecting:
+			 '1,   2, 3, 4, 5, 6'
+			 but was
+			 '1, 222, 3, 4'
+			
+			Differences found:
+			Index	Current	Expected	1	222	2	4	<N/A>	5	5	<N/A>	6	"""
+			.dedent().trim_prefix("\n"))
 	
 	assert_array(null, GdUnitAssert.EXPECT_FAIL) \
 		.is_equal([1, 2, 3])\
-		.has_failure_message("Expecting:\n"
-			+ " 1\n2\n3\n"
-			+ " but was\n"
-			+ " '<null>'")
+		.has_failure_message("""
+			Expecting:
+			 '1, 2, 3'
+			 but was
+			 '<null>'"""
+			.dedent().trim_prefix("\n"))
+
 
 func test_is_equal_big_arrays():
 	var expeted := Array()
@@ -65,13 +74,16 @@ func test_is_equal_big_arrays():
 	current[888] = "invalid"
 	
 	assert_array(current, GdUnitAssert.EXPECT_FAIL).is_equal(expeted)\
-		.has_failure_message("""Expecting:
- '0, 1, 2, 3, 4, 5, 6, 7, 8, 9,      10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, ...'
- but was
- '0, 1, 2, 3, 4, 5, 6, 7, 8, 9, invalid, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, ...'
+		.has_failure_message("""
+			Expecting:
+			 '0, 1, 2, 3, 4, 5, 6, 7, 8, 9,      10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, ...'
+			 but was
+			 '0, 1, 2, 3, 4, 5, 6, 7, 8, 9, invalid, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, ...'
+			
+			Differences found:
+			Index	Current	Expected	10	invalid	10	40	invalid	40	100	invalid	100	888	invalid	888	"""
+			.dedent().trim_prefix("\n"))
 
-Differences found:
-Index	Current	Expected	10	invalid	10	40	invalid	40	100	invalid	100	888	invalid	888	""")
 
 func test_is_equal_ignoring_case():
 	assert_array(["this", "is", "a", "message"]).is_equal_ignoring_case(["This", "is", "a", "Message"])
@@ -80,34 +92,60 @@ func test_is_equal_ignoring_case():
 		.is_equal_ignoring_case(["This", "is", "an", "Message"])
 	assert_array(null, GdUnitAssert.EXPECT_FAIL) \
 		.is_equal_ignoring_case(["This", "is"])\
-		.has_failure_message("Expecting:\n"
-			+ " This\nis\n"
-			+ " but was\n"
-			+ " '<null>'")
+		.has_failure_message("""
+			Expecting:
+			 'This, is'
+			 but was
+			 '<null>'"""
+			.dedent().trim_prefix("\n"))
+
 
 func test_is_not_equal():
 	assert_array(null).is_not_equal([1, 2, 3])
 	assert_array([1, 2, 3, 4, 5]).is_not_equal([1, 2, 3, 4, 5, 6])
 	# should fail because the array  contains same elements
 	assert_array([1, 2, 3, 4, 5], GdUnitAssert.EXPECT_FAIL) \
-		.is_not_equal([1, 2, 3, 4, 5])
+		.is_not_equal([1, 2, 3, 4, 5])\
+		.has_failure_message("""
+		Expecting:
+		 '1, 2, 3, 4, 5'
+		 not equal to
+		 '1, 2, 3, 4, 5'"""
+		.dedent().trim_prefix("\n"))
+
 
 func test_is_not_equal_ignoring_case():
 	assert_array(null).is_not_equal_ignoring_case(["This", "is", "an", "Message"])
 	assert_array(["this", "is", "a", "message"]).is_not_equal_ignoring_case(["This", "is", "an", "Message"])
 	# should fail because the array contains same elements ignoring case sensitive
 	assert_array(["this", "is", "a", "message"], GdUnitAssert.EXPECT_FAIL) \
-		.is_not_equal_ignoring_case(["This", "is", "a", "Message"])
+		.is_not_equal_ignoring_case(["This", "is", "a", "Message"])\
+		.has_failure_message("""
+		Expecting:
+		 'This, is, a, Message'
+		 not equal to (case insensitiv)
+		 'this, is, a, message'"""
+		.dedent().trim_prefix("\n"))
+
 
 func test_is_empty():
 	assert_array([]).is_empty()
 	# should fail because the array is not empty it has a size of one
 	assert_array([1], GdUnitAssert.EXPECT_FAIL) \
 		.is_empty()\
-		.has_failure_message("Expecting:\n must be empty but was\n 1")
+		.has_failure_message("""
+			Expecting:
+			 must be empty but was
+			 1"""
+			.dedent().trim_prefix("\n"))
 	assert_array(null, GdUnitAssert.EXPECT_FAIL) \
 		.is_empty()\
-		.has_failure_message("Expecting:\n must be empty but was\n '<null>'")
+		.has_failure_message("""
+			Expecting:
+			 must be empty but was
+			 '<null>'"""
+			.dedent().trim_prefix("\n"))
+
 
 func test_is_not_empty():
 	assert_array(null).is_not_empty()
@@ -117,83 +155,105 @@ func test_is_not_empty():
 		.is_not_empty()\
 		.has_failure_message("Expecting:\n must not be empty")
 
+
 func test_has_size():
 	assert_array([1, 2, 3, 4, 5]).has_size(5)
 	assert_array(["a", "b", "c", "d", "e", "f"]).has_size(6)
 	# should fail because the array has a size of 5
 	assert_array([1, 2, 3, 4, 5], GdUnitAssert.EXPECT_FAIL) \
 		.has_size(4)\
-		.has_failure_message("Expecting size:\n '4'\n but was\n '5'")
+		.has_failure_message("""
+			Expecting size:
+			 '4'
+			 but was
+			 '5'"""
+			.dedent().trim_prefix("\n"))
 	assert_array(null, GdUnitAssert.EXPECT_FAIL) \
 		.has_size(4)\
-		.has_failure_message("Expecting size:\n '4'\n but was\n '<null>'")
+		.has_failure_message("""
+			Expecting size:
+			 '4'
+			 but was
+			 '<null>'"""
+			.dedent().trim_prefix("\n"))
+
 
 func test_contains():
 	assert_array([1, 2, 3, 4, 5]).contains([])
 	assert_array([1, 2, 3, 4, 5]).contains([5, 2])
 	assert_array([1, 2, 3, 4, 5]).contains([5, 4, 3, 2, 1])
 	# should fail because the array not contains 7 and 6
-	var expected_error_message := """Expecting contains elements:
- 1, 2, 3, 4, 5
- do contains (in any order)
- 2, 7, 6
-but could not find elements:
- 7, 6"""
 	assert_array([1, 2, 3, 4, 5], GdUnitAssert.EXPECT_FAIL) \
 		.contains([2, 7, 6])\
-		.has_failure_message(expected_error_message)
+		.has_failure_message("""
+			Expecting contains elements:
+			 1, 2, 3, 4, 5
+			 do contains (in any order)
+			 2, 7, 6
+			but could not find elements:
+			 7, 6"""
+			.dedent().trim_prefix("\n"))
 	assert_array(null, GdUnitAssert.EXPECT_FAIL) \
 		.contains([2, 7, 6])\
-		.has_failure_message("Expecting contains elements:\n"
-			+ " '<null>'\n"
-			+ " do contains (in any order)\n"
-			+ " 2, 7, 6\n"
-			+ "but could not find elements:\n"
-			+ " 2, 7, 6")
+		.has_failure_message("""
+			Expecting contains elements:
+			 '<null>'
+			 do contains (in any order)
+			 2, 7, 6
+			but could not find elements:
+			 2, 7, 6"""
+			.dedent().trim_prefix("\n"))
+
 
 func test_contains_exactly():
 	assert_array([1, 2, 3, 4, 5]).contains_exactly([1, 2, 3, 4, 5])
 	# should fail because the array contains the same elements but in a different order
-	var expected_error_message := """Expecting contains exactly elements:
- 1, 2, 3, 4, 5
- do contains (in same order)
- 1, 4, 3, 2, 5
- but has different order at position '1'
- '2' vs '4'"""
 	assert_array([1, 2, 3, 4, 5], GdUnitAssert.EXPECT_FAIL) \
 		.contains_exactly([1, 4, 3, 2, 5])\
-		.has_failure_message(expected_error_message)
+		.has_failure_message("""
+			Expecting contains exactly elements:
+			 1, 2, 3, 4, 5
+			 do contains (in same order)
+			 1, 4, 3, 2, 5
+			 but has different order at position '1'
+			 '2' vs '4'"""
+			.dedent().trim_prefix("\n"))
 	
 	# should fail because the array contains more elements and in a different order
-	expected_error_message = """Expecting contains exactly elements:
- 1, 2, 3, 4, 5, 6, 7
- do contains (in same order)
- 1, 4, 3, 2, 5
-but some elements where not expected:
- 6, 7"""
 	assert_array([1, 2, 3, 4, 5, 6, 7], GdUnitAssert.EXPECT_FAIL) \
 		.contains_exactly([1, 4, 3, 2, 5])\
-		.has_failure_message(expected_error_message)
+		.has_failure_message("""
+			Expecting contains exactly elements:
+			 1, 2, 3, 4, 5, 6, 7
+			 do contains (in same order)
+			 1, 4, 3, 2, 5
+			but some elements where not expected:
+			 6, 7"""
+			.dedent().trim_prefix("\n"))
 	
 	# should fail because the array contains less elements and in a different order
-	expected_error_message = """Expecting contains exactly elements:
- 1, 2, 3, 4, 5
- do contains (in same order)
- 1, 4, 3, 2, 5, 6, 7
-but could not find elements:
- 6, 7"""
 	assert_array([1, 2, 3, 4, 5], GdUnitAssert.EXPECT_FAIL) \
 		.contains_exactly([1, 4, 3, 2, 5, 6, 7])\
-		.has_failure_message(expected_error_message)
+		.has_failure_message("""
+			Expecting contains exactly elements:
+			 1, 2, 3, 4, 5
+			 do contains (in same order)
+			 1, 4, 3, 2, 5, 6, 7
+			but could not find elements:
+			 6, 7"""
+			.dedent().trim_prefix("\n"))
 	
 	assert_array(null, GdUnitAssert.EXPECT_FAIL) \
 		.contains_exactly([1, 4, 3])\
-		.has_failure_message("Expecting contains exactly elements:\n"
-			+ " '<null>'\n"
-			+ " do contains (in same order)\n"
-			+ " 1, 4, 3\n"
-			+ "but could not find elements:\n"
-			+ " 1, 4, 3")
+		.has_failure_message("""
+			Expecting contains exactly elements:
+			 '<null>'
+			 do contains (in same order)
+			 1, 4, 3
+			but could not find elements:
+			 1, 4, 3"""
+			.dedent().trim_prefix("\n"))
+
 
 func test_contains_exactly_in_any_order():
 	assert_array([1, 2, 3, 4, 5]).contains_exactly_in_any_order([1, 2, 3, 4, 5])
@@ -201,39 +261,44 @@ func test_contains_exactly_in_any_order():
 	assert_array([1, 2, 3, 4, 5]).contains_exactly_in_any_order([5, 1, 2, 4, 3])
 	
 	# should fail because the array contains not exactly the same elements in any order
-	var expected_error_message := """Expecting contains exactly elements:
- 1, 2, 6, 4, 5
- do contains exactly (in any order)
- 5, 3, 2, 4, 1, 9, 10
-but some elements where not expected:
- 6
-and could not find elements:
- 3, 9, 10"""
 	assert_array([1, 2, 6, 4, 5], GdUnitAssert.EXPECT_FAIL) \
 		.contains_exactly_in_any_order([5, 3, 2, 4, 1, 9, 10])\
-		.has_failure_message(expected_error_message)
+		.has_failure_message("""
+			Expecting contains exactly elements:
+			 1, 2, 6, 4, 5
+			 do contains exactly (in any order)
+			 5, 3, 2, 4, 1, 9, 10
+			but some elements where not expected:
+			 6
+			and could not find elements:
+			 3, 9, 10"""
+			.dedent().trim_prefix("\n"))
 	
 	#should fail because the array contains the same elements but in a different order
-	expected_error_message = """Expecting contains exactly elements:
- 1, 2, 6, 9, 10, 4, 5
- do contains exactly (in any order)
- 5, 3, 2, 4, 1
-but some elements where not expected:
- 6, 9, 10
-and could not find elements:
- 3"""
 	assert_array([1, 2, 6, 9, 10, 4, 5], GdUnitAssert.EXPECT_FAIL) \
 		.contains_exactly_in_any_order([5, 3, 2, 4, 1])\
-		.has_failure_message(expected_error_message)
+		.has_failure_message("""
+			Expecting contains exactly elements:
+			 1, 2, 6, 9, 10, 4, 5
+			 do contains exactly (in any order)
+			 5, 3, 2, 4, 1
+			but some elements where not expected:
+			 6, 9, 10
+			and could not find elements:
+			 3"""
+			.dedent().trim_prefix("\n"))
 	
 	assert_array(null, GdUnitAssert.EXPECT_FAIL) \
 		.contains_exactly_in_any_order([1, 4, 3])\
-		.has_failure_message("Expecting contains exactly elements:\n"
-			+ " '<null>'\n"
-			+ " do contains exactly (in any order)\n"
-			+ " 1, 4, 3\n"
-			+ "but could not find elements:\n"
-			+ " 1, 4, 3")
+		.has_failure_message("""
+			Expecting contains exactly elements:
+			 '<null>'
+			 do contains exactly (in any order)
+			 1, 4, 3
+			but could not find elements:
+			 1, 4, 3"""
+			.dedent().trim_prefix("\n"))
+
 
 func test_fluent():
 	assert_array([])\
@@ -242,6 +307,7 @@ func test_fluent():
 		.is_not_null()\
 		.contains([])\
 		.contains_exactly([])
+
 
 func test_must_fail_has_invlalid_type():
 	assert_array(1, GdUnitAssert.EXPECT_FAIL) \
@@ -252,6 +318,7 @@ func test_must_fail_has_invlalid_type():
 		.has_failure_message("GdUnitArrayAssert inital error, unexpected type <bool>")
 	assert_array(Resource.new(), GdUnitAssert.EXPECT_FAIL) \
 		.has_failure_message("GdUnitArrayAssert inital error, unexpected type <Object>")
+
 
 func test_extract() -> void:
 	# try to extract checked base types
@@ -273,14 +340,17 @@ func test_extract() -> void:
 	
 	assert_array(null, GdUnitAssert.EXPECT_FAIL).extract("get_class")\
 		.contains_exactly(["AStar3D", "Node"])\
-		.has_failure_message("Expecting contains exactly elements:\n"
-			+ " <null>\n"
-			+ " do contains (in same order)\n"
-			+ " AStar3D, Node\n"
-			+ "but some elements where not expected:\n"
-			+ " <null>\n"
-			+ "and could not find elements:\n"
-			+ " AStar3D, Node")
+		.has_failure_message("""
+			Expecting contains exactly elements:
+			 <null>
+			 do contains (in same order)
+			 AStar3D, Node
+			but some elements where not expected:
+			 <null>
+			and could not find elements:
+			 AStar3D, Node"""
+			.dedent().trim_prefix("\n"))
+
 
 class TestObj:
 	var _name :String
@@ -328,6 +398,7 @@ class TestObj:
 	func get_x9() -> String:
 		return "x9"
 
+
 func test_extractv() -> void:
 	# single extract
 	assert_array([1, false, 3.14, null, Color.ALICE_BLUE])\
@@ -345,14 +416,17 @@ func test_extractv() -> void:
 	assert_array(null, GdUnitAssert.EXPECT_FAIL)\
 		.extractv(extr("get_name"), extr("get_value"), extr("get_x"))\
 		.contains_exactly([tuple("A", 10, null), tuple("B", "foo", "bar"), tuple("C", 11, 42)])\
-		.has_failure_message("Expecting contains exactly elements:\n"
-			+ " <null>\n"
-			+ " do contains (in same order)\n"
-			+ " tuple([\"A\", 10, <null>]), tuple([\"B\", \"foo\", \"bar\"]), tuple([\"C\", 11, 42])\n"
-			+ "but some elements where not expected:\n"
-			+ " <null>\n"
-			+ "and could not find elements:\n"
-			+ " tuple([\"A\", 10, <null>]), tuple([\"B\", \"foo\", \"bar\"]), tuple([\"C\", 11, 42])")
+		.has_failure_message("""
+			Expecting contains exactly elements:
+			 <null>
+			 do contains (in same order)
+			 tuple([\"A\", 10, <null>]), tuple([\"B\", \"foo\", \"bar\"]), tuple([\"C\", 11, 42])
+			but some elements where not expected:
+			 <null>
+			and could not find elements:
+			 tuple([\"A\", 10, <null>]), tuple([\"B\", \"foo\", \"bar\"]), tuple([\"C\", 11, 42])"""
+			.dedent().trim_prefix("\n"))
+
 
 func test_extractv_chained_func() -> void:
 	var root_a = TestObj.new("root_a", null)
@@ -373,6 +447,7 @@ func test_extractv_chained_func() -> void:
 			tuple("Y", "root_b")
 			])
 
+
 func test_extract_chained_func() -> void:
 	var root_a = TestObj.new("root_a", null)
 	var obj_a = TestObj.new("A", root_a)
@@ -392,6 +467,7 @@ func test_extract_chained_func() -> void:
 			"root_b",
 			])
 
+
 func test_extractv_max_args() -> void:
 		assert_array([TestObj.new("A", 10), TestObj.new("B", "foo", "bar"), TestObj.new("C", 11, 42)])\
 		.extractv(\
@@ -410,20 +486,24 @@ func test_extractv_max_args() -> void:
 			tuple("B", "x1", "x2", "x3", "x4", "x5", "x6", "x7", "x8", "x9"),
 			tuple("C", "x1", "x2", "x3", "x4", "x5", "x6", "x7", "x8", "x9")])
 
+
 func test_override_failure_message() -> void:
 	assert_array([], GdUnitAssert.EXPECT_FAIL)\
 		.override_failure_message("Custom failure message")\
 		.is_null()\
 		.has_failure_message("Custom failure message")
 
+
 var _value = 0
 func next_value() -> Array:
 	_value += 1
 	return [_value]
 
+
 func test_with_value_provider() -> void:
 	assert_array(CallBackValueProvider.new(self, "next_value"))\
 		.is_equal([1]).is_equal([2]).is_equal([3])
+
 
 # tests if an assert fails the 'is_failure' reflects the failure status
 func test_is_failure() -> void:
@@ -448,18 +528,22 @@ func test_is_failure() -> void:
 		return
 	assert_bool(true).override_failure_message("This line shold never be called").is_false()
 
+
 class ExampleTestClass extends RefCounted:
 	var _childs := Array()
 	var _parent = null
+	
 	
 	func add_child(child :ExampleTestClass) -> ExampleTestClass:
 		_childs.append(child)
 		child._parent = self
 		return self
 	
+	
 	func dispose():
 		_parent = null
 		_childs.clear()
+
 
 func test_contains_exactly_stuck() -> void:
 	var example_a := ExampleTestClass.new()\

--- a/addons/gdUnit4/test/asserts/GdUnitArrayAssertImplTest.gd
+++ b/addons/gdUnit4/test/asserts/GdUnitArrayAssertImplTest.gd
@@ -107,11 +107,11 @@ func test_is_not_equal():
 	assert_array([1, 2, 3, 4, 5], GdUnitAssert.EXPECT_FAIL) \
 		.is_not_equal([1, 2, 3, 4, 5])\
 		.has_failure_message("""
-		Expecting:
-		 '1, 2, 3, 4, 5'
-		 not equal to
-		 '1, 2, 3, 4, 5'"""
-		.dedent().trim_prefix("\n"))
+			Expecting:
+			 '1, 2, 3, 4, 5'
+			 not equal to
+			 '1, 2, 3, 4, 5'"""
+			.dedent().trim_prefix("\n"))
 
 
 func test_is_not_equal_ignoring_case():
@@ -121,11 +121,11 @@ func test_is_not_equal_ignoring_case():
 	assert_array(["this", "is", "a", "message"], GdUnitAssert.EXPECT_FAIL) \
 		.is_not_equal_ignoring_case(["This", "is", "a", "Message"])\
 		.has_failure_message("""
-		Expecting:
-		 'This, is, a, Message'
-		 not equal to (case insensitiv)
-		 'this, is, a, message'"""
-		.dedent().trim_prefix("\n"))
+			Expecting:
+			 'This, is, a, Message'
+			 not equal to (case insensitiv)
+			 'this, is, a, message'"""
+			.dedent().trim_prefix("\n"))
 
 
 func test_is_empty():

--- a/addons/gdUnit4/test/asserts/GdUnitArrayAssertImpl_PoolByteArrayTest.gd
+++ b/addons/gdUnit4/test/asserts/GdUnitArrayAssertImpl_PoolByteArrayTest.gd
@@ -1,15 +1,16 @@
 # GdUnit generated TestSuite
-class_name GdUnitArrayAssertImpl_PoolByteArrayTest
 extends GdUnitTestSuite
 
 # TestSuite generated from
 const __source = 'res://addons/gdUnit4/src/asserts/GdUnitArrayAssertImpl.gd'
 
+
 func test_is_null():
 	assert_array(null).is_null()
 	assert_array(PackedByteArray(), GdUnitAssert.EXPECT_FAIL) \
 		.is_null()\
-		.has_failure_message("Expecting: '<null>' but was empty")
+		.has_failure_message("Expecting: '<null>' but was '<empty>'")
+
 
 func test_is_not_null():
 	assert_array(PackedByteArray()).is_not_null()
@@ -17,20 +18,24 @@ func test_is_not_null():
 		.is_not_null()\
 		.has_failure_message("Expecting: not to be '<null>'")
 
+
 func test_is_equal():
 	assert_array(PackedByteArray([1, 2, 3, 4, 2, 5])).is_equal(PackedByteArray([1, 2, 3, 4, 2, 5]))
 	# should fail because the array not contains same elements and has diff size
 	assert_array(PackedByteArray([1, 2, 4, 5]), GdUnitAssert.EXPECT_FAIL) \
 		.is_equal(PackedByteArray([1, 2, 3, 4, 2, 5]))
 
+
 func test_is_equal_ignoring_case():
 	assert_array(PackedByteArray(["this", "is", "a", "message"])).is_equal_ignoring_case(PackedByteArray(["This", "is", "a", "Message"]))
+
 
 func test_is_not_equal():
 	assert_array(PackedByteArray([1, 2, 3, 4, 5])).is_not_equal(PackedByteArray([1, 2, 3, 4, 5, 6]))
 	# should fail because the array  contains same elements
 	assert_array(PackedByteArray([1, 2, 3, 4, 5]), GdUnitAssert.EXPECT_FAIL) \
 		.is_not_equal(PackedByteArray([1, 2, 3, 4, 5]))
+
 
 func test_must_fail_has_invlalid_type():
 	assert_array(1, GdUnitAssert.EXPECT_FAIL) \
@@ -42,12 +47,14 @@ func test_must_fail_has_invlalid_type():
 	assert_array(Resource.new(), GdUnitAssert.EXPECT_FAIL) \
 		.has_failure_message("GdUnitArrayAssert inital error, unexpected type <Object>")
 
+
 func test_is_empty():
 	assert_array(PackedByteArray()).is_empty()
 	# should fail because the array is not empty
 	assert_array(PackedByteArray([1]), GdUnitAssert.EXPECT_FAIL) \
 		.is_empty()\
 		.has_failure_message("Expecting:\n must be empty but was\n 1")
+
 
 func test_is_not_empty():
 	assert_array(PackedByteArray([1])).is_not_empty()
@@ -56,6 +63,7 @@ func test_is_not_empty():
 		.is_not_empty()\
 		.has_failure_message("Expecting:\n must not be empty")
 
+
 func test_has_size():
 	assert_array(PackedByteArray([1, 2, 3, 4, 5])).has_size(5)
 	# should fail because the array has a size of 5
@@ -63,31 +71,36 @@ func test_has_size():
 		.has_size(4)\
 		.has_failure_message("Expecting size:\n '4'\n but was\n '5'")
 
+
 func test_contains():
 	assert_array(PackedByteArray([1, 2, 3, 4, 5])).contains(PackedByteArray([5, 2]))
 	# should fail because the array not contains 7 and 6
-	var expected_error := """Expecting contains elements:
- 1, 2, 3, 4, 5
- do contains (in any order)
- 2, 7, 6
-but could not find elements:
- 7, 6""" 
 	assert_array(PackedByteArray([1, 2, 3, 4, 5]), GdUnitAssert.EXPECT_FAIL) \
 		.contains(PackedByteArray([2, 7, 6]))\
-		.has_failure_message(expected_error)
+		.has_failure_message("""
+			Expecting contains elements:
+			 1, 2, 3, 4, 5
+			 do contains (in any order)
+			 2, 7, 6
+			but could not find elements:
+			 7, 6"""
+			.dedent().trim_prefix("\n"))
+
 
 func test_contains_exactly():
 	assert_array(PackedByteArray([1, 2, 3, 4, 5])).contains_exactly(PackedByteArray([1, 2, 3, 4, 5]))
 	# should fail because the array not contains same elements but in different order
-	var expected_error_message := """Expecting contains exactly elements:
- 1, 2, 3, 4, 5
- do contains (in same order)
- 1, 4, 3, 2, 5
- but has different order at position '1'
- '2' vs '4'"""
 	assert_array(PackedByteArray([1, 2, 3, 4, 5]), GdUnitAssert.EXPECT_FAIL) \
 		.contains_exactly(PackedByteArray([1, 4, 3, 2, 5]))\
-		.has_failure_message(expected_error_message)
+		.has_failure_message("""
+			Expecting contains exactly elements:
+			 1, 2, 3, 4, 5
+			 do contains (in same order)
+			 1, 4, 3, 2, 5
+			 but has different order at position '1'
+			 '2' vs '4'"""
+			.dedent().trim_prefix("\n"))
+
 
 func test_override_failure_message() -> void:
 	assert_array(PackedByteArray([]), GdUnitAssert.EXPECT_FAIL)\
@@ -95,10 +108,12 @@ func test_override_failure_message() -> void:
 		.is_null()\
 		.has_failure_message("Custom failure message")
 
+
 var _value = 0
 func next_value() -> PackedByteArray:
 	_value += 1
 	return PackedByteArray([_value])
+
 
 func test_with_value_provider() -> void:
 	assert_array(CallBackValueProvider.new(self, "next_value"))\

--- a/addons/gdUnit4/test/asserts/GdUnitDictionaryAssertImplTest.gd
+++ b/addons/gdUnit4/test/asserts/GdUnitDictionaryAssertImplTest.gd
@@ -1,11 +1,11 @@
 # GdUnit generated TestSuite
-class_name GdUnitDictionaryAssertImplTest
 extends GdUnitTestSuite
 
 # TestSuite generated from
 const __source = 'res://addons/gdUnit4/src/asserts/GdUnitDictionaryAssertImpl.gd'
 
-func test_must_fail_has_invlalid_type():
+
+func test_must_fail_has_invlalid_type() -> void:
 	assert_dict(1, GdUnitAssert.EXPECT_FAIL) \
 		.has_failure_message("GdUnitDictionaryAssert inital error, unexpected type <int>")
 	assert_dict(1.3, GdUnitAssert.EXPECT_FAIL) \
@@ -19,21 +19,24 @@ func test_must_fail_has_invlalid_type():
 	assert_dict(Resource.new(), GdUnitAssert.EXPECT_FAIL) \
 		.has_failure_message("GdUnitDictionaryAssert inital error, unexpected type <Object>")
 
-func test_is_null():
+
+func test_is_null() -> void:
 	assert_dict(null).is_null()
 	
 	assert_dict({}, GdUnitAssert.EXPECT_FAIL)\
 		.is_null()\
-		.has_failure_message("Expecting: '<null>' but was '{  }'")
+		.has_failure_message("Expecting: '<null>' but was '{ }'")
 
-func test_is_not_null():
+
+func test_is_not_null() -> void:
 	assert_dict({}).is_not_null()
 	
 	assert_dict(null, GdUnitAssert.EXPECT_FAIL)\
 		.is_not_null()\
 		.has_failure_message("Expecting: not to be '<null>'")
 
-func test_is_equal():
+
+func test_is_equal() -> void:
 	assert_dict({}).is_equal({})
 	assert_dict({1:1}).is_equal({1:1})
 	assert_dict({1:1, "key_a": "value_a"}).is_equal({1:1, "key_a": "value_a" })
@@ -43,11 +46,13 @@ func test_is_equal():
 	# should fail
 	assert_dict(null, GdUnitAssert.EXPECT_FAIL)\
 		.is_equal({1:1})\
-		.has_failure_message("Expecting:\n"
-			+ " '{ 1: 1 }'\n"
-			+ " but was\n"
-			+ " '<null>'")
-		
+		.has_failure_message("""
+			Expecting:
+			 '{
+				1: 1
+			  }'
+			 but was
+			 '<null>'""".dedent().trim_prefix("\n"))
 	assert_dict({}, GdUnitAssert.EXPECT_FAIL)\
 		.is_equal({1:1})
 	assert_dict({1:1}, GdUnitAssert.EXPECT_FAIL)\
@@ -57,23 +62,35 @@ func test_is_equal():
 		.is_equal({1:2})
 	assert_dict({1:2}, GdUnitAssert.EXPECT_FAIL)\
 		.is_equal({1:1})
-		
+	
 	assert_dict({1:1}, GdUnitAssert.EXPECT_FAIL)\
 		.is_equal({1:1, "key_a": "value_a"})
 	assert_dict({1:1, "key_a": "value_a"}, GdUnitAssert.EXPECT_FAIL)\
 		.is_equal({1:1})
-		
+	
 	assert_dict({1:1, "key_a": "value_a"}, GdUnitAssert.EXPECT_FAIL)\
 		.is_equal({1:1, "key_b": "value_b"})
 	assert_dict({1:1, "key_b": "value_b"}, GdUnitAssert.EXPECT_FAIL)\
 		.is_equal({1:1, "key_a": "value_a"})
-
+	
 	assert_dict({"key_a": "value_a", 1:1}, GdUnitAssert.EXPECT_FAIL)\
 		.is_equal({1:1, "key_b": "value_b"})
 	assert_dict({1:1, "key_b": "value_b"}, GdUnitAssert.EXPECT_FAIL)\
-		.is_equal({"key_a": "value_a", 1:1})
+		.is_equal({"key_a": "value_a", 1:1})\
+		.has_failure_message("""
+			Expecting:
+			 '{
+				1: 1,
+				"key_a": "value_a"
+			  }'
+			 but was
+			 '{
+				1: 1,
+				"key_ab": "value_ab"
+			  }'""".dedent().trim_prefix("\n"))
 
-func test_is_not_equal():
+
+func test_is_not_equal() -> void:
 	assert_dict(null).is_not_equal({})
 	assert_dict({}).is_not_equal(null)
 	assert_dict({}).is_not_equal({1:1})
@@ -92,9 +109,21 @@ func test_is_not_equal():
 	assert_dict({1:1, "key_a": "value_a"}, GdUnitAssert.EXPECT_FAIL)\
 		.is_not_equal({1:1, "key_a": "value_a"})
 	assert_dict({"key_a": "value_a", 1:1}, GdUnitAssert.EXPECT_FAIL)\
-		.is_not_equal({1:1, "key_a": "value_a"})
+		.is_not_equal({1:1, "key_a": "value_a"})\
+		.has_failure_message("""
+			Expecting:
+			 '{
+				1: 1,
+				"key_a": "value_a"
+			  }'
+			 not equal to
+			 '{
+				1: 1,
+				"key_a": "value_a"
+			  }'""".dedent().trim_prefix("\n"))
 
-func test_is_empty():
+
+func test_is_empty() -> void:
 	assert_dict({}).is_empty()
 	
 	assert_dict(null, GdUnitAssert.EXPECT_FAIL)\
@@ -103,9 +132,16 @@ func test_is_empty():
 			+ " must be empty but was\n"
 			+ " '<null>'")
 	assert_dict({1:1}, GdUnitAssert.EXPECT_FAIL)\
-		.is_empty()
+		.is_empty()\
+		.has_failure_message("""
+			Expecting:
+			 must be empty but was
+			 '{
+				1: 1
+			  }'""".dedent().trim_prefix("\n"))
 
-func test_is_not_empty():
+
+func test_is_not_empty() -> void:
 	assert_dict({1:1}).is_not_empty()
 	assert_dict({1:1, "key_a": "value_a"}).is_not_empty()
 	
@@ -113,11 +149,12 @@ func test_is_not_empty():
 		.is_not_empty()\
 		.has_failure_message("Expecting:\n"
 			+ " must not be empty")
-		
+	
 	assert_dict({}, GdUnitAssert.EXPECT_FAIL)\
 		.is_not_empty()
 
-func test_has_size():
+
+func test_has_size() -> void:
 	assert_dict({}).has_size(0)
 	assert_dict({1:1}).has_size(1)
 	assert_dict({1:1, 2:1}).has_size(2)
@@ -133,47 +170,84 @@ func test_has_size():
 	assert_dict({1:1}, GdUnitAssert.EXPECT_FAIL)\
 		.has_size(0)
 	assert_dict({1:1}, GdUnitAssert.EXPECT_FAIL)\
-		.has_size(2)
+		.has_size(2)\
+		.has_failure_message("""
+			Expecting size:
+			 '2'
+			 but was
+			 '1'""".dedent().trim_prefix("\n"))
 
-func test_contains_keys():
+
+func test_contains_keys() -> void:
 	assert_dict({1:1, 2:2, 3:3}).contains_keys([2])
 	assert_dict({1:1, 2:2, "key_a": "value_a"}).contains_keys([2, "key_a"])
 	
 	assert_dict({1:1, 3:3}, GdUnitAssert.EXPECT_FAIL)\
 		.contains_keys([2])\
-		.has_failure_message("Expecting keys:\n 1, 3\n to contains:\n 2\n but can't find key's:\n 2")
+		.has_failure_message("""
+			Expecting keys:
+			 1, 3
+			 to contains:
+			 2
+			 but can't find key's:
+			 2""".dedent().trim_prefix("\n"))
 	assert_dict({1:1, 3:3}, GdUnitAssert.EXPECT_FAIL)\
 		.contains_keys([1, 4])\
-		.has_failure_message("Expecting keys:\n 1, 3\n to contains:\n 1, 4\n but can't find key's:\n 4")
+		.has_failure_message("""
+			Expecting keys:
+			 1, 3
+			 to contains:
+			 1, 4
+			 but can't find key's:
+			 4""".dedent().trim_prefix("\n"))
 	assert_dict(null, GdUnitAssert.EXPECT_FAIL)\
 		.contains_keys([1, 4])\
 		.has_failure_message("Expecting: not to be '<null>'")
 
-func test_contains_not_keys():
+
+func test_contains_not_keys() -> void:
 	assert_dict({}).contains_not_keys([2])
 	assert_dict({1:1, 3:3}).contains_not_keys([2])
 	assert_dict({1:1, 3:3}).contains_not_keys([2, 4])
 	
 	assert_dict({1:1, 2:2, 3:3}, GdUnitAssert.EXPECT_FAIL)\
 		.contains_not_keys([2, 4])\
-		.has_failure_message("Expecting keys:\n 1, 2, 3\n do not contains:\n 2, 4\n but contains key's:\n 2")
+		.has_failure_message("""
+			Expecting keys:
+			 1, 2, 3
+			 do not contains:
+			 2, 4
+			 but contains key's:
+			 2""".dedent().trim_prefix("\n"))
 	assert_dict({1:1, 2:2, 3:3}, GdUnitAssert.EXPECT_FAIL)\
 		.contains_not_keys([1, 2, 3, 4])\
-		.has_failure_message("Expecting keys:\n 1, 2, 3\n do not contains:\n 1, 2, 3, 4\n but contains key's:\n 1, 2, 3")
+		.has_failure_message("""
+			Expecting keys:
+			 1, 2, 3
+			 do not contains:
+			 1, 2, 3, 4
+			 but contains key's:
+			 1, 2, 3""".dedent().trim_prefix("\n"))
 	assert_dict(null, GdUnitAssert.EXPECT_FAIL)\
 		.contains_not_keys([1, 4])\
 		.has_failure_message("Expecting: not to be '<null>'")
 
-func test_contains_key_value():
+
+func test_contains_key_value() -> void:
 	assert_dict({1:1}).contains_key_value(1, 1)
 	assert_dict({1:1, 2:2, 3:3}).contains_key_value(3, 3).contains_key_value(1, 1)
 	
 	assert_dict({1:1}, GdUnitAssert.EXPECT_FAIL)\
 		.contains_key_value(1, 2)\
-		.has_failure_message("Expecting key and value:\n '1' : '2'\n but contains\n '1' : '1'")
+		.has_failure_message("""
+			Expecting key and value:
+			 '1' : '2'
+			 but contains
+			 '1' : '1'""".dedent().trim_prefix("\n"))
 	assert_dict(null, GdUnitAssert.EXPECT_FAIL)\
 		.contains_key_value(1, 2)\
 		.has_failure_message("Expecting: not to be '<null>'")
+
 
 func test_override_failure_message() -> void:
 	assert_dict({1:1}, GdUnitAssert.EXPECT_FAIL)\
@@ -181,33 +255,36 @@ func test_override_failure_message() -> void:
 		.is_null()\
 		.has_failure_message("Custom failure message")
 
+
 var _value = 0
 func next_value() -> Dictionary:
 	_value += 1
 	return { "key_%d" % _value : _value}
 
+
 func test_with_value_provider() -> void:
 	assert_dict(CallBackValueProvider.new(self, "next_value"))\
 		.is_equal({"key_1" : 1}).is_equal({"key_2" : 2}).is_equal({"key_3" : 3})
+
 
 # tests if an assert fails the 'is_failure' reflects the failure status
 func test_is_failure() -> void:
 	# initial is false
 	assert_bool(is_failure()).is_false()
-	
+
 	# checked success assert
 	assert_dict({}).is_empty()
 	assert_bool(is_failure()).is_false()
-	
+
 	# checked faild assert
 	assert_dict({}, GdUnitAssert.EXPECT_FAIL).is_not_empty()
 	assert_bool(is_failure()).is_true()
-	
+
 	# checked next success assert
 	assert_dict({}).is_empty()
 	# is true because we have an already failed assert
 	assert_bool(is_failure()).is_true()
-	
+
 	# should abort here because we had an failing assert
 	if is_failure():
 		return

--- a/addons/gdUnit4/test/asserts/GdUnitResultAssertImplTest.gd
+++ b/addons/gdUnit4/test/asserts/GdUnitResultAssertImplTest.gd
@@ -95,16 +95,16 @@ func test_is_value():
 	
 	assert_result(Result.success(""), GdUnitAssert.EXPECT_FAIL) \
 		.is_value("abc") \
-		.has_failure_message("Expecting to contain same value:\n 'abc'\n but was\n ''.")
+		.has_failure_message("Expecting to contain same value:\n 'abc'\n but was\n '<empty>'.")
 	assert_result(Result.success("abc"), GdUnitAssert.EXPECT_FAIL) \
 		.is_value("") \
-		.has_failure_message("Expecting to contain same value:\n ''\n but was\n 'abc'.")
+		.has_failure_message("Expecting to contain same value:\n '<empty>'\n but was\n 'abc'.")
 	assert_result(Result.success(result_value), GdUnitAssert.EXPECT_FAIL) \
 		.is_value("") \
-		.has_failure_message("Expecting to contain same value:\n ''\n but was\n <Node>.")
+		.has_failure_message("Expecting to contain same value:\n '<empty>'\n but was\n <Node>.")
 	assert_result(null, GdUnitAssert.EXPECT_FAIL) \
 		.is_value("") \
-		.has_failure_message("Expecting to contain same value:\n ''\n but was\n '<null>'.")
+		.has_failure_message("Expecting to contain same value:\n '<empty>'\n but was\n '<null>'.")
 
 
 func test_override_failure_message() -> void:

--- a/project.godot
+++ b/project.godot
@@ -54,11 +54,6 @@ _global_script_classes=[{
 "language": &"GDScript",
 "path": "res://addons/gdUnit4/src/asserts/CallBackValueProvider.gd"
 }, {
-"base": "GdUnitTestSuite",
-"class": &"CallBackValueProviderTest",
-"language": &"GDScript",
-"path": "res://addons/gdUnit4/test/asserts/CallBackValueProviderTest.gd"
-}, {
 "base": "GdUnitArgumentMatcher",
 "class": &"ChainedArgumentMatcher",
 "language": &"GDScript",
@@ -369,16 +364,6 @@ _global_script_classes=[{
 "language": &"GDScript",
 "path": "res://addons/gdUnit4/src/asserts/GdUnitArrayAssertImpl.gd"
 }, {
-"base": "GdUnitTestSuite",
-"class": &"GdUnitArrayAssertImplTest",
-"language": &"GDScript",
-"path": "res://addons/gdUnit4/test/asserts/GdUnitArrayAssertImplTest.gd"
-}, {
-"base": "GdUnitTestSuite",
-"class": &"GdUnitArrayAssertImpl_PoolByteArrayTest",
-"language": &"GDScript",
-"path": "res://addons/gdUnit4/test/asserts/GdUnitArrayAssertImpl_PoolByteArrayTest.gd"
-}, {
 "base": "RefCounted",
 "class": &"GdUnitAssert",
 "language": &"GDScript",
@@ -389,7 +374,7 @@ _global_script_classes=[{
 "language": &"GDScript",
 "path": "res://addons/gdUnit4/src/asserts/GdUnitAssertImpl.gd"
 }, {
-"base": "GdUnitTestSuite",
+"base": "Node",
 "class": &"GdUnitAssertImplTest",
 "language": &"GDScript",
 "path": "res://addons/gdUnit4/test/asserts/GdUnitAssertImplTest.gd"
@@ -414,7 +399,7 @@ _global_script_classes=[{
 "language": &"GDScript",
 "path": "res://addons/gdUnit4/src/asserts/GdUnitBoolAssertImpl.gd"
 }, {
-"base": "GdUnitTestSuite",
+"base": "Node",
 "class": &"GdUnitBoolAssertImplTest",
 "language": &"GDScript",
 "path": "res://addons/gdUnit4/test/asserts/GdUnitBoolAssertImplTest.gd"
@@ -453,11 +438,6 @@ _global_script_classes=[{
 "class": &"GdUnitDictionaryAssertImpl",
 "language": &"GDScript",
 "path": "res://addons/gdUnit4/src/asserts/GdUnitDictionaryAssertImpl.gd"
-}, {
-"base": "GdUnitTestSuite",
-"class": &"GdUnitDictionaryAssertImplTest",
-"language": &"GDScript",
-"path": "res://addons/gdUnit4/test/asserts/GdUnitDictionaryAssertImplTest.gd"
 }, {
 "base": "Resource",
 "class": &"GdUnitEvent",
@@ -499,7 +479,7 @@ _global_script_classes=[{
 "language": &"GDScript",
 "path": "res://addons/gdUnit4/src/asserts/GdUnitFloatAssertImpl.gd"
 }, {
-"base": "GdUnitTestSuite",
+"base": "Node",
 "class": &"GdUnitFloatAssertImplTest",
 "language": &"GDScript",
 "path": "res://addons/gdUnit4/test/asserts/GdUnitFloatAssertImplTest.gd"
@@ -519,7 +499,7 @@ _global_script_classes=[{
 "language": &"GDScript",
 "path": "res://addons/gdUnit4/src/asserts/GdUnitFuncAssertImpl.gd"
 }, {
-"base": "GdUnitTestSuite",
+"base": "Node",
 "class": &"GdUnitFuncAssertImplTest",
 "language": &"GDScript",
 "path": "res://addons/gdUnit4/test/asserts/GdUnitFuncAssertImplTest.gd"
@@ -569,7 +549,7 @@ _global_script_classes=[{
 "language": &"GDScript",
 "path": "res://addons/gdUnit4/src/asserts/GdUnitIntAssertImpl.gd"
 }, {
-"base": "GdUnitTestSuite",
+"base": "Node",
 "class": &"GdUnitIntAssertImplTest",
 "language": &"GDScript",
 "path": "res://addons/gdUnit4/test/asserts/GdUnitIntAssertImplTest.gd"
@@ -639,7 +619,7 @@ _global_script_classes=[{
 "language": &"GDScript",
 "path": "res://addons/gdUnit4/src/asserts/GdUnitObjectAssertImpl.gd"
 }, {
-"base": "GdUnitTestSuite",
+"base": "Node",
 "class": &"GdUnitObjectAssertImplTest",
 "language": &"GDScript",
 "path": "res://addons/gdUnit4/test/asserts/GdUnitObjectAssertImplTest.gd"
@@ -779,11 +759,6 @@ _global_script_classes=[{
 "language": &"GDScript",
 "path": "res://addons/gdUnit4/src/asserts/GdUnitSignalAssertImpl.gd"
 }, {
-"base": "GdUnitTestSuite",
-"class": &"GdUnitSignalAssertImplTest",
-"language": &"GDScript",
-"path": "res://addons/gdUnit4/test/asserts/GdUnitSignalAssertImplTest.gd"
-}, {
 "base": "RefCounted",
 "class": &"GdUnitSignalAwaiter",
 "language": &"GDScript",
@@ -843,11 +818,6 @@ _global_script_classes=[{
 "class": &"GdUnitStringAssertImpl",
 "language": &"GDScript",
 "path": "res://addons/gdUnit4/src/asserts/GdUnitStringAssertImpl.gd"
-}, {
-"base": "GdUnitTestSuite",
-"class": &"GdUnitStringAssertImplTest",
-"language": &"GDScript",
-"path": "res://addons/gdUnit4/test/asserts/GdUnitStringAssertImplTest.gd"
 }, {
 "base": "RefCounted",
 "class": &"GdUnitTask",
@@ -979,11 +949,6 @@ _global_script_classes=[{
 "language": &"GDScript",
 "path": "res://addons/gdUnit4/src/asserts/GdUnitVector2AssertImpl.gd"
 }, {
-"base": "GdUnitTestSuite",
-"class": &"GdUnitVector2AssertImplTest",
-"language": &"GDScript",
-"path": "res://addons/gdUnit4/test/asserts/GdUnitVector2AssertImplTest.gd"
-}, {
 "base": "GdUnitAssert",
 "class": &"GdUnitVector3Assert",
 "language": &"GDScript",
@@ -993,11 +958,6 @@ _global_script_classes=[{
 "class": &"GdUnitVector3AssertImpl",
 "language": &"GDScript",
 "path": "res://addons/gdUnit4/src/asserts/GdUnitVector3AssertImpl.gd"
-}, {
-"base": "GdUnitTestSuite",
-"class": &"GdUnitVector3AssertImplTest",
-"language": &"GDScript",
-"path": "res://addons/gdUnit4/test/asserts/GdUnitVector3AssertImplTest.gd"
 }, {
 "base": "Resource",
 "class": &"GdUnit_Test_CustomClassName",
@@ -1234,7 +1194,6 @@ _global_script_class_icons={
 "AnyClazzArgumentMatcherTest": "",
 "BaseTest": "",
 "CallBackValueProvider": "",
-"CallBackValueProviderTest": "",
 "ChainedArgumentMatcher": "",
 "ChainedArgumentMatcherTest": "",
 "City": "",
@@ -1297,8 +1256,6 @@ _global_script_class_icons={
 "GdUnitArgumentMatchersTest": "",
 "GdUnitArrayAssert": "",
 "GdUnitArrayAssertImpl": "",
-"GdUnitArrayAssertImplTest": "",
-"GdUnitArrayAssertImpl_PoolByteArrayTest": "",
 "GdUnitAssert": "",
 "GdUnitAssertImpl": "",
 "GdUnitAssertImplTest": "",
@@ -1314,7 +1271,6 @@ _global_script_class_icons={
 "GdUnitContextMenuItem": "",
 "GdUnitDictionaryAssert": "",
 "GdUnitDictionaryAssertImpl": "",
-"GdUnitDictionaryAssertImplTest": "",
 "GdUnitEvent": "",
 "GdUnitEventTest": "",
 "GdUnitExecutor": "",
@@ -1379,7 +1335,6 @@ _global_script_class_icons={
 "GdUnitSettingsTest": "",
 "GdUnitSignalAssert": "",
 "GdUnitSignalAssertImpl": "",
-"GdUnitSignalAssertImplTest": "",
 "GdUnitSignalAwaiter": "",
 "GdUnitSignalAwaiterTest": "",
 "GdUnitSingleton": "",
@@ -1392,7 +1347,6 @@ _global_script_class_icons={
 "GdUnitStop": "",
 "GdUnitStringAssert": "",
 "GdUnitStringAssertImpl": "",
-"GdUnitStringAssertImplTest": "",
 "GdUnitTask": "",
 "GdUnitTcpClient": "",
 "GdUnitTcpServer": "",
@@ -1419,10 +1373,8 @@ _global_script_class_icons={
 "GdUnitValueExtractor": "",
 "GdUnitVector2Assert": "",
 "GdUnitVector2AssertImpl": "",
-"GdUnitVector2AssertImplTest": "",
 "GdUnitVector3Assert": "",
 "GdUnitVector3AssertImpl": "",
-"GdUnitVector3AssertImplTest": "",
 "GdUnit_Test_CustomClassName": "",
 "GeneratedPersonTest": "",
 "GodotClassNameFuzzer": "",
@@ -1497,6 +1449,7 @@ enabled=PackedStringArray("res://addons/gdUnit4/plugin.cfg")
 
 settings/common/update_notification_enabled=false
 report/assert/verbose_errors=false
+report/assert/verbose_warnings=false
 
 [network]
 

--- a/project.godot
+++ b/project.godot
@@ -54,6 +54,11 @@ _global_script_classes=[{
 "language": &"GDScript",
 "path": "res://addons/gdUnit4/src/asserts/CallBackValueProvider.gd"
 }, {
+"base": "GdUnitTestSuite",
+"class": &"CallBackValueProviderTest",
+"language": &"GDScript",
+"path": "res://addons/gdUnit4/test/asserts/CallBackValueProviderTest.gd"
+}, {
 "base": "GdUnitArgumentMatcher",
 "class": &"ChainedArgumentMatcher",
 "language": &"GDScript",
@@ -374,7 +379,7 @@ _global_script_classes=[{
 "language": &"GDScript",
 "path": "res://addons/gdUnit4/src/asserts/GdUnitAssertImpl.gd"
 }, {
-"base": "Node",
+"base": "GdUnitTestSuite",
 "class": &"GdUnitAssertImplTest",
 "language": &"GDScript",
 "path": "res://addons/gdUnit4/test/asserts/GdUnitAssertImplTest.gd"
@@ -399,7 +404,7 @@ _global_script_classes=[{
 "language": &"GDScript",
 "path": "res://addons/gdUnit4/src/asserts/GdUnitBoolAssertImpl.gd"
 }, {
-"base": "Node",
+"base": "GdUnitTestSuite",
 "class": &"GdUnitBoolAssertImplTest",
 "language": &"GDScript",
 "path": "res://addons/gdUnit4/test/asserts/GdUnitBoolAssertImplTest.gd"
@@ -479,7 +484,7 @@ _global_script_classes=[{
 "language": &"GDScript",
 "path": "res://addons/gdUnit4/src/asserts/GdUnitFloatAssertImpl.gd"
 }, {
-"base": "Node",
+"base": "GdUnitTestSuite",
 "class": &"GdUnitFloatAssertImplTest",
 "language": &"GDScript",
 "path": "res://addons/gdUnit4/test/asserts/GdUnitFloatAssertImplTest.gd"
@@ -499,7 +504,7 @@ _global_script_classes=[{
 "language": &"GDScript",
 "path": "res://addons/gdUnit4/src/asserts/GdUnitFuncAssertImpl.gd"
 }, {
-"base": "Node",
+"base": "GdUnitTestSuite",
 "class": &"GdUnitFuncAssertImplTest",
 "language": &"GDScript",
 "path": "res://addons/gdUnit4/test/asserts/GdUnitFuncAssertImplTest.gd"
@@ -549,7 +554,7 @@ _global_script_classes=[{
 "language": &"GDScript",
 "path": "res://addons/gdUnit4/src/asserts/GdUnitIntAssertImpl.gd"
 }, {
-"base": "Node",
+"base": "GdUnitTestSuite",
 "class": &"GdUnitIntAssertImplTest",
 "language": &"GDScript",
 "path": "res://addons/gdUnit4/test/asserts/GdUnitIntAssertImplTest.gd"
@@ -619,7 +624,7 @@ _global_script_classes=[{
 "language": &"GDScript",
 "path": "res://addons/gdUnit4/src/asserts/GdUnitObjectAssertImpl.gd"
 }, {
-"base": "Node",
+"base": "GdUnitTestSuite",
 "class": &"GdUnitObjectAssertImplTest",
 "language": &"GDScript",
 "path": "res://addons/gdUnit4/test/asserts/GdUnitObjectAssertImplTest.gd"
@@ -759,6 +764,11 @@ _global_script_classes=[{
 "language": &"GDScript",
 "path": "res://addons/gdUnit4/src/asserts/GdUnitSignalAssertImpl.gd"
 }, {
+"base": "GdUnitTestSuite",
+"class": &"GdUnitSignalAssertImplTest",
+"language": &"GDScript",
+"path": "res://addons/gdUnit4/test/asserts/GdUnitSignalAssertImplTest.gd"
+}, {
 "base": "RefCounted",
 "class": &"GdUnitSignalAwaiter",
 "language": &"GDScript",
@@ -818,6 +828,11 @@ _global_script_classes=[{
 "class": &"GdUnitStringAssertImpl",
 "language": &"GDScript",
 "path": "res://addons/gdUnit4/src/asserts/GdUnitStringAssertImpl.gd"
+}, {
+"base": "GdUnitTestSuite",
+"class": &"GdUnitStringAssertImplTest",
+"language": &"GDScript",
+"path": "res://addons/gdUnit4/test/asserts/GdUnitStringAssertImplTest.gd"
 }, {
 "base": "RefCounted",
 "class": &"GdUnitTask",
@@ -949,6 +964,11 @@ _global_script_classes=[{
 "language": &"GDScript",
 "path": "res://addons/gdUnit4/src/asserts/GdUnitVector2AssertImpl.gd"
 }, {
+"base": "GdUnitTestSuite",
+"class": &"GdUnitVector2AssertImplTest",
+"language": &"GDScript",
+"path": "res://addons/gdUnit4/test/asserts/GdUnitVector2AssertImplTest.gd"
+}, {
 "base": "GdUnitAssert",
 "class": &"GdUnitVector3Assert",
 "language": &"GDScript",
@@ -958,6 +978,11 @@ _global_script_classes=[{
 "class": &"GdUnitVector3AssertImpl",
 "language": &"GDScript",
 "path": "res://addons/gdUnit4/src/asserts/GdUnitVector3AssertImpl.gd"
+}, {
+"base": "GdUnitTestSuite",
+"class": &"GdUnitVector3AssertImplTest",
+"language": &"GDScript",
+"path": "res://addons/gdUnit4/test/asserts/GdUnitVector3AssertImplTest.gd"
 }, {
 "base": "Resource",
 "class": &"GdUnit_Test_CustomClassName",
@@ -1194,6 +1219,7 @@ _global_script_class_icons={
 "AnyClazzArgumentMatcherTest": "",
 "BaseTest": "",
 "CallBackValueProvider": "",
+"CallBackValueProviderTest": "",
 "ChainedArgumentMatcher": "",
 "ChainedArgumentMatcherTest": "",
 "City": "",
@@ -1335,6 +1361,7 @@ _global_script_class_icons={
 "GdUnitSettingsTest": "",
 "GdUnitSignalAssert": "",
 "GdUnitSignalAssertImpl": "",
+"GdUnitSignalAssertImplTest": "",
 "GdUnitSignalAwaiter": "",
 "GdUnitSignalAwaiterTest": "",
 "GdUnitSingleton": "",
@@ -1347,6 +1374,7 @@ _global_script_class_icons={
 "GdUnitStop": "",
 "GdUnitStringAssert": "",
 "GdUnitStringAssertImpl": "",
+"GdUnitStringAssertImplTest": "",
 "GdUnitTask": "",
 "GdUnitTcpClient": "",
 "GdUnitTcpServer": "",
@@ -1373,8 +1401,10 @@ _global_script_class_icons={
 "GdUnitValueExtractor": "",
 "GdUnitVector2Assert": "",
 "GdUnitVector2AssertImpl": "",
+"GdUnitVector2AssertImplTest": "",
 "GdUnitVector3Assert": "",
 "GdUnitVector3AssertImpl": "",
+"GdUnitVector3AssertImplTest": "",
 "GdUnit_Test_CustomClassName": "",
 "GeneratedPersonTest": "",
 "GodotClassNameFuzzer": "",


### PR DESCRIPTION
# Why
The failure report of `assert_dict` was broken and shows a list of numbers

# What
- fixed to see human readable failure message
- cleanup/format code