### PR TITLE
GD-78: Fix spy on function with return type `Varaiant`

### DIFF
--- a/addons/gdUnit4/src/core/GdUnitClassDoubler.gd
+++ b/addons/gdUnit4/src/core/GdUnitClassDoubler.gd
@@ -87,15 +87,9 @@ static func double_functions(clazz_name :String, clazz_path :PackedStringArray, 
 	# double regular class functions
 	var clazz_functions := GdObjects.extract_class_functions(clazz_name, clazz_path)
 	for method in clazz_functions:
-		_hotfix_invalid_method_descriptors(method)
 		var func_descriptor := GdFunctionDescriptor.extract_from(method)
 		if functions.has(func_descriptor.name()) or exclude_override_functions.has(func_descriptor.name()):
 			continue
 		functions.append(func_descriptor.name())
 		doubled_source += func_doubler.double(func_descriptor)
 	return doubled_source
-
-# hot fix https://github.com/godotengine/godot/issues/67544
-static func _hotfix_invalid_method_descriptors(method :Dictionary):
-	if method["name"] == "get_script":
-		method["return"]["type"] = GdObjects.TYPE_VARIANT

--- a/addons/gdUnit4/src/core/parse/GdFunctionDescriptor.gd
+++ b/addons/gdUnit4/src/core/parse/GdFunctionDescriptor.gd
@@ -12,6 +12,7 @@ var _return_class :String
 var _args : Array[GdFunctionArgument]
 var _varargs :Array[GdFunctionArgument]
 
+
 func _init(name :String,
 	line_number :int,
 	is_virtual :bool,
@@ -32,26 +33,34 @@ func _init(name :String,
 	_args = args
 	_varargs = varargs
 
+
 func name() -> String:
 	return _name
+
 
 func line_number() -> int:
 	return _line_number
 
+
 func is_virtual() -> bool:
 	return _is_virtual
+
 
 func is_static() -> bool:
 	return _is_static
 
+
 func is_engine() -> bool:
 	return _is_engine
+
 
 func is_vararg() -> bool:
 	return not _varargs.is_empty()
 
+
 func is_coroutine() -> bool:
 	return _is_coroutine
+
 
 func is_parameterized() -> bool:
 	for current in _args:
@@ -60,27 +69,35 @@ func is_parameterized() -> bool:
 			return true
 	return false
 
+
 func return_type() -> int:
 	return _return_type
-	
+
+
 func return_type_as_string() -> String:
 	if return_type() == TYPE_OBJECT and not _return_class.is_empty():
 		return _return_class
 	return GdObjects.type_as_string(return_type())
 
+
 func args() -> Array[GdFunctionArgument]:
 	return _args
 
+
 func varargs() -> Array[GdFunctionArgument]:
 	return _varargs
+
 
 func typeless() -> String:
 	var func_signature := ""
 	if _return_type == TYPE_NIL:
 		func_signature = "func %s(%s):" % [name(), typeless_args()]
+	elif _return_type == GdObjects.TYPE_VARIANT:
+		func_signature = "func %s(%s) -> Variant:" % [name(), typeless_args()]
 	else:
 		func_signature = "func %s(%s) -> %s:" % [name(), typeless_args(), return_type_as_string()]
 	return "static " + func_signature if is_static() else func_signature
+
 
 func typeless_args() -> String:
 	var collect := PackedStringArray()
@@ -93,6 +110,7 @@ func typeless_args() -> String:
 		collect.push_back(arg.name() + "=" + arg.value_as_string())
 	return ", ".join(collect)
 
+
 func typed_args() -> String:
 	var collect := PackedStringArray()
 	for arg in args():
@@ -100,6 +118,7 @@ func typed_args() -> String:
 	for arg in varargs():
 		collect.push_back(arg._to_string())
 	return ", ".join(collect)
+
 
 func _to_string() -> String:
 	var fsignature := "virtual " if is_virtual() else ""
@@ -109,6 +128,7 @@ func _to_string() -> String:
 	if is_static():
 		func_template= "[Line:%s] static func %s(%s) -> %s:"
 	return func_template % [line_number(), name(), typed_args(), return_type_as_string()]
+
 
 # extract function description given by Object.get_method_list()
 static func extract_from(method_descriptor :Dictionary) -> GdFunctionDescriptor:
@@ -131,11 +151,20 @@ static func extract_from(method_descriptor :Dictionary) -> GdFunctionDescriptor:
 		is_virtual,
 		is_static,
 		true,
-		method_descriptor["return"]["type"],
+		_extract_return_type(method_descriptor["return"]),
 		method_descriptor["return"]["class_name"],
 		_extract_args(method_descriptor),
 		_build_varargs(is_vararg)
 	)
+
+
+static func _extract_return_type(return_info :Dictionary) -> int:
+	var type :int = return_info["type"]
+	var usage :int = return_info["usage"]
+	if type == TYPE_NIL and usage & PROPERTY_USAGE_NIL_IS_VARIANT:
+		return GdObjects.TYPE_VARIANT
+	return type
+
 
 static func _extract_args(method_descriptor :Dictionary) -> Array[GdFunctionArgument]:
 	var args :Array[GdFunctionArgument] = []
@@ -152,6 +181,7 @@ static func _extract_args(method_descriptor :Dictionary) -> Array[GdFunctionArgu
 		args.push_front(GdFunctionArgument.new(arg_name, arg_type, arg_default))
 	return args
 
+
 static func _build_varargs(is_vararg :bool) -> Array[GdFunctionArgument]:
 	var varargs :Array[GdFunctionArgument] = []
 	if not is_vararg:
@@ -162,9 +192,11 @@ static func _build_varargs(is_vararg :bool) -> Array[GdFunctionArgument]:
 		varargs.push_back(GdFunctionArgument.new("vararg%d_" % index, type, "\"%s\"" % GdObjects.TYPE_VARARG_PLACEHOLDER_VALUE))
 	return varargs
 
+
 static func _argument_name(arg :Dictionary) -> String:
 	# add suffix to the name to prevent clash with reserved names
 	return (arg["name"] + "_") as String
+
 
 static func _argument_type(arg :Dictionary) -> int:
 	var type :int = arg["type"]
@@ -172,6 +204,7 @@ static func _argument_type(arg :Dictionary) -> int:
 		if arg["class_name"] == "Node":
 			return GdObjects.TYPE_NODE
 	return type
+
 
 static func _argument_type_as_string(arg :Dictionary) -> String:
 	var type := _argument_type(arg)
@@ -185,6 +218,7 @@ static func _argument_type_as_string(arg :Dictionary) -> String:
 			return ""
 		_:
 			return GdObjects.type_as_string(type)
+
 
 static func _argument_default_value(arg :Dictionary, default_value) -> String:
 	if default_value == null:
@@ -209,7 +243,6 @@ static func _argument_default_value(arg :Dictionary, default_value) -> String:
 			var clazz_name := arg["class_name"] as String
 			if default_value == null:
 				return "null"
-
 	if GdObjects.is_primitive_type(default_value):
 		return str(default_value)
 	if GdObjects.is_type_array(type):

--- a/addons/gdUnit4/test/core/parse/GdFunctionDescriptorTest.gd
+++ b/addons/gdUnit4/test/core/parse/GdFunctionDescriptorTest.gd
@@ -5,6 +5,7 @@ extends GdUnitTestSuite
 # TestSuite generated from
 const __source = 'res://addons/gdUnit4/src/core/parse/GdFunctionDescriptor.gd'
 
+
 # helper to get method descriptor
 static func get_method_description(clazz_name :String, method_name :String) -> Dictionary:
 	var method_list :Array = ClassDB.class_get_method_list(clazz_name)
@@ -12,6 +13,7 @@ static func get_method_description(clazz_name :String, method_name :String) -> D
 		if method_descriptor["name"] == method_name:
 			return method_descriptor
 	return Dictionary()
+
 
 func test_extract_from_func_without_return_type():
 	# void add_sibling(sibling: Node, force_readable_name: bool = false)
@@ -30,6 +32,7 @@ func test_extract_from_func_without_return_type():
 	# void add_sibling(node: Node, child_node: Node, legible_unique_name: bool = false)
 	assert_str(fd.typeless()).is_equal("func add_sibling(sibling_, force_readable_name_=false):")
 
+
 func test_extract_from_func_with_return_type():
 	# Node find_child(pattern: String, recursive: bool = true, owned: bool = true) const
 	var method_descriptor := get_method_description("Node", "find_child")
@@ -47,6 +50,7 @@ func test_extract_from_func_with_return_type():
 	])
 	# Node find_child(mask: String, recursive: bool = true, owned: bool = true) const
 	assert_str(fd.typeless()).is_equal("func find_child(pattern_, recursive_=true, owned_=true) -> Node:")
+
 
 func test_extract_from_func_with_vararg():
 	# Error emit_signal(signal: StringName, ...) vararg
@@ -73,6 +77,7 @@ func test_extract_from_func_with_vararg():
 	])
 	assert_str(fd.typeless()).is_equal("func emit_signal(signal_, vararg0_=\"__null__\", vararg1_=\"__null__\", vararg2_=\"__null__\", vararg3_=\"__null__\", vararg4_=\"__null__\", vararg5_=\"__null__\", vararg6_=\"__null__\", vararg7_=\"__null__\", vararg8_=\"__null__\", vararg9_=\"__null__\") -> int:")
 
+
 func test_extract_from_descriptor_is_virtual_func():
 	var method_descriptor := get_method_description("Node", "_enter_tree")
 	var fd := GdFunctionDescriptor.extract_from(method_descriptor)
@@ -85,6 +90,7 @@ func test_extract_from_descriptor_is_virtual_func():
 	assert_array(fd.args()).is_empty()
 	# void _enter_tree() virtual
 	assert_str(fd.typeless()).is_equal("func _enter_tree():")
+
 
 func test_extract_from_descriptor_is_virtual_func_full_check():
 	var methods := ClassDB.class_get_method_list("Node")
@@ -118,3 +124,19 @@ func test_extract_from_descriptor_is_virtual_func_full_check():
 			_count += 1
 			assert_array(expected_virtual_functions).contains([fd.name()])
 	assert_int(_count).is_equal(expected_virtual_functions.size())
+
+
+func test_extract_from_func_with_return_type_variant():
+	var method_descriptor := get_method_description("Node", "get")
+	var fd := GdFunctionDescriptor.extract_from(method_descriptor)
+	assert_str(fd.name()).is_equal("get")
+	assert_bool(fd.is_virtual()).is_false()
+	assert_bool(fd.is_static()).is_false()
+	assert_bool(fd.is_engine()).is_true()
+	assert_bool(fd.is_vararg()).is_false()
+	assert_int(fd.return_type()).is_equal(GdObjects.TYPE_VARIANT)
+	assert_array(fd.args()).contains_exactly([
+		GdFunctionArgument.new("property_", TYPE_STRING_NAME),
+	])
+	# Variant get(property: String) const
+	assert_str(fd.typeless()).is_equal("func get(property_) -> Variant:")


### PR DESCRIPTION
# Why
Spy on a function with return type `Variant` was wrong doubled and has return always nothing.

# What
- Check the usage flag of the return descriptor and check for `PROPERTY_USAGE_NIL_IS_VARIANT` to determine it is a `Variant`