### PR TITLE
GD-75: Fix test parameter parsing of parameterized tests with String arguments

### DIFF
--- a/addons/gdUnit4/src/core/parse/GdScriptParser.gd
+++ b/addons/gdUnit4/src/core/parse/GdScriptParser.gd
@@ -18,7 +18,7 @@ var TOKEN_FUNCTION_RETURN_TYPE := Token.new("->")
 var TOKEN_FUNCTION_END := Token.new("):")
 var TOKEN_ARGUMENT_ASIGNMENT := Token.new("=")
 var TOKEN_ARGUMENT_TYPE_ASIGNMENT := Token.new(":=")
-var TOKEN_ARGUMENT_FUZZER := FuzzerToken.new(GdUnitTools.to_regex("((?!(fuzzer_(seed|iterations)))fuzzer?\\w+)(=|:=|:Fuzzer=)"))
+var TOKEN_ARGUMENT_FUZZER := FuzzerToken.new(GdUnitTools.to_regex("((?!(fuzzer_(seed|iterations)))fuzzer?\\w+)( ?+= ?+| ?+:= ?+| ?+:Fuzzer ?+= ?+|)"))
 var TOKEN_ARGUMENT_TYPE := Token.new(":")
 var TOKEN_ARGUMENT_SEPARATOR := Token.new(",")
 var TOKEN_BRACKET_OPEN := Token.new("(")
@@ -66,7 +66,7 @@ var _scanned_inner_classes := PackedStringArray()
 
 
 static func clean_up_row(row :String) -> String:
-	return to_unix_format(row.replace(" ", "").replace("	", ""))
+	return to_unix_format(row.replace(" ", "").replace("\t", ""))
 
 
 static func to_unix_format(input :String) -> String:
@@ -79,7 +79,7 @@ class Token extends RefCounted:
 	var _is_operator: bool
 	var _regex :RegEx
 	
-	func _init(token: String, is_operator := false, regex :RegEx = null):
+	func _init(token: String, is_operator := false, regex :RegEx = null) -> void:
 		_token = token
 		_is_operator = is_operator
 		_consumed = token.length()
@@ -360,20 +360,22 @@ func parse_func_return_type(row: String) -> int:
 		return TYPE_NIL
 	return token.type()
 
-
-func parse_return_token(row: String) -> Token:
-	var input := clean_up_row(row)
+func parse_return_token(input: String) -> Token:
 	var index := input.rfind(TOKEN_FUNCTION_RETURN_TYPE._token)
 	if index == -1:
 		return TOKEN_NOT_MATCH
-	return next_token(input, index + TOKEN_FUNCTION_RETURN_TYPE._consumed)
+	index += TOKEN_FUNCTION_RETURN_TYPE._consumed
+	var token := next_token(input, index)
+	if token == TOKEN_SPACE:
+		index += TOKEN_SPACE._consumed
+		token = next_token(input, index)
+	return token
 
 
 # Parses the argument into a argument signature
 # e.g. func foo(arg1 :int, arg2 = 20) -> [arg1, arg2]
-func parse_arguments(row: String) -> Array[GdFunctionArgument]:
+func parse_arguments(input: String) -> Array[GdFunctionArgument]:
 	var args := Array()
-	var input := clean_up_row(row)
 	var current_index := 0
 	var token :Token = null
 	var bracket := 0
@@ -381,6 +383,8 @@ func parse_arguments(row: String) -> Array[GdFunctionArgument]:
 	while current_index < len(input):
 		token = next_token(input, current_index)
 		current_index += token._consumed
+		if token == TOKEN_SPACE:
+			continue
 		if token == TOKEN_BRACKET_OPEN:
 			in_function = true
 			bracket += 1
@@ -410,8 +414,14 @@ func parse_arguments(row: String) -> Array[GdFunctionArgument]:
 			while current_index < len(input):
 				token = next_token(input, current_index)
 				current_index += token._consumed
-				if token == TOKEN_ARGUMENT_TYPE:
+				#match token:
+				if token == TOKEN_SPACE:
+						continue
+				elif token == TOKEN_ARGUMENT_TYPE:
 						token = next_token(input, current_index)
+						if token == TOKEN_SPACE:
+							current_index += token._consumed
+							token = next_token(input, current_index)
 						arg_type = GdObjects.string_as_typeof(token._token)
 				elif token == TOKEN_ARGUMENT_TYPE_ASIGNMENT:
 						arg_value = _parse_end_function(input.substr(current_index), true)
@@ -438,7 +448,9 @@ func parse_arguments(row: String) -> Array[GdFunctionArgument]:
 				elif token == TOKEN_ARGUMENT_SEPARATOR:
 						if bracket <= 1:
 							break
+			arg_value = arg_value.lstrip(" ")
 			if arg_type == TYPE_NIL and arg_value != GdFunctionArgument.UNDEFINED:
+				var value_type := TYPE_STRING
 				if arg_value.begins_with("Color."):
 					arg_type = TYPE_COLOR
 				elif arg_value.begins_with("Vector2."):
@@ -547,9 +559,9 @@ func extract_source_code(script_path :PackedStringArray) -> PackedStringArray:
 func extract_func_signature(rows :PackedStringArray, index :int) -> String:
 	var signature = ""
 	for rowIndex in range(index, rows.size()):
-		signature += rows[rowIndex].strip_edges()
+		signature += rows[rowIndex].strip_edges().replace("\t", "")
 		if is_func_end(signature):
-			return clean_up_row(signature)
+			return signature
 	push_error("Can't fully extract function signature of '%s'" % rows[index])
 	return ""
 
@@ -589,11 +601,15 @@ func get_class_name(script :GDScript) -> String:
 
 func parse_func_name(row :String) -> String:
 	var input = clean_up_row(row)
-	var token := next_token(input, 0)
+	var current_index = 0
+	var token := next_token(input, current_index)
+	current_index += token._consumed
 	if token != TOKEN_FUNCTION_STATIC_DECLARATION and token != TOKEN_FUNCTION_DECLARATION:
 		return ""
-	var next := next_token(input, token._consumed)
-	return next._token
+	while not token is Variable:
+		token = next_token(input, current_index)
+		current_index += token._consumed
+	return token._token
 
 
 func parse_functions(rows :PackedStringArray, clazz_name :String, clazz_path :PackedStringArray, included_functions :PackedStringArray = PackedStringArray()) -> Array:

--- a/addons/gdUnit4/test/core/GdUnitExecutorTest.gd
+++ b/addons/gdUnit4/test/core/GdUnitExecutorTest.gd
@@ -11,20 +11,25 @@ var _executor :GdUnitExecutor
 var _events :Array = Array()
 var _stack : Array = []
 
+
 func before():
 	_executor = GdUnitExecutor.new(true)
 	_executor.gdunit_event_test.connect(Callable(self, "_on_gdunit_event_test"))
 	add_child(_executor)
 
+
 func before_test():
 	# clean the stack before every test run
 	_stack.clear()
 
+
 func resource(resource_path :String) -> GdUnitTestSuite:
 	return GdUnitTestResourceLoader.load_test_suite(resource_path) as GdUnitTestSuite
 
+
 func _on_gdunit_event_test(event :GdUnitEvent) -> void:
 	_events.append(event)
+
 
 func execute(test_suite :GdUnitTestSuite, enable_orphan_detection := true):
 	add_child(test_suite)
@@ -33,6 +38,7 @@ func execute(test_suite :GdUnitTestSuite, enable_orphan_detection := true):
 	_executor.execute(test_suite)
 	await _executor.ExecutionCompleted
 	return _events
+
 
 func filter_failures(events :Array) -> Array:
 	var filtered_events := Array()
@@ -43,8 +49,10 @@ func filter_failures(events :Array) -> Array:
 			filtered_events.append(event)
 	return filtered_events
 
+
 func flating_message(message :String) -> String:
 	return GdUnitAssertImpl._normalize_bbcode(message)
+
 
 func assert_event_reports(events :Array, reports1 :Array, reports2 :Array, reports3 :Array, reports4 :Array, reports5 :Array, reports6 :Array) -> void:
 	var expected_reports := [reports1, reports2, reports3, reports4, reports5, reports6]
@@ -61,8 +69,8 @@ func assert_event_reports(events :Array, reports1 :Array, reports2 :Array, repor
 			else:
 				assert_str("<N/A>").is_equal(expected[m])
 
+
 func assert_event_list(events :Array, suite_name :String, test_case_names = ["test_case1", "test_case2"]) -> void:
-	
 	var expected_events := Array()
 	expected_events.append(tuple(GdUnitEvent.TESTSUITE_BEFORE, suite_name, "before", test_case_names.size()))
 	for test_case in test_case_names:
@@ -74,11 +82,14 @@ func assert_event_list(events :Array, suite_name :String, test_case_names = ["te
 		extr("type"), extr("suite_name"), extr("test_name"), extr("total_count"))\
 		.contains_exactly(expected_events)
 
+
 func assert_event_counters(events :Array) -> GdUnitArrayAssert:
 	return assert_array(events).extractv(extr("type"), extr("error_count"), extr("failed_count"), extr("orphan_nodes"))
 
+
 func assert_event_states(events :Array) -> GdUnitArrayAssert:
 	return assert_array(events).extractv(extr("test_name"), extr("is_success"), extr("is_warning"), extr("is_failed"), extr("is_error"))
+
 
 func test_execute_success() -> void:
 	var test_suite := resource("res://addons/gdUnit4/test/core/resources/testsuites/TestSuiteAllStagesSuccess.resource")
@@ -107,6 +118,7 @@ func test_execute_success() -> void:
 	])
 	# all success no reports expected
 	assert_event_reports(events, [], [], [], [], [], [])
+
 
 func test_execute_failure_on_stage_before() -> void:
 	var test_suite := resource("res://addons/gdUnit4/test/core/resources/testsuites/TestSuiteFailOnStageBefore.resource")
@@ -145,6 +157,7 @@ func test_execute_failure_on_stage_before() -> void:
 		[], 
 		["failed on before()"])
 
+
 func test_execute_failure_on_stage_after() -> void:
 	var test_suite := resource("res://addons/gdUnit4/test/core/resources/testsuites/TestSuiteFailOnStageAfter.resource")
 	# verify all test cases loaded
@@ -181,6 +194,7 @@ func test_execute_failure_on_stage_after() -> void:
 		[], 
 		[],
 		["failed on after()"])
+
 
 func test_execute_failure_on_stage_before_test() -> void:
 	var test_suite := resource("res://addons/gdUnit4/test/core/resources/testsuites/TestSuiteFailOnStageBeforeTest.resource")
@@ -222,6 +236,7 @@ func test_execute_failure_on_stage_before_test() -> void:
 		["failed on before_test()"],
 		[])
 
+
 func test_execute_failure_on_stage_after_test() -> void:
 	var test_suite := resource("res://addons/gdUnit4/test/core/resources/testsuites/TestSuiteFailOnStageAfterTest.resource")
 	# verify all test cases loaded
@@ -262,6 +277,7 @@ func test_execute_failure_on_stage_after_test() -> void:
 		["failed on after_test()"],
 		[])
 
+
 func test_execute_failure_on_stage_test_case1() -> void:
 	var test_suite := resource("res://addons/gdUnit4/test/core/resources/testsuites/TestSuiteFailOnStageTestCase1.resource")
 	# verify all test cases loaded
@@ -298,6 +314,7 @@ func test_execute_failure_on_stage_test_case1() -> void:
 		[], 
 		[], 
 		[])
+
 
 func test_execute_failure_on_multiple_stages() -> void:
 	# this is a more complex failure state, we expect to find multipe failures on different stages
@@ -340,6 +357,7 @@ func test_execute_failure_on_multiple_stages() -> void:
 		["failed on before_test()"],
 		# and one failure detected at stage 'after'
 		["failed on after()"])
+
 
 # GD-63
 func test_execute_failure_and_orphans() -> void:
@@ -392,6 +410,7 @@ func test_execute_failure_and_orphans() -> void:
 		# and one failure detected at stage 'after'
 		["WARNING:\n Detected <1> orphan nodes during test suite setup stage! Check before() and after()!"])
 
+
 # GD-62
 func test_execute_failure_and_orphans_report_orphan_disabled() -> void:
 	# this is a more complex failure state, we expect to find multipe orphans on different stages
@@ -433,6 +452,7 @@ func test_execute_failure_and_orphans_report_orphan_disabled() -> void:
 		# ends with a failure
 		["faild on test_case2()"],
 		[])
+
 
 # GD-66
 func test_execute_error_on_test_timeout() -> void:
@@ -476,6 +496,7 @@ func test_execute_error_on_test_timeout() -> void:
 		[],
 		[])
 
+
 func test_execute_failure_fuzzer_iteration() -> void:
 	# this tests a timeout on a test case reported as error
 	var test_suite := resource("res://addons/gdUnit4/test/core/resources/testsuites/GdUnitFuzzerTest.resource")
@@ -516,6 +537,7 @@ func test_execute_failure_fuzzer_iteration() -> void:
 		["Found an error after '3' test iterations\n Expecting: 'false' but is 'true'"],
 		[])
 
+
 func test_execute_add_child_on_before_GD_106() -> void:
 	var test_suite := resource("res://addons/gdUnit4/test/core/resources/testsuites/TestSuiteFailAddChildStageBefore.resource")
 	# verify all test cases loaded
@@ -543,6 +565,7 @@ func test_execute_add_child_on_before_GD_106() -> void:
 	])
 	# all success no reports expected
 	assert_event_reports(events, [], [], [], [], [], [])
+
 
 func test_fuzzer_before_before(fuzzer := Fuzzers.rangei(0, 1000), fuzzer_iterations = 1000):
 	# verify the used stack is cleaned by 'before_test'
@@ -614,6 +637,7 @@ func test_execute_parameterizied_tests() -> void:
 		])
 	# restore default settings
 	ProjectSettings.set_setting(GdUnitSettings.REPORT_ASSERT_STRICT_NUMBER_TYPE_COMPARE, true)
+
 
 func add_expected_test_case_events(suite_name :String, test_name :String, parameters :Array = []) -> Array:
 	var expected_events := Array()

--- a/addons/gdUnit4/test/core/GdUnitTestSuiteScannerTest.gd
+++ b/addons/gdUnit4/test/core/GdUnitTestSuiteScannerTest.gd
@@ -218,21 +218,21 @@ func test_create_test_case():
 func test_build_test_suite_path() -> void:
 	# checked project root
 	assert_str(GdUnitTestSuiteScanner.resolve_test_suite_path("res://new_script.gd")).is_equal("res://test/new_script_test.gd")
-
+	
 	# checked project without src folder
 	assert_str(GdUnitTestSuiteScanner.resolve_test_suite_path("res://foo/bar/new_script.gd")).is_equal("res://test/foo/bar/new_script_test.gd")
-
+	
 	# project code structured by 'src'
 	assert_str(GdUnitTestSuiteScanner.resolve_test_suite_path("res://src/new_script.gd")).is_equal("res://test/new_script_test.gd")
 	assert_str(GdUnitTestSuiteScanner.resolve_test_suite_path("res://src/foo/bar/new_script.gd")).is_equal("res://test/foo/bar/new_script_test.gd")
 	# folder name contains 'src' in name
 	assert_str(GdUnitTestSuiteScanner.resolve_test_suite_path("res://foo/srcare/new_script.gd")).is_equal("res://test/foo/srcare/new_script_test.gd")
-
+	
 	# checked plugins without src folder
 	assert_str(GdUnitTestSuiteScanner.resolve_test_suite_path("res://addons/plugin/foo/bar/new_script.gd")).is_equal("res://addons/plugin/test/foo/bar/new_script_test.gd")
 	# plugin code structured by 'src'
 	assert_str(GdUnitTestSuiteScanner.resolve_test_suite_path("res://addons/plugin/src/foo/bar/new_script.gd")).is_equal("res://addons/plugin/test/foo/bar/new_script_test.gd")
-
+	
 	# checked user temp folder
 	var tmp_path := GdUnitTools.create_temp_dir("projectX/entity")
 	var source_path := tmp_path + "/Person.gd"
@@ -246,7 +246,7 @@ func test_parse_and_add_test_cases() -> void:
 	var test_suite :GdUnitTestSuite = auto_free(GdUnitTestSuite.new())
 	test_suite.set_script( load("res://addons/gdUnit4/test/core/resources/test_script_with_arguments.gd"))
 	var line_number :int = 0
-
+	
 	var test_case_names := PackedStringArray([
 		"test_no_args",
 		"test_with_timeout",
@@ -262,23 +262,23 @@ func test_parse_and_add_test_cases() -> void:
 		.contains_exactly([
 			tuple("test_no_args", default_time, [], Fuzzer.ITERATION_DEFAULT_COUNT),
 			tuple("test_with_timeout", 2000, [], Fuzzer.ITERATION_DEFAULT_COUNT),
-			tuple("test_with_fuzzer", default_time, [GdFunctionArgument.new("fuzzer", GdObjects.TYPE_FUZZER, "Fuzzers.rangei(-10,22)")], Fuzzer.ITERATION_DEFAULT_COUNT),
-			tuple("test_with_fuzzer_iterations", default_time, [GdFunctionArgument.new("fuzzer", GdObjects.TYPE_FUZZER, "Fuzzers.rangei(-10,22)")], 10),
-			tuple("test_with_multible_fuzzers", default_time, [GdFunctionArgument.new("fuzzer_a", GdObjects.TYPE_FUZZER, "Fuzzers.rangei(-10,22)"),
-				GdFunctionArgument.new("fuzzer_b", GdObjects.TYPE_FUZZER, "Fuzzers.rangei(23,42)")], 10),
-			tuple("test_multiline_arguments_a", default_time, [GdFunctionArgument.new("fuzzer_a", GdObjects.TYPE_FUZZER, "Fuzzers.rangei(-10,22)"),
-				GdFunctionArgument.new("fuzzer_b", GdObjects.TYPE_FUZZER, "Fuzzers.rangei(23,42)")], 42),
-			tuple("test_multiline_arguments_b", default_time, [GdFunctionArgument.new("fuzzer_a", GdObjects.TYPE_FUZZER, "Fuzzers.rangei(-10,22)"),
-				GdFunctionArgument.new("fuzzer_b", GdObjects.TYPE_FUZZER, "Fuzzers.rangei(23,42)")], 23),
-			tuple("test_multiline_arguments_c", 2000, [GdFunctionArgument.new("fuzzer_a", GdObjects.TYPE_FUZZER, "Fuzzers.rangei(-10,22)"),
-				GdFunctionArgument.new("fuzzer_b", GdObjects.TYPE_FUZZER, "Fuzzers.rangei(23,42)")], 33)
+			tuple("test_with_fuzzer", default_time, [GdFunctionArgument.new("fuzzer", GdObjects.TYPE_FUZZER, "Fuzzers.rangei(-10, 22)")], Fuzzer.ITERATION_DEFAULT_COUNT),
+			tuple("test_with_fuzzer_iterations", default_time, [GdFunctionArgument.new("fuzzer", GdObjects.TYPE_FUZZER, "Fuzzers.rangei(-10, 22)")], 10),
+			tuple("test_with_multible_fuzzers", default_time, [GdFunctionArgument.new("fuzzer_a", GdObjects.TYPE_FUZZER, "Fuzzers.rangei(-10, 22)"),
+				GdFunctionArgument.new("fuzzer_b", GdObjects.TYPE_FUZZER, "Fuzzers.rangei(23, 42)")], 10),
+			tuple("test_multiline_arguments_a", default_time, [GdFunctionArgument.new("fuzzer_a", GdObjects.TYPE_FUZZER, "Fuzzers.rangei(-10, 22)"),
+				GdFunctionArgument.new("fuzzer_b", GdObjects.TYPE_FUZZER, "Fuzzers.rangei(23, 42)")], 42),
+			tuple("test_multiline_arguments_b", default_time, [GdFunctionArgument.new("fuzzer_a", GdObjects.TYPE_FUZZER, "Fuzzers.rangei(-10, 22)"),
+				GdFunctionArgument.new("fuzzer_b", GdObjects.TYPE_FUZZER, "Fuzzers.rangei(23, 42)")], 23),
+			tuple("test_multiline_arguments_c", 2000, [GdFunctionArgument.new("fuzzer_a", GdObjects.TYPE_FUZZER, "Fuzzers.rangei(-10, 22)"),
+				GdFunctionArgument.new("fuzzer_b", GdObjects.TYPE_FUZZER, "Fuzzers.rangei(23, 42)")], 33)
 			])
 
 
 func test_scan_by_inheritance_class_name() -> void:
 	var scanner :GdUnitTestSuiteScanner = auto_free(GdUnitTestSuiteScanner.new())
 	var test_suites := scanner.scan("res://addons/gdUnit4/test/core/resources/scan_testsuite_inheritance/by_class_name/")
-
+	
 	assert_array(test_suites).extractv(extr("get_name"), extr("get_script.get_path"), extr("get_children.get_name"))\
 		.contains_exactly_in_any_order([
 			tuple("BaseTest", "res://addons/gdUnit4/test/core/resources/scan_testsuite_inheritance/by_class_name/BaseTest.gd", [&"test_foo1"]),
@@ -293,7 +293,7 @@ func test_scan_by_inheritance_class_name() -> void:
 func test_scan_by_inheritance_class_path() -> void:
 	var scanner :GdUnitTestSuiteScanner = auto_free(GdUnitTestSuiteScanner.new())
 	var test_suites := scanner.scan("res://addons/gdUnit4/test/core/resources/scan_testsuite_inheritance/by_class_path/")
-
+	
 	assert_array(test_suites).extractv(extr("get_name"), extr("get_script.get_path"), extr("get_children.get_name"))\
 		.contains_exactly_in_any_order([
 			tuple("BaseTest", "res://addons/gdUnit4/test/core/resources/scan_testsuite_inheritance/by_class_path/BaseTest.gd", [&"test_foo1"]),
@@ -315,12 +315,12 @@ func test__to_naming_convention() -> void:
 	assert_str(GdUnitTestSuiteScanner._to_naming_convention("MyClass")).is_equal("MyClassTest")
 	assert_str(GdUnitTestSuiteScanner._to_naming_convention("my_class")).is_equal("my_class_test")
 	assert_str(GdUnitTestSuiteScanner._to_naming_convention("myclass")).is_equal("myclass_test")
-
+	
 	ProjectSettings.set_setting(GdUnitSettings.TEST_SITE_NAMING_CONVENTION, GdUnitSettings.NAMING_CONVENTIONS.SNAKE_CASE)
 	assert_str(GdUnitTestSuiteScanner._to_naming_convention("MyClass")).is_equal("my_class_test")
 	assert_str(GdUnitTestSuiteScanner._to_naming_convention("my_class")).is_equal("my_class_test")
 	assert_str(GdUnitTestSuiteScanner._to_naming_convention("myclass")).is_equal("myclass_test")
-
+	
 	ProjectSettings.set_setting(GdUnitSettings.TEST_SITE_NAMING_CONVENTION, GdUnitSettings.NAMING_CONVENTIONS.PASCAL_CASE)
 	assert_str(GdUnitTestSuiteScanner._to_naming_convention("MyClass")).is_equal("MyClassTest")
 	assert_str(GdUnitTestSuiteScanner._to_naming_convention("my_class")).is_equal("MyClassTest")
@@ -340,7 +340,7 @@ func test_is_script_format_supported() -> void:
 
 func test_load_parameterized_test_suite():
 	var test_suite :GdUnitTestSuite = auto_free(GdUnitTestResourceLoader.load_test_suite("res://addons/gdUnit4/test/core/resources/testsuites/TestSuiteInvalidParameterizedTests.resource"))
-
+	
 	assert_that(test_suite.name).is_equal("TestSuiteInvalidParameterizedTests")
 	assert_that(test_suite.get_children()).extractv(extr("get_name"), extr("is_skipped"))\
 		.contains_exactly_in_any_order([

--- a/addons/gdUnit4/test/core/ParameterizedTestCaseTest.gd
+++ b/addons/gdUnit4/test/core/ParameterizedTestCaseTest.gd
@@ -151,3 +151,16 @@ func test_dictionary_div_number_types(
 	# allow to compare type unsave
 	ProjectSettings.set_setting(GdUnitSettings.REPORT_ASSERT_STRICT_NUMBER_TYPE_COMPARE, false)
 	assert_that(value).is_equal(expected)
+	ProjectSettings.set_setting(GdUnitSettings.REPORT_ASSERT_STRICT_NUMBER_TYPE_COMPARE, true)
+
+
+func test_with_string_paramset(
+	values : Array,
+	expected : String,
+	test_parameters : Array = [
+		[ ["a"], "a" ],
+		[ ["a", "very", "long", "argument"], "a very long argument" ],
+	]
+):
+	var current := " ".join(values)
+	assert_that(current.strip_edges()).is_equal(expected)

--- a/addons/gdUnit4/test/core/parse/GdScriptParserTest.gd
+++ b/addons/gdUnit4/test/core/parse/GdScriptParserTest.gd
@@ -2,8 +2,10 @@ extends GdUnitTestSuite
 
 var _parser: GdScriptParser
 
+
 func before():
 	_parser = GdScriptParser.new()
+
 
 func test_parse_argument():
 	# create example row whit different assignment types
@@ -12,21 +14,26 @@ func test_parse_argument():
 	assert_that(_parser.parse_argument(row, "arg2", 23)).is_equal(42)
 	assert_that(_parser.parse_argument(row, "arg3", 23)).is_equal(43)
 
+
 func test_parse_argument_default_value():
 	# arg4 not exists expect to return the default value
 	var row = "func test_foo(arg1 = 41, arg2 := 42, arg3 : int = 43)"
 	assert_that(_parser.parse_argument(row, "arg4", 23)).is_equal(23)
 
+
 func test_parse_argument_has_no_arguments():
 	assert_that(_parser.parse_argument("func test_foo()", "arg4", 23)).is_equal(23)
-	
+
+
 func test_parse_argument_with_bad_formatting():
-	var row = "func test_foo(arg1 =   41, arg2 :	 = 42, arg3 	: int 	=    43)"
+	var row = "func test_foo(	arg1 =   41, arg2 :	 = 42, arg3 	: int 	=    43  )"
 	assert_that(_parser.parse_argument(row, "arg3", 23)).is_equal(43)
+
 
 func test_parse_argument_with_same_func_name():
 	var row = "func test_arg1(arg1 = 41)"
 	assert_that(_parser.parse_argument(row, "arg1", 23)).is_equal(41)
+
 
 func test_parse_argument_timeout():
 	var DEFAULT_TIMEOUT = 1000
@@ -35,6 +42,7 @@ func test_parse_argument_timeout():
 	assert_that(_parser.parse_argument("func test_foo(timeout: = 2000)", "timeout", DEFAULT_TIMEOUT)).is_equal(2000)
 	assert_that(_parser.parse_argument("func test_foo(timeout:int = 2000)", "timeout", DEFAULT_TIMEOUT)).is_equal(2000)
 	assert_that(_parser.parse_argument("func test_foo(arg1 = false, timeout=2000)", "timeout", DEFAULT_TIMEOUT)).is_equal(2000)
+
 
 func test_parse_arguments():
 	assert_array(_parser.parse_arguments("func foo():")) \
@@ -49,17 +57,17 @@ func test_parse_arguments():
 			GdFunctionArgument.new("arg2", TYPE_NIL),
 			GdFunctionArgument.new("name", TYPE_NIL)])
 	
-	assert_array(_parser.parse_arguments("func foo(arg1 :int, arg2 :bool, name :String = \"abc\"):")) \
+	assert_array(_parser.parse_arguments('func foo(arg1 :int, arg2 :bool, name :String = "abc"):')) \
 		.contains_exactly([
 			GdFunctionArgument.new("arg1", TYPE_INT), 
 			GdFunctionArgument.new("arg2", TYPE_BOOL),
-			GdFunctionArgument.new("name", TYPE_STRING, "\"abc\"")])
+			GdFunctionArgument.new("name", TYPE_STRING, '"abc"')])
 	
-	assert_array(_parser.parse_arguments("func bar(arg1 :int, arg2 :int = 23, name :String = \"test\") -> String:")) \
+	assert_array(_parser.parse_arguments('func bar(arg1 :int, arg2 :int = 23, name :String = "test") -> String:')) \
 		.contains_exactly([
 			GdFunctionArgument.new("arg1", TYPE_INT),
 			GdFunctionArgument.new("arg2", TYPE_INT, "23"),
-			GdFunctionArgument.new("name", TYPE_STRING, "\"test\"")])
+			GdFunctionArgument.new("name", TYPE_STRING, '"test"')])
 	
 	assert_array(_parser.parse_arguments("func foo(arg1, arg2=value(1,2,3), name:=foo()):")) \
 		.contains_exactly([
@@ -79,7 +87,7 @@ func test_parse_arguments():
 		.contains_exactly([
 			GdFunctionArgument.new("a", TYPE_INT),
 			GdFunctionArgument.new("b", TYPE_INT),
-			GdFunctionArgument.new("parameters", TYPE_ARRAY, "[[1,2],[3,4],[5,6]]")])
+			GdFunctionArgument.new("parameters", TYPE_ARRAY, "[[1, 2], [3, 4], [5, 6]]")])
 	
 	assert_array(_parser.parse_arguments("func test_values(a:Vector2, b:Vector2, expected:Vector2, test_parameters:=[[Vector2.ONE,Vector2.ONE,Vector2(1,1)]]):"))\
 		.contains_exactly([
@@ -89,26 +97,29 @@ func test_parse_arguments():
 			GdFunctionArgument.new("test_parameters", TYPE_ARRAY, "[[Vector2.ONE,Vector2.ONE,Vector2(1,1)]]"),
 		])
 
+
 func test_parse_arguments_with_super_constructor():
 	assert_array(_parser.parse_arguments('func foo().foo("abc"):')).is_empty()
 	assert_array(_parser.parse_arguments('func foo(arg1 = "arg").foo("abc", arg1):'))\
 		.contains_exactly([GdFunctionArgument.new("arg1", TYPE_STRING, '"arg"')])
 
+
 func test_parse_arguments_default_build_in_type_String():
-	assert_array(_parser.parse_arguments("func foo(arg1 :String, arg2=\"default\"):")) \
+	assert_array(_parser.parse_arguments('func foo(arg1 :String, arg2="default"):')) \
 		.contains_exactly([
 			GdFunctionArgument.new("arg1", TYPE_STRING),
-			GdFunctionArgument.new("arg2", TYPE_STRING, "\"default\"")])
+			GdFunctionArgument.new("arg2", TYPE_STRING, '"default"')])
 	
-	assert_array(_parser.parse_arguments("func foo(arg1 :String, arg2 :=\"default\"):")) \
+	assert_array(_parser.parse_arguments('func foo(arg1 :String, arg2 :="default"):')) \
 		.contains_exactly([
 			GdFunctionArgument.new("arg1", TYPE_STRING),
-			GdFunctionArgument.new("arg2", TYPE_STRING, "\"default\"")])
+			GdFunctionArgument.new("arg2", TYPE_STRING, '"default"')])
 	
-	assert_array(_parser.parse_arguments("func foo(arg1 :String, arg2 :String =\"default\"):")) \
+	assert_array(_parser.parse_arguments('func foo(arg1 :String, arg2 :String ="default"):')) \
 		.contains_exactly([
 			GdFunctionArgument.new("arg1", TYPE_STRING),
-			GdFunctionArgument.new("arg2", TYPE_STRING, "\"default\"")])
+			GdFunctionArgument.new("arg2", TYPE_STRING, '"default"')])
+
 
 func test_parse_arguments_default_build_in_type_Boolean():
 	assert_array(_parser.parse_arguments("func foo(arg1 :String, arg2=false):")) \
@@ -126,6 +137,7 @@ func test_parse_arguments_default_build_in_type_Boolean():
 			GdFunctionArgument.new("arg1", TYPE_STRING),
 			GdFunctionArgument.new("arg2", TYPE_BOOL, "false")])
 
+
 func test_parse_arguments_default_build_in_type_Real():
 	assert_array(_parser.parse_arguments("func foo(arg1 :String, arg2=3.14):")) \
 		.contains_exactly([
@@ -142,6 +154,7 @@ func test_parse_arguments_default_build_in_type_Real():
 			GdFunctionArgument.new("arg1", TYPE_STRING),
 			GdFunctionArgument.new("arg2", TYPE_FLOAT, "3.14")])
 
+
 func test_parse_arguments_default_build_in_type_Array():
 	assert_array(_parser.parse_arguments("func foo(arg1 :String, arg2 :Array=[]):")) \
 		.contains_exactly([
@@ -156,12 +169,12 @@ func test_parse_arguments_default_build_in_type_Array():
 	assert_array(_parser.parse_arguments("func foo(arg1 :String, arg2 :Array=[1, 2, 3]):")) \
 		.contains_exactly([
 			GdFunctionArgument.new("arg1", TYPE_STRING),
-			GdFunctionArgument.new("arg2", TYPE_ARRAY, "[1,2,3]")])
+			GdFunctionArgument.new("arg2", TYPE_ARRAY, "[1, 2, 3]")])
 	
 	assert_array(_parser.parse_arguments("func foo(arg1 :String, arg2 :=[1, 2, 3]):")) \
 		.contains_exactly([
 			GdFunctionArgument.new("arg1", TYPE_STRING),
-			GdFunctionArgument.new("arg2", TYPE_ARRAY, "[1,2,3]")])
+			GdFunctionArgument.new("arg2", TYPE_ARRAY, "[1, 2, 3]")])
 	
 	assert_array(_parser.parse_arguments("func foo(arg1 :String, arg2=[]):")) \
 		.contains_exactly([
@@ -171,8 +184,9 @@ func test_parse_arguments_default_build_in_type_Array():
 	assert_array(_parser.parse_arguments("func foo(arg1 :String, arg2 :Array=[1, 2, 3], arg3 := false):")) \
 		.contains_exactly([
 			GdFunctionArgument.new("arg1", TYPE_STRING),
-			GdFunctionArgument.new("arg2", TYPE_ARRAY, "[1,2,3]"),
+			GdFunctionArgument.new("arg2", TYPE_ARRAY, "[1, 2, 3]"),
 			GdFunctionArgument.new("arg3", TYPE_BOOL, "false")])
+
 
 func test_parse_arguments_default_build_in_type_Color():
 	assert_array(_parser.parse_arguments("func foo(arg1 :String, arg2=Color.RED):")) \
@@ -190,6 +204,7 @@ func test_parse_arguments_default_build_in_type_Color():
 			GdFunctionArgument.new("arg1", TYPE_STRING),
 			GdFunctionArgument.new("arg2", TYPE_COLOR, "Color.RED")])
 
+
 func test_parse_arguments_default_build_in_type_Vector():
 	assert_array(_parser.parse_arguments("func bar(arg1 :String, arg2 =Vector3.FORWARD):")) \
 		.contains_exactly([
@@ -206,6 +221,7 @@ func test_parse_arguments_default_build_in_type_Vector():
 			GdFunctionArgument.new("arg1", TYPE_STRING),
 			GdFunctionArgument.new("arg2", TYPE_VECTOR3, "Vector3.FORWARD")])
 
+
 func test_parse_arguments_default_build_in_type_AABB():
 	assert_array(_parser.parse_arguments("func bar(arg1 :String, arg2 := AABB()):")) \
 		.contains_exactly([
@@ -217,12 +233,14 @@ func test_parse_arguments_default_build_in_type_AABB():
 			GdFunctionArgument.new("arg1", TYPE_STRING),
 			GdFunctionArgument.new("arg2", TYPE_AABB, "AABB()")])
 
+
 func test_parse_arguments_default_build_in_types():
 	assert_array(_parser.parse_arguments("func bar(arg1 :String, arg2 := Vector3.FORWARD, aabb := AABB()):")) \
 		.contains_exactly([
 			GdFunctionArgument.new("arg1", TYPE_STRING),
 			GdFunctionArgument.new("arg2", TYPE_VECTOR3, "Vector3.FORWARD"),
 			GdFunctionArgument.new("aabb", TYPE_AABB, "AABB()")])
+
 
 func test_parse_arguments_fuzzers() -> void:
 	assert_array(_parser.parse_arguments("func test_foo(fuzzer_a = fuzz_a(), fuzzer_b := fuzz_b(), fuzzer_c :Fuzzer = fuzz_c(), fuzzer_iterations = 234, fuzzer_seed = 100):")) \
@@ -233,12 +251,15 @@ func test_parse_arguments_fuzzers() -> void:
 			GdFunctionArgument.new("fuzzer_iterations", TYPE_INT, "234"),
 			GdFunctionArgument.new("fuzzer_seed", TYPE_INT, "100"),])
 
+
 func test_parse_arguments_no_function():
 	assert_array(_parser.parse_arguments("var x:=10")) \
 		.has_size(0)
 
+
 class TestObject:
 	var x
+
 
 func test_parse_function_return_type():
 	assert_that(_parser.parse_func_return_type("func foo():")).is_equal(TYPE_NIL)
@@ -270,6 +291,7 @@ func test_parse_function_return_type():
 	assert_that(_parser.parse_func_return_type("func foo() -> PackedVector3Array:")).is_equal(TYPE_PACKED_VECTOR3_ARRAY)
 	assert_that(_parser.parse_func_return_type("func foo() -> PackedColorArray:")).is_equal(TYPE_PACKED_COLOR_ARRAY)
 
+
 func test_parse_func_name():
 	assert_str(_parser.parse_func_name("func foo():")).is_equal("foo")
 	assert_str(_parser.parse_func_name("static func foo():")).is_equal("foo")
@@ -280,6 +302,7 @@ func test_parse_func_name():
 	assert_str(_parser.parse_func_name("#func foo():")).is_empty()
 	assert_str(_parser.parse_func_name("var x")).is_empty()
 
+
 func test_extract_source_code():
 	var path := GdObjects.extract_class_path(AdvancedTestClass)
 	var rows = _parser.extract_source_code(path)
@@ -287,11 +310,13 @@ func test_extract_source_code():
 	var file_content := resource_as_array(path[0])
 	assert_array(rows).contains_exactly(file_content)
 
+
 func test_extract_source_code_inner_class_AtmosphereData():
 	var path := GdObjects.extract_class_path(AdvancedTestClass.AtmosphereData)
 	var rows = _parser.extract_source_code(path)
 	var file_content := resource_as_array("res://addons/gdUnit4/test/core/resources/AtmosphereData.txt")
 	assert_array(rows).contains_exactly(file_content)
+
 
 func test_extract_source_code_inner_class_SoundData():
 	var path := GdObjects.extract_class_path(AdvancedTestClass.SoundData)
@@ -299,24 +324,28 @@ func test_extract_source_code_inner_class_SoundData():
 	var file_content := resource_as_array("res://addons/gdUnit4/test/core/resources/SoundData.txt")
 	assert_array(rows).contains_exactly(file_content)
 
+
 func test_extract_source_code_inner_class_Area4D():
 	var path := GdObjects.extract_class_path(AdvancedTestClass.Area4D)
 	var rows = _parser.extract_source_code(path)
 	var file_content := resource_as_array("res://addons/gdUnit4/test/core/resources/Area4D.txt")
 	assert_array(rows).contains_exactly(file_content)
 
+
 func test_extract_function_signature() -> void:
 	var path := GdObjects.extract_class_path("res://addons/gdUnit4/test/mocker/resources/ClassWithCustomFormattings.gd")
 	var rows = _parser.extract_source_code(path)
 	
 	assert_that(_parser.extract_func_signature(rows, 9))\
-		.is_equal("funca1(set_name:String,path:String=\"\",load_on_init:bool=false,set_auto_save:bool=false,set_network_sync:bool=false)->void:")
+		.is_equal('func a1(set_name:String, path:String="", load_on_init:bool=false,set_auto_save:bool=false, set_network_sync:bool=false) -> void:')
 	assert_that(_parser.extract_func_signature(rows, 14))\
-		.is_equal("funca2(set_name:String,path:String=\"\",load_on_init:bool=false,set_auto_save:bool=false,set_network_sync:bool=false)->void:")
+		.is_equal('func a2(set_name:String, path:String="", load_on_init:bool=false,set_auto_save:bool=false, set_network_sync:bool=false) -> void:')
 	assert_that(_parser.extract_func_signature(rows, 19))\
-		.is_equal("funca3(set_name:String,path:String=\"\",load_on_init:bool=false,set_auto_save:bool=false,set_network_sync:bool=false):")
+		.is_equal('func a3(set_name:String, path:String="", load_on_init:bool=false,set_auto_save:bool=false, set_network_sync:bool=false) :')
 	assert_that(_parser.extract_func_signature(rows, 24))\
-		.is_equal("funca4(set_name:String,path:String=\"\",load_on_init:bool=false,set_auto_save:bool=false,set_network_sync:bool=false):")
+		.is_equal('func a4(set_name:String,path:String="",load_on_init:bool=false,set_auto_save:bool=false,set_network_sync:bool=false):')
+	assert_that(_parser.extract_func_signature(rows, 32))\
+		.is_equal('func a5(value : Array,expected : String,test_parameters : Array = [[ ["a"], "a" ],[ ["a", "very", "long", "argument"], "a very long argument" ],]):')
 
 
 func test_strip_leading_spaces():
@@ -327,9 +356,11 @@ func test_strip_leading_spaces():
 	assert_str(GdScriptParser.TokenInnerClass._strip_leading_spaces("var x=")).is_equal("var x=")
 	assert_str(GdScriptParser.TokenInnerClass._strip_leading_spaces("class foo")).is_equal("class foo")
 
+
 func test_extract_clazz_name():
 	assert_str(_parser.extract_clazz_name("classSoundData:\n")).is_equal("SoundData")
 	assert_str(_parser.extract_clazz_name("classSoundDataextendsNode:\n")).is_equal("SoundData")
+
 
 func test_is_virtual_func() -> void:
 	# checked non virtual func
@@ -341,6 +372,7 @@ func test_is_virtual_func() -> void:
 	assert_bool(_parser.is_virtual_func("Node", [""], "_ready")).is_true()
 	assert_bool(_parser.is_virtual_func("Node", [""], "_init")).is_true()
 
+
 func test_is_static_func():
 	assert_bool(_parser.is_static_func("")).is_false()
 	assert_bool(_parser.is_static_func("var a=0")).is_false()
@@ -348,6 +380,7 @@ func test_is_static_func():
 	assert_bool(_parser.is_static_func("func foo() -> void:")).is_false()
 	assert_bool(_parser.is_static_func("static func foo():")).is_true()
 	assert_bool(_parser.is_static_func("static func foo() -> void:")).is_true()
+
 
 func test_parse_func_description():
 	var fd := _parser.parse_func_description("func foo():", "clazz_name", [""], 10)
@@ -379,6 +412,7 @@ func test_parse_func_description():
 	])
 	assert_str(fd.typeless()).is_equal("static func foo(arg1, arg2=false) -> Variant:")
 
+
 func test_parse_class_inherits():
 	var clazz_path := GdObjects.extract_class_path(CustomClassExtendsCustomClass)
 	var clazz_name := GdObjects.extract_class_name_from_class_path(clazz_path)
@@ -407,7 +441,7 @@ func test_parse_class_inherits():
 		GdFunctionDescriptor.new("bar", 13, false, false, false, TYPE_STRING, "", [
 			GdFunctionArgument.new("arg1", TYPE_INT),
 			GdFunctionArgument.new("arg2", TYPE_INT, "23"),
-			GdFunctionArgument.new("name", TYPE_STRING, "\"test\""),
+			GdFunctionArgument.new("name", TYPE_STRING, '"test"'),
 		]),
 		GdFunctionDescriptor.new("foo5", 16, false, false, false, GdObjects.TYPE_VARIANT, "", []),
 	])
@@ -416,17 +450,20 @@ func test_parse_class_inherits():
 	clazz_desccriptor = clazz_desccriptor.parent()
 	assert_object(clazz_desccriptor).is_null()
 
+
 func test_get_class_name_pascal_case() -> void:
 	assert_str(_parser.get_class_name(load("res://addons/gdUnit4/test/core/resources/naming_conventions/PascalCaseWithClassName.gd")))\
 		.is_equal("PascalCaseWithClassName")
 	assert_str(_parser.get_class_name(load("res://addons/gdUnit4/test/core/resources/naming_conventions/PascalCaseWithoutClassName.gd")))\
 		.is_equal("PascalCaseWithoutClassName")
 
+
 func test_get_class_name_snake_case() -> void:
 	assert_str(_parser.get_class_name(load("res://addons/gdUnit4/test/core/resources/naming_conventions/snake_case_with_class_name.gd")))\
 		.is_equal("SnakeCaseWithClassName")
 	assert_str(_parser.get_class_name(load("res://addons/gdUnit4/test/core/resources/naming_conventions/snake_case_without_class_name.gd")))\
 		.is_equal("SnakeCaseWithoutClassName")
+
 
 func test_is_func_end() -> void:
 	assert_bool(_parser.is_func_end("")).is_false()
@@ -441,6 +478,7 @@ func test_is_func_end() -> void:
 	assert_bool(_parser.is_func_end("		) -> void :")).is_true()
 	assert_bool(_parser.is_func_end("func test_a(arg1, arg2 = {1:2} ):")).is_true()
 
+
 func test_extract_func_signature_multiline() -> void:
 	var source_code = [
 	"func test_parameterized(a: int, b :int, c :int, expected :int, parameters = [\n",
@@ -452,7 +490,8 @@ func test_extract_func_signature_multiline() -> void:
 	]
 	var fs = _parser.extract_func_signature(source_code, 0)
 	
-	assert_that(fs).is_equal("functest_parameterized(a:int,b:int,c:int,expected:int,parameters=[[1,2,3,6],[3,4,5,11],[6,7,8,21]]):")
+	assert_that(fs).is_equal("func test_parameterized(a: int, b :int, c :int, expected :int, parameters = [[1, 2, 3, 6],[3, 4, 5, 11],[6, 7, 8, 21] ]):")
+
 
 func test_parse_func_description_paramized_test():
 	var fd = _parser.parse_func_description("functest_parameterized(a:int,b:int,c:int,expected:int,parameters=[[1,2,3,6],[3,4,5,11],[6,7,8,21]]):", "class", ["path"], 22)
@@ -465,12 +504,15 @@ func test_parse_func_description_paramized_test():
 		GdFunctionArgument.new("parameters", TYPE_ARRAY, "[[1,2,3,6],[3,4,5,11],[6,7,8,21]]"),
 	]))
 
+
 func test_parse_func_descriptor_with_fuzzers():
-	var source_code = ["func test_foo(fuzzer_a = fuzz_a(), fuzzer_b := fuzz_b(),\n",
-		"fuzzer_c :Fuzzer = fuzz_c(),\n",
-		"fuzzer = Fuzzers.random_rangei(-23, 22),\n",
-		"fuzzer_iterations = 234,\n",
-		"fuzzer_seed = 100):\n"]
+	var source_code := """
+	func test_foo(fuzzer_a = fuzz_a(), fuzzer_b := fuzz_b(),
+		fuzzer_c :Fuzzer = fuzz_c(),
+		fuzzer = Fuzzers.random_rangei(-23, 22),
+		fuzzer_iterations = 234,
+		fuzzer_seed = 100):
+	""".split("\n")
 	var fs = _parser.extract_func_signature(source_code, 0)
 	var fd = _parser.parse_func_description(fs, "class", ["path"], 22)
 	
@@ -478,7 +520,7 @@ func test_parse_func_descriptor_with_fuzzers():
 		GdFunctionArgument.new("fuzzer_a", GdObjects.TYPE_FUZZER, "fuzz_a()"),
 		GdFunctionArgument.new("fuzzer_b", GdObjects.TYPE_FUZZER, "fuzz_b()"),
 		GdFunctionArgument.new("fuzzer_c", GdObjects.TYPE_FUZZER, "fuzz_c()"),
-		GdFunctionArgument.new("fuzzer", GdObjects.TYPE_FUZZER, "Fuzzers.random_rangei(-23,22)"),
+		GdFunctionArgument.new("fuzzer", GdObjects.TYPE_FUZZER, "Fuzzers.random_rangei(-23, 22)"),
 		GdFunctionArgument.new("fuzzer_iterations", TYPE_INT, "234"),
 		GdFunctionArgument.new("fuzzer_seed", TYPE_INT, "100")
 	]))

--- a/addons/gdUnit4/test/mocker/resources/ClassWithCustomFormattings.gd
+++ b/addons/gdUnit4/test/mocker/resources/ClassWithCustomFormattings.gd
@@ -29,3 +29,13 @@ func a4(set_name:String,
 	set_network_sync:bool=false
 ):
 	pass
+
+func a5(
+	value : Array,
+	expected : String,
+	test_parameters : Array = [
+		[ ["a"], "a" ],
+		[ ["a", "very", "long", "argument"], "a very long argument" ],
+	]
+):
+	pass


### PR DESCRIPTION

# Why
Using Strings containing spaces or tabs was failing on parameterized tests. The valus was distorted.

# What
- Fix the test argument parsing by do not clean up the function signature to pare the arguments
- Fix also failing GdUnitExecutor test based on changed gdunit settings during test run


cherry-picked from GdUnit3
