### PR TITLE
Add missing `GdUnitSignals.dispose()`

### DIFF
--- a/addons/gdUnit4/plugin.gd
+++ b/addons/gdUnit4/plugin.gd
@@ -50,4 +50,5 @@ func _exit_tree():
 	if Engine.has_meta("GdUnitEditorPlugin"):
 		Engine.remove_meta("GdUnitEditorPlugin")
 	prints("Unload GdUnit4 Plugin success")
+	GdUnitSignals.dispose()
 	GdUnitSingleton.dispose()


### PR DESCRIPTION
This adds a missing singleton dispose, which made my editor crash on exit.