### PR TITLE
#154 - Switched from Forward+ to Compatibility rendering mode

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -38,4 +38,5 @@ limits/debugger_stdout/max_warnings_per_second=1000
 
 [rendering]
 
+renderer/rendering_method="gl_compatibility"
 environment/default_environment="res://default_env.tres"


### PR DESCRIPTION
Changes the rendering mode to Compatibility so that machines that can't run Forward+ don't have the Godot4 engine crash when opening the project.