### PR TITLE
GD-95: Let the test case skip if invalid test arguments used

### DIFF
--- a/addons/gdUnit4/bin/GdUnitCmdTool.gd
+++ b/addons/gdUnit4/bin/GdUnitCmdTool.gd
@@ -362,7 +362,7 @@ class CLIRunner extends Node:
 		for report in reports:
 			_rtf.clear()
 			_rtf.parse_bbcode(report._to_string())
-			if(report.is_failure() or report.is_error() or report.is_warning()):
+			if report.is_failure() or report.is_error() or report.is_warning() or report.is_skipped():
 				_console.prints_color("	Report:", Color.DARK_TURQUOISE, CmdConsole.BOLD|CmdConsole.UNDERLINE)
 				for line in _rtf.get_parsed_text().split("\n"):
 					_console.prints_color("		%s" % line, Color.DARK_TURQUOISE)

--- a/addons/gdUnit4/src/asserts/GdAssertMessages.gd
+++ b/addons/gdUnit4/src/asserts/GdAssertMessages.gd
@@ -154,6 +154,10 @@ static func test_timeout(timeout :int) -> String:
 	return "%s\n %s" % [_error("Timeout !"), _colored_value("Test timed out after %s" %  LocalTime.elapsed(timeout))]
 
 
+static func test_skipped(hint :String) -> String:
+	return "%s\n %s" % [_error("This test is skipped!"), "Reason: %s" % _colored_value(hint)]
+
+
 static func error_not_implemented() -> String:
 	return _error("Test not implemented!")
 

--- a/addons/gdUnit4/src/core/GdUnitExecutor.gd
+++ b/addons/gdUnit4/src/core/GdUnitExecutor.gd
@@ -59,7 +59,7 @@ func fire_test_skipped(test_suite :GdUnitTestSuite, test_case :_TestCase):
 		GdUnitEvent.SKIPPED: true,
 		GdUnitEvent.SKIPPED_COUNT: 1,
 	}
-	var report := GdUnitReport.new().create(GdUnitReport.WARN, test_case.line_number(), "Test skipped %s" % test_case.error())
+	var report := GdUnitReport.new().create(GdUnitReport.SKIPPED, test_case.line_number(), GdAssertMessages.test_skipped(test_case.skip_info()))
 	fire_event(GdUnitEvent.new()\
 		.test_after(test_suite.get_script().resource_path, test_suite.get_name(), test_case.get_name(), statistics, [report]))
 

--- a/addons/gdUnit4/src/core/_TestCase.gd
+++ b/addons/gdUnit4/src/core/_TestCase.gd
@@ -16,7 +16,7 @@ var _test_param_index := -1
 var _line_number: int = -1
 var _script_path: String
 var _skipped := false
-var _error := ""
+var _skip_info := ""
 var _expect_to_interupt := false
 var _timer : Timer
 var _interupted :bool = false
@@ -30,14 +30,13 @@ func _init():
 	_default_timeout = GdUnitSettings.test_timeout()
 
 
-func configure(name: String, line_number: int, script_path: String, timeout :int = DEFAULT_TIMEOUT, fuzzers :Array = [], iterations: int = 1, seed_ :int = -1, skipped := false) -> _TestCase:
+func configure(name: String, line_number: int, script_path: String, timeout :int = DEFAULT_TIMEOUT, fuzzers :Array = [], iterations: int = 1, seed_ :int = -1) -> _TestCase:
 	set_name(name)
 	_line_number = line_number
 	_fuzzers = fuzzers
 	_iterations = iterations
 	_seed = seed_
 	_script_path = script_path
-	_skipped = skipped
 	_timeout = _default_timeout
 	if timeout != DEFAULT_TIMEOUT:
 		_timeout = timeout
@@ -132,6 +131,9 @@ func report() -> GdUnitReport:
 	return _report
 
 
+func skip_info() -> String:
+	return _skip_info
+
 func line_number() -> int:
 	return _line_number
 
@@ -171,7 +173,7 @@ func generate_seed() -> void:
 
 func skip(skipped :bool, error :String = "") -> void:
 	_skipped = skipped
-	_error = error
+	_skip_info = error
 
 
 func set_test_parameters(test_parameters :Array) -> void:

--- a/addons/gdUnit4/src/core/report/GdUnitReport.gd
+++ b/addons/gdUnit4/src/core/report/GdUnitReport.gd
@@ -9,12 +9,14 @@ enum {
 	ORPHAN,
 	TERMINATED,
 	INTERUPTED,
-	ABORT
+	ABORT,
+	SKIPPED,
 }
 
 var _type :int
 var _line_number :int
 var _message :String
+
 
 func create(type, line_number :int, message :String) -> GdUnitReport:
 	_type = type
@@ -22,28 +24,40 @@ func create(type, line_number :int, message :String) -> GdUnitReport:
 	_message = message
 	return self
 
+
 func type() -> int:
 	return _type
-	
+
+
 func line_number() -> int:
 	return _line_number
-	
+
+
 func message() -> String:
 	return _message
+
+
+func is_skipped() -> bool:
+	return _type == SKIPPED
+
 
 func is_warning() -> bool:
 	return _type == WARN
 
+
 func is_failure() -> bool:
 	return _type == FAILURE
 
+
 func is_error() -> bool:
 	return _type == TERMINATED or _type == INTERUPTED or _type == ABORT
+
 
 func _to_string():
 	if _line_number == -1:
 		return "[color=green]line [/color][color=aqua]<n/a>:[/color] %s" % [_message]
 	return "[color=green]line [/color][color=aqua]%d:[/color] %s" % [_line_number, _message]
+
 
 func serialize() -> Dictionary:
 	return {
@@ -51,6 +65,7 @@ func serialize() -> Dictionary:
 		"line_number" :_line_number,
 		"message"     :_message
 	}
+
 
 func deserialize(serialized:Dictionary) -> GdUnitReport:
 	_type        = serialized["type"]

--- a/addons/gdUnit4/src/core/report/GdUnitReportCollector.gd
+++ b/addons/gdUnit4/src/core/report/GdUnitReportCollector.gd
@@ -13,36 +13,43 @@ var _current_stage :int
 
 
 var _reports_by_state :Dictionary = {
-	STAGE_TEST_SUITE_BEFORE : Array(),
-	STAGE_TEST_SUITE_AFTER : Array(),
-	STAGE_TEST_CASE_BEFORE : Array(),
-	STAGE_TEST_CASE_AFTER : Array(),
-	STAGE_TEST_CASE_EXECUTE : Array(),
+	STAGE_TEST_SUITE_BEFORE : [] as Array[GdUnitReport],
+	STAGE_TEST_SUITE_AFTER : [] as Array[GdUnitReport],
+	STAGE_TEST_CASE_BEFORE : [] as Array[GdUnitReport],
+	STAGE_TEST_CASE_AFTER : [] as Array[GdUnitReport],
+	STAGE_TEST_CASE_EXECUTE : [] as Array[GdUnitReport],
 }
 
-func get_reports_by_state(execution_state :int) -> Array:
+
+func get_reports_by_state(execution_state :int) -> Array[GdUnitReport]:
 	return _reports_by_state.get(execution_state)
+
 
 func add_report(execution_state :int, report :GdUnitReport) -> void:
 	get_reports_by_state(execution_state).append(report)
 
+
 func push_front(execution_state :int, report :GdUnitReport) -> void:
 	get_reports_by_state(execution_state).push_front(report)
 
+
 func pop_front(execution_state :int) -> GdUnitReport:
 	return get_reports_by_state(execution_state).pop_front()
+
 
 func clear_reports(execution_states :int) -> void:
 	for state in ALL_REPORT_STATES:
 		if execution_states&state == state:
 			get_reports_by_state(state).clear()
 
-func get_reports(execution_states :int) -> Array:
-	var reports :Array = Array()
+
+func get_reports(execution_states :int) -> Array[GdUnitReport]:
+	var reports :Array[GdUnitReport] = []
 	for state in ALL_REPORT_STATES:
 		if execution_states&state == state:
 			GdUnitTools.append_array(reports, get_reports_by_state(state))
 	return reports
+
 
 func has_errors(execution_states :int) -> bool:
 	for state in ALL_REPORT_STATES:
@@ -51,6 +58,7 @@ func has_errors(execution_states :int) -> bool:
 				if report.is_error():
 					return true
 	return false
+
 
 func count_errors(execution_states :int) -> int:
 	var count := 0
@@ -61,6 +69,7 @@ func count_errors(execution_states :int) -> int:
 					count += 1
 	return count
 
+
 func has_failures(execution_states :int) -> bool:
 	for state in ALL_REPORT_STATES:
 		if execution_states&state == state:
@@ -68,6 +77,7 @@ func has_failures(execution_states :int) -> bool:
 				if report.type() == GdUnitReport.FAILURE:
 					return true
 	return false
+
 
 func count_failures(execution_states :int) -> int:
 	var count := 0
@@ -78,6 +88,7 @@ func count_failures(execution_states :int) -> int:
 					count += 1
 	return count
 
+
 func has_warnings(execution_states :int) -> bool:
 	for state in ALL_REPORT_STATES:
 		if execution_states&state == state:
@@ -86,8 +97,10 @@ func has_warnings(execution_states :int) -> bool:
 					return true
 	return false
 
+
 func set_stage(stage :int) -> void:
 	_current_stage = stage
+
 
 func consume(report :GdUnitReport) -> void:
 	add_report(_current_stage, report)

--- a/addons/gdUnit4/test/GdUnitTestSuiteTest.gd
+++ b/addons/gdUnit4/test/GdUnitTestSuiteTest.gd
@@ -5,6 +5,24 @@ extends GdUnitTestSuite
 # TestSuite generated from
 const __source = 'res://addons/gdUnit4/src/GdUnitTestSuite.gd'
 
+var _events :Array[GdUnitEvent] = []
+
+func collect_report(event :GdUnitEvent):
+	_events.push_back(event)
+
+
+func before():
+	# register to receive test reports
+	GdUnitSignals.instance().gdunit_event.connect(collect_report)
+
+
+func after():
+	# verify the test case `test_unknown_argument_in_test_case` was skipped
+	assert_array(_events).extractv(extr("type"), extr("is_skipped"), extr("test_name"))\
+		.contains([tuple(GdUnitEvent.TESTCASE_AFTER, true, "test_unknown_argument_in_test_case")])
+	GdUnitSignals.instance().gdunit_event.disconnect(collect_report)
+
+
 func test_assert_that_types() -> void:
 	assert_object(assert_that(true)).is_instanceof(GdUnitBoolAssert)
 	assert_object(assert_that(1)).is_instanceof(GdUnitIntAssert)
@@ -18,3 +36,7 @@ func test_assert_that_types() -> void:
 	# all not a built-in types mapped to default GdUnitAssert
 	assert_object(assert_that(Color.RED)).is_instanceof(GdUnitAssertImpl)
 	assert_object(assert_that(Plane.PLANE_XY)).is_instanceof(GdUnitAssertImpl)
+
+
+func test_unknown_argument_in_test_case(invalid_arg) -> void:
+	fail("This test case should be not executed, it must be skipped.")


### PR DESCRIPTION
# Why
A test case was reported as success when the test case signature contains invalid arguments. The error was only reported by push_error

# What
Mark a invalid test case now as skipped and add a report why.