### PR TITLE
GD-123: Change to rendermode opengl for c-pr

### DIFF
--- a/.github/actions/godot-install/action.yml
+++ b/.github/actions/godot-install/action.yml
@@ -37,10 +37,11 @@ runs:
       run: |
         mkdir -p ${{ inputs.godot-cache-path }}
         chmod 770 ${{ inputs.godot-cache-path }}
-        mkdir ~/.cache
-        chmod 770 ~/.cache
-        mkdir -p ~/.config/godot
-        chmod 770 ~/.config/godot
+        DIR="$HOME/.config/godot"
+        if [ ! -d "$DIR" ]; then
+          mkdir -p "$DIR"
+          chmod 770 "$DIR"
+        fi
         wget https://downloads.tuxfamily.org/godotengine/${{ inputs.godot-version }}/${{ inputs.godot-status-version }}/${{ env.GODOT_PACKAGE }} -P ${{ inputs.godot-cache-path }}
         unzip ${{ inputs.godot-cache-path }}/${{ env.GODOT_PACKAGE }} -d ${{ inputs.godot-cache-path }}
         if ${{runner.OS == 'Linux'}}; then

--- a/.github/actions/unit-test/action.yml
+++ b/.github/actions/unit-test/action.yml
@@ -15,11 +15,14 @@ runs:
     - name: "Unit Test Linux"
       if: ${{ runner.OS == 'Linux' }}
       env:
+        DISPLAY: :1
         GODOT_BIN: "/home/runner/godot-linux/godot"
       shell: bash
       run: |
+        Xvfb :1 -screen 0 1600x1200x24 &
         chmod +x ./runtest.sh
-        ./runtest.sh --add ${{ inputs.test-includes }} --continue --verbose
+        ./runtest.sh --add ${{ inputs.test-includes }} --display-driver x11 --rendering-driver opengl3 --screen 0 --continue --verbose
+        killall Xvfb
 
 
 # not tested yet

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -32,7 +32,7 @@ jobs:
             godot-executable_path: '~/godot-linux/godot'
             godot-cache-path: '~/godot-linux'
             godot-mono: false
-            install-linux-dependencies: true
+            install-opengl: true
 
     steps:
       - name: "Checkout GdUnit Repository"
@@ -48,6 +48,19 @@ jobs:
           godot-status-version: ${{ matrix.godot-status-version }}
           godot-bin-name: ${{ matrix.godot-bin-name }}
           godot-cache-path: ${{ matrix.godot-cache-path }}
+
+      - name: "Install OpenGl Drivers"
+        if: ${{ matrix.install-opengl && !cancelled() }}
+        shell: bash
+        run: |
+          sudo apt-get -y update
+          sudo Xvfb -ac :99 -screen 0 1280x1024x24 > /dev/null 2>&1 &
+          export DISPLAY=:99
+          sudo apt-get install cmake pkg-config
+          sudo apt-get install mesa-utils libglu1-mesa-dev freeglut3-dev mesa-common-dev
+          sudo apt-get install libglew-dev libglfw3-dev libglm-dev
+          sudo apt-get install libao-dev libmpg123-dev
+          glxinfo | grep OpenGL
 
       - name: "Setup .NET"
         # we only setup .Net for mono versions

--- a/addons/gdUnit4/bin/GdUnitCmdTool.gd
+++ b/addons/gdUnit4/bin/GdUnitCmdTool.gd
@@ -5,6 +5,7 @@ extends SceneTree
 class CLIRunner extends Node:
 	
 	enum {
+		READY,
 		INIT,
 		RUN,
 		STOP,
@@ -14,9 +15,10 @@ class CLIRunner extends Node:
 	const DEFAULT_REPORT_COUNT = 20
 	const RETURN_SUCCESS  =   0
 	const RETURN_ERROR    = 100
+	const RETURN_ERROR_HEADLESS_NOT_SUPPORTED  = 103
 	const RETURN_WARNING  = 101
 
-	var _state = INIT
+	var _state = READY
 	var _test_suites_to_process :Array
 	var _executor
 	var _report :GdUnitHtmlReport
@@ -172,6 +174,14 @@ class CLIRunner extends Node:
 		_console.prints_color("----------------------------------------------------------------------------------------------", Color.DARK_SALMON)
 		_console.prints_color(" GdUnit4 Comandline Tool", Color.DARK_SALMON)
 		_console.new_line()
+		
+		if DisplayServer.get_name() == "headless":
+			_console.prints_error("Headless mode is not supported!").new_line()
+			_console.print_color("Tests that use UI interaction do not work in headless mode because 'InputEvents' are not transported by the Godot engine and thus have no effect!", Color.CORNFLOWER_BLUE)\
+			.new_line().new_line()
+			_console.prints_error("Abnormal exit with %d" % RETURN_ERROR_HEADLESS_NOT_SUPPORTED)
+			quit(RETURN_ERROR_HEADLESS_NOT_SUPPORTED)
+			return
 		
 		var cmd_parser := CmdArgumentParser.new(_cmd_options, "GdUnitCmdTool.gd")
 		var result := cmd_parser.parse(OS.get_cmdline_args())


### PR DESCRIPTION
# Why
In the current ci-pr WF, the Godot engine runs in headless mode due to missing display and render drivers. Using headless mode only works for tests without UI interactions and will not work with the GdUnit4 SceneRunner. The SceneRunner uses Input.warp_mouse() and Input.parse_input_event() which are not supported in headless mode.

# What
- exit with error 103 if starting the cmd tool with option `--headless`
- remove the headless mode from ci-pr unit test run
- download and install opengl driver if need
- run tests now with option `--display-driver x11 --rendering-driver opengl3 --screen 0`