### PR TITLE
GD-128: Update GdUnit core to work with Godot.RC5

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -24,7 +24,7 @@ jobs:
       matrix:
         os: [ubuntu-22.04]
         godot-version: ['4.0']
-        godot-status-version: ['rc2']
+        godot-status-version: ['rc5']
         include:
           - os: ubuntu-22.04
             name: Godot 🐧 Linux Build

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 ---
 <h1 align="center">GdUnit4 Beta </h1>
-<p align="center">This is a beta version of GdUnit4 which is based on Godot <strong>v4.0.rc1.official [8843d9ad3]</strong> (master branch)</p>
+<p align="center">This is a beta version of GdUnit4 which is based on Godot <strong>v4.0.rc4.official [e0de3573f]</strong> (master branch)</p>
 
 <h1 align="center">ATTENTION!</h1>
 

--- a/addons/gdUnit4/src/asserts/GdUnitFuncAssertImpl.gd
+++ b/addons/gdUnit4/src/asserts/GdUnitFuncAssertImpl.gd
@@ -2,6 +2,7 @@ class_name GdUnitFuncAssertImpl
 extends GdUnitFuncAssert
 
 signal value_provided(value)
+
 const DEFAULT_TIMEOUT := 2000
 
 var _current_value_provider :ValueProvider
@@ -13,6 +14,7 @@ var _is_failed := false
 var _timeout := DEFAULT_TIMEOUT
 var _expect_result :int
 var _interrupted := false
+
 
 func _init(instance :Object, func_name :String, args := Array(), expect_result := EXPECT_SUCCESS):
 	_line_number = GdUnitAssertImpl._get_line_number()
@@ -27,16 +29,20 @@ func _init(instance :Object, func_name :String, args := Array(), expect_result :
 	else:
 		_current_value_provider = CallBackValueProvider.new(instance, func_name, args)
 
+
 func report_success() -> GdUnitAssert:
 	return GdAssertReports.report_success(self)
+
 
 func report_error(error_message :String) -> GdUnitAssert:
 	if _custom_failure_message == "":
 		return GdAssertReports.report_error(error_message, self, _line_number)
 	return GdAssertReports.report_error(_custom_failure_message, self, _line_number)
 
+
 func send_report(report :GdUnitReport)-> void:
 	GdUnitSignals.instance().gdunit_report.emit(report)
+
 
 # -------- Base Assert wrapping ------------------------------------------------
 func has_failure_message(expected: String) -> GdUnitFuncAssert:
@@ -49,6 +55,7 @@ func has_failure_message(expected: String) -> GdUnitFuncAssert:
 		report_error(GdAssertMessages.error_not_same_error(current, expected))
 	return self
 
+
 func starts_with_failure_message(expected: String) -> GdUnitFuncAssert:
 	var current_error := GdUnitAssertImpl._normalize_bbcode(_current_error_message)
 	if not current_error.begins_with(expected):
@@ -59,9 +66,11 @@ func starts_with_failure_message(expected: String) -> GdUnitFuncAssert:
 		report_error(GdAssertMessages.error_not_same_error(current, expected))
 	return self
 
+
 func override_failure_message(message :String) -> GdUnitAssert:
 	_custom_failure_message = message
 	return self
+
 
 func wait_until(timeout := 2000) -> GdUnitAssert:
 	if timeout <= 0:
@@ -71,57 +80,49 @@ func wait_until(timeout := 2000) -> GdUnitAssert:
 		_timeout = timeout
 	return self
 
+
 func is_null() -> GdUnitAssert:
-	return await _validate_callback("is_null")
+	return await _validate_callback(func is_null(c, e): return c == null)
+
 
 func is_not_null() -> GdUnitAssert:
-	return await _validate_callback("is_not_null")
+	return await _validate_callback(func is_not_null(c, e): return c != null)
+
 
 func is_false() -> GdUnitAssert:
-	return await _validate_callback("is_false")
+	return await _validate_callback(func is_false(c, e): return c == false)
+
 
 func is_true() -> GdUnitAssert:
-	return await _validate_callback("is_true")
+	return await _validate_callback(func is_true(c, e): return c == true)
+
 
 func is_equal(expected) -> GdUnitAssert:
-	return await _validate_callback("is_equal", expected)
+	return await _validate_callback(func is_equal(c, e): return GdObjects.equals(c, e), expected)
+
 
 func is_not_equal(expected) -> GdUnitAssert:
-	return await _validate_callback("is_not_equal", expected)
+	return await _validate_callback(func is_not_equal(c, e): return not GdObjects.equals(c, e), expected)
 
-# -------- assert implementations
-func _is_null(current, expected) -> bool:
-	return current == null
 
-func _is_not_null(current, expected) -> bool:
-	return current != null
-
-func _is_equal(current, expected) -> bool:
-	return GdObjects.equals(current, expected)
-
-func _is_not_equal(current, expected) -> bool:
-	return not GdObjects.equals(current, expected)
-
-func _is_true(current, expected) -> bool:
-	return current == true
-
-func _is_false(current, expected) -> bool:
-	return current == false
-
-func _validate_callback(func_name :String, expected = null) -> GdUnitFuncAssert:
+func _validate_callback(predicate :Callable, expected = null) -> GdUnitFuncAssert:
 	# if initial failed?
 	if _is_failed:
 		#await Engine.get_main_loop().process_frame
 		return self
-	var assert_cb := Callable(self, "_" + func_name)
 	var time_scale = Engine.get_time_scale()
-	var timeout = Timer.new()
-	Engine.get_main_loop().root.add_child(timeout)
-	timeout.set_one_shot(true)
-	timeout.connect("timeout", Callable(self, "_on_timeout"))
-	timeout.start((_timeout/1000.0)*time_scale)
-	
+	var timer := Timer.new()
+	timer.set_name("gdunit_interrupt_timer_%d" % timer.get_instance_id())
+	Engine.get_main_loop().root.add_child(timer)
+	timer.add_to_group("GdUnitTimers")
+	timer.timeout.connect(func do_interrupt():
+		_interrupted = true
+		value_provided.emit(null)
+		, CONNECT_REFERENCE_COUNTED)
+	timer.set_one_shot(true)
+	timer.start((_timeout/1000.0)*time_scale)
 	var sleep := Timer.new()
+	sleep.set_name("gdunit_sleep_timer_%d" % sleep.get_instance_id() )
 	Engine.get_main_loop().root.add_child(sleep)
 	
 	while true:
@@ -129,7 +130,7 @@ func _validate_callback(func_name :String, expected = null) -> GdUnitFuncAssert:
 		var current = await value_provided
 		if _interrupted:
 			break
-		var is_success = assert_cb.call(current, expected)
+		var is_success = predicate.call(current, expected)
 		if _expect_result != EXPECT_FAIL and is_success:
 			break
 		sleep.start(0.05)
@@ -137,27 +138,26 @@ func _validate_callback(func_name :String, expected = null) -> GdUnitFuncAssert:
 	
 	sleep.stop()
 	sleep.queue_free()
-	timeout.stop()
-	timeout.disconnect("timeout", Callable(self, "_on_timeout"))
-	timeout.free()
-	_current_value_provider.dispose()
+	
 	await Engine.get_main_loop().process_frame
+	dispose()
 	if _interrupted:
-		report_error(GdAssertMessages.error_interrupted(func_name, expected, LocalTime.elapsed(_timeout)))
+		# https://github.com/godotengine/godot/issues/73052
+		#var predicate_name = predicate.get_method()
+		var predicate_name = str(predicate).split('(')[0]
+		report_error(GdAssertMessages.error_interrupted(predicate_name, expected, LocalTime.elapsed(_timeout)))
 	else:
 		report_success()
-	dispose()
 	return self
+
 
 func next_current_value():
 	var current = await _current_value_provider.get_value()
 	call_deferred("emit_signal", "value_provided", current)
 
-func _on_timeout():
-	_interrupted = true
-	call_deferred("emit_signal", "value_provided", null)
 
 # it is important to free all references/connections to prevent orphan nodes
 func dispose():
 	GdUnitTools.release_connections(self)
+	_current_value_provider.dispose()
 	_current_value_provider = null

--- a/addons/gdUnit4/src/asserts/GdUnitObjectAssertImpl.gd
+++ b/addons/gdUnit4/src/asserts/GdUnitObjectAssertImpl.gd
@@ -85,7 +85,7 @@ func is_not_same(expected) -> GdUnitObjectAssert:
 # Verifies that the current value is an instance of the given type.
 func is_instanceof(type :Object) -> GdUnitObjectAssert:
 	var current :Object = __current()
-	if not GdObjects.is_instanceof(current, type):
+	if not is_instance_of(current, type):
 		var result_expected: = GdObjects.extract_class_name(type)
 		var result_current: = GdObjects.extract_class_name(current)
 		report_error(GdAssertMessages.error_is_instanceof(result_current, result_expected))
@@ -96,7 +96,7 @@ func is_instanceof(type :Object) -> GdUnitObjectAssert:
 # Verifies that the current value is not an instance of the given type.
 func is_not_instanceof(type) -> GdUnitObjectAssert:
 	var current :Variant = __current()
-	if GdObjects.is_instanceof(current, type):
+	if is_instance_of(current, type):
 		var result: = GdObjects.extract_class_name(type)
 		if result.is_success():
 			report_error("Expected not be a instance of <%s>" % result.value())

--- a/addons/gdUnit4/src/asserts/GdUnitSignalAssertImpl.gd
+++ b/addons/gdUnit4/src/asserts/GdUnitSignalAssertImpl.gd
@@ -2,7 +2,7 @@ class_name GdUnitSignalAssertImpl
 extends GdUnitSignalAssert
 
 const DEFAULT_TIMEOUT := 2000
-const NO_ARG = "<--null-->"
+const NO_ARG = GdUnitConstants.NO_ARG
 
 var _emitter :Object
 var _current_error_message :String = ""
@@ -29,6 +29,7 @@ class SignalCollector extends GdUnitSingleton:
 	# }
 	var _collected_signals :Dictionary = {}
 	
+	
 	# connect to all possible signals defined by the emitter
 	# prepares the signal collection to store received signals and arguments
 	func register_emitter(emitter :Object):
@@ -38,8 +39,8 @@ class SignalCollector extends GdUnitSingleton:
 				return
 			_collected_signals[emitter] = Dictionary()
 			# connect to 'tree_exiting' of the emitter to finally release all acquired resources/connections.
-			if !emitter.is_connected("tree_exiting", Callable(self, "unregister_emitter")):
-				emitter.connect("tree_exiting", Callable(self, "unregister_emitter").bind(emitter))
+			if !emitter.tree_exiting.is_connected(unregister_emitter):
+				emitter.tree_exiting.connect(unregister_emitter.bind(emitter))
 			# connect to all signals of the emitter we want to collect
 			for signal_def in emitter.get_signal_list():
 				var signal_name = signal_def["name"]
@@ -48,10 +49,11 @@ class SignalCollector extends GdUnitSingleton:
 					_collected_signals[emitter][signal_name] = Array()
 				if SIGNAL_BLACK_LIST.find(signal_name) != -1:
 					continue
-				if !emitter.is_connected(signal_name,Callable(self, "_on_signal_emmited")):
-					var err := emitter.connect(signal_name, Callable(self, "_on_signal_emmited").bind(emitter, signal_name))
+				if !emitter.is_connected(signal_name, _on_signal_emmited):
+					var err := emitter.connect(signal_name, _on_signal_emmited.bind(emitter, signal_name))
 					if err != OK:
 						push_error("Can't connect to signal %s on %s. Error: %s" % [signal_name, emitter, error_string(err)])
+	
 	
 	# unregister all acquired resources/connections, otherwise it ends up in orphans
 	# is called when the emitter is removed from the parent
@@ -59,6 +61,7 @@ class SignalCollector extends GdUnitSingleton:
 		GdUnitTools.release_connections(emitter)
 		if is_instance_valid(emitter):
 			_collected_signals.erase(emitter)
+	
 	
 	# receives the signal from the emitter with all emitted signal arguments and additional the emitter and signal_name as last two arguements
 	func _on_signal_emmited( arg0=NO_ARG, arg1=NO_ARG, arg2=NO_ARG, arg3=NO_ARG, arg4=NO_ARG, arg5=NO_ARG, arg6=NO_ARG, arg7=NO_ARG, arg8=NO_ARG, arg9=NO_ARG, arg10=NO_ARG, arg11=NO_ARG):
@@ -70,6 +73,7 @@ class SignalCollector extends GdUnitSingleton:
 		if is_signal_collecting(emitter, signal_name):
 			_collected_signals[emitter][signal_name].append(signal_args)
 	
+	
 	func reset_received_signals(emitter :Object):
 		#_debug_signal_list("before claer");
 		if _collected_signals.has(emitter):
@@ -77,8 +81,10 @@ class SignalCollector extends GdUnitSingleton:
 				_collected_signals[emitter][signal_name].clear()
 		#_debug_signal_list("after claer");
 	
+	
 	func is_signal_collecting(emitter :Object, signal_name :String) -> bool:
 		return _collected_signals.has(emitter) and _collected_signals[emitter].has(signal_name)
+	
 	
 	func match(emitter :Object, signal_name :String, args :Array) -> bool:
 		#prints("match", signal_name,  _collected_signals[emitter][signal_name]);
@@ -90,6 +96,7 @@ class SignalCollector extends GdUnitSingleton:
 				return true
 		return false
 	
+	
 	func _debug_signal_list(message :String):
 		prints("-----", message, "-------")
 		prints("senders {")
@@ -99,7 +106,8 @@ class SignalCollector extends GdUnitSingleton:
 				var args = _collected_signals[emitter][signal_name]
 				prints("\t\t", signal_name, args)
 		prints("}")
-
+	
+	
 func _init(emitter :Object, expect_result := EXPECT_SUCCESS):
 	_line_number = GdUnitAssertImpl._get_line_number()
 	_emitter =  emitter
@@ -108,21 +116,26 @@ func _init(emitter :Object, expect_result := EXPECT_SUCCESS):
 	# we expect the test will fail
 	if expect_result == EXPECT_FAIL:
 		_expect_fail = true
-
+	
+	
 func report_success() -> GdUnitAssert:
 	return GdAssertReports.report_success(self)
-
+	
+	
 func report_warning(message :String) -> GdUnitAssert:
 	return GdAssertReports.report_warning(self, message, GdUnitAssertImpl._get_line_number())
-
+	
+	
 func report_error(error_message :String) -> GdUnitAssert:
 	if _custom_failure_message == "":
 		return GdAssertReports.report_error(error_message, self, _line_number)
 	return GdAssertReports.report_error(_custom_failure_message, self, _line_number)
-
+	
+	
 func send_report(report :GdUnitReport)-> void:
 	GdUnitSignals.instance().gdunit_report.emit(report)
-
+	
+	
 # -------- Base Assert wrapping ------------------------------------------------
 func has_failure_message(expected: String) -> GdUnitSignalAssert:
 	var current_error := GdUnitAssertImpl._normalize_bbcode(_current_error_message)
@@ -133,7 +146,8 @@ func has_failure_message(expected: String) -> GdUnitSignalAssert:
 		_custom_failure_message = ""
 		report_error(GdAssertMessages.error_not_same_error(current, expected))
 	return self
-
+	
+	
 func starts_with_failure_message(expected: String) -> GdUnitSignalAssert:
 	var current_error := GdUnitAssertImpl._normalize_bbcode(_current_error_message)
 	if not current_error.begins_with(expected):
@@ -143,11 +157,13 @@ func starts_with_failure_message(expected: String) -> GdUnitSignalAssert:
 		_custom_failure_message = ""
 		report_error(GdAssertMessages.error_not_same_error(current, expected))
 	return self
-
+	
+	
 func override_failure_message(message :String) -> GdUnitSignalAssert:
 	_custom_failure_message = message
 	return self
-
+	
+	
 func wait_until(timeout := 2000) -> GdUnitSignalAssert:
 	if timeout <= 0:
 		report_warning("Invalid timeout parameter, allowed timeouts must be greater than 0, use default timeout instead!")
@@ -155,23 +171,27 @@ func wait_until(timeout := 2000) -> GdUnitSignalAssert:
 	else:
 		_timeout = timeout
 	return self
-
+	
+	
 # Verifies the signal exists checked the emitter
 func is_signal_exists(signal_name :String) -> GdUnitSignalAssert:
 	if not _emitter.has_signal(signal_name):
 		report_error("The signal '%s' not exists checked object '%s'." % [signal_name, _emitter.get_class()])
 	return self
-
+	
+	
 # Verifies that given signal is emitted until waiting time
 func is_emitted(name :String, args := []) -> GdUnitSignalAssert:
 	_line_number = GdUnitAssertImpl._get_line_number()
 	return await _wail_until_signal(name, args, false)
-
+	
+	
 # Verifies that given signal is NOT emitted until waiting time
 func is_not_emitted(name :String, args := []) -> GdUnitSignalAssert:
 	_line_number = GdUnitAssertImpl._get_line_number()
 	return await _wail_until_signal(name, args, true)
-
+	
+	
 func _wail_until_signal(signal_name :String, expected_args :Array, expect_not_emitted: bool) -> GdUnitSignalAssert:
 	if _emitter == null:
 		report_error("Can't wait for signal checked a NULL object.")
@@ -182,23 +202,21 @@ func _wail_until_signal(signal_name :String, expected_args :Array, expect_not_em
 		return self
 	_signal_collector.register_emitter(_emitter)
 	var time_scale = Engine.get_time_scale()
-	var timeout = Timer.new()
-	Engine.get_main_loop().root.add_child(timeout)
-	timeout.set_one_shot(true)
-	timeout.connect("timeout",Callable(self,"_on_timeout"))
-	timeout.start((_timeout/1000.0)*time_scale)
+	var timer := Timer.new()
+	Engine.get_main_loop().root.add_child(timer)
+	timer.add_to_group("GdUnitTimers")
+	timer.set_one_shot(true)
+	timer.timeout.connect(func on_timeout(): _interrupted = true)
+	timer.start((_timeout/1000.0)*time_scale)
 	var is_signal_emitted = false
 	while not _interrupted and not is_signal_emitted:
 		await Engine.get_main_loop().process_frame
 		is_signal_emitted = _signal_collector.match(_emitter, signal_name, expected_args)
 		if is_signal_emitted and expect_not_emitted:
-			report_error(GdAssertMessages.error_signal_emitted(signal_name, expected_args, LocalTime.elapsed(_timeout-timeout.time_left*1000)))
-
+			report_error(GdAssertMessages.error_signal_emitted(signal_name, expected_args, LocalTime.elapsed(_timeout-timer.time_left*1000)))
+	
 	if _interrupted and not expect_not_emitted:
 		report_error(GdAssertMessages.error_wait_signal(signal_name, expected_args, LocalTime.elapsed(_timeout)))
-	timeout.free()
+	timer.free()
 	_signal_collector.reset_received_signals(_emitter)
 	return self
-
-func _on_timeout():
-	_interrupted = true

--- a/addons/gdUnit4/src/core/GdObjects.gd
+++ b/addons/gdUnit4/src/core/GdObjects.gd
@@ -12,6 +12,7 @@ const TYPE_NODE 	= TYPE_MAX + 2001
 # missing Godot types
 const TYPE_CONTROL	= TYPE_MAX + 2002
 const TYPE_CANVAS	= TYPE_MAX + 2003
+const TYPE_ENUM		= TYPE_MAX + 2004
 
 
 # used as default value for varargs
@@ -483,10 +484,6 @@ static func is_instance_scene(instance) -> bool:
 		var node := instance as Node
 		return node.get_scene_file_path() != null and not node.get_scene_file_path().is_empty()
 	return false
-
-
-static func is_instanceof(obj :Object, type: Object) -> bool:
-	return is_type(type) and obj is type
 
 
 static func can_be_instantiate(obj :Variant) -> bool:

--- a/addons/gdUnit4/src/core/GdUnitSignalAwaiter.gd
+++ b/addons/gdUnit4/src/core/GdUnitSignalAwaiter.gd
@@ -10,32 +10,37 @@ var _interrupted := false
 var _time_left := 0
 var _timeout_millis :int
 
+
 func _init(timeout_millis :int, wait_on_idle_frame := false):
 	_timeout_millis = timeout_millis
 	_wait_on_idle_frame = wait_on_idle_frame
 
-func _on_timeout():
-	_interrupted = true
-	signal_emitted.emit(null)
 
 func _on_signal_emmited(arg0=NO_ARG, arg1=NO_ARG, arg2=NO_ARG, arg3=NO_ARG, arg4=NO_ARG, arg5=NO_ARG, arg6=NO_ARG, arg7=NO_ARG, arg8=NO_ARG, arg9=NO_ARG):
 	var signal_args := GdObjects.array_filter_value([arg0,arg1,arg2,arg3,arg4,arg5,arg6,arg7,arg8,arg9], NO_ARG)
 	signal_emitted.emit(signal_args)
 
+
 func is_interrupted() -> bool:
 	return _interrupted
+
 
 func elapsed_time() -> int:
 	return _time_left
 
+
 func on_signal(source :Object, signal_name :String, expected_signal_args :Array) -> Variant:
 	# register checked signal to wait for
-	source.connect(signal_name, Callable(self, "_on_signal_emmited"))
+	source.connect(signal_name, _on_signal_emmited)
 	# install timeout timer
 	var timer = Timer.new()
 	Engine.get_main_loop().root.add_child(timer)
+	timer.add_to_group("GdUnitTimers")
 	timer.set_one_shot(true)
-	timer.connect("timeout", Callable(self, "_on_timeout"), CONNECT_DEFERRED)
+	timer.timeout.connect(func do_interrupt():
+		_interrupted = true
+		signal_emitted.emit(null)
+	, CONNECT_DEFERRED)
 	timer.start(_timeout_millis * 0.001 * Engine.get_time_scale())
 	
 	# holds the emited value
@@ -51,12 +56,8 @@ func on_signal(source :Object, signal_name :String, expected_signal_args :Array)
 			break
 		await Engine.get_main_loop().process_frame
 	
-	source.disconnect(signal_name, Callable(self, "_on_signal_emmited"))
-	# stop/cleanup timers
+	source.disconnect(signal_name, _on_signal_emmited)
 	_time_left = timer.time_left
-	timer.stop()
-	Engine.get_main_loop().root.remove_child(timer)
-	timer.free()
 	await Engine.get_main_loop().process_frame
 	if value is Array and value.size() == 1:
 		return value[0]

--- a/addons/gdUnit4/src/core/GdUnitTools.gd
+++ b/addons/gdUnit4/src/core/GdUnitTools.gd
@@ -224,6 +224,13 @@ static func release_connections(instance :Object):
 			#prints("callable", callable_.get_object())
 			if instance.has_signal(signal_.get_name()) and instance.is_connected(signal_.get_name(), callable_):
 				instance.disconnect(signal_.get_name(), callable_)
+	
+	# we go the new way to hold all gdunit timers in group 'GdUnitTimers'
+	for node in Engine.get_main_loop().root.get_children():
+		if node.is_in_group("GdUnitTimers"):
+			if is_instance_valid(node):
+				node.stop()
+				node.free()
 
 
 # if instance an mock or spy we need manually freeing the self reference

--- a/addons/gdUnit4/src/core/parse/GdFunctionDescriptor.gd
+++ b/addons/gdUnit4/src/core/parse/GdFunctionDescriptor.gd
@@ -7,7 +7,7 @@ var _is_engine :bool
 var _is_coroutine :bool
 var _name :String
 var _line_number :int
-var _return_type :Variant
+var _return_type :int
 var _return_class :String
 var _args : Array[GdFunctionArgument]
 var _varargs :Array[GdFunctionArgument]
@@ -18,7 +18,7 @@ func _init(name :String,
 	is_virtual :bool,
 	is_static :bool,
 	is_engine :bool,
-	return_type :Variant,
+	return_type :int,
 	return_class :String,
 	args : Array[GdFunctionArgument],
 	varargs :Array[GdFunctionArgument] = []):
@@ -79,7 +79,7 @@ func return_type() -> Variant:
 
 
 func return_type_as_string() -> String:
-	if return_type() == TYPE_OBJECT and not _return_class.is_empty():
+	if (return_type() == TYPE_OBJECT or return_type() == GdObjects.TYPE_ENUM) and not _return_class.is_empty():
 		return _return_class
 	return GdObjects.type_as_string(return_type())
 
@@ -94,9 +94,7 @@ func varargs() -> Array[GdFunctionArgument]:
 
 func typeless() -> String:
 	var func_signature := ""
-	if _return_type is StringName:
-		func_signature = "func %s(%s) -> %s:" % [name(), typeless_args(), _return_type]
-	elif _return_type == TYPE_NIL:
+	if _return_type == TYPE_NIL:
 		func_signature = "func %s(%s) -> void:" % [name(), typeless_args()]
 	elif _return_type == GdObjects.TYPE_VARIANT:
 		func_signature = "func %s(%s) -> Variant:" % [name(), typeless_args()]
@@ -186,15 +184,12 @@ const enum_fix := [
 	"Variant.Type",
 	"Control.LayoutMode"]
 
+
 static func _extract_return_type(return_info :Dictionary) -> Variant:
 	var type :int = return_info["type"]
 	var usage :int = return_info["usage"]
 	if type == TYPE_INT and usage & PROPERTY_USAGE_CLASS_IS_ENUM:
-		var enum_value :Variant = return_info["class_name"]
-		# GD-110: bug Error is not work as enum, convert it to int
-		if enum_fix.has(enum_value):
-			return TYPE_INT
-		return enum_value
+		return GdObjects.TYPE_ENUM
 	if type == TYPE_NIL and usage & PROPERTY_USAGE_NIL_IS_VARIANT:
 		return GdObjects.TYPE_VARIANT
 	return type

--- a/addons/gdUnit4/src/matchers/AnyClazzArgumentMatcher.gd
+++ b/addons/gdUnit4/src/matchers/AnyClazzArgumentMatcher.gd
@@ -11,4 +11,4 @@ func is_match(value :Variant) -> bool:
 		return false
 	if is_instance_valid(value) and GdObjects.is_script(_clazz):
 		return value.get_script() == _clazz
-	return GdObjects.is_instanceof(value, _clazz)
+	return is_instance_of(value, _clazz)

--- a/addons/gdUnit4/src/network/GdUnitTcpServer.gd
+++ b/addons/gdUnit4/src/network/GdUnitTcpServer.gd
@@ -81,8 +81,8 @@ class TcpConnection extends Node:
 		# Reset the buffer if a completely terminated packet was received
 			_readBuffer = ""
 		# remove empty packages
-		for index in range(json_array.size()-1, -1, -1):
-			if json_array[index].is_empty():
+		for index in json_array.size():
+			if index < json_array.size() and json_array[index].is_empty():
 				json_array.remove_at(index)
 		return json_array
 	

--- a/addons/gdUnit4/test/asserts/GdUnitSignalAssertImplTest.gd
+++ b/addons/gdUnit4/test/asserts/GdUnitSignalAssertImplTest.gd
@@ -19,11 +19,11 @@ class TestEmitter extends Node:
 		_trigger_count = trigger_count
 	
 	func _process(_delta):
-		#prints("_process", _count, _delta)
 		if _count >= _trigger_count:
-			emit_signal("test_signal_counted", _count)
+			test_signal_counted.emit(_count)
+		
 		if _count == 20:
-			emit_signal("test_signal")
+			test_signal.emit()
 		_count += 1
 
 var signal_emitter :TestEmitter

--- a/addons/gdUnit4/test/core/GdObjectsTest.gd
+++ b/addons/gdUnit4/test/core/GdObjectsTest.gd
@@ -228,10 +228,6 @@ func test_is_instance_false():
 	assert_bool(_is_instance(TestClassForIsType)).is_false()
 	assert_bool(_is_instance(CustomClass.InnerClassC)).is_false()
 
-func test_is_instanceof():
-	var obj = auto_free(Camera3D.new())
-	assert_bool(GdObjects.is_instanceof(obj, Node)).is_true()
-	assert_bool(GdObjects.is_instanceof(obj, AStar2D)).is_false()
 
 # shorter helper func to extract class name and using auto_free
 func extract_class_name(value) -> Result:
@@ -497,8 +493,7 @@ func test_extract_class_functions() -> void:
 			assert_str(GdFunctionDescriptor.extract_from(f)._to_string()).is_equal("[Line:-1] func get_path() -> String:")
 
 func test_all_types() -> void:
-	
-	var expected_types :Array[int] = [] 
+	var expected_types :Array[int] = []
 	for type_index in TYPE_MAX:
 		expected_types.append(type_index)
 	expected_types.append(GdObjects.TYPE_VOID)

--- a/addons/gdUnit4/test/core/parse/GdFunctionDescriptorTest.gd
+++ b/addons/gdUnit4/test/core/parse/GdFunctionDescriptorTest.gd
@@ -61,7 +61,7 @@ func test_extract_from_func_with_vararg():
 	assert_bool(fd.is_static()).is_false()
 	assert_bool(fd.is_engine()).is_true()
 	assert_bool(fd.is_vararg()).is_true()
-	assert_int(fd.return_type()).is_equal(TYPE_INT)
+	assert_int(fd.return_type()).is_equal(GdObjects.TYPE_ENUM)
 	assert_array(fd.args()).contains_exactly([GdFunctionArgument.new("signal_", TYPE_STRING_NAME)])
 	assert_array(fd.varargs()).contains_exactly([
 		GdFunctionArgument.new("vararg0_", GdObjects.TYPE_VARARG, "\"%s\"" % GdObjects.TYPE_VARARG_PLACEHOLDER_VALUE),
@@ -75,7 +75,7 @@ func test_extract_from_func_with_vararg():
 		GdFunctionArgument.new("vararg8_", GdObjects.TYPE_VARARG, "\"%s\"" % GdObjects.TYPE_VARARG_PLACEHOLDER_VALUE),
 		GdFunctionArgument.new("vararg9_", GdObjects.TYPE_VARARG, "\"%s\"" % GdObjects.TYPE_VARARG_PLACEHOLDER_VALUE)
 	])
-	assert_str(fd.typeless()).is_equal("func emit_signal(signal_, vararg0_=\"__null__\", vararg1_=\"__null__\", vararg2_=\"__null__\", vararg3_=\"__null__\", vararg4_=\"__null__\", vararg5_=\"__null__\", vararg6_=\"__null__\", vararg7_=\"__null__\", vararg8_=\"__null__\", vararg9_=\"__null__\") -> int:")
+	assert_str(fd.typeless()).is_equal("func emit_signal(signal_, vararg0_=\"__null__\", vararg1_=\"__null__\", vararg2_=\"__null__\", vararg3_=\"__null__\", vararg4_=\"__null__\", vararg5_=\"__null__\", vararg6_=\"__null__\", vararg7_=\"__null__\", vararg8_=\"__null__\", vararg9_=\"__null__\") -> Error:")
 
 
 func test_extract_from_descriptor_is_virtual_func():

--- a/addons/gdUnit4/test/mocker/GdUnitMockBuilderTest.gd
+++ b/addons/gdUnit4/test/mocker/GdUnitMockBuilderTest.gd
@@ -104,17 +104,17 @@ func test_double_int_function_with_varargs() -> void:
 	var fd := get_function_description("Object", "emit_signal")
 	var expected := [
 		'@warning_ignore("native_method_override")',
-		'func emit_signal(signal_, vararg0_="__null__", vararg1_="__null__", vararg2_="__null__", vararg3_="__null__", vararg4_="__null__", vararg5_="__null__", vararg6_="__null__", vararg7_="__null__", vararg8_="__null__", vararg9_="__null__") -> int:',
+		'func emit_signal(signal_, vararg0_="__null__", vararg1_="__null__", vararg2_="__null__", vararg3_="__null__", vararg4_="__null__", vararg5_="__null__", vararg6_="__null__", vararg7_="__null__", vararg8_="__null__", vararg9_="__null__") -> Error:',
 		'	var varargs :Array = __filter_vargs([vararg0_, vararg1_, vararg2_, vararg3_, vararg4_, vararg5_, vararg6_, vararg7_, vararg8_, vararg9_])',
 		'	var args :Array = ["emit_signal", signal_] + varargs',
 		'	',
 		'	if __is_prepare_return_value():',
 		'		if false:',
 		'			push_error("Mocking a void function \'emit_signal(<args>) -> void:\' is not allowed.")',
-		'		return 0',
+		'		return OK',
 		'	if __is_verify_interactions():',
 		'		__verify_interactions(args)',
-		'		return 0',
+		'		return OK',
 		'	else:',
 		'		__save_function_interaction(args)',
 		'	',
@@ -131,7 +131,7 @@ func test_double_int_function_with_varargs() -> void:
 		'			8: return super(signal_, varargs[0], varargs[1], varargs[2], varargs[3], varargs[4], varargs[5], varargs[6], varargs[7])',
 		'			9: return super(signal_, varargs[0], varargs[1], varargs[2], varargs[3], varargs[4], varargs[5], varargs[6], varargs[7], varargs[8])',
 		'			10: return super(signal_, varargs[0], varargs[1], varargs[2], varargs[3], varargs[4], varargs[5], varargs[6], varargs[7], varargs[8], varargs[9])',
-		'	return 0',
+		'	return OK',
 		'',
 		'']
 	assert_array(doubler.double(fd)).contains_exactly(expected)
@@ -234,7 +234,7 @@ func test_double_virtual_script_function_with_arg() -> void:
 
 func test_mock_on_script_path_without_class_name() -> void:
 	var instance = load("res://addons/gdUnit4/test/mocker/resources/ClassWithoutNameA.gd").new()
-	var script := GdUnitMockBuilder.mock_on_script(instance, "res://addons/gdUnit4/test/mocker/resources/ClassWithoutNameA.gd", [], false);
+	var script := GdUnitMockBuilder.mock_on_script(instance, "res://addons/gdUnit4/test/mocker/resources/ClassWithoutNameA.gd", [], true);
 	assert_that(script.resource_name).is_equal("MockClassWithoutNameA.gd")
 	assert_that(script.get_instance_base_type()).is_equal("Resource")
 	# finally check the mocked script is valid

--- a/addons/gdUnit4/test/spy/GdUnitSpyBuilderTest.gd
+++ b/addons/gdUnit4/test/spy/GdUnitSpyBuilderTest.gd
@@ -122,13 +122,13 @@ func test_double_return_typed_function_with_args_and_varargs() -> void:
 	var fd := get_function_description("Object", "emit_signal")
 	var expected := [
 		'@warning_ignore("native_method_override")',
-		'func emit_signal(signal_, vararg0_="__null__", vararg1_="__null__", vararg2_="__null__", vararg3_="__null__", vararg4_="__null__", vararg5_="__null__", vararg6_="__null__", vararg7_="__null__", vararg8_="__null__", vararg9_="__null__") -> int:',
+		'func emit_signal(signal_, vararg0_="__null__", vararg1_="__null__", vararg2_="__null__", vararg3_="__null__", vararg4_="__null__", vararg5_="__null__", vararg6_="__null__", vararg7_="__null__", vararg8_="__null__", vararg9_="__null__") -> Error:',
 		'	var varargs :Array = __filter_vargs([vararg0_, vararg1_, vararg2_, vararg3_, vararg4_, vararg5_, vararg6_, vararg7_, vararg8_, vararg9_])',
 		'	var args :Array = ["emit_signal", signal_] + varargs',
 		'	',
 		'	if __is_verify_interactions():',
 		'		__verify_interactions(args)',
-		'		return 0',
+		'		return OK',
 		'	else:',
 		'		__save_function_interaction(args)',
 		'	',


### PR DESCRIPTION
# Why
With RC3, RC4, RC3 some regressions are introduced and needs to be addapt to get GdUnit4 running


# What
- fix bug in releasing internal memory store
- fix function doubling according to fixed issue (https://github.com/godotengine/godot/issues/73046)
- remove custom `is_instanceof` and replace it by new engine function `is_instance_of`
- do code formattings
- use new signal code style to connect/disconnect
- use workaround for `GlobalScript` enums (https://github.com/godotengine/godot/issues/73835)
- use workaround for `Timer.timeout.connect` (https://github.com/godotengine/godot/issues/73889)
- use workarount for `Callable.get_method()` (https://github.com/godotengine/godot/issues/73052)
- switch to RC5 on ci-pr WF