### PR TITLE
GD-77: Fix run `Debug Test` on  MacOS

### DIFF
--- a/addons/gdUnit4/src/ui/GdUnitInspector.gd
+++ b/addons/gdUnit4/src/ui/GdUnitInspector.gd
@@ -189,7 +189,11 @@ func _gdUnit_run(debug :bool) -> void:
 		_is_running = true
 		return
 	var arguments := Array()
+	if OS.is_stdout_verbose():
+		arguments.append("--verbose")
 	arguments.append("--no-window")
+	arguments.append("--path")
+	arguments.append(ProjectSettings.globalize_path("res://"))
 	arguments.append("res://addons/gdUnit4/src/core/GdUnitRunner.tscn")
 	_current_runner_process_id = OS.create_process(OS.get_executable_path(), arguments, false);
 	_is_running = true


### PR DESCRIPTION
# Why
The command 'Debug Test' was not working on MacOS

# What
Add a path argument to run the GdUnitRunner scene. Seems to be a required argument under macOS