### PR TITLE
GD-69: Allow to compare real vs int typed dictionary

### DIFF
--- a/addons/gdUnit4/src/core/GdUnitSettings.gd
+++ b/addons/gdUnit4/src/core/GdUnitSettings.gd
@@ -28,6 +28,7 @@ const REPORT_ORPHANS  = REPORT_SETTINGS + "/verbose_orphans"
 const GROUP_ASSERT = REPORT_SETTINGS + "/assert"
 const REPORT_ASSERT_WARNINGS = GROUP_ASSERT + "/verbose_warnings"
 const REPORT_ASSERT_ERRORS   = GROUP_ASSERT + "/verbose_errors"
+const REPORT_ASSERT_STRICT_NUMBER_TYPE_COMPARE = GROUP_ASSERT + "/strict_number_type_compare"
 
 # Godot debug stdout/logging settings
 const CATEGORY_LOGGING := "debug/file_logging/"
@@ -55,6 +56,7 @@ enum NAMING_CONVENTIONS {
 	PASCAL_CASE,
 }
 
+
 static func setup():
 	create_property_if_need(UPDATE_NOTIFICATION_ENABLED, true, "Enables/Disables the update notification checked startup.")
 	create_property_if_need(SERVER_TIMEOUT, DEFAULT_SERVER_TIMEOUT, "Sets the server connection timeout in minutes.")
@@ -66,6 +68,7 @@ static func setup():
 	create_property_if_need(REPORT_ORPHANS, true, "Enables/Disables orphan reporting.")
 	create_property_if_need(REPORT_ASSERT_ERRORS, true, "Enables/Disables error reporting checked asserts.")
 	create_property_if_need(REPORT_ASSERT_WARNINGS, true, "Enables/Disables warning reporting checked asserts")
+	create_property_if_need(REPORT_ASSERT_STRICT_NUMBER_TYPE_COMPARE, true, "Enabled/disabled number values will be compared strictly by type. (real vs int)")
 	create_property_if_need(INSPECTOR_NODE_COLLAPSE, true, "Enables/disables that the testsuite node is closed after a successful test run.")
 	create_property_if_need(TEMPLATE_TS_GD, GdUnitTestSuiteDefaultTemplate.DEFAULT_TEMP_TS_GD, "Defines the test suite template")
 
@@ -138,6 +141,10 @@ static func is_verbose_assert_errors() -> bool:
 
 static func is_verbose_orphans() -> bool:
 	return get_setting(REPORT_ORPHANS, true)
+
+
+static func is_strict_number_type_compare() -> bool:
+	return get_setting(REPORT_ASSERT_STRICT_NUMBER_TYPE_COMPARE, true)
 
 
 static func is_report_push_errors() -> bool:

--- a/addons/gdUnit4/src/core/_TestCase.gd
+++ b/addons/gdUnit4/src/core/_TestCase.gd
@@ -184,8 +184,8 @@ func test_parameter_index() -> int:
 func test_case_names() -> PackedStringArray:
 	var test_case_names :=  PackedStringArray()
 	var test_name = get_name()
-	for input_values in _test_parameters:
-		test_case_names.append("%s %s" % [test_name, str(input_values)])
+	for index in _test_parameters.size():
+		test_case_names.append("%s:%d %s" % [test_name, index, str(_test_parameters[index])])
 	return test_case_names
 
 

--- a/addons/gdUnit4/test/core/GdObjectsTest.gd
+++ b/addons/gdUnit4/test/core/GdObjectsTest.gd
@@ -27,6 +27,12 @@ func test_equals_string():
 	assert_bool(GdObjects.equals(d, Vector2.ONE)).is_false()
 	assert_bool(GdObjects.equals(d, Vector3.ONE)).is_false()
 
+
+func test_equals_stringname():
+	assert_bool(GdObjects.equals("",  &"")).is_true()
+	assert_bool(GdObjects.equals("abc", &"abc")).is_true()
+	assert_bool(GdObjects.equals("abc", &"abC")).is_false()
+
 func test_equals_array():
 	var a := []
 	var b := []
@@ -197,6 +203,7 @@ func _is_instance(value) -> bool:
 	return GdObjects.is_instance(auto_free(value))
 
 func test_is_instance_true():
+	assert_bool(_is_instance(RefCounted.new())).is_true()
 	assert_bool(_is_instance(Node.new())).is_true()
 	assert_bool(_is_instance(AStar3D.new())).is_true()
 	assert_bool(_is_instance(PackedScene.new())).is_true()
@@ -208,6 +215,7 @@ func test_is_instance_true():
 	assert_bool(_is_instance(CustomClass.InnerClassC.new())).is_true()
 
 func test_is_instance_false():
+	assert_bool(_is_instance(RefCounted)).is_false()
 	assert_bool(_is_instance(Node)).is_false()
 	assert_bool(_is_instance(AStar3D)).is_false()
 	assert_bool(_is_instance(PackedScene)).is_false()

--- a/addons/gdUnit4/test/core/ParameterizedTestCaseTest.gd
+++ b/addons/gdUnit4/test/core/ParameterizedTestCaseTest.gd
@@ -136,3 +136,18 @@ func test_parameterized_dict_values(data: Dictionary, expected :String, test_par
 	]):
 	collect_test_call("test_parameterized_dict_values", [data, expected])
 	assert_that(str(data).replace(" ", "")).is_equal(expected)
+
+
+func test_dictionary_div_number_types(
+	value : Dictionary,
+	expected : Dictionary,
+	test_parameters : Array = [
+		[{ top = 50.0,	bottom = 50.0,	left = 50.0,	right = 50.0},	{ top = 50, 	bottom = 50,	left = 50,  	right = 50}],
+		[{ top = 50.0,	bottom = 50.0,	left = 50.0,	right = 50.0},	{ top = 50.0,	bottom = 50.0,	left = 50.0,	right = 50.0}],
+		[{ top = 50,	bottom = 50,	left = 50,  	right = 50},	{ top = 50.0,	bottom = 50.0,	left = 50.0,	right = 50.0}],
+		[{ top = 50,	bottom = 50,	left = 50,  	right = 50},	{ top = 50, 	bottom = 50,	left = 50,  	right = 50}],
+	]
+) -> void:
+	# allow to compare type unsave
+	ProjectSettings.set_setting(GdUnitSettings.REPORT_ASSERT_STRICT_NUMBER_TYPE_COMPARE, false)
+	assert_that(value).is_equal(expected)

--- a/addons/gdUnit4/test/core/resources/testsuites/TestSuiteParameterizedTests.resource
+++ b/addons/gdUnit4/test/core/resources/testsuites/TestSuiteParameterizedTests.resource
@@ -64,3 +64,16 @@ func test_parameterized_obj_values(a: Object, b :Object, expected :String, test_
 	[TestObj.new("abc"), TestObj.new("def"), "abcdef"]]):
 
 	assert_that(a.to_string()+b.to_string()).is_equal(expected)
+
+
+func test_dictionary_div_number_types(
+		value : Dictionary,
+		expected : Dictionary,
+		test_parameters : Array = [
+			[{ top = 50.0,	bottom = 50.0,	left = 50.0,	right = 50.0},	{ top = 50, 	bottom = 50,	left = 50,  	right = 50}],
+			[{ top = 50.0,	bottom = 50.0,	left = 50.0,	right = 50.0},	{ top = 50.0,	bottom = 50.0,	left = 50.0,	right = 50.0}],
+			[{ top = 50,	bottom = 50,	left = 50,  	right = 50},	{ top = 50.0,	bottom = 50.0,	left = 50.0,	right = 50.0}],
+			[{ top = 50,	bottom = 50,	left = 50,  	right = 50},	{ top = 50, 	bottom = 50,	left = 50,  	right = 50}],
+		]
+	) -> void:
+		assert_that(value).is_equal(expected)


### PR DESCRIPTION
# Why
Comparing a dictionary with diverent number types was result into a failure. Godot comparing of dictionarys are type save and needs to be handled customized.

# What
- intoduced a new settings to enable/disable number type save comparision. 
![image](https://user-images.githubusercontent.com/347037/214333133-6afaedd2-8f12-49f9-9af4-9c4e697b9755.png)


- fixed ui bug to add failure report to the right tree item