### PR TITLE
GD-15: Remove GdUnit classes inherits form Godot.Node form the node inspector

### DIFF
--- a/addons/gdUnit4/plugin.gd
+++ b/addons/gdUnit4/plugin.gd
@@ -7,6 +7,23 @@ var _gd_console :Node
 var _update_tool :Node
 var _singleton :GdUnitSingleton
 
+
+# removes GdUnit classes inherits from Godot.Node from the node inspecor, ohterwise it takes very long to popup the dialog
+func _fixup_node_inspector() -> void:
+	var classes := PackedStringArray([
+		"GdUnitTestSuite",
+		"_TestCase",
+		"GdMarkDownReader",
+		"GdUnitInspecor",
+		"GdUnitExecutor",
+		"GdUnitUpdateClient",
+		"GdUnitUpdate",
+		"GdUnitTcpClient",
+		"GdUnitTcpServer"])
+	for clazz in classes:
+		remove_custom_type(clazz)
+
+
 func _enter_tree():
 	Engine.set_meta("GdUnitEditorPlugin", self)
 	_singleton = GdUnitSingleton.new()
@@ -29,7 +46,9 @@ func _enter_tree():
 	var err := _gd_inspector.connect("gdunit_runner_stop",Callable(_server_node,"_on_gdunit_runner_stop"))
 	if err != OK:
 		prints("ERROR", GdUnitTools.error_as_string(err))
+	_fixup_node_inspector()
 	prints("Loading GdUnit3 Plugin success")
+
 
 func _exit_tree():
 	if is_instance_valid(_gd_inspector):

--- a/addons/gdUnit4/src/GdUnitTestSuite.gd
+++ b/addons/gdUnit4/src/GdUnitTestSuite.gd
@@ -1,4 +1,7 @@
-################################################################################
+
+## Main class for all GdUnit test suites
+
+#################################################################################
 # This class is the main class to implement your unit tests
 # You have to extend and implement your test cases as described
 # e.g


### PR DESCRIPTION
# Why
The node inspector was loading very long and each search action takes around a minute

# What
Unregister GdUnit classes where inherits form Godot.Node form the node inspector
The classes are still shown in the inspector but the inspector is usable without timeouts