### PR TITLE
GD-60: Allow to run a single parameterized test from the inspector

### DIFF
--- a/addons/gdUnit4/src/core/GdUnitExecutor.gd
+++ b/addons/gdUnit4/src/core/GdUnitExecutor.gd
@@ -236,8 +236,12 @@ func execute_test_case_parameterized(test_suite :GdUnitTestSuite, test_case :_Te
 	var current_failed_count = _total_test_failed
 	var current_warning_count =_total_test_warnings
 	var test_case_parameters := test_case.test_parameters()
+	var test_parameter_index := test_case.test_parameter_index()
 	var test_case_names := test_case.test_case_names()
 	for test_case_index in test_case.test_parameters().size():
+		# is test_parameter_index is set, we run this parameterized test only
+		if test_parameter_index != -1 and test_parameter_index != test_case_index:
+			continue
 		await test_before(test_suite, test_case, test_case_names[test_case_index])
 		set_stage(STAGE_TEST_CASE_EXECUTE)
 		_memory_pool.set_pool(test_suite, GdUnitMemoryPool.POOL.EXECUTE, true)

--- a/addons/gdUnit4/src/core/GdUnitRunnerConfig.gd
+++ b/addons/gdUnit4/src/core/GdUnitRunnerConfig.gd
@@ -20,39 +20,50 @@ var _config := {
 		SERVER_PORT : -1
 	}
 
+
 func clear() -> GdUnitRunnerConfig:
 	_config[INCLUDED] = Dictionary()
 	_config[SKIPPED] = Dictionary()
 	return self
 
+
 func set_server_port(port :int) -> GdUnitRunnerConfig:
 	_config[SERVER_PORT] = port
 	return self
 
+
 func server_port() -> int:
 	return _config.get(SERVER_PORT, -1)
+
 
 func self_test() -> GdUnitRunnerConfig:
 	add_test_suite("res://addons/gdUnit4/test/")
 	add_test_suite("res://addons/gdUnit4/mono/test/")
 	return self
 
+
 func add_test_suite(resource_path :String) -> GdUnitRunnerConfig:
 	var to_execute := to_execute()
 	to_execute[resource_path] = to_execute.get(resource_path, Array())
 	return self
+
 
 func add_test_suites(resource_paths :PackedStringArray) -> GdUnitRunnerConfig:
 	for resource_path in resource_paths:
 		add_test_suite(resource_path)
 	return self
 
-func add_test_case(resource_path :String, test_name :StringName) -> GdUnitRunnerConfig:
+
+func add_test_case(resource_path :String, test_name :StringName, test_param_index :int = -1) -> GdUnitRunnerConfig:
 	var to_execute := to_execute()
 	var test_cases :Array[StringName] = to_execute.get(resource_path, [])
-	test_cases.append(test_name)
+	if test_param_index != -1:
+		test_cases.append("%s:%d" % [test_name, test_param_index])
+	else:
+		test_cases.append(test_name)
 	to_execute[resource_path] = test_cases
 	return self
+
 
 # supports full path or suite name with optional test case name
 # <test_suite_name|path>[:<test_case_name>]
@@ -68,10 +79,12 @@ func skip_test_suite(value :StringName) -> GdUnitRunnerConfig:
 		2: skip_test_case(parts[0], parts[1])
 	return self
 
+
 func skip_test_suites(resource_paths :PackedStringArray) -> GdUnitRunnerConfig:
 	for resource_path in resource_paths:
 		skip_test_suite(resource_path)
 	return self
+
 
 func skip_test_case(resource_path :String, test_name :StringName) -> GdUnitRunnerConfig:
 	var to_ignore := skipped()
@@ -80,11 +93,14 @@ func skip_test_case(resource_path :String, test_name :StringName) -> GdUnitRunne
 	to_ignore[resource_path] = test_cases
 	return self
 
+
 func to_execute() -> Dictionary:
 	return _config.get(INCLUDED, {"res://" : []})
 
+
 func skipped() -> Dictionary:
 	return _config.get(SKIPPED, Array())
+
 
 func save(path :String = CONFIG_FILE) -> Result:
 	var file := FileAccess.open(path, FileAccess.WRITE)
@@ -94,6 +110,7 @@ func save(path :String = CONFIG_FILE) -> Result:
 	_config[VERSION] = CONFIG_VERSION
 	file.store_string(JSON.new().stringify(_config))
 	return Result.success(path)
+
 
 func load(path :String = CONFIG_FILE) -> Result:
 	if not FileAccess.file_exists(path):
@@ -115,10 +132,12 @@ func load(path :String = CONFIG_FILE) -> Result:
 		fix_value_types()
 	return Result.success(path)
 
+
 func fix_value_types():
 	# fix float value to int json stores all numbers as float
 	var server_port :int = _config.get(SERVER_PORT, -1)
 	_config[SERVER_PORT] = server_port
+
 
 func _to_string() -> String:
 	return str(_config)

--- a/addons/gdUnit4/src/core/_TestCase.gd
+++ b/addons/gdUnit4/src/core/_TestCase.gd
@@ -11,6 +11,7 @@ var _iterations: int = 1
 var _seed: int
 var _fuzzers: Array[GdFunctionArgument] = []
 var _test_parameters := Array()
+var _test_param_index := -1
 var _line_number: int = -1
 var _script_path: String
 var _skipped := false
@@ -22,8 +23,10 @@ var _timeout :int
 var _default_timeout :int
 var _monitor := GodotGdErrorMonitor.new()
 
+
 func _init():
 	_default_timeout = GdUnitSettings.test_timeout()
+
 
 func configure(name: String, line_number: int, script_path: String, timeout :int = DEFAULT_TIMEOUT, fuzzers :Array = [], iterations: int = 1, seed_ :int = -1, skipped := false) -> _TestCase:
 	set_name(name)
@@ -37,6 +40,7 @@ func configure(name: String, line_number: int, script_path: String, timeout :int
 	if timeout != DEFAULT_TIMEOUT:
 		_timeout = timeout
 	return self
+
 
 func execute(test_parameter := Array(), iteration := 0):
 	if iteration == 0:
@@ -52,8 +56,10 @@ func execute(test_parameter := Array(), iteration := 0):
 	for report in _monitor.reports():
 		GdUnitAssertImpl.new(get_parent(), null).send_report(report)
 
+
 func dispose():
 	stop_timer()
+
 
 func _execute_test_case(name :String, test_parameter :Array):
 	# needs at least on await otherwise it braks the awaiting chain
@@ -61,10 +67,12 @@ func _execute_test_case(name :String, test_parameter :Array):
 	await get_tree().create_timer(0.0001).timeout
 	completed.emit()
 
+
 func update_fuzzers(input_values :Array, iteration :int):
 	for fuzzer in input_values:
 		if fuzzer is Fuzzer:
 			fuzzer._iteration_index = iteration + 1
+
 
 func set_timeout():
 	var time :float = _timeout * 0.001
@@ -76,9 +84,11 @@ func set_timeout():
 	_timer.set_autostart(false)
 	_timer.start()
 
+
 func _test_case_timeout():
 	_interupted = true
 	completed.emit()
+
 
 func stop_timer() :
 	# finish outstanding timeouts
@@ -88,61 +98,88 @@ func stop_timer() :
 		_timer.stop()
 		_timer.call_deferred("free")
 
+
 func expect_to_interupt() -> void:
 	_expect_to_interupt = true
+
 
 func is_interupted() -> bool:
 	return _interupted
 
+
 func is_expect_interupted() -> bool:
 	return _expect_to_interupt
+
 
 func is_parameterized() -> bool:
 	return _test_parameters.size() != 0
 
+
 func is_skipped() -> bool:
 	return _skipped
+
 
 func error() -> String:
 	return _error
 
+
 func line_number() -> int:
 	return _line_number
+
 
 func iterations() -> int:
 	return _iterations
 
+
 func timeout() -> int:
 	return _timeout
 
+
 func seed_value() -> int:
 	return _seed
-	
+
+
 func has_fuzzer() -> bool:
 	return not _fuzzers.is_empty()
-	
+
+
 func fuzzer_arguments() -> Array[GdFunctionArgument]:
 	return _fuzzers
 
+
 func script_path() -> String:
 	return _script_path
-	
+
+
 func ResourcePath() -> String:
 	return _script_path
+
 
 func generate_seed() -> void:
 	if _seed != -1:
 		seed(_seed)
 
+
 func skip(skipped :bool, error :String = "") -> void:
 	_skipped = skipped
 	_error = error
 
+
 func set_test_parameters(test_parameters :Array) -> void:
 	_test_parameters = test_parameters
 
+
+func set_test_parameter_index(index :int) -> void:
+	_test_param_index = index
+
+
 func test_parameters() -> Array:
 	return _test_parameters
+
+
+func test_parameter_index() -> int:
+	return _test_param_index
+
 
 func test_case_names() -> PackedStringArray:
 	var test_case_names :=  PackedStringArray()
@@ -150,6 +187,7 @@ func test_case_names() -> PackedStringArray:
 	for input_values in _test_parameters:
 		test_case_names.append("%s %s" % [test_name, str(input_values)])
 	return test_case_names
+
 
 func _to_string():
 	return "%s :%d (%dms)" % [get_name(), _line_number, _timeout]

--- a/addons/gdUnit4/src/ui/GdUnitInspector.gd
+++ b/addons/gdUnit4/src/ui/GdUnitInspector.gd
@@ -118,7 +118,7 @@ func add_script_editor_context_menu():
 			var func_name := result.get_string(2).strip_edges()
 			prints("Run test:", func_name, "debug", debug)
 			if func_name.begins_with("test_"):
-				run_test_case(script.resource_path, func_name, debug)
+				run_test_case(script.resource_path, func_name, -1, debug)
 				return
 		# otherwise run the full test suite
 		var selected_test_suites := [script.resource_path]
@@ -153,11 +153,11 @@ func run_test_suites(test_suite_paths :PackedStringArray, debug :bool, rerun :bo
 	_gdUnit_run(debug)
 
 
-func run_test_case(test_suite_resource_path :String, test_case :String, debug :bool, rerun := false) -> void:
+func run_test_case(test_suite_resource_path :String, test_case :String, test_param_index :int, debug :bool, rerun := false) -> void:
 	# create new runner config for fresh run otherwise use saved one
 	if not rerun:
 		var result := _runner_config.clear()\
-			.add_test_case(test_suite_resource_path, test_case)\
+			.add_test_case(test_suite_resource_path, test_case, test_param_index)\
 			.save()
 		if result.is_error():
 			push_error(result.error_message())
@@ -234,8 +234,8 @@ func _on_MainPanel_run_testsuite(test_suite_paths :Array, debug :bool):
 	run_test_suites(test_suite_paths, debug)
 
 
-func _on_MainPanel_run_testcase(resource_path :String, test_case :String, debug :bool):
-	run_test_case(resource_path, test_case, debug)
+func _on_MainPanel_run_testcase(resource_path :String, test_case :String, test_param_index :int, debug :bool):
+	run_test_case(resource_path, test_case, test_param_index, debug)
 
 
 ##########################################################################


### PR DESCRIPTION
# Why
By default, you can execute only one selected test or test suite. For parameterized tests, the inspector is populated with all parameterized tests when the test is executed. If a test fails, you have to re-run the entire test case, but it would be nice if you could select one of the parameterized test runs and re-run it as a single case.

![image](https://user-images.githubusercontent.com/347037/208474744-c29e65a6-74cf-43dd-883b-d9cf0cd0eb58.png)


# What
Implemented to run a selected parameterized test case via the inspector context menu.

![image](https://user-images.githubusercontent.com/347037/208474980-482b9954-81eb-4702-8e82-7974027f8811.png)