### PR TITLE
GD-12: Reenable tests where was temporary disabled

### DIFF
--- a/addons/gdUnit4/src/cmd/CmdCommand.gd
+++ b/addons/gdUnit4/src/cmd/CmdCommand.gd
@@ -1,12 +1,12 @@
 class_name CmdCommand
 extends RefCounted
 
-var _name :String
-var _arguments :PackedStringArray
+var _name: String
+var _arguments: PackedStringArray
 
-func _init(name :String, arguments := PackedStringArray()):
+func _init(name: String, arguments: = []):
 	_name = name
-	_arguments = arguments
+	_arguments = PackedStringArray(arguments)
 
 func name() -> String:
 	return _name
@@ -14,7 +14,7 @@ func name() -> String:
 func arguments() -> PackedStringArray:
 	return _arguments
 
-func add_argument(arg :String) -> void:
+func add_argument(arg: String) -> void:
 	_arguments.append(arg)
 
 func _to_string():

--- a/addons/gdUnit4/src/cmd/CmdCommandHandler.gd
+++ b/addons/gdUnit4/src/cmd/CmdCommandHandler.gd
@@ -13,18 +13,20 @@ const NO_CB := Callable()
 # we only able to check cb function name since Godot 3.3.x
 var _enhanced_fr_test := false
 
-func _init(cmd_options :CmdOptions):
+
+func _init(cmd_options: CmdOptions):
 	_cmd_options = cmd_options
-	var major :int = Engine.get_version_info()["major"]
-	var minor :int = Engine.get_version_info()["minor"]
+	var major: int = Engine.get_version_info()["major"]
+	var minor: int = Engine.get_version_info()["minor"]
 	if major == 3 and minor == 3:
 		_enhanced_fr_test = true
+
 
 # register a callback function for given command
 # cmd_name short name of the command
 # fr_arg a funcref to a function with a single argument
-func register_cb(cmd_name :String, cb :Callable = NO_CB) -> CmdCommandHandler:
-	var registered_cb :Array = _command_cbs.get(cmd_name, [NO_CB, NO_CB])
+func register_cb(cmd_name: String, cb: Callable = NO_CB) -> CmdCommandHandler:
+	var registered_cb: Array = _command_cbs.get(cmd_name, [NO_CB, NO_CB])
 	if registered_cb[CB_SINGLE_ARG]:
 		push_error("A function for command '%s' is already registered!" % cmd_name)
 		return self
@@ -32,10 +34,11 @@ func register_cb(cmd_name :String, cb :Callable = NO_CB) -> CmdCommandHandler:
 	_command_cbs[cmd_name] = registered_cb
 	return self
 
+
 # register a callback function for given command
 # cb a funcref to a function with a variable number of arguments but expects all parameters to be passed via a single Array.
-func register_cbv(cmd_name :String, cb :Callable) -> CmdCommandHandler:
-	var registered_cb :Array = _command_cbs.get(cmd_name, [NO_CB, NO_CB])
+func register_cbv(cmd_name: String, cb: Callable) -> CmdCommandHandler:
+	var registered_cb: Array = _command_cbs.get(cmd_name, [NO_CB, NO_CB])
 	if registered_cb[CB_MULTI_ARGS]:
 		push_error("A function for command '%s' is already registered!" % cmd_name)
 		return self
@@ -43,19 +46,20 @@ func register_cbv(cmd_name :String, cb :Callable) -> CmdCommandHandler:
 	_command_cbs[cmd_name] = registered_cb
 	return self
 
+
 func _validate() -> Result:
-	var errors := PackedStringArray()
-	var registered_cbs := Dictionary()
+	var errors: = PackedStringArray()
+	var registered_cbs: = Dictionary()
 	
 	for cmd_name in _command_cbs.keys():
-		var cb :Callable = _command_cbs[cmd_name][CB_SINGLE_ARG] if _command_cbs[cmd_name][CB_SINGLE_ARG] else _command_cbs[cmd_name][CB_MULTI_ARGS]
+		var cb: Callable = _command_cbs[cmd_name][CB_SINGLE_ARG] if _command_cbs[cmd_name][CB_SINGLE_ARG] else _command_cbs[cmd_name][CB_MULTI_ARGS]
 		if cb != NO_CB and not cb.is_valid():
 			errors.append("Invalid function reference for command '%s', Check the function reference!" % cmd_name)
 		if _cmd_options.get_option(cmd_name) == null:
 			errors.append("The command '%s' is unknown, verify your CmdOptions!" % cmd_name)
 		# verify for multiple registered command callbacks
 		if _enhanced_fr_test and cb != NO_CB:
-			var cb_method := cb.get_method()
+			var cb_method: = cb.get_method()
 			if registered_cbs.has(cb_method):
 				var already_registered_cmd = registered_cbs[cb_method] 
 				errors.append("The function reference '%s' already registerd for command '%s'!" % [cb_method, already_registered_cmd])
@@ -65,6 +69,7 @@ func _validate() -> Result:
 		return Result.success(true)
 	else:
 		return Result.error("\n".join(errors))
+
 
 func execute(commands :Array) -> Result:
 	var result := _validate()

--- a/addons/gdUnit4/test/cmd/CmdCommandHandlerTest.gd
+++ b/addons/gdUnit4/test/cmd/CmdCommandHandlerTest.gd
@@ -5,8 +5,9 @@ extends GdUnitTestSuite
 # TestSuite generated from
 const __source = 'res://addons/gdUnit4/src/cmd/CmdCommandHandler.gd'
 
-var _cmd_options :CmdOptions
-var _cmd_instance : TestCommands
+var _cmd_options: CmdOptions
+var _cmd_instance: TestCommands
+
 
 # small example of command class
 class TestCommands:
@@ -19,13 +20,14 @@ class TestCommands:
 	func cmd_bar(value :String) -> String:
 		return value
 	
-	func cmd_bar2(value :Array) -> Array:
-		return value
+	func cmd_bar2(value_a: String, value_b: String) -> Array:
+		return [value_a, value_b]
 
 	func cmd_x() -> String:
 		return "cmd_x"
 
-func before():
+
+func before() -> void:
 	# setup command options
 	_cmd_options = CmdOptions.new([
 		CmdOption.new("-a", "some help text a", "some description a"),
@@ -39,21 +41,24 @@ func before():
 	])
 	_cmd_instance = TestCommands.new()
 
-func test__validate_no_registerd_commands():
+
+func test__validate_no_registerd_commands() -> void:
 	var cmd_handler := CmdCommandHandler.new(_cmd_options)
 	
 	assert_result(cmd_handler._validate()).is_success()
 
-func test__validate_registerd_commands():
-	var cmd_handler := CmdCommandHandler.new(_cmd_options)
+
+func test__validate_registerd_commands() -> void:
+	var cmd_handler: = CmdCommandHandler.new(_cmd_options)
 	cmd_handler.register_cb("-a", Callable(_cmd_instance, "cmd_a"))
 	cmd_handler.register_cb("-f", Callable(_cmd_instance, "cmd_foo"))
 	cmd_handler.register_cb("-b", Callable(_cmd_instance, "cmd_bar"))
 	
 	assert_result(cmd_handler._validate()).is_success()
 
-func test__validate_registerd_unknown_commands():
-	var cmd_handler := CmdCommandHandler.new(_cmd_options)
+
+func test__validate_registerd_unknown_commands() -> void:
+	var cmd_handler: = CmdCommandHandler.new(_cmd_options)
 	cmd_handler.register_cb("-a", Callable(_cmd_instance, "cmd_a"))
 	cmd_handler.register_cb("-d", Callable(_cmd_instance, "cmd_foo"))
 	cmd_handler.register_cb("-b", Callable(_cmd_instance, "cmd_bar"))
@@ -63,7 +68,8 @@ func test__validate_registerd_unknown_commands():
 		.is_error()\
 		.contains_message("The command '-d' is unknown, verify your CmdOptions!\nThe command '-y' is unknown, verify your CmdOptions!")
 
-func test__validate_registerd_invalid_callbacks():
+
+func test__validate_registerd_invalid_callbacks() -> void:
 	var cmd_handler := CmdCommandHandler.new(_cmd_options)
 	cmd_handler.register_cb("-a", Callable(_cmd_instance, "cmd_a"))
 	cmd_handler.register_cb("-f")
@@ -73,8 +79,9 @@ func test__validate_registerd_invalid_callbacks():
 		.is_error()\
 		.contains_message("Invalid function reference for command '-b', Check the function reference!")
 
-func test__validate_registerd_register_same_callback_twice():
-	var cmd_handler := CmdCommandHandler.new(_cmd_options)
+
+func test__validate_registerd_register_same_callback_twice() -> void:
+	var cmd_handler: = CmdCommandHandler.new(_cmd_options)
 	cmd_handler.register_cb("-a", Callable(_cmd_instance, "cmd_a"))
 	cmd_handler.register_cb("-b", Callable(_cmd_instance, "cmd_a"))
 	if cmd_handler._enhanced_fr_test:
@@ -82,16 +89,19 @@ func test__validate_registerd_register_same_callback_twice():
 			.is_error()\
 			.contains_message("The function reference 'cmd_a' already registerd for command '-a'!")
 
-func test_execute_no_commands():
-	var cmd_handler := CmdCommandHandler.new(_cmd_options)
+
+func test_execute_no_commands() -> void:
+	var cmd_handler: = CmdCommandHandler.new(_cmd_options)
 	assert_result(cmd_handler.execute([])).is_success()
 
-func test_execute_commands_no_cb_registered():
-	var cmd_handler := CmdCommandHandler.new(_cmd_options)
+
+func test_execute_commands_no_cb_registered() -> void:
+	var cmd_handler: = CmdCommandHandler.new(_cmd_options)
 	assert_result(cmd_handler.execute([CmdCommand.new("-a")])).is_success()
 
-func _test_execute_commands_with_cb_registered():
-	var cmd_handler := CmdCommandHandler.new(_cmd_options)
+
+func test_execute_commands_with_cb_registered() -> void:
+	var cmd_handler: = CmdCommandHandler.new(_cmd_options)
 	var cmd_spy = spy(_cmd_instance)
 	
 	cmd_handler.register_cb("-a", Callable(cmd_spy, "cmd_a"))
@@ -109,5 +119,5 @@ func _test_execute_commands_with_cb_registered():
 		CmdCommand.new("-b2", ["value1", "value2"])])).is_success()
 	verify(cmd_spy).cmd_a()
 	verify(cmd_spy).cmd_bar("some_value")
-	verify(cmd_spy).cmd_bar2( ["value1", "value2"] as PackedStringArray)
+	verify(cmd_spy).cmd_bar2("value1", "value2")
 	verify_no_more_interactions(cmd_spy)

--- a/addons/gdUnit4/test/mocker/GdUnitMockerTest.gd
+++ b/addons/gdUnit4/test/mocker/GdUnitMockerTest.gd
@@ -570,7 +570,7 @@ func _test_mock_godot_class_calls_sub_function():
 	verify(mock, 1).set_mesh(any_class(Mesh))
 	verify(mock, 1)._mesh_changed()
 
-func _test_mock_class_with_inner_classs():
+func test_mock_class_with_inner_classs():
 	var mock_advanced = mock(AdvancedTestClass)
 	assert_that(mock_advanced).is_not_null()
 

--- a/addons/gdUnit4/test/spy/GdUnitSpyTest.gd
+++ b/addons/gdUnit4/test/spy/GdUnitSpyTest.gd
@@ -136,7 +136,7 @@ func test_spy_copied_class_members_on_node():
 	node.set_name("foo")
 	assert_that(spy(node).name).is_equal("foo")
 
-func _test_spy_on_inner_class():
+func test_spy_on_inner_class():
 	var instance := AdvancedTestClass.AtmosphereData.new()
 	var spy_instance = spy(instance)
 	
@@ -391,7 +391,7 @@ func test_spy_Node_use_real_func_vararg():
 	assert_that(spy_node).is_not_null()
 	
 	assert_bool(_test_signal_is_emited).is_false()
-	spy_node.connect("ready",Callable(self,"_emit_ready"))
+	spy_node.connect("ready", Callable(self, "_emit_ready"))
 	spy_node.emit_signal("ready", "aa", "bb", "cc")
 	
 	# sync signal is emited


### PR DESCRIPTION
- enable CmdCommandHandlerTest#test_execute_commands_with_cb_registered():
- Code formating on CmdCommand and CmdCommandHandler
- enable GdUnitSpyTest#test_spy_on_inner_class():