### PR TITLE
GD-96: Fixed usage of `EditorPlugin.new()`

### DIFF
--- a/addons/gdUnit4/src/ui/GdUnitConsole.gd
+++ b/addons/gdUnit4/src/ui/GdUnitConsole.gd
@@ -37,12 +37,11 @@ func _notification(what):
 
 
 func init_colors() -> void:
-	var plugin := EditorPlugin.new()
+	var plugin :EditorPlugin = Engine.get_meta("GdUnitEditorPlugin")
 	var settings := plugin.get_editor_interface().get_editor_settings()
 	_text_color = settings.get_setting("text_editor/theme/highlighting/text_color")
 	_function_color = settings.get_setting("text_editor/theme/highlighting/function_color")
 	_engine_type_color = settings.get_setting("text_editor/theme/highlighting/engine_type_color")
-	plugin.free()
 
 
 func init_statistics(event :GdUnitEvent) :

--- a/addons/gdUnit4/src/ui/GdUnitInspector.gd
+++ b/addons/gdUnit4/src/ui/GdUnitInspector.gd
@@ -28,7 +28,7 @@ func _ready():
 	GdUnitSignals.instance().gdunit_client_connected.connect(Callable(self, "_on_client_connected"))
 	GdUnitSignals.instance().gdunit_client_disconnected.connect(Callable(self, "_on_client_disconnected"))
 	GdUnitSignals.instance().gdunit_event.connect(Callable(self, "_on_event"))
-	var plugin :EditorPlugin = Engine.get_meta("GdUnitEditorPlugin") as EditorPlugin
+	var plugin :EditorPlugin = Engine.get_meta("GdUnitEditorPlugin")
 	_editor_interface = plugin.get_editor_interface()
 	if Engine.is_editor_hint():
 		_getEditorThemes(_editor_interface)
@@ -55,7 +55,7 @@ func _process(_delta):
 	_check_test_run_stopped_manually()
 
 
-# is checking if the user has press the editor stop scene 
+# is checking if the user has press the editor stop scene
 func _check_test_run_stopped_manually():
 	if _is_test_running_but_stop_pressed():
 		if GdUnitSettings.is_verbose_assert_warnings():
@@ -132,7 +132,7 @@ func add_script_editor_context_menu():
 			return
 		var info := result.value() as Dictionary
 		ScriptEditorControls.edit_script(info.get("path"), info.get("line"))
-	
+
 	var menu := [
 		GdUnitContextMenuItem.new(GdUnitContextMenuItem.MENU_ID.TEST_RUN, "Run Tests", is_test_suite.bind(true), is_enabled, run_test.bind(false)),
 		GdUnitContextMenuItem.new(GdUnitContextMenuItem.MENU_ID.TEST_DEBUG, "Debug Tests", is_test_suite.bind(true), is_enabled, run_test.bind(true)),
@@ -169,7 +169,7 @@ func _gdUnit_run(debug :bool) -> void:
 	# don't start is already running
 	if _is_running:
 		return
-	
+
 	grab_focus()
 	show()
 	# save current selected excution config

--- a/addons/gdUnit4/src/ui/GdUnitToolsDialog.gd
+++ b/addons/gdUnit4/src/ui/GdUnitToolsDialog.gd
@@ -56,14 +56,14 @@ func setup_common_properties(properties_parent :Node, property_category) -> void
 		label.custom_minimum_size = Vector2(_font_size * 20, 0)
 		grid.add_child(label)
 		min_size += label.size.x
-		
+
 		# property reset btn
 		var reset_btn :Button = _properties_template.get_child(1).duplicate()
 		reset_btn.icon = _get_btn_icon("Reload")
 		reset_btn.disabled = property.value() == property.default()
 		grid.add_child(reset_btn)
 		min_size += reset_btn.size.x
-		
+
 		# property type specific input element
 		var input :Node = _create_input_element(property, reset_btn)
 		input.custom_minimum_size = Vector2(_font_size * 15, 0)
@@ -91,7 +91,7 @@ func _create_input_element(property: GdUnitProperty, reset_btn :Button) -> Node:
 		options.connect("item_selected", Callable(self, "_on_option_selected").bind(property, reset_btn))
 		options.select(property.value())
 		return options
-	if property.type() == TYPE_BOOL: 
+	if property.type() == TYPE_BOOL:
 		var check_btn := CheckButton.new()
 		check_btn.connect("toggled", Callable(self, "_on_property_text_changed").bind(property, reset_btn))
 		check_btn.button_pressed = property.value()
@@ -149,14 +149,13 @@ func _install_examples() -> void:
 
 func rescan(update_scripts :bool = false) -> void:
 	await get_tree().idle_frame
-	var plugin := EditorPlugin.new()
+	var plugin :EditorPlugin = Engine.get_meta("GdUnitEditorPlugin")
 	var fs := plugin.get_editor_interface().get_resource_filesystem()
 	fs.scan_sources()
 	while fs.is_scanning():
 		await get_tree().create_timer(1).timeout
 	if update_scripts:
 		plugin.get_editor_interface().get_resource_filesystem().update_script_classes()
-	plugin.free()
 
 
 func _on_btn_report_bug_pressed():

--- a/addons/gdUnit4/src/ui/parts/InspectorProgressBar.gd
+++ b/addons/gdUnit4/src/ui/parts/InspectorProgressBar.gd
@@ -8,11 +8,7 @@ extends ProgressBar
 func _ready():
 	GdUnitSignals.instance().gdunit_event.connect(Callable(self, "_on_gdunit_event"))
 	style.bg_color = Color.DARK_GREEN
-	#var plugin := EditorPlugin.new()
-	#var settings := plugin.get_editor_interface().get_editor_settings()
-	#var font_size = settings.get_setting("interface/editor/main_font_size")
-	#bar.minimum_size.y = font_size + 4 * plugin.get_editor_interface().get_editor_scale()
-	#plugin.free()
+
 
 func progress_init(max_value :int) -> void:
 	bar.value = 0

--- a/addons/gdUnit4/src/update/GdUnitUpdate.gd
+++ b/addons/gdUnit4/src/update/GdUnitUpdate.gd
@@ -8,7 +8,6 @@ extends ConfirmationDialog
 
 
 var _debug_mode := false
-var _plugin :EditorPlugin = Engine.get_meta("GdUnitEditorPlugin")
 
 
 func init_progress(max_value : int) -> void:
@@ -65,7 +64,8 @@ func run_update() -> void:
 func rescan() -> void:
 	await get_tree().process_frame
 	prints("Rescan Project")
-	var fs := _plugin.get_editor_interface().get_resource_filesystem()
+	var plugin :EditorPlugin = Engine.get_meta("GdUnitEditorPlugin")
+	var fs := plugin.get_editor_interface().get_resource_filesystem()
 	fs.scan_sources()
 	fs.update_script_classes()
 	fs.scan()
@@ -76,7 +76,8 @@ func rescan() -> void:
 
 func restart_godot() -> void:
 	prints("Force restart Godot")
-	_plugin.get_editor_interface().restart_editor(true)
+	var plugin :EditorPlugin = Engine.get_meta("GdUnitEditorPlugin")
+	plugin.get_editor_interface().restart_editor(true)
 
 
 static func enable_gdUnit() -> void:
@@ -90,7 +91,8 @@ static func enable_gdUnit() -> void:
 
 
 func disable_gdUnit() -> void:
-	_plugin.get_editor_interface().set_plugin_enabled("gdUnit4", false)
+	var plugin :EditorPlugin = Engine.get_meta("GdUnitEditorPlugin")
+	plugin.get_editor_interface().set_plugin_enabled("gdUnit4", false)
 
 
 const GDUNIT_TEMP := "user://tmp"

--- a/addons/gdUnit4/src/update/GdUnitUpdateNotify.gd
+++ b/addons/gdUnit4/src/update/GdUnitUpdateNotify.gd
@@ -117,12 +117,11 @@ func rescan() -> void:
 	await get_tree().process_frame
 	if Engine.is_editor_hint():
 		prints("Rescan Project")
-		var plugin := EditorPlugin.new()
+		var plugin :EditorPlugin = Engine.get_meta("GdUnitEditorPlugin")
 		var fs := plugin.get_editor_interface().get_resource_filesystem()
 		fs.scan()
 		while fs.is_scanning():
 			await get_tree().create_timer(.2).timeout
-		plugin.free()
 
 
 func _on_update_pressed():

--- a/addons/gdUnit4/test/ui/templates/TestSuiteTemplateTest.gd
+++ b/addons/gdUnit4/test/ui/templates/TestSuiteTemplateTest.gd
@@ -21,11 +21,11 @@ func test_load_template_gd() -> void:
 	runner.invoke("load_template", GdUnitTestSuiteTemplate.TEMPLATE_ID_GD)
 	
 	assert_int(runner.get_property("_selected_template")).is_equal(GdUnitTestSuiteTemplate.TEMPLATE_ID_GD)
-	assert_str(runner.get_property("_template_editor").text).is_equal(GdUnitTestSuiteDefaultTemplate.DEFAULT_TEMP_TS_GD.replace("\r\n", "\n"))
+	assert_str(runner.get_property("_template_editor").text).is_equal(GdUnitTestSuiteTemplate.default_GD_template().replace("\r", ""))
 
 func test_load_template_cs() -> void:
 	var runner := scene_runner("res://addons/gdUnit4/src/ui/templates/TestSuiteTemplate.tscn")
 	runner.invoke("load_template", GdUnitTestSuiteTemplate.TEMPLATE_ID_CS)
 	
 	assert_int(runner.get_property("_selected_template")).is_equal(GdUnitTestSuiteTemplate.TEMPLATE_ID_CS)
-	assert_str(runner.get_property("_template_editor").text).is_equal(GdUnitTestSuiteDefaultTemplate.DEFAULT_TEMP_TS_CS.replace("\r\n", "\n"))
+	assert_str(runner.get_property("_template_editor").text).is_equal(GdUnitTestSuiteTemplate.default_CS_template().replace("\r", ""))


### PR DESCRIPTION
# Why
Since beta15/16 the direct access to the editor interface over a manuall created editor plugin is broken.


# What
Reuse the already stored `GdUnitEditorPlugin` instance from the engine meta store instead