### PR TITLE
GD-10: Using auto_free() on inner class results in runtime error

### DIFF
--- a/addons/gdUnit4/src/core/GdUnitTools.gd
+++ b/addons/gdUnit4/src/core/GdUnitTools.gd
@@ -189,11 +189,11 @@ static func free_instance(instance :Variant) -> bool:
 	# is instance already freed?
 	if not is_instance_valid(instance) or ClassDB.class_get_property(instance, "new"):
 		return false
+	
+	release_double(instance)
 	if instance is RefCounted:
 		instance.notification(Object.NOTIFICATION_PREDELETE)
-		release_double(instance)
 		return true
-		release_double(instance)
 	else:
 		release_connections(instance)
 		if instance is Timer:
@@ -204,14 +204,6 @@ static func free_instance(instance :Variant) -> bool:
 		instance.free()
 		return !is_instance_valid(instance)
 
-
-#static func release_connections(instance :Object):
-#	for connection in instance.get_incoming_connections():
-#		var signal_name = connection["signal_name"]
-#		var source = connection["source"]
-#		var method = connection["method_name"]
-#		if source == instance:
-#			source.disconnect(signal_name,Callable(instance,method))
 
 static func release_connections(instance :Object):
 	if is_instance_valid(instance):
@@ -224,6 +216,7 @@ static func release_connections(instance :Object):
 			#prints("callable", callable_.get_object())
 			if instance.has_signal(signal_.get_name()) and instance.is_connected(signal_.get_name(), callable_):
 				instance.disconnect(signal_.get_name(), callable_)
+
 
 # if instance an mock or spy we need manually freeing the self reference
 static func release_double(instance :Object) -> void:

--- a/addons/gdUnit4/test/core/GdUnitToolsTest.gd
+++ b/addons/gdUnit4/test/core/GdUnitToolsTest.gd
@@ -224,11 +224,20 @@ func test_extract_package_invalid_package() -> void:
 	assert_array(GdUnitTools.scan_dir(tmp_path)).is_empty()
 
 
+class InnerTestNodeClass extends Node:
+	pass
+
+class InnerTestRefCountedClass extends RefCounted:
+	pass
+
+
 func test_free_instance() -> void:
 	# on valid instances
 	assert_that(GdUnitTools.free_instance(RefCounted.new())).is_true()
 	assert_that(GdUnitTools.free_instance(Node.new())).is_true()
 	assert_that(GdUnitTools.free_instance(JavaClass.new())).is_true()
+	assert_that(GdUnitTools.free_instance(InnerTestNodeClass.new())).is_true()
+	assert_that(GdUnitTools.free_instance(InnerTestRefCountedClass.new())).is_true()
 	
 	# on invalid instances
 	assert_that(GdUnitTools.free_instance(null)).is_false()

--- a/addons/gdUnit4/test/spy/GdUnitSpyTest.gd
+++ b/addons/gdUnit4/test/spy/GdUnitSpyTest.gd
@@ -136,9 +136,10 @@ func test_spy_copied_class_members_on_node():
 	node.set_name("foo")
 	assert_that(spy(node).name).is_equal("foo")
 
+
 func test_spy_on_inner_class():
-	var instance := AdvancedTestClass.AtmosphereData.new()
-	var spy_instance = spy(instance)
+	var instance :AdvancedTestClass.AtmosphereData = auto_free(AdvancedTestClass.AtmosphereData.new())
+	var spy_instance :AdvancedTestClass.AtmosphereData = spy(instance)
 	
 	# verify we have currently no interactions
 	verify_no_interactions(spy_instance)


### PR DESCRIPTION
# Why
It was failing on beta3 but is fixed now

# What
- Revert the changes
- Extend `test_free_instance()` to test free on inner class