### PR TITLE
GD-83: Fix auto_free on class type aborts the test run without any messages

### DIFF
--- a/addons/gdUnit4/src/core/GdUnitTools.gd
+++ b/addons/gdUnit4/src/core/GdUnitTools.gd
@@ -185,25 +185,25 @@ static func prints_verbose(message :String) -> void:
 		print_debug(message)
 
 
-static func free_instance(instance :Variant) -> void:
+static func free_instance(instance :Variant) -> bool:
 	# is instance already freed?
-	if not is_instance_valid(instance) or str(instance).contains("GDScriptNativeClass"):
-		return
-	# needs to manually exculde JavaClass
-	# see https://github.com/godotengine/godot/issues/44932
-	if not(instance is JavaClass):
-		if not instance is RefCounted:
-			release_double(instance)
-			release_connections(instance)
-			if instance is Timer:
-				instance.stop()
-				#instance.queue_free()
-				instance.call_deferred("free")
-				return
-			instance.free()
-		else:
-			instance.notification(Object.NOTIFICATION_PREDELETE)
-			release_double(instance)
+	if not is_instance_valid(instance) or ClassDB.class_get_property(instance, "new"):
+		return false
+	if instance is RefCounted:
+		instance.notification(Object.NOTIFICATION_PREDELETE)
+		release_double(instance)
+		return true
+		release_double(instance)
+	else:
+		release_connections(instance)
+		if instance is Timer:
+			instance.stop()
+			#instance.queue_free()
+			instance.call_deferred("free")
+			return true
+		instance.free()
+		return !is_instance_valid(instance)
+
 
 #static func release_connections(instance :Object):
 #	for connection in instance.get_incoming_connections():
@@ -226,7 +226,7 @@ static func release_connections(instance :Object):
 				instance.disconnect(signal_.get_name(), callable_)
 
 # if instance an mock or spy we need manually freeing the self reference
-static func release_double(instance :Object):
+static func release_double(instance :Object) -> void:
 	if instance.has_method("__release_double"):
 		instance.call("__release_double")
 

--- a/addons/gdUnit4/test/core/GdUnitToolsTest.gd
+++ b/addons/gdUnit4/test/core/GdUnitToolsTest.gd
@@ -222,3 +222,19 @@ func test_extract_package_invalid_package() -> void:
 	assert_result(result).is_error()\
 		.contains_message("Extracting `%s` failed! Please collect the error log and report this. Error Code: 1" % source)
 	assert_array(GdUnitTools.scan_dir(tmp_path)).is_empty()
+
+
+func test_free_instance() -> void:
+	# on valid instances
+	assert_that(GdUnitTools.free_instance(RefCounted.new())).is_true()
+	assert_that(GdUnitTools.free_instance(Node.new())).is_true()
+	assert_that(GdUnitTools.free_instance(JavaClass.new())).is_true()
+	
+	# on invalid instances
+	assert_that(GdUnitTools.free_instance(null)).is_false()
+	assert_that(GdUnitTools.free_instance(RefCounted)).is_false()
+	
+	# on already freed instances
+	var node := Node.new()
+	node.free()
+	assert_that(GdUnitTools.free_instance(node)).is_false()


### PR DESCRIPTION

# Why
The test run was aborted when using a pure class type on auto_free

# What
The Godot function `is_instance_valid(instance)` is not recognice a class type as invalid. I added a hack to check by using `ClassDB.class_get_property(instance, "new")`