### PR TITLE
GD-88: Fix script runtime error detection

### DIFF
--- a/addons/gdUnit4/src/asserts/GdAssertMessages.gd
+++ b/addons/gdUnit4/src/asserts/GdAssertMessages.gd
@@ -124,6 +124,11 @@ static func fuzzer_interuped(iterations: int, error: String) -> String:
 		_error("test iterations"), 
 		error]
 
+
+static func test_timeout(timeout :int) -> String:
+	return "%s\n %s" % [_error("Timeout !"), _colored_value("Test timed out after %s" %  LocalTime.elapsed(timeout))]
+
+
 static func error_not_implemented() -> String:
 	return _error("Test not implemented!")
 

--- a/addons/gdUnit4/src/asserts/GdUnitFuncAssertImpl.gd
+++ b/addons/gdUnit4/src/asserts/GdUnitFuncAssertImpl.gd
@@ -128,6 +128,9 @@ func _validate_callback(func_name :String, expected = null) -> GdUnitFuncAssert:
 	timeout.connect("timeout", Callable(self, "_on_timeout"))
 	timeout.start((_timeout/1000.0)*time_scale)
 	
+	var sleep := Timer.new()
+	caller.add_child(sleep)
+	
 	while true:
 		next_current_value()
 		var current = await value_provided
@@ -136,8 +139,11 @@ func _validate_callback(func_name :String, expected = null) -> GdUnitFuncAssert:
 		var is_success = assert_cb.call(current, expected)
 		if _expect_result != EXPECT_FAIL and is_success:
 			break
-		await Engine.get_main_loop().process_frame
+		sleep.start(0.05)
+		await sleep.timeout
 	
+	sleep.stop()
+	sleep.queue_free()
 	timeout.stop()
 	timeout.disconnect("timeout", Callable(self, "_on_timeout"))
 	timeout.free()

--- a/addons/gdUnit4/src/core/GdObjects.gd
+++ b/addons/gdUnit4/src/core/GdObjects.gd
@@ -324,10 +324,10 @@ static func _is_type_equivalent(type_a, type_b) -> bool:
 		or type_a == type_b)
 
 
-static func is_engine_type(value :Variant) -> bool:
+static func is_engine_type(value :Object) -> bool:
 	if value is GDScript or value is ScriptExtension:
 		return false
-	return str(value).contains("GDScriptNativeClass")
+	return value.is_class("GDScriptNativeClass")
 
 
 static func is_type(value :Variant) -> bool:

--- a/addons/gdUnit4/src/core/GdUnitExecutor.gd
+++ b/addons/gdUnit4/src/core/GdUnitExecutor.gd
@@ -143,9 +143,10 @@ func test_after(test_suite :GdUnitTestSuite, test_case :_TestCase, test_case_nam
 		_report_collector.push_front(STAGE_TEST_CASE_EXECUTE, GdUnitReport.new() \
 			.create(GdUnitReport.WARN, test_case.line_number(), GdAssertMessages.orphan_detected_on_test(execution_orphan_nodes)))
 	
+	var is_error := false
 	if test_case.is_interupted() and not test_case.is_expect_interupted():
-		_report_collector.add_report(STAGE_TEST_CASE_EXECUTE, GdUnitReport.new() \
-				.create(GdUnitReport.INTERUPTED, test_case.line_number(), "Test timed out after %s" % LocalTime.elapsed(test_case.timeout())))
+		_report_collector.add_report(STAGE_TEST_CASE_EXECUTE, test_case.report())
+		is_error = true
 	
 	set_stage(STAGE_TEST_CASE_AFTER)
 	_memory_pool.set_pool(test_suite, GdUnitMemoryPool.POOL.TESTCASE)
@@ -161,7 +162,6 @@ func test_after(test_suite :GdUnitTestSuite, test_case :_TestCase, test_case_nam
 			.create(GdUnitReport.WARN, test_case.line_number(), GdAssertMessages.orphan_detected_on_test_setup(test_setup_orphan_nodes)))
 	
 	var reports := _report_collector.get_reports(STAGE_TEST_CASE_BEFORE|STAGE_TEST_CASE_EXECUTE|STAGE_TEST_CASE_AFTER)
-	var is_error :bool = test_case.is_interupted() and not test_case.is_expect_interupted()
 	var error_count := _report_collector.count_errors(STAGE_TEST_CASE_BEFORE|STAGE_TEST_CASE_EXECUTE|STAGE_TEST_CASE_AFTER) if is_error else 0
 	var failure_count := _report_collector.count_failures(STAGE_TEST_CASE_BEFORE|STAGE_TEST_CASE_EXECUTE|STAGE_TEST_CASE_AFTER)
 	var is_warning := _report_collector.has_warnings(STAGE_TEST_CASE_BEFORE|STAGE_TEST_CASE_EXECUTE|STAGE_TEST_CASE_AFTER)
@@ -217,8 +217,6 @@ func execute_test_case_iterative(test_suite :GdUnitTestSuite, test_case :_TestCa
 		
 		if test_case.is_interupted():
 			is_failure = true
-			_report_collector.add_report(STAGE_TEST_CASE_EXECUTE, GdUnitReport.new() \
-					.create(GdUnitReport.INTERUPTED, test_case.line_number(), GdAssertMessages.fuzzer_interuped(iteration, "timedout")))
 		
 		# call after_test for each iteration
 		await test_after(test_suite, test_case, test_case.get_name(), iteration==test_case.iterations()-1 or is_failure)

--- a/addons/gdUnit4/src/core/GdUnitTools.gd
+++ b/addons/gdUnit4/src/core/GdUnitTools.gd
@@ -180,6 +180,14 @@ static func max_length(left, right) -> int:
 	return rs if ls < rs else ls
 
 
+static func to_regex(pattern :String) -> RegEx:
+	var regex := RegEx.new()
+	var err := regex.compile(pattern)
+	if err != OK:
+		push_error("Can't compiling regx '%s'.\n ERROR: %s" % [pattern, GdUnitTools.error_as_string(err)])
+	return regex
+
+
 static func prints_verbose(message :String) -> void:
 	if OS.is_stdout_verbose():
 		print_debug(message)

--- a/addons/gdUnit4/src/core/parse/GdScriptParser.gd
+++ b/addons/gdUnit4/src/core/parse/GdScriptParser.gd
@@ -18,7 +18,7 @@ var TOKEN_FUNCTION_RETURN_TYPE := Token.new("->")
 var TOKEN_FUNCTION_END := Token.new("):")
 var TOKEN_ARGUMENT_ASIGNMENT := Token.new("=")
 var TOKEN_ARGUMENT_TYPE_ASIGNMENT := Token.new(":=")
-var TOKEN_ARGUMENT_FUZZER := FuzzerToken.new(prepare_regex("((?!(fuzzer_(seed|iterations)))fuzzer?\\w+)(=|:=|:Fuzzer=)"))
+var TOKEN_ARGUMENT_FUZZER := FuzzerToken.new(GdUnitTools.to_regex("((?!(fuzzer_(seed|iterations)))fuzzer?\\w+)(=|:=|:Fuzzer=)"))
 var TOKEN_ARGUMENT_TYPE := Token.new(":")
 var TOKEN_ARGUMENT_SEPARATOR := Token.new(",")
 var TOKEN_BRACKET_OPEN := Token.new("(")
@@ -63,14 +63,6 @@ var TOKENS := [
 var _regex_clazz_name :RegEx
 var _base_clazz :String
 var _scanned_inner_classes := PackedStringArray()
-
-
-static func prepare_regex(pattern :String) -> RegEx:
-	var regex := RegEx.new()
-	var err := regex.compile(pattern)
-	if err != OK:
-		push_error("Can't compiling regx '%s'.\n ERROR: %s" % [pattern, GdUnitTools.error_as_string(err)])
-	return regex
 
 
 static func clean_up_row(row :String) -> String:
@@ -276,7 +268,7 @@ class TokenInnerClass extends Token:
 
 
 func _init():
-	_regex_clazz_name = prepare_regex("(class)([a-zA-Z0-9]+)(extends[a-zA-Z]+:)|(class)([a-zA-Z0-9]+)(:)")
+	_regex_clazz_name = GdUnitTools.to_regex("(class)([a-zA-Z0-9]+)(extends[a-zA-Z]+:)|(class)([a-zA-Z0-9]+)(:)")
 
 
 func get_token(input :String, current_index) -> Token:

--- a/addons/gdUnit4/src/monitor/GodotGdErrorMonitor.gd
+++ b/addons/gdUnit4/src/monitor/GodotGdErrorMonitor.gd
@@ -1,66 +1,93 @@
 class_name GodotGdErrorMonitor
 extends GdUnitMonitor
 
+
+const USER_SCRIPT_ERROR := "USER SCRIPT ERROR:"
+const USER_PUSH_ERROR := "USER ERROR:"
+
 var _godot_log_file :String
 var _eof :int
 var _report_enabled := false
 
+
 func _init():
 	super("GodotGdErrorMonitor")
 	_godot_log_file = GdUnitSettings.get_log_path().get_base_dir() + "/godot.log"
-	_report_enabled = is_reporting_enabled()
+
 
 func start():
+	_report_enabled = is_reporting_enabled()
 	if _report_enabled:
 		var file = FileAccess.open(_godot_log_file, FileAccess.READ)
-		file.seek_end(0)
-		_eof = file.get_length()
+		if file:
+			file.seek_end(0)
+			_eof = file.get_length()
+
 
 func stop():
 	pass
 
-func reports() -> Array:
+
+func reports() -> Array[GdUnitReport]:
+	var reports :Array[GdUnitReport] = Array()
 	if _report_enabled:
-		return _scan_for_errors()
-	return []
+		var loggs := _collect_log_entries()
+		for index in loggs.size():
+			var message := loggs[index]
+			if _is_report_script_errors() and message.contains(USER_SCRIPT_ERROR):
+				reports.append(_report_runtime_error(message, loggs[index+1]))
+			if _is_report_push_errors() and message.contains(USER_PUSH_ERROR):
+				reports.append(_report_user_error(message, loggs[index+1]))
+	return reports
+
 
 func is_reporting_enabled() -> bool:
 	return _is_report_script_errors() or _is_report_push_errors()
 
-func _collect_seek_log() -> String:
+
+static func _report_runtime_error(error :String, details :String) -> GdUnitReport:
+	error = error.replace(USER_SCRIPT_ERROR, "").strip_edges()
+	details = details.strip_edges()
+	var line := _parse_error_line_number(details)
+	var failure := "%s\n\t%s\n%s %s" % [
+		GdAssertMessages._error("Runtime Error !"),
+		GdAssertMessages._colored_value(details),
+		GdAssertMessages._error("Error:"),
+		GdAssertMessages._colored_value(error)] 
+	return GdUnitReport.new().create(GdUnitReport.ABORT, line, failure)
+
+
+static func _report_user_error(error :String, details :String) -> GdUnitReport:
+	error = error.replace(USER_PUSH_ERROR, "").strip_edges()
+	details = details.strip_edges()
+	var line := _parse_error_line_number(details)
+	var failure := "%s\n\t%s\n%s %s" % [
+		GdAssertMessages._error("User Error !"),
+		GdAssertMessages._colored_value(details),
+		GdAssertMessages._error("Error:"),
+		GdAssertMessages._colored_value(error)] 
+	return GdUnitReport.new().create(GdUnitReport.ABORT, line, failure)
+
+
+func _collect_log_entries() -> PackedStringArray:
 	var file = FileAccess.open(_godot_log_file, FileAccess.READ)
 	file.seek(_eof)
-	var current_log := ""
-	var line := file.get_line()
-	while line != null and not file.eof_reached():
-		current_log += line + "\n"
-		line = file.get_line()
+	var current_log := PackedStringArray()
+	while not file.eof_reached():
+		current_log.append(file.get_line())
 	return current_log
 
-func _scan_for_errors() -> Array:
-	var _reports :Array = Array()
-	var loggs := _collect_seek_log().split("\n")
-	for index in loggs.size():
-		var message := loggs[index] as String
-		if _is_report_script_errors() and message.find("**SCRIPT ERROR**:") != -1:
-			var error = message + "\n" + loggs[index+1]
-			var line := _parse_error_line_number(error)
-			_reports.append(GdUnitReport.new().create(GdUnitReport.FAILURE, line, error))
-		if _is_report_push_errors() and message.find("**ERROR**:") != -1:
-			var error = message + "\n" + loggs[index+1]
-			_reports.append(GdUnitReport.new().create(GdUnitReport.FAILURE, -1, error))
-	return _reports
 
-func _parse_error_line_number(error :String) -> int:
-	var _regex := RegEx.new()
-	_regex.compile("(At: res:\\/\\/.*\\:(\\d+):)")
-	var matches := _regex.search_all(error)
-	if matches != null and matches.size() > 0:
-		return matches[0].get_string(2).to_int()
+static func _parse_error_line_number(error :String) -> int:
+	var matches := GdUnitTools.to_regex("at: .*res://.*:(\\d+)").search(error)
+	if matches != null:
+		return matches.get_string(1).to_int()
 	return -1
+
 
 func _is_report_push_errors() -> bool:
 	return GdUnitSettings.is_report_push_errors()
-	
+
+
 func _is_report_script_errors() -> bool:
 	return GdUnitSettings.is_report_script_errors()

--- a/addons/gdUnit4/src/ui/parts/InspectorTreeMainPanel.gd
+++ b/addons/gdUnit4/src/ui/parts/InspectorTreeMainPanel.gd
@@ -225,7 +225,7 @@ func set_state_failed(item :TreeItem) -> void:
 func set_state_error(item :TreeItem) -> void:
 	item.set_meta(META_GDUNIT_STATE, STATE.ERROR)
 	item.set_custom_color(0, Color.DARK_RED)
-	item.set_suffix(0, "timeout! " + item.get_suffix(0))
+	item.set_suffix(0, item.get_suffix(0))
 	item.set_icon(0, ICON_TEST_ERROR)
 	item.collapsed = false
 

--- a/addons/gdUnit4/test/core/GdUnitExecutorTest.gd
+++ b/addons/gdUnit4/test/core/GdUnitExecutorTest.gd
@@ -471,7 +471,7 @@ func test_execute_error_on_test_timeout() -> void:
 		[],
 		[],
 		# verify error reports to 'test_case1'
-		["Test timed out after 2s 0ms"],
+		["Timeout !\n 'Test timed out after 2s 0ms'"],
 		[],
 		[],
 		[])
@@ -569,6 +569,8 @@ func test_execute_parameterizied_tests() -> void:
 	var events = await execute(test_suite)
 	var suite_name = "TestSuiteParameterizedTests"
 	
+	# run the tests with to compare type save
+	ProjectSettings.set_setting(GdUnitSettings.REPORT_ASSERT_STRICT_NUMBER_TYPE_COMPARE, true)
 	# the test is partial failing because of diverent type in the dictionary
 	assert_array(events).extractv(
 		extr("type"), extr("suite_name"), extr("test_name"), extr("is_error"), extr("is_failed"), extr("orphan_nodes"))\

--- a/addons/gdUnit4/test/monitor/GodotGdErrorMonitorTest.gd
+++ b/addons/gdUnit4/test/monitor/GodotGdErrorMonitorTest.gd
@@ -9,56 +9,53 @@ const __source = 'res://addons/gdUnit4/src/monitor/GodotGdErrorMonitor.gd'
 
 
 const error_report = """
-	**ERROR**: Error parsing JSON at line 0: 
-   At: core/bind/core_bind.cpp:3293:parse() - Error parsing JSON at line 0: 
+	USER ERROR: this is an error
+	   at: push_error (core/variant/variant_utility.cpp:880)
 	"""
 const script_error = """
-	**SCRIPT ERROR**: Invalid call. Nonexistent function 'foo' in base 'RefCounted'.
-   At: res://test_test/test_test.gd:14:TestTest.test_with_script_errors() - Invalid call. Nonexistent function 'foo' in base 'RefCounted'.
-	"""
+	USER SCRIPT ERROR: Trying to call a function on a previously freed instance.
+	   at: GdUnitScriptTypeTest.test_xx (res://addons/gdUnit4/test/GdUnitScriptTypeTest.gd:22)
+"""
+
 
 func test_parse_script_error_line_number() -> void:
-	var line := GodotGdErrorMonitor.new()._parse_error_line_number(script_error)
-	assert_int(line).is_equal(14)
+	var line := GodotGdErrorMonitor.new()._parse_error_line_number(script_error.dedent())
+	assert_int(line).is_equal(22)
+
 
 func test_parse_push_error_line_number() -> void:
-	var line := GodotGdErrorMonitor.new()._parse_error_line_number(error_report)
+	var line := GodotGdErrorMonitor.new()._parse_error_line_number(error_report.dedent())
 	assert_int(line).is_equal(-1)
+
 
 func test_scan_for_push_errors() -> void:
 	var monitor := mock(GodotGdErrorMonitor, CALL_REAL_FUNC) as GodotGdErrorMonitor
 	monitor._report_enabled = true
-	do_return(error_report).checked(monitor)._collect_seek_log()
+	do_return(error_report.dedent().split('\n')).checked(monitor)._collect_log_entries()
 	
 	# with disabled push_error reporting
 	do_return(false).checked(monitor)._is_report_push_errors()
-	monitor._scan_for_errors()
 	assert_array(monitor.reports()).is_empty()
 	
 	# with enabled push_error reporting
 	do_return(true).checked(monitor)._is_report_push_errors()
-	monitor._scan_for_errors()
-	var error =\
-"""	**ERROR**: Error parsing JSON at line 0: 
-   At: core/bind/core_bind.cpp:3293:parse() - Error parsing JSON at line 0: """
-	var expected_report = GdUnitReport.new().create(GdUnitReport.FAILURE, -1, error)
+	
+	var expected_report := GodotGdErrorMonitor._report_user_error("USER ERROR: this is an error", "at: push_error (core/variant/variant_utility.cpp:880)")
 	assert_array(monitor.reports()).contains_exactly([expected_report])
+
 
 func test_scan_for_script_errors() -> void:
 	var monitor := mock(GodotGdErrorMonitor, CALL_REAL_FUNC) as GodotGdErrorMonitor
 	monitor._report_enabled = true
-	do_return(script_error).checked(monitor)._collect_seek_log()
+	do_return(script_error.dedent().split('\n')).checked(monitor)._collect_log_entries()
 	
 	# with disabled push_error reporting
 	do_return(false).checked(monitor)._is_report_script_errors()
-	monitor._scan_for_errors()
 	assert_array(monitor.reports()).is_empty()
 	
 	# with enabled push_error reporting
 	do_return(true).checked(monitor)._is_report_script_errors()
-	monitor._scan_for_errors()
-	var error =\
-"""	**SCRIPT ERROR**: Invalid call. Nonexistent function 'foo' in base 'RefCounted'.
-   At: res://test_test/test_test.gd:14:TestTest.test_with_script_errors() - Invalid call. Nonexistent function 'foo' in base 'RefCounted'."""
-	var expected_report = GdUnitReport.new().create(GdUnitReport.FAILURE, 14, error)
+	
+	var expected_report := GodotGdErrorMonitor._report_runtime_error("USER SCRIPT ERROR: Trying to call a function on a previously freed instance.",\
+		"at: GdUnitScriptTypeTest.test_xx (res://addons/gdUnit4/test/GdUnitScriptTypeTest.gd:22)")
 	assert_array(monitor.reports()).contains_exactly([expected_report])

--- a/project.godot
+++ b/project.godot
@@ -23,29 +23,15 @@ default_bus_layout=""
 gdscript/warnings/unused_signal=false
 gdscript/warnings/return_value_discarded=false
 
-[editor]
-
-export/convert_text_resources_to_binary=true
-
 [editor_plugins]
 
 enabled=PackedStringArray("res://addons/gdUnit4/plugin.cfg")
 
 [gdunit4]
 
+settings/common/update_notification_enabled=false
 report/assert/verbose_errors=false
 report/assert/verbose_warnings=false
-settings/common/update_notification_enabled=false
-settings/test/test_suite_naming_convention=0
-templates/testsuite/GDScript="# GdUnit generated TestSuite
-class_name ${suite_class_name}
-extends GdUnitTestSuite
-@warning_ignore(unused_parameter)
-@warning_ignore(return_value_discarded)
-
-# TestSuite generated from
-const __source = '${source_resource_path}'
-"
 
 [network]
 


### PR DESCRIPTION
# Why
When running test without debug info script errors was ignored and results into success

# What
- Fix the error monitor to parse godot.log for script errors
- Fix function await assert runtime errors
- Fix runtime error when test for `is_engine_type`
- rework on test timeout report generation
- Moved reg_ex helper func to 'GdUnitTools.to_regex'
- Removed invalid prefix 'timeout!' from tree inspector when a test has state error