### PR TITLE
GD-111: Upgrade GdUnit4 to run with Godot4.RC1

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 ---
 <h1 align="center">GdUnit4 Beta </h1>
-<p align="center">This is a beta version of GdUnit4 which is based on Godot <strong>v4.0.beta16.official</strong> (master branch)</p>
+<p align="center">This is a beta version of GdUnit4 which is based on Godot <strong>v4.0.rc1.official [8843d9ad3]</strong> (master branch)</p>
 
 <h1 align="center">ATTENTION!</h1>
 
@@ -40,8 +40,8 @@ The C# support is currently not enabled and is untested.
 
 ## What is GdUnit4
 gdunit4 is a framework for testing Gd-Scrips/C# and Scenes within the Godot editor. GdUnit4 is very useful for test-driven development and will help you get your code bug-free.
- 
- 
+
+
 ## Features
 * Fully embedded in the Godot editor
 * Run test-suite(s) by using the context menu on FileSystem, ScriptEditor or GdUnitInspector
@@ -54,8 +54,8 @@ gdunit4 is a framework for testing Gd-Scrips/C# and Scenes within the Godot edit
 * Parameterized Tests (Test Cases)
 * Mocking a class to simulate the implementation in which you define the output of the certain function
 * Spy on an instance to verify that a function has been called with certain parameters.
-* Mock or Spy on a Scene 
-* Provides a scene runner to simulate interactions on a scene 
+* Mock or Spy on a Scene
+* Provides a scene runner to simulate interactions on a scene
   * Simulate by Input events like mouse and/or keyboard
   * Simulate scene processing by a certain number of frames
   * Simulate scene processing by waiting for a specific signal
@@ -63,11 +63,11 @@ gdunit4 is a framework for testing Gd-Scrips/C# and Scenes within the Godot edit
 * Command Line Tool
 * CI - Continuous Integration support
   * generates HTML report
-  * generates JUnit report 
+  * generates JUnit report
 * Visual Studio Code extension
 ---
 
- 
+
 ## Short Example
  ```
  # this assertion succeeds
@@ -76,7 +76,7 @@ assert_int(13).is_not_negative()
 # this assertion fails because the value '-13' is negative
 assert_int(-13).is_not_negative()
  ```
- 
+
  ---
 
 ## Documentation
@@ -118,7 +118,3 @@ assert_int(-13).is_not_negative()
 ### Thank you for supporting my project!
 ---
 ## Sponsors:
-
-
-
-

--- a/addons/gdUnit4/bin/GdUnitCmdTool.gd
+++ b/addons/gdUnit4/bin/GdUnitCmdTool.gd
@@ -103,7 +103,7 @@ class CLIRunner extends Node:
 		_executor.fail_fast(false)
 
 	func run_self_test() -> void:
-		_console.prints_color("Run GdUnit3 self tests.", Color.DEEP_SKY_BLUE)
+		_console.prints_color("Run GdUnit4 self tests.", Color.DEEP_SKY_BLUE)
 		disable_fail_fast()
 		_runner_config.self_test()
 
@@ -111,7 +111,7 @@ class CLIRunner extends Node:
 		_console.prints_color("Godot %s" % Engine.get_version_info().get("string"), Color.DARK_SALMON)
 		var config = ConfigFile.new()
 		config.load('addons/gdUnit4/plugin.cfg')
-		_console.prints_color("GdUnit3 %s" % config.get_value('plugin', 'version'), Color.DARK_SALMON)
+		_console.prints_color("GdUnit4 %s" % config.get_value('plugin', 'version'), Color.DARK_SALMON)
 		get_tree().quit(RETURN_SUCCESS)
 
 	func show_options(show_advanced :bool = false) -> void:
@@ -147,7 +147,7 @@ class CLIRunner extends Node:
 
 	func gdUnitInit() -> void:
 		_console.prints_color("----------------------------------------------------------------------------------------------", Color.DARK_SALMON)
-		_console.prints_color(" GdUnit3 Comandline Tool", Color.DARK_SALMON)
+		_console.prints_color(" GdUnit4 Comandline Tool", Color.DARK_SALMON)
 		_console.new_line()
 		
 		var cmd_parser := CmdArgumentParser.new(_cmd_options, "GdUnitCmdTool.gd")

--- a/addons/gdUnit4/src/asserts/GdUnitObjectAssertImpl.gd
+++ b/addons/gdUnit4/src/asserts/GdUnitObjectAssertImpl.gd
@@ -84,7 +84,7 @@ func is_not_same(expected) -> GdUnitObjectAssert:
 
 # Verifies that the current value is an instance of the given type.
 func is_instanceof(type :Object) -> GdUnitObjectAssert:
-	var current :Variant = __current()
+	var current :Object = __current()
 	if not GdObjects.is_instanceof(current, type):
 		var result_expected: = GdObjects.extract_class_name(type)
 		var result_current: = GdObjects.extract_class_name(current)

--- a/addons/gdUnit4/src/mocking/GdUnitMockFunctionDoubler.gd
+++ b/addons/gdUnit4/src/mocking/GdUnitMockFunctionDoubler.gd
@@ -78,7 +78,9 @@ func _init(push_errors :bool = false):
 	super._init(push_errors)
 
 
-func get_template(return_type, is_vararg :bool) -> String:
+func get_template(return_type :Variant, is_vararg :bool) -> String:
 	if is_vararg:
 		return TEMPLATE_FUNC_VARARG_RETURN_VALUE
+	if return_type is StringName:
+		return TEMPLATE_FUNC_WITH_RETURN_VALUE
 	return TEMPLATE_FUNC_WITH_RETURN_VOID if (return_type == TYPE_NIL or return_type == GdObjects.TYPE_VOID) else TEMPLATE_FUNC_WITH_RETURN_VALUE

--- a/addons/gdUnit4/src/spy/GdUnitSpyFunctionDoubler.gd
+++ b/addons/gdUnit4/src/spy/GdUnitSpyFunctionDoubler.gd
@@ -67,7 +67,9 @@ func _init(push_errors :bool = false):
 	super._init(push_errors)
 
 
-func get_template(return_type :int, is_vararg :bool) -> String:
+func get_template(return_type :Variant, is_vararg :bool) -> String:
 	if is_vararg:
 		return TEMPLATE_RETURN_VOID_VARARG if return_type == TYPE_NIL else TEMPLATE_RETURN_VARIANT_VARARG
+	if return_type is StringName:
+		return TEMPLATE_RETURN_VARIANT
 	return TEMPLATE_RETURN_VOID if (return_type == TYPE_NIL or return_type == GdObjects.TYPE_VOID) else TEMPLATE_RETURN_VARIANT

--- a/addons/gdUnit4/test/asserts/GdUnitAssertImplTest.gd
+++ b/addons/gdUnit4/test/asserts/GdUnitAssertImplTest.gd
@@ -8,39 +8,47 @@ const __source = 'res://addons/gdUnit4/src/asserts/GdUnitAssertImpl.gd'
 func before():
 	assert_int(GdUnitAssertImpl._get_line_number()).is_equal(9)
 
+
 func after():
 	assert_int(10, GdUnitAssert.EXPECT_FAIL).is_equal(42)
-	assert_int(GdAssertReports.get_last_error_line_number()).is_equal(12)
+	assert_int(GdAssertReports.get_last_error_line_number()).is_equal(13)
+
 
 func before_test():
 	assert_int(10, GdUnitAssert.EXPECT_FAIL).is_equal(42)
-	assert_int(GdAssertReports.get_last_error_line_number()).is_equal(16)
+	assert_int(GdAssertReports.get_last_error_line_number()).is_equal(18)
+
 
 func after_test():
 	assert_int(10, GdUnitAssert.EXPECT_FAIL).is_equal(42)
-	assert_int(GdAssertReports.get_last_error_line_number()).is_equal(20)
+	assert_int(GdAssertReports.get_last_error_line_number()).is_equal(23)
+
 
 func test_get_line_number():
 	# test to return the current line number for an failure
 	assert_int(10, GdUnitAssert.EXPECT_FAIL).is_equal(42)
-	assert_int(GdAssertReports.get_last_error_line_number()).is_equal(25)
+	assert_int(GdAssertReports.get_last_error_line_number()).is_equal(29)
+
 
 func test_get_line_number_yielded():
 	# test to return the current line number after using yield
 	await get_tree().create_timer(0.100).timeout
 	assert_int(10, GdUnitAssert.EXPECT_FAIL).is_equal(42)
-	assert_int(GdAssertReports.get_last_error_line_number()).is_equal(31)
+	assert_int(GdAssertReports.get_last_error_line_number()).is_equal(36)
+
 
 func test_get_line_number_multiline():
 	# test to return the current line number for an failure
 	# https://github.com/godotengine/godot/issues/43326
 	assert_int(10, GdUnitAssert.EXPECT_FAIL).is_not_negative().is_equal(42)
-	assert_int(GdAssertReports.get_last_error_line_number()).is_equal(37)
+	assert_int(GdAssertReports.get_last_error_line_number()).is_equal(43)
+
 
 func test_get_line_number_verify():
 	var obj = mock(RefCounted)
 	verify(obj, 1, GdUnitAssert.EXPECT_FAIL).get_reference_count()
-	assert_int(GdAssertReports.get_last_error_line_number()).is_equal(42)
+	assert_int(GdAssertReports.get_last_error_line_number()).is_equal(49)
+
 
 func test_is_null():
 	assert_that(null).is_null()
@@ -49,12 +57,14 @@ func test_is_null():
 		.is_null()\
 		.starts_with_failure_message("Expecting: '<null>' but was 'Color(1, 0, 0, 1)'")
 
+
 func test_is_not_null():
 	assert_that(Color.RED).is_not_null()
 	# should fail because the current is null
 	assert_that(null, GdUnitAssert.EXPECT_FAIL) \
 		.is_not_null()\
 		.has_failure_message("Expecting: not to be '<null>'")
+
 
 func test_is_equal():
 	assert_that(Color.RED).is_equal(Color.RED)
@@ -63,6 +73,7 @@ func test_is_equal():
 		.is_equal(Color.GREEN) \
 		.has_failure_message("Expecting:\n 'Color(0, 1, 0, 1)'\n but was\n 'Color(1, 0, 0, 1)'")
 
+
 func test_is_not_equal():
 	assert_that(Color.RED).is_not_equal(Color.GREEN)
 	assert_that(Plane.PLANE_XY).is_not_equal(Plane.PLANE_XZ)
@@ -70,21 +81,25 @@ func test_is_not_equal():
 		.is_not_equal(Color.RED) \
 		.has_failure_message("Expecting:\n 'Color(1, 0, 0, 1)'\n not equal to\n 'Color(1, 0, 0, 1)'")
 
+
 func test_override_failure_message() -> void:
 	assert_that(Color.RED, GdUnitAssert.EXPECT_FAIL)\
 		.override_failure_message("Custom failure message")\
 		.is_null()\
 		.has_failure_message("Custom failure message")
 
+
 func test_construct_with_value() -> void:
 	var assert_imp := GdUnitAssertImpl.new(self, "a value")
 	assert_bool(assert_imp._current_value_provider is DefaultValueProvider).is_true()
 	assert_str(assert_imp.__current()).is_equal("a value")
 
+
 var _value = 0
 func next_value() -> int:
 	_value += 1
 	return _value
+
 
 func test_construct_with_value_provider() -> void:
 	var assert_imp := GdUnitAssertImpl.new(self, CallBackValueProvider.new(self, "next_value"))

--- a/addons/gdUnit4/test/mocker/GdUnitMockBuilderTest.gd
+++ b/addons/gdUnit4/test/mocker/GdUnitMockBuilderTest.gd
@@ -20,6 +20,7 @@ func test_double_return_typed_function_without_arg() -> void:
 	# String get_class() const
 	var fd := get_function_description("Object", "get_class")
 	var expected := [
+		'@warning_ignore("native_method_override")',
 		'func get_class() -> String:',
 		'	var args :Array = ["get_class", ]',
 		'	',
@@ -47,6 +48,7 @@ func test_double_return_typed_function_with_args() -> void:
 	# bool is_connected(signal: String, callable_: Callable)) const
 	var fd := get_function_description("Object", "is_connected")
 	var expected := [
+		'@warning_ignore("native_method_override")',
 		'func is_connected(signal_, callable_) -> bool:',
 		'	var args :Array = ["is_connected", signal_, callable_]',
 		'	',
@@ -75,6 +77,7 @@ func test_double_return_untyped_function_with_args() -> void:
 	# void disconnect(signal: StringName, callable: Callable)
 	var fd := get_function_description("Object", "disconnect")
 	var expected := [
+		'@warning_ignore("native_method_override")',
 		'func disconnect(signal_, callable_) -> void:',
 		'	var args :Array = ["disconnect", signal_, callable_]',
 		'	',
@@ -100,6 +103,7 @@ func test_double_int_function_with_varargs() -> void:
 	# Error emit_signal(signal: StringName, ...) vararg
 	var fd := get_function_description("Object", "emit_signal")
 	var expected := [
+		'@warning_ignore("native_method_override")',
 		'func emit_signal(signal_, vararg0_="__null__", vararg1_="__null__", vararg2_="__null__", vararg3_="__null__", vararg4_="__null__", vararg5_="__null__", vararg6_="__null__", vararg7_="__null__", vararg8_="__null__", vararg9_="__null__") -> int:',
 		'	var varargs :Array = __filter_vargs([vararg0_, vararg1_, vararg2_, vararg3_, vararg4_, vararg5_, vararg6_, vararg7_, vararg8_, vararg9_])',
 		'	var args :Array = ["emit_signal", signal_] + varargs',
@@ -180,6 +184,7 @@ func test_double_virtual_script_function_without_arg() -> void:
 	# void _ready() virtual
 	var fd := get_function_description("Node", "_ready")
 	var expected := [
+		'@warning_ignore("native_method_override")',
 		'func _ready() -> void:',
 		'	var args :Array = ["_ready", ]',
 		'	',
@@ -206,6 +211,7 @@ func test_double_virtual_script_function_with_arg() -> void:
 	# void _input(event: InputEvent) virtual
 	var fd := get_function_description("Node", "_input")
 	var expected := [
+		'@warning_ignore("native_method_override")',
 		'func _input(event_) -> void:',
 		'	var args :Array = ["_input", event_]',
 		'	',

--- a/addons/gdUnit4/test/mocker/GodotClassNameFuzzer.gd
+++ b/addons/gdUnit4/test/mocker/GodotClassNameFuzzer.gd
@@ -3,7 +3,10 @@ class_name GodotClassNameFuzzer
 extends Fuzzer
 
 var class_names := []
-const EXCLUDED_CLASSES = ["JavaClass", "_ClassDB", "MainLoop", "JNISingleton", "SceneTree", "WebRTC", "WebRTCPeerConnection", "Tween"]
+const EXCLUDED_CLASSES = ["JavaClass", "_ClassDB", "MainLoop", "JNISingleton", "SceneTree", "WebRTC", "WebRTCPeerConnection", "Tween", "TextServerAdvanced",
+# GD-110 - missing enum `Vector3.Axis`
+"Sprite3D", "AnimatedSprite3D",
+]
 
 func _init(no_singleton :bool = false,only_instancialbe :bool = false):
 	#class_names = ClassDB.get_class_list()

--- a/addons/gdUnit4/test/mocker/resources/ClassWithVariables.gd
+++ b/addons/gdUnit4/test/mocker/resources/ClassWithVariables.gd
@@ -1,6 +1,6 @@
 @tool
 class_name ClassWithVariables
-extends Resource
+extends Node
 
 enum{
 	A,
@@ -24,7 +24,7 @@ const T2 = 2
 
 signal source_changed( text )
 
-@onready var name_label = "../HBoxContainer/Effect Name"
+@onready var name_label = load("res://addons/gdUnit4/test/mocker/resources/ClassWithNameA.gd")
 
 @export var path: NodePath = ".."
 

--- a/addons/gdUnit4/test/spy/GdUnitSpyBuilderTest.gd
+++ b/addons/gdUnit4/test/spy/GdUnitSpyBuilderTest.gd
@@ -31,6 +31,7 @@ func test_double_return_typed_function_without_arg() -> void:
 	# String get_class() const
 	var fd := get_function_description("Object", "get_class")
 	var expected := [
+		'@warning_ignore("native_method_override")',
 		'func get_class() -> String:',
 		'	var args :Array = ["get_class", ]',
 		'	',
@@ -53,6 +54,7 @@ func test_double_return_typed_function_with_args() -> void:
 	# bool is_connected(signal: String,Callable(target: Object,method: String)) const
 	var fd := get_function_description("Object", "is_connected")
 	var expected := [
+		'@warning_ignore("native_method_override")',
 		'func is_connected(signal_, callable_) -> bool:',
 		'	var args :Array = ["is_connected", signal_, callable_]',
 		'	',
@@ -75,6 +77,7 @@ func test_double_return_void_function_with_args() -> void:
 	# void disconnect(signal: StringName, callable: Callable)
 	var fd := get_function_description("Object", "disconnect")
 	var expected := [
+		'@warning_ignore("native_method_override")',
 		'func disconnect(signal_, callable_) -> void:',
 		'	var args :Array = ["disconnect", signal_, callable_]',
 		'	',
@@ -96,6 +99,7 @@ func test_double_return_void_function_without_args() -> void:
 	# void free()
 	var fd := get_function_description("Object", "free")
 	var expected := [
+		'@warning_ignore("native_method_override")',
 		'func free() -> void:',
 		'	var args :Array = ["free", ]',
 		'	',
@@ -117,6 +121,7 @@ func test_double_return_typed_function_with_args_and_varargs() -> void:
 	# Error emit_signal(signal: StringName, ...) vararg
 	var fd := get_function_description("Object", "emit_signal")
 	var expected := [
+		'@warning_ignore("native_method_override")',
 		'func emit_signal(signal_, vararg0_="__null__", vararg1_="__null__", vararg2_="__null__", vararg3_="__null__", vararg4_="__null__", vararg5_="__null__", vararg6_="__null__", vararg7_="__null__", vararg8_="__null__", vararg9_="__null__") -> int:',
 		'	var varargs :Array = __filter_vargs([vararg0_, vararg1_, vararg2_, vararg3_, vararg4_, vararg5_, vararg6_, vararg7_, vararg8_, vararg9_])',
 		'	var args :Array = ["emit_signal", signal_] + varargs',
@@ -249,6 +254,7 @@ func test_double_virtual_return_void_function_with_arg() -> void:
 	# void _input(event: InputEvent) virtual
 	var fd := get_function_description("Node", "_input")
 	var expected := [
+		'@warning_ignore("native_method_override")',
 		'func _input(event_) -> void:',
 		'	var args :Array = ["_input", event_]',
 		'	',
@@ -270,6 +276,7 @@ func test_double_virtual_return_void_function_without_arg() -> void:
 	# void _ready() virtual
 	var fd := get_function_description("Node", "_ready")
 	var expected := [
+		'@warning_ignore("native_method_override")',
 		'func _ready() -> void:',
 		'	var args :Array = ["_ready", ]',
 		'	',


### PR DESCRIPTION
# Why
With Godot4.RC1 the mock and spy was broken and needs to be fixed.

# What
- add `@warning_ignore("native_method_override")` to mark shadowed core functions as allowed
- temporary fix to skip mock functions with return type enum defined at GlobalScope
- adapt changes of function description to allow enums as return type