### PR TITLE
GD-118: JUnitXMLReport: use HTML encoding for test-case names

### DIFF
--- a/addons/gdUnit4/src/core/_TestCase.gd
+++ b/addons/gdUnit4/src/core/_TestCase.gd
@@ -194,7 +194,7 @@ func test_case_names() -> PackedStringArray:
 	var test_case_names :=  PackedStringArray()
 	var test_name = get_name()
 	for index in _test_parameters.size():
-		test_case_names.append("%s:%d %s" % [test_name, index, str(_test_parameters[index])])
+		test_case_names.append("%s:%d %s" % [test_name, index, str(_test_parameters[index]).replace('"', "'")])
 	return test_case_names
 
 

--- a/addons/gdUnit4/src/report/GdUnitByPathReport.gd
+++ b/addons/gdUnit4/src/report/GdUnitByPathReport.gd
@@ -1,9 +1,11 @@
 class_name GdUnitByPathReport
 extends GdUnitReportSummary
 
+
 func _init(path :String,reports :Array):
 	_resource_path = path
 	_reports = reports
+
 
 static func sort_reports_by_path(reports :Array) -> Dictionary:
 	var by_path := Dictionary()
@@ -14,11 +16,14 @@ static func sort_reports_by_path(reports :Array) -> Dictionary:
 		by_path[suite_path] = suite_report
 	return by_path
 
+
 func path() -> String:
 	return _resource_path.replace("res://", "")
 
+
 func create_record(report_link :String) -> String:
 	return GdUnitHtmlPatterns.build(GdUnitHtmlPatterns.TABLE_RECORD_PATH, self, report_link)
+
 
 func write(report_dir :String) -> String:
 	var template := GdUnitHtmlPatterns.load_template("res://addons/gdUnit4/src/report/template/folder_report.html")
@@ -31,6 +36,7 @@ func write(report_dir :String) -> String:
 		DirAccess.make_dir_recursive_absolute(dir)
 	FileAccess.open(output_path, FileAccess.WRITE).store_string(path_report)
 	return output_path
+
 
 static func apply_testsuite_reports(report_dir :String, template :String, reports :Array) -> String:
 	var table_records := PackedStringArray()

--- a/addons/gdUnit4/src/report/GdUnitHtmlPatterns.gd
+++ b/addons/gdUnit4/src/report/GdUnitHtmlPatterns.gd
@@ -65,6 +65,7 @@ static func current_date() -> String:
 	return Time.get_datetime_string_from_system(true, true)
 	#return "%02d.%02d.%04d   %02d:%02d:%02d" % [date["day"], date["month"], date["year"], date["hour"], date["minute"], date["second"]]
 
+
 static func build(template :String, report :GdUnitReportSummary, report_link :String) -> String:
 	return template\
 		.replace(PATH, report.path())\
@@ -79,6 +80,7 @@ static func build(template :String, report :GdUnitReportSummary, report_link :St
 		.replace(REPORT_STATE, report.report_state())\
 		.replace(REPORT_LINK, report_link)\
 		.replace(BUILD_DATE, current_date())
+
 
 static func load_template(template_name :String) -> String:
 	return FileAccess.open(template_name, FileAccess.READ).get_as_text()

--- a/addons/gdUnit4/src/report/GdUnitHtmlReport.gd
+++ b/addons/gdUnit4/src/report/GdUnitHtmlReport.gd
@@ -6,42 +6,49 @@ const REPORT_DIR_PREFIX = "report_"
 var _report_path :String
 var _iteration :int
 
+
 func _init(path :String):
 	_iteration = GdUnitTools.find_last_path_index(path, REPORT_DIR_PREFIX) + 1
 	_report_path = "%s/%s%d" % [path, REPORT_DIR_PREFIX, _iteration]
 
+
 func add_testsuite_report(suite_report :GdUnitTestSuiteReport):
 	_reports.append(suite_report)
+
 
 func add_testcase_report(resource_path :String, suite_report :GdUnitTestCaseReport) -> void:
 	for report in _reports:
 		if report.resource_path() == resource_path:
 			report.add_report(suite_report)
 
+
 func update_test_suite_report(resource_path :String, duration :int) -> void:
 	for report in _reports:
 		if report.resource_path() == resource_path:
 			report.set_duration(duration)
+
 
 func update_testcase_report(resource_path :String, test_report :GdUnitTestCaseReport):
 	for report in _reports:
 		if report.resource_path() == resource_path:
 			report.update(test_report)
 
+
 func write() -> String:
 	var template := GdUnitHtmlPatterns.load_template("res://addons/gdUnit4/src/report/template/index.html")
 	var to_write = GdUnitHtmlPatterns.build(template, self, "")
 	to_write = apply_path_reports(_report_path, to_write, _reports)
 	to_write = apply_testsuite_reports(_report_path, to_write, _reports)
-
 	# write report
 	var index_file := "%s/index.html" % _report_path
 	FileAccess.open(index_file, FileAccess.WRITE).store_string(to_write)
 	GdUnitTools.copy_directory("res://addons/gdUnit4/src/report/template/css/", _report_path + "/css")
 	return index_file
 
+
 func delete_history(max_reports :int) -> int:
 	return GdUnitTools.delete_path_index_lower_equals_than(_report_path.get_base_dir(), REPORT_DIR_PREFIX, _iteration-max_reports)
+
 
 static func apply_path_reports(report_dir :String, template :String, reports :Array) -> String:
 	var path_report_mapping := GdUnitByPathReport.sort_reports_by_path(reports)
@@ -54,13 +61,14 @@ static func apply_path_reports(report_dir :String, template :String, reports :Ar
 		table_records.append(report.create_record(report_link))
 	return template.replace(GdUnitHtmlPatterns.TABLE_BY_PATHS, "\n".join(table_records))
 
+
 static func apply_testsuite_reports(report_dir :String, template :String, reports :Array) -> String:
 	var table_records := PackedStringArray()
-
 	for report in reports:
 		var report_link :String = report.write(report_dir).replace(report_dir, ".")
 		table_records.append(report.create_record(report_link))
 	return template.replace(GdUnitHtmlPatterns.TABLE_BY_TESTSUITES, "\n".join(table_records))
+
 
 func iteration() -> int:
 	return _iteration

--- a/addons/gdUnit4/src/report/GdUnitReportSummary.gd
+++ b/addons/gdUnit4/src/report/GdUnitReportSummary.gd
@@ -1,6 +1,11 @@
 class_name GdUnitReportSummary
 extends RefCounted
 
+const CHARACTERS_TO_ENCODE := {
+	'<' : '&lt;',
+	'>' : '&gt;'
+}
+
 var _resource_path :String
 var _name :String
 var _suite_count := 0
@@ -12,17 +17,22 @@ var _skipped_count := 0
 var _duration := 0
 var _reports:Array = Array()
 
+
 func name() -> String:
-	return _name
+	return html_encode(_name)
+
 
 func path() -> String:
 	return _resource_path.get_base_dir().replace("res://", "")
 
+
 func resource_path() -> String:
 	return _resource_path
 
+
 func suite_count() -> int:
 	return _reports.size()
+
 
 func test_count() -> int:
 	var count := _test_count
@@ -30,11 +40,13 @@ func test_count() -> int:
 		count += report.test_count()
 	return count
 
+
 func error_count() -> int:
 	var count := _error_count
 	for report in _reports:
 		count += report.error_count()
 	return count
+
 
 func failure_count() -> int:
 	var count := _failure_count
@@ -42,11 +54,13 @@ func failure_count() -> int:
 		count += report.failure_count()
 	return count
 
+
 func skipped_count() -> int:
 	var count := _skipped_count
 	for report in _reports:
 		count += report.skipped_count()
 	return count
+
 
 func orphan_count() -> int:
 	var count := _orphan_count
@@ -54,23 +68,29 @@ func orphan_count() -> int:
 		count += report.orphan_count()
 	return count
 
+
 func duration() -> int:
 	var count := _duration
 	for report in _reports:
 		count += report.duration()
 	return count
 
+
 func reports() -> Array:
 	return _reports
+
 
 func add_report(report :GdUnitReportSummary) -> void:
 	_reports.append(report)
 
+
 func report_state() -> String:
 	return calculate_state(error_count(), failure_count(), orphan_count())
 
+
 func succes_rate() -> String:
 	return calculate_succes_rate(test_count(), error_count(), failure_count())
+
 
 static func calculate_state(error_count :int, failure_count :int, orphan_count :int) -> String:
 	if error_count > 0:
@@ -81,10 +101,18 @@ static func calculate_state(error_count :int, failure_count :int, orphan_count :
 		return "warning"
 	return "success"
 
+
 static func calculate_succes_rate(test_count :int, error_count: int, failure_count: int) -> String:
 	if failure_count == 0:
 		return "100%"
 	return "%d" % ((test_count-failure_count-error_count) * 100 / test_count) + "%"
 
+
 func create_summary(report_dir :String) -> String:
 	return ""
+
+
+func html_encode(value :String) -> String:
+	for key in CHARACTERS_TO_ENCODE.keys():
+		value =value.replace(key, CHARACTERS_TO_ENCODE[key])
+	return value

--- a/addons/gdUnit4/src/report/GdUnitTestCaseReport.gd
+++ b/addons/gdUnit4/src/report/GdUnitTestCaseReport.gd
@@ -5,7 +5,17 @@ var _suite_name :String
 var _failure_reports :Array
 var _rtf :RichTextLabel
 
-func _init(rtf :RichTextLabel,resource_path :String,suite_name :String,test_name :String,is_error := false,is_failed := false,orphans :int = 0,is_skipped := false,failure_reports :Array = [],duration :int = 0):
+
+func _init(rtf :RichTextLabel,
+		resource_path :String,
+		suite_name :String,
+		test_name :String,
+		is_error := false,
+		is_failed := false,
+		orphans :int = 0,
+		is_skipped := false,
+		failure_reports :Array = [],
+		duration :int = 0):
 	_rtf = rtf
 	_resource_path = resource_path
 	_suite_name = suite_name
@@ -18,18 +28,20 @@ func _init(rtf :RichTextLabel,resource_path :String,suite_name :String,test_name
 	_failure_reports = failure_reports
 	_duration = duration
 
+
 func suite_name() -> String:
 	return _suite_name
+
 
 func failure_report() -> String:
 	var html_report := ""
 	for r in _failure_reports:
 		var report: GdUnitReport = r
-		# TODO convert rtf to html
-		html_report += convert_rtf_to_text(report._to_string())
+		html_report += convert_rtf_to_html(report._to_string())
 	return html_report
 
-func convert_rtf_to_text(bbcode :String) -> String:
+
+func convert_rtf_to_html(bbcode :String) -> String:
 	_rtf.clear()
 	_rtf.parse_bbcode(bbcode)
 	var as_text: = _rtf.text
@@ -39,6 +51,7 @@ func convert_rtf_to_text(bbcode :String) -> String:
 		converted.append("<p>%s</p>" % line)
 	return "\n".join(converted)
 
+
 func create_record(report_dir :String) -> String:
 	return GdUnitHtmlPatterns.TABLE_RECORD_TESTCASE\
 		.replace(GdUnitHtmlPatterns.REPORT_STATE, report_state())\
@@ -47,6 +60,7 @@ func create_record(report_dir :String) -> String:
 		.replace(GdUnitHtmlPatterns.ORPHAN_COUNT, str(orphan_count()))\
 		.replace(GdUnitHtmlPatterns.DURATION, LocalTime.elapsed(_duration))\
 		.replace(GdUnitHtmlPatterns.FAILURE_REPORT, failure_report())
+
 
 func update(report :GdUnitTestCaseReport) -> void:
 	_error_count += report.error_count()

--- a/addons/gdUnit4/src/report/GdUnitTestSuiteReport.gd
+++ b/addons/gdUnit4/src/report/GdUnitTestSuiteReport.gd
@@ -3,19 +3,24 @@ extends GdUnitReportSummary
 
 var _time_stamp :int
 
+
 func _init(resource_path :String,name :String):
 	_resource_path = resource_path
 	_name = name
 	_time_stamp = Time.get_unix_time_from_system()
 
+
 func create_record(report_link :String) -> String:
 	return GdUnitHtmlPatterns.build(GdUnitHtmlPatterns.TABLE_RECORD_TESTSUITE, self, report_link)
+
 
 func output_path(report_dir :String) -> String:
 	return "%s/test_suites/%s.%s.html" % [report_dir, path().replace("/", "."), name()]
 
+
 func path_as_link() -> String:
 	return "../path/%s.html" % path().replace("/", ".")
+
 
 func write(report_dir :String) -> String:
 	var template := GdUnitHtmlPatterns.load_template("res://addons/gdUnit4/src/report/template/suite_report.html")
@@ -35,24 +40,31 @@ func write(report_dir :String) -> String:
 	FileAccess.open(report_output_path, FileAccess.WRITE).store_string(template)
 	return report_output_path
 
+
 func set_duration(duration :int) -> void:
 	_duration = duration
+
 
 func time_stamp() -> int:
 	return _time_stamp
 
+
 func duration() -> int:
 	return _duration
+
 
 func set_skipped(skipped :int) -> void:
 	_skipped_count = skipped
 
+
 func set_orphans(orphans :int) -> void:
 	_orphan_count = orphans
+
 
 func set_failed(failed :bool) -> void:
 	if failed:
 		_failure_count += 1
+
 
 func update(test_report :GdUnitTestCaseReport) -> void:
 	for report in _reports:

--- a/addons/gdUnit4/src/report/JUnitXmlReport.gd
+++ b/addons/gdUnit4/src/report/JUnitXmlReport.gd
@@ -3,15 +3,6 @@
 class_name JUnitXmlReport
 extends RefCounted
 
-var _report_path :String
-var _iteration :int
-var _rtf :RichTextLabel
-
-func _init(path :String,iteration :int,rtf :RichTextLabel):
-	_iteration = iteration
-	_report_path = path
-	_rtf = rtf
-
 const ATTR_CLASSNAME := "classname"
 const ATTR_ERRORS := "errors"
 const ATTR_FAILURES := "failures"
@@ -28,6 +19,17 @@ const ATTR_TYPE := "type"
 
 const HEADER := '<?xml version="1.0" encoding="UTF-8" ?>\n'
 
+var _report_path :String
+var _iteration :int
+var _rtf :RichTextLabel
+
+
+func _init(path :String,iteration :int,rtf :RichTextLabel):
+	_iteration = iteration
+	_report_path = path
+	_rtf = rtf
+
+
 func write(report :GdUnitReportSummary) -> String:
 	var result_file: String = "%s/results.xml" % _report_path
 	var file = FileAccess.open(result_file, FileAccess.WRITE)
@@ -35,6 +37,7 @@ func write(report :GdUnitReportSummary) -> String:
 		push_warning("Can't saving the result to '%s'\n Error: %s" % [result_file, error_string(FileAccess.get_open_error())])
 	file.store_string(build_junit_report(report))
 	return result_file
+
 
 func build_junit_report(report :GdUnitReportSummary) -> String:
 	var ISO8601_datetime := Time.get_date_string_from_system()
@@ -48,6 +51,7 @@ func build_junit_report(report :GdUnitReportSummary) -> String:
 	var as_string = test_suites.to_xml()
 	test_suites.dispose()
 	return HEADER + as_string
+
 
 func build_test_suites(summary :GdUnitReportSummary) -> Array:
 	var test_suites :Array = Array()
@@ -68,6 +72,7 @@ func build_test_suites(summary :GdUnitReportSummary) -> Array:
 			.add_childs(build_test_cases(suite_report)))
 	return test_suites
 
+
 func build_test_cases(suite_report :GdUnitTestSuiteReport) -> Array:
 	var test_cases :Array = Array()
 	for index in suite_report.reports().size():
@@ -78,6 +83,7 @@ func build_test_cases(suite_report :GdUnitTestSuiteReport) -> Array:
 			.attribute(ATTR_TIME, to_time(report.duration()))\
 			.add_childs(build_reports(report)))
 	return test_cases
+
 
 func build_reports(testReport :GdUnitTestCaseReport) -> Array:
 	var failure_reports :Array = Array()
@@ -101,10 +107,12 @@ func build_reports(testReport :GdUnitTestCaseReport) -> Array:
 				.attribute(ATTR_MESSAGE, "SKIPPED: %s:%d" % [testReport._resource_path, report.line_number()]))
 	return failure_reports
 
+
 func convert_rtf_to_text(bbcode :String) -> String:
 	_rtf.clear()
 	_rtf.parse_bbcode(bbcode)
 	return _rtf.text
+
 
 static func to_type(type :int) -> String:
 	match type:
@@ -124,8 +132,10 @@ static func to_type(type :int) -> String:
 			return "ABORT"
 	return "UNKNOWN"
 
+
 static func to_time(duration :int) -> String:
 	return "%4.03f" % (duration / 1000.0)
+
 
 #static func to_ISO8601_datetime() -> String:
 	#return "%04d-%02d-%02dT%02d:%02d:%02d" % [date["year"], date["month"], date["day"],  date["hour"], date["minute"], date["second"]]

--- a/addons/gdUnit4/src/report/XmlElement.gd
+++ b/addons/gdUnit4/src/report/XmlElement.gd
@@ -7,8 +7,10 @@ var _childs :Array = []
 var _parent = null
 var _text :String = ""
 
+
 func _init(name :String):
 	_name = name
+
 
 func dispose():
 	for child in _childs:
@@ -17,26 +19,32 @@ func dispose():
 	_attributes.clear()
 	_parent = null
 
+
 func attribute(name :String, value) -> XmlElement:
 	_attributes[name] = str(value)
 	return self
 
+
 func text(text :String) -> XmlElement:
 	_text = text if text.ends_with("\n") else text + "\n"
 	return self
+
 
 func add_child(child :XmlElement) -> XmlElement:
 	_childs.append(child)
 	child._parent = self
 	return self
 
+
 func add_childs(childs :Array) -> XmlElement:
 	for child in childs:
 		add_child(child)
 	return self
 
+
 func _indentation() -> String:
 	return "" if _parent == null else _parent._indentation() + "	"
+
 
 func to_xml() -> String:
 	var attributes := ""
@@ -53,6 +61,7 @@ func to_xml() -> String:
 			"childs": childs, 
 			"_indentation": _indentation(),
 			"text": cdata(_text)})
+
 
 func cdata(text :String) -> String:
 	return "" if text.is_empty() else "<![CDATA[\n{text}]]>\n".format({"text" : text})

--- a/addons/gdUnit4/test/core/GdUnitExecutorTest.gd
+++ b/addons/gdUnit4/test/core/GdUnitExecutorTest.gd
@@ -651,4 +651,4 @@ func add_expected_test_case_events(suite_name :String, test_name :String, parame
 
 
 func buld_test_case_name(test_name :String, index :int, parameter :Array) -> String:
-	return "%s:%d %s" % [test_name, index, str(parameter)]
+	return "%s:%d %s" % [test_name, index, str(parameter).replace('"', "'")]


### PR DESCRIPTION
# Why
The report was corruped by using unescaped characters inside the html code

# What
- do html encoding on test-case names
- use single quotes for building test_case_names
- reformat code according code style