### PR TITLE
GD-107: Fix runtime errors occuring with Godot beta17 typed Array changes

### DIFF
--- a/addons/gdUnit4/src/core/GdUnitExecutor.gd
+++ b/addons/gdUnit4/src/core/GdUnitExecutor.gd
@@ -346,7 +346,7 @@ func dispose_timers(test_suite :GdUnitTestSuite):
 static func create_fuzzers(test_suite :GdUnitTestSuite, test_case :_TestCase) -> Array[Fuzzer]:
 	if not test_case.has_fuzzer():
 		return Array()
-	var fuzzers :Array[Fuzzer]= Array()
+	var fuzzers :Array[Fuzzer] = []
 	for fuzzer_arg in test_case.fuzzer_arguments():
 		var fuzzer := FuzzerTool.create_fuzzer(test_suite.get_script(), fuzzer_arg)
 		fuzzer._iteration_index = 0

--- a/addons/gdUnit4/src/core/GdUnitRunner.gd
+++ b/addons/gdUnit4/src/core/GdUnitRunner.gd
@@ -104,7 +104,7 @@ func load_test_suits() -> Array:
 	var test_suites := Array()
 	var _scanner := GdUnitTestSuiteScanner.new()
 	for resource_path in to_execute.keys():
-		var selected_tests :Array[StringName] = to_execute.get(resource_path)
+		var selected_tests :PackedStringArray = to_execute.get(resource_path)
 		var scaned_suites := _scanner.scan(resource_path)
 		_filter_test_case(scaned_suites, selected_tests)
 		test_suites += scaned_suites
@@ -120,7 +120,7 @@ func gdUnitInit() -> void:
 		send_test_suite(test_suite)
 
 
-func _filter_test_case(test_suites :Array, included_tests :Array[StringName]) -> void:
+func _filter_test_case(test_suites :Array, included_tests :PackedStringArray) -> void:
 	if included_tests.is_empty():
 		return
 	for test_suite in test_suites:
@@ -128,7 +128,7 @@ func _filter_test_case(test_suites :Array, included_tests :Array[StringName]) ->
 			_do_filter_test_case(test_suite, test_case, included_tests)
 
 
-func _do_filter_test_case(test_suite :Node, test_case :Node, included_tests :Array[StringName]) -> void:
+func _do_filter_test_case(test_suite :Node, test_case :Node, included_tests :PackedStringArray) -> void:
 	for included_test in included_tests:
 		var test_meta :PackedStringArray = included_test.split(":")
 		var test_name := test_meta[0]

--- a/addons/gdUnit4/src/core/GdUnitRunnerConfig.gd
+++ b/addons/gdUnit4/src/core/GdUnitRunnerConfig.gd
@@ -44,7 +44,7 @@ func self_test() -> GdUnitRunnerConfig:
 
 func add_test_suite(resource_path :String) -> GdUnitRunnerConfig:
 	var to_execute := to_execute()
-	to_execute[resource_path] = to_execute.get(resource_path, Array())
+	to_execute[resource_path] = to_execute.get(resource_path, PackedStringArray())
 	return self
 
 
@@ -56,7 +56,7 @@ func add_test_suites(resource_paths :PackedStringArray) -> GdUnitRunnerConfig:
 
 func add_test_case(resource_path :String, test_name :StringName, test_param_index :int = -1) -> GdUnitRunnerConfig:
 	var to_execute := to_execute()
-	var test_cases :Array[StringName] = to_execute.get(resource_path, [])
+	var test_cases :PackedStringArray = to_execute.get(resource_path, PackedStringArray())
 	if test_param_index != -1:
 		test_cases.append("%s:%d" % [test_name, test_param_index])
 	else:
@@ -75,7 +75,7 @@ func skip_test_suite(value :StringName) -> GdUnitRunnerConfig:
 		parts.pop_front()
 	parts[0] = GdUnitTools.make_qualified_path(parts[0])
 	match parts.size():
-		1: skipped()[parts[0]] = Array()
+		1: skipped()[parts[0]] = PackedStringArray()
 		2: skip_test_case(parts[0], parts[1])
 	return self
 
@@ -88,18 +88,18 @@ func skip_test_suites(resource_paths :PackedStringArray) -> GdUnitRunnerConfig:
 
 func skip_test_case(resource_path :String, test_name :StringName) -> GdUnitRunnerConfig:
 	var to_ignore := skipped()
-	var test_cases :Array[StringName] = to_ignore.get(resource_path, [])
+	var test_cases :PackedStringArray = to_ignore.get(resource_path, PackedStringArray())
 	test_cases.append(test_name)
 	to_ignore[resource_path] = test_cases
 	return self
 
 
 func to_execute() -> Dictionary:
-	return _config.get(INCLUDED, {"res://" : []})
+	return _config.get(INCLUDED, {"res://" : PackedStringArray()})
 
 
 func skipped() -> Dictionary:
-	return _config.get(SKIPPED, Array())
+	return _config.get(SKIPPED, PackedStringArray())
 
 
 func save(path :String = CONFIG_FILE) -> Result:

--- a/addons/gdUnit4/src/core/GdUnitSettings.gd
+++ b/addons/gdUnit4/src/core/GdUnitSettings.gd
@@ -164,7 +164,7 @@ static func is_log_enabled() -> bool:
 
 
 static func list_settings(category :String) -> Array[GdUnitProperty]:
-	var settings := Array()
+	var settings :Array[GdUnitProperty] = []
 	for property in ProjectSettings.get_property_list():
 		var property_name :String = property["name"]
 		if property_name.begins_with(category):

--- a/addons/gdUnit4/src/core/parse/GdFunctionDescriptor.gd
+++ b/addons/gdUnit4/src/core/parse/GdFunctionDescriptor.gd
@@ -21,7 +21,7 @@ func _init(name :String,
 	return_type :int,
 	return_class :String,
 	args : Array[GdFunctionArgument],
-	varargs :Array = []):
+	varargs :Array[GdFunctionArgument] = []):
 	_name = name
 	_line_number = line_number
 	_return_type = return_type

--- a/addons/gdUnit4/src/core/parse/GdScriptParser.gd
+++ b/addons/gdUnit4/src/core/parse/GdScriptParser.gd
@@ -375,7 +375,7 @@ func parse_return_token(input: String) -> Token:
 # Parses the argument into a argument signature
 # e.g. func foo(arg1 :int, arg2 = 20) -> [arg1, arg2]
 func parse_arguments(input: String) -> Array[GdFunctionArgument]:
-	var args := Array()
+	var args :Array[GdFunctionArgument] = []
 	var current_index := 0
 	var token :Token = null
 	var bracket := 0

--- a/addons/gdUnit4/src/monitor/GodotGdErrorMonitor.gd
+++ b/addons/gdUnit4/src/monitor/GodotGdErrorMonitor.gd
@@ -29,7 +29,7 @@ func stop():
 
 
 func reports() -> Array[GdUnitReport]:
-	var reports :Array[GdUnitReport] = Array()
+	var reports :Array[GdUnitReport] = []
 	if _report_enabled:
 		var loggs := _collect_log_entries()
 		for index in loggs.size():

--- a/addons/gdUnit4/src/ui/GdUnitInspector.gd
+++ b/addons/gdUnit4/src/ui/GdUnitInspector.gd
@@ -96,7 +96,7 @@ func add_file_system_dock_context_menu() -> void:
 		return !_runButton.disabled
 	var run_test := func run_test(resource_paths :PackedStringArray, debug :bool):
 		run_test_suites(resource_paths, debug)
-	var menu := [
+	var menu :Array[GdUnitContextMenuItem] = [
 		GdUnitContextMenuItem.new(GdUnitContextMenuItem.MENU_ID.TEST_RUN, "Run Tests", is_test_suite.bind(true), is_enabled, run_test.bind(false)),
 		GdUnitContextMenuItem.new(GdUnitContextMenuItem.MENU_ID.TEST_DEBUG, "Debug Tests", is_test_suite.bind(true), is_enabled, run_test.bind(true)),
 	]
@@ -133,7 +133,7 @@ func add_script_editor_context_menu():
 		var info := result.value() as Dictionary
 		ScriptEditorControls.edit_script(info.get("path"), info.get("line"))
 
-	var menu := [
+	var menu :Array[GdUnitContextMenuItem] = [
 		GdUnitContextMenuItem.new(GdUnitContextMenuItem.MENU_ID.TEST_RUN, "Run Tests", is_test_suite.bind(true), is_enabled, run_test.bind(false)),
 		GdUnitContextMenuItem.new(GdUnitContextMenuItem.MENU_ID.TEST_DEBUG, "Debug Tests", is_test_suite.bind(true), is_enabled, run_test.bind(true)),
 		GdUnitContextMenuItem.new(GdUnitContextMenuItem.MENU_ID.CREATE_TEST, "Create Test", is_test_suite.bind(false), is_enabled, create_test)

--- a/addons/gdUnit4/src/ui/ScriptEditorControls.gd
+++ b/addons/gdUnit4/src/ui/ScriptEditorControls.gd
@@ -106,7 +106,7 @@ static func edit_script(script_path :String, line_number :int = -1):
 # Register the given context menu to the current script editor
 # Is called when the plugin is activated
 # The active script is connected to the ScriptEditorContextMenuHandler
-static func register_context_menu(menu :Array) -> void:
+static func register_context_menu(menu :Array[GdUnitContextMenuItem]) -> void:
 	script_editor().editor_script_changed.connect(ScriptEditorContextMenuHandler.create(menu).bind(script_editor()))
 
 

--- a/addons/gdUnit4/test/core/GdUnitRunnerConfigTest.gd
+++ b/addons/gdUnit4/test/core/GdUnitRunnerConfigTest.gd
@@ -43,7 +43,7 @@ func test_self_test():
 	
 	# configure self test
 	var to_execute := config.self_test().to_execute()
-	assert_dict(to_execute).contains_key_value("res://addons/gdUnit4/test/", [])
+	assert_dict(to_execute).contains_key_value("res://addons/gdUnit4/test/", PackedStringArray())
 
 func test_add_test_suite():
 	var config := GdUnitRunnerConfig.new()
@@ -51,14 +51,14 @@ func test_add_test_suite():
 	config.skip_test_suite("res://bar")
 	
 	config.add_test_suite("res://foo")
-	assert_dict(config.to_execute()).contains_key_value("res://foo", [])
+	assert_dict(config.to_execute()).contains_key_value("res://foo", PackedStringArray())
 	# add two more
 	config.add_test_suite("res://foo2")
 	config.add_test_suite("res://bar/foo")
 	assert_dict(config.to_execute())\
-		.contains_key_value("res://foo", [])\
-		.contains_key_value("res://foo2", [])\
-		.contains_key_value("res://bar/foo", [])
+		.contains_key_value("res://foo", PackedStringArray())\
+		.contains_key_value("res://foo2", PackedStringArray())\
+		.contains_key_value("res://bar/foo", PackedStringArray())
 
 func test_add_test_suites():
 	var config := GdUnitRunnerConfig.new()
@@ -68,9 +68,9 @@ func test_add_test_suites():
 	config.add_test_suites(PackedStringArray(["res://foo2", "res://bar/foo", "res://foo1"]))
 	
 	assert_dict(config.to_execute())\
-		.contains_key_value("res://foo1", [])\
-		.contains_key_value("res://foo2", [])\
-		.contains_key_value("res://bar/foo", [])
+		.contains_key_value("res://foo1", PackedStringArray())\
+		.contains_key_value("res://foo2", PackedStringArray())\
+		.contains_key_value("res://bar/foo", PackedStringArray())
 
 func test_add_test_case():
 	var config := GdUnitRunnerConfig.new()
@@ -78,13 +78,13 @@ func test_add_test_case():
 	config.skip_test_suite("res://bar")
 	
 	config.add_test_case("res://foo1", "testcaseA")
-	assert_dict(config.to_execute()).contains_key_value("res://foo1", ["testcaseA"])
+	assert_dict(config.to_execute()).contains_key_value("res://foo1", PackedStringArray(["testcaseA"]))
 	# add two more
 	config.add_test_case("res://foo1", "testcaseB")
 	config.add_test_case("res://foo2", "testcaseX")
 	assert_dict(config.to_execute())\
-		.contains_key_value("res://foo1", ["testcaseA", "testcaseB"])\
-		.contains_key_value("res://foo2", ["testcaseX"])
+		.contains_key_value("res://foo1", PackedStringArray(["testcaseA", "testcaseB"]))\
+		.contains_key_value("res://foo2", PackedStringArray(["testcaseX"]))
 
 func test_add_test_suites_and_test_cases_combi():
 	var config := GdUnitRunnerConfig.new()
@@ -98,25 +98,25 @@ func test_add_test_suites_and_test_cases_combi():
 	
 	assert_dict(config.to_execute())\
 		.has_size(6)\
-		.contains_key_value("res://foo1", ["testcaseA", "testcaseB"])\
-		.contains_key_value("res://foo2", [])\
-		.contains_key_value("res://foo3", [])\
-		.contains_key_value("res://foo4", [])\
-		.contains_key_value("res://bar/foo3", [])\
-		.contains_key_value("res://bar/foo", [])
+		.contains_key_value("res://foo1", PackedStringArray(["testcaseA", "testcaseB"]))\
+		.contains_key_value("res://foo2", PackedStringArray())\
+		.contains_key_value("res://foo3", PackedStringArray())\
+		.contains_key_value("res://foo4", PackedStringArray())\
+		.contains_key_value("res://bar/foo3", PackedStringArray())\
+		.contains_key_value("res://bar/foo", PackedStringArray())
 
 func test_skip_test_suite():
 	var config := GdUnitRunnerConfig.new()
 	
 	config.skip_test_suite("res://foo1")
-	assert_dict(config.skipped()).contains_key_value("res://foo1", [])
+	assert_dict(config.skipped()).contains_key_value("res://foo1", PackedStringArray())
 	# add two more
 	config.skip_test_suite("res://foo2")
 	config.skip_test_suite("res://bar/foo1")
 	assert_dict(config.skipped())\
-		.contains_key_value("res://foo1", [])\
-		.contains_key_value("res://foo2", [])\
-		.contains_key_value("res://bar/foo1", [])
+		.contains_key_value("res://foo1", PackedStringArray())\
+		.contains_key_value("res://foo2", PackedStringArray())\
+		.contains_key_value("res://bar/foo1", PackedStringArray())
 
 func test_skip_test_suite_and_test_case():
 	var possible_paths :PackedStringArray = [
@@ -133,21 +133,21 @@ func test_skip_test_suite_and_test_case():
 		config.skip_test_suite(path)
 	assert_dict(config.skipped())\
 		.has_size(3)\
-		.contains_key_value("res://foo/MyTest.gd", ["test_x", "test_y"])\
-		.contains_key_value("MyTest", ["test"])\
-		.contains_key_value("MyTestX", [])
+		.contains_key_value("res://foo/MyTest.gd", PackedStringArray(["test_x", "test_y"]))\
+		.contains_key_value("MyTest", PackedStringArray(["test"]))\
+		.contains_key_value("MyTestX", PackedStringArray())
 
 func test_skip_test_case():
 	var config := GdUnitRunnerConfig.new()
 	
 	config.skip_test_case("res://foo1", "testcaseA")
-	assert_dict(config.skipped()).contains_key_value("res://foo1", ["testcaseA"])
+	assert_dict(config.skipped()).contains_key_value("res://foo1", PackedStringArray(["testcaseA"]))
 	# add two more
 	config.skip_test_case("res://foo1", "testcaseB")
 	config.skip_test_case("res://foo2", "testcaseX")
 	assert_dict(config.skipped())\
-		.contains_key_value("res://foo1", ["testcaseA", "testcaseB"])\
-		.contains_key_value("res://foo2", ["testcaseX"])
+		.contains_key_value("res://foo1", PackedStringArray(["testcaseA", "testcaseB"]))\
+		.contains_key_value("res://foo2", PackedStringArray(["testcaseX"]))
 
 func test_load_fail():
 	var config := GdUnitRunnerConfig.new()


### PR DESCRIPTION

# Why
After upgrade to Godot.beta17 a lot of runtime errors occurs when running the tests. This happens because of the typed array changes in the beta17.

# What
- Fixed typed array initalisation
- Fixed argument type missmatch of arguments using typed arrays