### PR TITLE
GD-63: Using a dictionary parameter in parameterized tests results into a runtime error

### DIFF
--- a/addons/gdUnit4/src/core/parse/GdScriptParser.gd
+++ b/addons/gdUnit4/src/core/parse/GdScriptParser.gd
@@ -371,25 +371,10 @@ func parse_func_return_type(row: String) -> int:
 
 func parse_return_token(row: String) -> Token:
 	var input := clean_up_row(row)
-	var current_index := 0
-	var token :Token = null
-	var bracket := 0
-	while current_index < len(input):
-		token = next_token(input, current_index) as Token
-		current_index += token._consumed
-		if token == TOKEN_BRACKET_OPEN:
-			bracket += 1
-		if token == TOKEN_BRACKET_CLOSE:
-			bracket -= 1
-		# function end reached ?
-		if bracket == 0 and token == TOKEN_BRACKET_CLOSE:
-			token = next_token(input, current_index) as Token
-			current_index += token._consumed
-			if token == TOKEN_FUNCTION_RETURN_TYPE:
-				return next_token(input, current_index) as Token
-			else:
-				return TOKEN_NOT_MATCH
-	return TOKEN_NOT_MATCH
+	var index := input.rfind(TOKEN_FUNCTION_RETURN_TYPE._token)
+	if index == -1:
+		return TOKEN_NOT_MATCH
+	return next_token(input, index + TOKEN_FUNCTION_RETURN_TYPE._consumed)
 
 
 # Parses the argument into a argument signature

--- a/addons/gdUnit4/test/core/ParameterizedTestCaseTest.gd
+++ b/addons/gdUnit4/test/core/ParameterizedTestCaseTest.gd
@@ -35,11 +35,15 @@ var _expected_tests = {
 	],
 	"test_parameterized_obj_values" : [
 		[TestObj.new("abc"), TestObj.new("def"), "abcdef"]
+	],
+	"test_parameterized_dict_values" : [
+		[{"key_a":"value_a"}, '{"key_a":"value_a"}'],
+		[{"key_b":"value_b"}, '{"key_b":"value_b"}']
 	]
 }
 
-func after():
 
+func after():
 	for test_name in _expected_tests.keys():
 		if _collected_tests.has(test_name):
 			var current_values = _collected_tests[test_name]
@@ -50,16 +54,19 @@ func after():
 		else:
 			fail("Missing test '%s' executed!" % test_name)
 
+
 func collect_test_call(test_name :String, values :Array) -> void:
 	if not _collected_tests.has(test_name):
 		_collected_tests[test_name] = Array()
 	_collected_tests[test_name].append(values)
+
 
 func test_parameterized_bool_value(a: int, expected :bool, test_parameters := [
 	[0, false],
 	[1, true]]):
 	collect_test_call("test_parameterized_bool_value", [a, expected])
 	assert_that(bool(a)).is_equal(expected)
+
 
 func test_parameterized_int_values(a: int, b :int, c :int, expected :int, test_parameters := [
 	[1, 2, 3, 6],
@@ -69,6 +76,7 @@ func test_parameterized_int_values(a: int, b :int, c :int, expected :int, test_p
 	collect_test_call("test_parameterized_int_values", [a, b, c, expected])
 	assert_that(a+b+c).is_equal(expected)
 
+
 func test_parameterized_float_values(a: float, b :float, expected :float, test_parameters := [
 	[2.2, 2.2, 4.4],
 	[2.2, 2.3, 4.5],
@@ -76,6 +84,7 @@ func test_parameterized_float_values(a: float, b :float, expected :float, test_p
 	
 	collect_test_call("test_parameterized_float_values", [a, b, expected])
 	assert_float(a+b).is_equal(expected)
+
 
 func test_parameterized_string_values(a: String, b :String, expected :String, test_parameters := [
 	["2.2", "2.2", "2.22.2"],
@@ -85,6 +94,7 @@ func test_parameterized_string_values(a: String, b :String, expected :String, te
 	collect_test_call("test_parameterized_string_values", [a, b, expected])
 	assert_that(a+b).is_equal(expected)
 
+
 func test_parameterized_Vector2_values(a: Vector2, b :Vector2, expected :Vector2, test_parameters := [
 	[Vector2.ONE, Vector2.ONE, Vector2(2, 2)],
 	[Vector2.LEFT, Vector2.RIGHT, Vector2.ZERO],
@@ -93,6 +103,7 @@ func test_parameterized_Vector2_values(a: Vector2, b :Vector2, expected :Vector2
 	collect_test_call("test_parameterized_Vector2_values", [a, b, expected])
 	assert_that(a+b).is_equal(expected)
 
+
 func test_parameterized_Vector3_values(a: Vector3, b :Vector3, expected :Vector3, test_parameters := [
 	[Vector3.ONE, Vector3.ONE, Vector3(2, 2, 2)],
 	[Vector3.LEFT, Vector3.RIGHT, Vector3.ZERO],
@@ -100,6 +111,7 @@ func test_parameterized_Vector3_values(a: Vector3, b :Vector3, expected :Vector3
 	
 	collect_test_call("test_parameterized_Vector3_values", [a, b, expected])
 	assert_that(a+b).is_equal(expected)
+
 
 class TestObj extends RefCounted:
 	var _value :String
@@ -110,9 +122,17 @@ class TestObj extends RefCounted:
 	func _to_string() -> String:
 		return _value
 
+
 func test_parameterized_obj_values(a: Object, b :Object, expected :String, test_parameters := [
 	[TestObj.new("abc"), TestObj.new("def"), "abcdef"]]):
 	
 	collect_test_call("test_parameterized_obj_values", [a, b, expected])
 	assert_that(a.to_string()+b.to_string()).is_equal(expected)
 
+
+func test_parameterized_dict_values(data: Dictionary, expected :String, test_parameters := [
+	[{"key_a" : "value_a"}, '{"key_a":"value_a"}'],
+	[{"key_b" : "value_b"}, '{"key_b":"value_b"}']
+	]):
+	collect_test_call("test_parameterized_dict_values", [data, expected])
+	assert_that(str(data).replace(" ", "")).is_equal(expected)


### PR DESCRIPTION


# Why
Using dictionary on a parameterized was end up into a runtime error.

# What
Fix the script parser to work with dictionaries as test arguments