### PR TITLE
GD-72: Fix gdunit console wrong indent of failure reports

### DIFF
--- a/addons/gdUnit4/src/ui/GdUnitConsole.gd
+++ b/addons/gdUnit4/src/ui/GdUnitConsole.gd
@@ -19,8 +19,10 @@ var _summary = {
 	"orphan_nodes": 0
 }
 
+
 func _ready():
 	init_colors()
+	GdUnitFonts.init_fonts(output)
 	GdUnit4Version.init_version_label(title)
 	GdUnitSignals.instance().gdunit_event.connect(Callable(self, "_on_gdunit_event"))
 	GdUnitSignals.instance().gdunit_message.connect(Callable(self, "_on_gdunit_message"))
@@ -28,9 +30,11 @@ func _ready():
 	GdUnitSignals.instance().gdunit_client_disconnected.connect(Callable(self, "_on_gdunit_client_disconnected"))
 	output.clear()
 
+
 func _notification(what):
 	if what == EditorSettings.NOTIFICATION_EDITOR_SETTINGS_CHANGED:
 		init_colors()
+
 
 func init_colors() -> void:
 	var plugin := EditorPlugin.new()
@@ -40,6 +44,7 @@ func init_colors() -> void:
 	_engine_type_color = settings.get_setting("text_editor/theme/highlighting/engine_type_color")
 	plugin.free()
 
+
 func init_statistics(event :GdUnitEvent) :
 	_statistics["total_count"] = event.total_count()
 	_statistics["error_count"] = 0
@@ -47,6 +52,7 @@ func init_statistics(event :GdUnitEvent) :
 	_statistics["skipped_count"] = 0
 	_statistics["orphan_nodes"] = 0
 	_summary["total_count"] += event.total_count()
+
 
 func update_statistics(event :GdUnitEvent) :
 	_statistics["error_count"] += event.error_count()
@@ -58,80 +64,78 @@ func update_statistics(event :GdUnitEvent) :
 	_summary["skipped_count"] += event.skipped_count()
 	_summary["orphan_nodes"] += event.orphan_nodes()
 
+
+func print_message(message :String, color :Color = _text_color, indent :int = 0) -> void:
+	for i in indent:
+		output.push_indent(1)
+	output.push_color(color)
+	output.append_text(message)
+	output.pop()
+	for i in indent:
+		output.pop()
+
+
+func println_message(message :String, color :Color = _text_color, indent :int = -1) -> void:
+	print_message(message, color, indent)
+	output.newline()
+
+
 func _on_gdunit_event(event :GdUnitEvent):
 	match event.type():
 		GdUnitEvent.INIT:
 			_summary["total_count"] = 0
 		GdUnitEvent.STOP:
-			output.newline()
-			output.push_color(Color.LIGHT_GREEN.to_html())
-			output.append_text("Test Run Summary:")
-			output.push_color(_text_color.to_html())
-			output.push_indent(1)
-			output.append_text("| %d total | %d error | %d failed | %d skipped | %d orphans |\n" % [_summary["total_count"], _summary["error_count"], _summary["failed_count"], _summary["skipped_count"], _summary["orphan_nodes"]])
-			output.pop()
+			print_message("Summary:", Color.DODGER_BLUE)
+			println_message("| %d total | %d error | %d failed | %d skipped | %d orphans |" % [_summary["total_count"], _summary["error_count"], _summary["failed_count"], _summary["skipped_count"], _summary["orphan_nodes"]], _text_color, 1)
+		
 		GdUnitEvent.TESTSUITE_BEFORE:
 			init_statistics(event)
-			output.append_text("Run Test Suite: %s" %  event._suite_name)
-			output.newline()
+			print_message("Execute: ", Color.DODGER_BLUE)
+			println_message( event._suite_name, _engine_type_color)
+		
 		GdUnitEvent.TESTSUITE_AFTER:
 			if event.is_success():
-				output.push_color(Color.LIGHT_GREEN.to_html())
-				output.append_text("[wave]PASSED[/wave]")
+				print_message("[wave]PASSED[/wave]", Color.LIGHT_GREEN)
 			else:
-				output.push_color(Color.FIREBRICK.to_html())
-				output.append_text("[shake rate=5 level=10][b]FAILED[/b][/shake]")
-			output.pop()
-			output.append_text(" %+12s" % LocalTime.elapsed(event.elapsed_time()))
-			output.newline()
-			output.push_color(_text_color.to_html())
-			output.push_indent(1)
-			output.append_text("| %d total | %d error | %d failed | %d skipped | %d orphans |\n" % [_statistics["total_count"], _statistics["error_count"], _statistics["failed_count"], _statistics["skipped_count"], _statistics["orphan_nodes"]])
-			output.pop()
-			output.pop()
-			output.newline()
+				print_message("[shake rate=5 level=10][b]FAILED[/b][/shake]", Color.FIREBRICK)
+			print_message(" | %d total | %d error | %d failed | %d skipped | %d orphans |" % [_statistics["total_count"], _statistics["error_count"], _statistics["failed_count"], _statistics["skipped_count"], _statistics["orphan_nodes"]])
+			println_message("%+12s" % LocalTime.elapsed(event.elapsed_time()))
+			println_message(" ")
+		
 		GdUnitEvent.TESTCASE_BEFORE:
 			var spaces = "-%d" % (80 - event._suite_name.length())
-			output.push_indent(1)
-			output.append_text(("[color=#" + _engine_type_color.to_html() + "]%s[/color]:[color=#" + _function_color.to_html() + "]%"+spaces+"s[/color]") % [event._suite_name, event._test_name])
-			output.pop()
+			print_message(event._suite_name, _engine_type_color, 1)
+			print_message(":")
+			print_message(("%"+spaces+"s") % event._test_name, _function_color)
+		
 		GdUnitEvent.TESTCASE_AFTER:
 			var reports := event.reports()
 			update_statistics(event)
-			if not output.text.ends_with("\n"):
-				if event.is_success():
-					output.push_color(Color.LIGHT_GREEN.to_html())
-					output.append_text("PASSED")
-					output.pop()
-					output.append_text(" %+12s" % LocalTime.elapsed(event.elapsed_time()))
-				else:
-					if event.is_skipped():
-						output.push_color(Color.GOLDENROD.to_html())
-						output.append_text("SKIPPED")
-					if event.is_error() or event.is_failed():
-						output.push_color(Color.FIREBRICK.to_html())
-						output.append_text("FAILED")
-					output.pop()
-					output.append_text(" %+12s" % LocalTime.elapsed(event.elapsed_time()))
-					output.newline()
-					output.push_color(_text_color.to_html())
-					var report :GdUnitReport = null if reports.is_empty() else reports[0]
-					if report:
-						output.push_indent(2)
-						output.append_text("line %d %s" % [report._line_number, report._message])
-						output.pop()
-					output.pop()
-				output.newline()
+			if event.is_success():
+				print_message("PASSED", Color.LIGHT_GREEN)
+			elif event.is_skipped():
+				print_message("SKIPPED", Color.GOLDENROD)
+			elif event.is_error() or event.is_failed():
+				print_message("FAILED", Color.FIREBRICK)
+			elif event.is_warning():
+				print_message("WARNING", Color.YELLOW)
+			println_message(" %+12s" % LocalTime.elapsed(event.elapsed_time()))
+			
+			var report :GdUnitReport = null if reports.is_empty() else reports[0]
+			if report:
+				println_message("line %d %s" % [report._line_number, report._message], _text_color, 2)
+
 
 func _on_gdunit_client_connected(client_id :int) -> void:
 	output.clear()
+	output.append_text("[color=#9887c4]GdUnit Test Client connected with id %d[/color]\n" % client_id)
 	output.newline()
-	output.append_text("[color=#9887c4]GdUnit Test Client connected with id %d[/color]" % client_id)
+
 
 func _on_gdunit_client_disconnected(client_id :int) -> void:
+	output.append_text("[color=#9887c4]GdUnit Test Client disconnected with id %d[/color]\n" % client_id)
 	output.newline()
-	output.append_text("[color=#9887c4]GdUnit Test Client disconnected with id %d[/color]" % client_id)
-	output.append_text("[wave][/wave]")
+
 
 func _on_gdunit_message(message :String):
 	output.newline()

--- a/addons/gdUnit4/src/ui/GdUnitConsole.gd
+++ b/addons/gdUnit4/src/ui/GdUnitConsole.gd
@@ -87,6 +87,7 @@ func _on_gdunit_event(event :GdUnitEvent):
 		GdUnitEvent.STOP:
 			print_message("Summary:", Color.DODGER_BLUE)
 			println_message("| %d total | %d error | %d failed | %d skipped | %d orphans |" % [_summary["total_count"], _summary["error_count"], _summary["failed_count"], _summary["skipped_count"], _summary["orphan_nodes"]], _text_color, 1)
+			print_message("[wave][/wave]")
 		
 		GdUnitEvent.TESTSUITE_BEFORE:
 			init_statistics(event)
@@ -116,7 +117,7 @@ func _on_gdunit_event(event :GdUnitEvent):
 			elif event.is_skipped():
 				print_message("SKIPPED", Color.GOLDENROD)
 			elif event.is_error() or event.is_failed():
-				print_message("FAILED", Color.FIREBRICK)
+				print_message("[wave]FAILED[/wave]", Color.FIREBRICK)
 			elif event.is_warning():
 				print_message("WARNING", Color.YELLOW)
 			println_message(" %+12s" % LocalTime.elapsed(event.elapsed_time()))


### PR DESCRIPTION
# Why
The gdunit console was reporting an runtime error because of invalid indentation handling

# What
- Reworked the console message handling to avoid invalid `pop` calls on RichTextLabel
- Add missing font initalisation to render messages with a mono font