### PR TITLE
GD-99: Fix JSON parse exception occures on TCPServer when  many tests executed

### DIFF
--- a/addons/gdUnit4/src/asserts/GdUnitSignalAssertImpl.gd
+++ b/addons/gdUnit4/src/asserts/GdUnitSignalAssertImpl.gd
@@ -41,7 +41,7 @@ class SignalCollector extends GdUnitSingleton:
 			_collected_signals[emitter] = Dictionary()
 			# connect to 'tree_exiting' of the emitter to finally release all acquired resources/connections.
 			if !emitter.is_connected("tree_exiting", Callable(self, "unregister_emitter")):
-				emitter.connect("tree_exiting", Callable(self, "unregister_emitter").bind(self, emitter))
+				emitter.connect("tree_exiting", Callable(self, "unregister_emitter").bind(emitter))
 			# connect to all signals of the emitter we want to collect
 			for signal_def in emitter.get_signal_list():
 				var signal_name = signal_def["name"]
@@ -51,11 +51,13 @@ class SignalCollector extends GdUnitSingleton:
 				if SIGNAL_BLACK_LIST.find(signal_name) != -1:
 					continue
 				if !emitter.is_connected(signal_name,Callable(self, "_on_signal_emmited")):
-					emitter.connect(signal_name, Callable(self, "_on_signal_emmited").bind(emitter, signal_name))
+					var err := emitter.connect(signal_name, Callable(self, "_on_signal_emmited").bind(emitter, signal_name))
+					if err != OK:
+						push_error("Can't connect to signal %s on %s. Error: %s" % [signal_name, emitter, error_string(err)])
 	
 	# unregister all acquired resources/connections, otherwise it ends up in orphans
 	# is called when the emitter is removed from the parent
-	func unregister_emitter(receiver :SignalCollector, emitter :Object):
+	func unregister_emitter(emitter :Object):
 		GdUnitTools.release_connections(emitter)
 		if is_instance_valid(emitter):
 			_collected_signals.erase(emitter)

--- a/addons/gdUnit4/src/network/GdUnitTcpServer.gd
+++ b/addons/gdUnit4/src/network/GdUnitTcpServer.gd
@@ -8,64 +8,100 @@ signal rpc_data(rpc_data)
 
 var _server :TCPServer
 
+
 class TcpConnection extends Node:
 	var _id :int
-	var _stream : StreamPeerTCP
+	var _stream
+	var _readBuffer :String = ""
 	
-	func _init(server :TCPServer):
+	
+	func _init(server):
+		#assert(server is TCPServer)
 		_stream = server.take_connection()
 		_stream.set_big_endian(true)
 		_id = _stream.get_instance_id()
 		rpc_send(RPCClientConnect.new().with_id(_id))
 	
+	
 	func _ready():
-		get_parent().emit_signal("client_connected", _id)
+		server().client_connected.emit(_id)
+	
 	
 	func close() -> void:
 		rpc_send(RPCClientDisconnect.new().with_id(_id))
-		get_parent().emit_signal("client_disconnected", _id)
+		server().client_disconnected.emit(_id)
 		_stream.disconnect_from_host()
+		_readBuffer = ""
+	
 	
 	func id() -> int:
 		return _id
 	
+	
+	func server() -> GdUnitTcpServer:
+		return get_parent()
+	
+	
 	func rpc_send(rpc :RPC) -> void:
 		_stream.put_var(rpc.serialize(), true)
 	
+	
 	func _process(_delta):
 		if _stream.get_status() != StreamPeerTCP.STATUS_CONNECTED:
-			return null
-		var available_bytes := _stream.get_available_bytes()
+			return
+		receive_packages()
+	
+	
+	func receive_packages() -> void:
+		var available_bytes = _stream.get_available_bytes()
 		if available_bytes > 0:
-			var data := _stream.get_partial_data(available_bytes)
+			var partial_data = _stream.get_partial_data(available_bytes)
 			# Check for read error.
-			if data[0] != OK:
-				push_error("Error getting data from stream: %s " % data[0])
+			if partial_data[0] != OK:
+				push_error("Error getting data from stream: %s " % partial_data[0])
 				return
 			else:
-				var data_package :PackedByteArray = data[1]
-				var json_array := data_package.get_string_from_ascii().split(GdUnitServerConstants.JSON_RESPONSE_DELIMITER)
-				for json in json_array:
-					# ignore empty jsons
-					if json.is_empty():
-						continue
-					var rpc = RPC.deserialize(json)
+				var received_data := partial_data[1] as PackedByteArray
+				for package in _read_next_data_packages(received_data):
+					var rpc = RPC.deserialize(package)
 					if rpc is RPCClientDisconnect:
 						close()
-					get_parent().emit_signal("rpc_data", rpc)
+					server().rpc_data.emit(rpc)
+	
+	
+	func _read_next_data_packages(data_package :PackedByteArray) -> PackedStringArray:
+		_readBuffer += data_package.get_string_from_ascii()
+		var json_array := _readBuffer.split(GdUnitServerConstants.JSON_RESPONSE_DELIMITER)
+		# We need to check if the current data is terminated by the delemiter (data packets can be split unspecifically).
+		# If not, store the last part in _readBuffer and complete it on the next data packet that is received
+		if not _readBuffer.ends_with(GdUnitServerConstants.JSON_RESPONSE_DELIMITER):
+			_readBuffer = json_array[-1]
+			json_array.remove_at(json_array.size()-1)
+		else:
+		# Reset the buffer if a completely terminated packet was received
+			_readBuffer = ""
+		# remove empty packages
+		for index in range(json_array.size()-1, -1, -1):
+			if json_array[index].is_empty():
+				json_array.remove_at(index)
+		return json_array
+	
 	
 	func console(message :String) -> void:
 		#print_debug("TCP Connection:", message)
 		pass
 
+
 func _ready():
 	_server = TCPServer.new()
-	connect("client_connected", Callable(self, "_on_client_connected"))
-	connect("client_disconnected", Callable(self, "_on_client_disconnected"))
+	client_connected.connect(Callable(self, "_on_client_connected"))
+	client_disconnected.connect(Callable(self, "_on_client_disconnected"))
+
 
 func _notification(what):
 	if what == NOTIFICATION_PREDELETE:
 		stop()
+
 
 func start() -> Result:
 	var server_port := GdUnitServerConstants.GD_TEST_SERVER_PORT
@@ -73,47 +109,54 @@ func start() -> Result:
 	for retry in GdUnitServerConstants.DEFAULT_SERVER_START_RETRY_TIMES:
 		err = _server.listen(server_port, "127.0.0.1")
 		if err != OK:
-			prints("GdUnit3: Can't establish server checked port %d, error code: %s" % [server_port, err])
+			prints("GdUnit3: Can't establish server checked port: %d, Error: %s" % [server_port, error_string(err)])
 			server_port += 1
 			prints("GdUnit3: Retry (%d) ..." % retry)
 		else:
 			break
 	if err != OK:
 		if err == ERR_ALREADY_IN_USE:
-			return Result.error("GdUnit3: Can't establish server, error code: %s, The server is already in use" % err)
-		return Result.error("GdUnit3: Can't establish server, error code: %s" % err)
-	prints("GdUnit3: Server successfully started checked port %d" % server_port)
+			return Result.error("GdUnit3: Can't establish server, the server is already in use. Error: %s, " % error_string(err))
+		return Result.error("GdUnit3: Can't establish server. Error: %s." % error_string(err))
+	prints("GdUnit3: Test server successfully started checked port: %d" % server_port)
 	return Result.success(server_port)
 
+
 func stop() -> void:
-	_server.stop()
+	if _server:
+		_server.stop()
 	for connection in get_children():
 		if connection is TcpConnection:
 			connection.close()
 			remove_child(connection)
+
 
 func disconnect_client(client_id :int) -> void:
 	for connection in get_children():
 		if connection is TcpConnection and connection.id() == client_id:
 			connection.close()
 
+
 func _process(_delta):
 	if not _server.is_listening():
 		return
-	
 	# check is new connection incomming
 	if _server.is_connection_available():
 		add_child(TcpConnection.new(_server))
 
+
 func _on_client_connected(client_id :int):
-	console("client connected %d" % client_id)
+	console("Client connected %d" % client_id)
+
 
 func _on_client_disconnected(client_id :int):
-	console("client disconnected %d" % client_id)
+	console("Client disconnected %d" % client_id)
 	for connection in get_children():
 		if connection is TcpConnection and connection.id() == client_id:
 			remove_child(connection)
-	
+
+
+
 func console(message :String) -> void:
 	#print_debug("TCP Server:", message)
 	pass

--- a/addons/gdUnit4/test/network/GdUnitTcpServerTest.gd
+++ b/addons/gdUnit4/test/network/GdUnitTcpServerTest.gd
@@ -1,0 +1,88 @@
+# GdUnit generated TestSuite
+class_name GdUnitTcpServerTest
+extends GdUnitTestSuite
+@warning_ignore('unused_parameter')
+@warning_ignore('return_value_discarded')
+
+# TestSuite generated from
+const __source = 'res://addons/gdUnit4/src/network/GdUnitTcpServer.gd'
+
+const DLM := GdUnitServerConstants.JSON_RESPONSE_DELIMITER
+
+func test_read_next_data_packages() -> void:
+	var server = mock(TCPServer)
+	var stream = mock(StreamPeerTCP)
+	
+	do_return(stream).checked(server).take_connection()
+	
+	var connection :GdUnitTcpServer.TcpConnection = auto_free(GdUnitTcpServer.TcpConnection.new(server))
+	
+	# single package
+	var data = DLM + "aaaa" + DLM
+	var data_packages := connection._read_next_data_packages(data.to_utf8_buffer())
+	assert_array(data_packages).contains_exactly(["aaaa"])
+	
+	# many package
+	data = DLM + "aaaa" + DLM + "bbbb" + DLM + "cccc" + DLM + "dddd" + DLM + "eeee" + DLM
+	data_packages = connection._read_next_data_packages(data.to_utf8_buffer())
+	assert_array(data_packages).contains_exactly(["aaaa", "bbbb", "cccc", "dddd", "eeee"])
+	
+	# with splitted package
+	data_packages.clear()
+	var data1 := DLM + "aaaa" + DLM + "bbbb" + DLM + "cc"
+	var data2 := "cc" + DLM + "dd"
+	var data3 := "dd" + DLM + "eeee" + DLM
+	data_packages.append_array(connection._read_next_data_packages(data1.to_utf8_buffer()))
+	data_packages.append_array(connection._read_next_data_packages(data2.to_utf8_buffer()))
+	data_packages.append_array(connection._read_next_data_packages(data3.to_utf8_buffer()))
+	assert_array(data_packages).contains_exactly(["aaaa", "bbbb", "cccc", "dddd", "eeee"])
+
+
+func test_receive_packages() -> void:
+	var server = mock(TCPServer)
+	var stream = mock(StreamPeerTCP)
+	
+	do_return(stream).checked(server).take_connection()
+	
+	var connection :GdUnitTcpServer.TcpConnection = auto_free(GdUnitTcpServer.TcpConnection.new(server))
+	var test_server :GdUnitTcpServer = auto_free(GdUnitTcpServer.new())
+	test_server.add_child(connection)
+	# create a signal collector to catch all signals emitted on the test server during `receive_packages()`
+	var signal_collector := signal_collector(test_server)
+	
+	# mock send RPCMessage
+	var data := DLM + RPCMessage.of("Test Message").serialize() + DLM
+	var package_data = [0, data.to_ascii_buffer()]
+	do_return(data.length()).checked(stream).get_available_bytes()
+	do_return(package_data).checked(stream).get_partial_data(data.length())
+	
+	# do receive next packages
+	connection.receive_packages()
+	
+	# expect the RPCMessage is received and emitted
+	assert_that(signal_collector.is_emitted("rpc_data", [RPCMessage.of("Test Message")])).is_true()
+
+
+# TODO refactor out and provide as public interface to can be reuse on other tests
+class GdUnitSignalCollector:
+	var _signalCollector :GdUnitSignalAssertImpl.SignalCollector
+	var _emitter :Variant
+	
+	
+	func _init(emitter :Variant):
+		_emitter = emitter
+		_signalCollector = GdUnitSignalAssertImpl.SignalCollector.new()
+		_signalCollector.register_emitter(emitter)
+	
+	
+	func is_emitted(signal_name :String, expected_args :Array) -> bool:
+		return _signalCollector.match(_emitter, signal_name, expected_args)
+	
+	
+	func _notification(what):
+		if what == NOTIFICATION_PREDELETE:
+			_signalCollector.unregister_emitter(_emitter)
+
+
+func signal_collector(instance :Variant) -> GdUnitSignalCollector:
+	return GdUnitSignalCollector.new(instance)


### PR DESCRIPTION
# Why
Run tests over the whole project was resuling in a JSON parse exception. The received packages can be partial data and needs to handled before parsing.

# What
- Rework on `TcpConnection` and store first data packages in a temporary read buffer.
- Process the read buffer and extract only valid packages by using the delemiter
- Add test coverage for handling partial data packages
 - using a signal collector to check the expected RPC data is emitted
- simplify and improve SignalCollector by better error handling