### PR TITLE
GD-164: Extend `assert_array` by `not_contains(expected)` validation

### DIFF
--- a/addons/gdUnit4/src/GdUnitArrayAssert.gd
+++ b/addons/gdUnit4/src/GdUnitArrayAssert.gd
@@ -71,7 +71,14 @@ func contains_exactly_in_any_order(expected) -> GdUnitArrayAssert:
 	return self
 
 
-## Verifies that the current Array do NOT contains the given values, in any order.
+## Verifies that the current Array do NOT contains the given values, in any order.[br]
+## [b]Example:[/b]
+## [codeblock]
+## # will succeed
+## assert_array([1, 2, 3, 4, 5]).not_contains([6])
+## # will fail
+## assert_array([1, 2, 3, 4, 5]).not_contains([2, 6])
+## [/codeblock]
 @warning_ignore("unused_parameter")
 func not_contains(expected) -> GdUnitArrayAssert:
 	return self

--- a/addons/gdUnit4/src/GdUnitArrayAssert.gd
+++ b/addons/gdUnit4/src/GdUnitArrayAssert.gd
@@ -71,6 +71,12 @@ func contains_exactly_in_any_order(expected) -> GdUnitArrayAssert:
 	return self
 
 
+## Verifies that the current Array do NOT contains the given values, in any order.
+@warning_ignore("unused_parameter")
+func not_contains(expected) -> GdUnitArrayAssert:
+	return self
+
+
 ## Extracts all values by given function name and optional arguments into a new ArrayAssert.
 ## If the elements not accessible by `func_name` the value is converted to `"n.a"`, expecting null values
 @warning_ignore("unused_parameter")

--- a/addons/gdUnit4/src/asserts/GdAssertMessages.gd
+++ b/addons/gdUnit4/src/asserts/GdAssertMessages.gd
@@ -88,6 +88,8 @@ static func array_to_string(elements :Array, encode_value := true) -> String:
 
 
 static func _typed_value(value) -> String:
+	if value == null:
+		return "<null>"
 	return GdDefaultValueDecoder.decode(typeof(value), value)
 
 

--- a/addons/gdUnit4/src/asserts/GdAssertMessages.gd
+++ b/addons/gdUnit4/src/asserts/GdAssertMessages.gd
@@ -67,6 +67,29 @@ static func _colored_array_div(characters :PackedByteArray) -> String:
 	result.append_array(format_chars(additional_chars, ADD_COLOR))
 	return result.get_string_from_utf8()
 
+const max_elements := 32
+
+static func array_to_string(elements :Array, encode_value := true) -> String:
+	var delemiter = ", "
+	if elements == null:
+		return "<null>"
+	if elements.is_empty():
+		return "empty"
+	var formatted := ""
+	var index := 0
+	for element in elements:
+		if max_elements != -1 and index > max_elements:
+			return formatted + delemiter + "..."
+		if formatted.length() > 0 :
+			formatted += delemiter
+		formatted += _typed_value(element) if encode_value else str(element)
+		index += 1
+	return formatted
+
+
+static func _typed_value(value) -> String:
+	return GdDefaultValueDecoder.decode(typeof(value), value)
+
 
 static func _warning(error :String) -> String:
 	return "[color=%s]%s[/color]" % [WARN_COLOR, error]
@@ -93,9 +116,9 @@ static func _colored_value(value, _delimiter ="\n", detailed := false) -> String
 		TYPE_INT:
 			return "'[color=%s]%d[/color]'" % [VALUE_COLOR, value]
 		TYPE_FLOAT:
-			return "'[color=%s]%f[/color]'" % [VALUE_COLOR, value]
+			return "'[color=%s]%s[/color]'" % [VALUE_COLOR, _typed_value(value)]
 		TYPE_COLOR:
-			return "'[color=%s]Color%s[/color]'" % [VALUE_COLOR, value]
+			return "'[color=%s]%s[/color]'" % [VALUE_COLOR, _typed_value(value)]
 		TYPE_OBJECT:
 			if value == null:
 				return "'[color=%s]<null>[/color]'" % [VALUE_COLOR]
@@ -108,7 +131,7 @@ static func _colored_value(value, _delimiter ="\n", detailed := false) -> String
 			return "'[color=%s]%s[/color]'" % [VALUE_COLOR, _format_dict(value)]
 		_:
 			if GdObjects.is_array_type(value):
-				return "[color=%s]%s[/color]" % [VALUE_COLOR, GdObjects.array_to_string(value, ', ')]
+				return "[color=%s]%s[/color]" % [VALUE_COLOR, array_to_string(value)]
 			return "'[color=%s]%s[/color]'" % [VALUE_COLOR, value]
 
 
@@ -355,6 +378,14 @@ static func error_arr_contains_exactly_in_any_order(current, expected :Array, no
 	return error
 
 
+static func error_arr_not_contains(current :Array, expected :Array, found :Array) -> String:
+	var error := "%s\n %s\n do not contains\n %s" % [_error("Expecting:"), _colored_value(current, ", "), _colored_value(expected, ", ")]
+	if not found.is_empty():
+		error += "\n but found elements:\n %s" % _colored_value(found, ", ")
+	return error
+
+
+
 # - DictionaryAssert specific messages ----------------------------------------------
 static func error_contains_keys(current :Array, expected :Array, keys_not_found :Array) -> String:
 	return "%s\n %s\n to contains:\n %s\n but can't find key's:\n %s" % [_error("Expecting keys:"), _colored_value(current, ", "), _colored_value(expected, ", "), _colored_value(keys_not_found, ", ")]
@@ -489,7 +520,7 @@ static func _find_first_diff( left :Array, right :Array) -> String:
 		var l = left[index]
 		var r = "<no entry>" if index >= right.size() else right[index]
 		if not GdObjects.equals(l, r):
-			return "at position %s\n %s vs %s" % [_colored_value(index), _colored_value(l), _colored_value(r)]
+			return "at position %s\n '%s' vs '%s'" % [_colored_value(index), _typed_value(l), _typed_value(r)]
 	return ""
 
 

--- a/addons/gdUnit4/src/asserts/GdUnitArrayAssertImpl.gd
+++ b/addons/gdUnit4/src/asserts/GdUnitArrayAssertImpl.gd
@@ -110,11 +110,11 @@ func is_equal(expected) -> GdUnitArrayAssert:
 	var current_ = __current()
 	var expected_ = __expected(expected)
 	if current_ == null and expected_ != null:
-		return report_error(GdAssertMessages.error_equal(null, GdObjects.array_to_string(expected_, ", ", 32)))
+		return report_error(GdAssertMessages.error_equal(null, GdAssertMessages.array_to_string(expected_)))
 	if not GdObjects.equals(current_, expected_):
 		var diff := _array_equals_div(current_, expected_)
-		var expected_as_list := GdObjects.array_to_string(diff[0], ", ", 32)
-		var current_as_list := GdObjects.array_to_string(diff[1], ", ", 32)
+		var expected_as_list := GdAssertMessages.array_to_string(diff[0], false)
+		var current_as_list := GdAssertMessages.array_to_string(diff[1], false)
 		var index_report = diff[2]
 		return report_error(GdAssertMessages.error_equal(expected_as_list, current_as_list, index_report))
 	return report_success()
@@ -125,11 +125,11 @@ func is_equal_ignoring_case(expected) -> GdUnitArrayAssert:
 	var current_ = __current()
 	var expected_ = __expected(expected)
 	if current_ == null and expected_ != null:
-		return report_error(GdAssertMessages.error_equal(null, GdObjects.array_to_string(expected_, ", ", 32)))
+		return report_error(GdAssertMessages.error_equal(null, GdAssertMessages.array_to_string(expected_)))
 	if not GdObjects.equals(current_, expected_, true):
 		var diff := _array_equals_div(current_, expected_, true)
-		var expected_as_list := GdObjects.array_to_string(diff[0], ", ", 32)
-		var current_as_list := GdObjects.array_to_string(diff[1], ", ", 32)
+		var expected_as_list := GdAssertMessages.array_to_string(diff[0], false)
+		var current_as_list := GdAssertMessages.array_to_string(diff[1], false)
 		var index_report = diff[2]
 		return report_error(GdAssertMessages.error_equal(expected_as_list, current_as_list, index_report))
 	return report_success()
@@ -139,8 +139,8 @@ func is_not_equal(expected) -> GdUnitArrayAssert:
 	var current_ = __current()
 	var expected_ = __expected(expected)
 	if GdObjects.equals(current_, expected_):
-		var c := GdObjects.array_to_string(current_, ", ", 32)
-		var e := GdObjects.array_to_string(expected_, ", ", 32)
+		var c := GdAssertMessages.array_to_string(current_)
+		var e := GdAssertMessages.array_to_string(expected_)
 		return report_error(GdAssertMessages.error_not_equal(c, e))
 	return report_success()
 
@@ -149,8 +149,8 @@ func is_not_equal_ignoring_case(expected) -> GdUnitArrayAssert:
 	var current_ = __current()
 	var expected_ = __expected(expected)
 	if GdObjects.equals(current_, expected_, true):
-		var c := GdObjects.array_to_string(current_, ", ", 32)
-		var e := GdObjects.array_to_string(expected_, ", ", 32)
+		var c := GdAssertMessages.array_to_string(current_)
+		var e := GdAssertMessages.array_to_string(expected_)
 		return report_error(GdAssertMessages.error_not_equal_case_insensetiv(c, e))
 	return report_success()
 
@@ -219,6 +219,22 @@ func contains_exactly_in_any_order(expected) -> GdUnitArrayAssert:
 	if not_expect.is_empty() and not_found.is_empty():
 		return report_success()
 	return report_error(GdAssertMessages.error_arr_contains_exactly_in_any_order(current_, expected_, not_expect, not_found))
+
+
+@warning_ignore("unused_parameter")
+func not_contains(expected) -> GdUnitArrayAssert:
+	if not __validate_value_type(expected):
+		return report_error("Unexpected type: <%s>\n You only allowed to verify against Array Types!" % GdObjects.typeof_as_string(expected))
+	var current_ = __current()
+	var expected_ = __expected(expected)
+	if current_ == null:
+		return report_error(GdAssertMessages.error_arr_contains_exactly_in_any_order(current_, expected_, [], expected_))
+	var diffs := _array_div(current_, expected_)
+	var found := diffs[0] as Array
+	if found.size() == current_.size():
+		return report_success()
+	var diffs2 := _array_div(expected_, diffs[1])
+	return report_error(GdAssertMessages.error_arr_not_contains(current_, expected_, diffs2[0]))
 
 
 @warning_ignore("shadowed_global_identifier")

--- a/addons/gdUnit4/src/asserts/GdUnitArrayAssertImpl.gd
+++ b/addons/gdUnit4/src/asserts/GdUnitArrayAssertImpl.gd
@@ -221,7 +221,6 @@ func contains_exactly_in_any_order(expected) -> GdUnitArrayAssert:
 	return report_error(GdAssertMessages.error_arr_contains_exactly_in_any_order(current_, expected_, not_expect, not_found))
 
 
-@warning_ignore("unused_parameter")
 func not_contains(expected) -> GdUnitArrayAssert:
 	if not __validate_value_type(expected):
 		return report_error("Unexpected type: <%s>\n You only allowed to verify against Array Types!" % GdObjects.typeof_as_string(expected))

--- a/addons/gdUnit4/src/core/GdObjects.gd
+++ b/addons/gdUnit4/src/core/GdObjects.gd
@@ -665,23 +665,6 @@ static func default_value_by_type(type :int):
 	return null
 
 
-static func array_to_string(elements :Array, delimiter := "\n", max_elements := -1) -> String:
-	if elements == null:
-		return "<null>"
-	if elements.is_empty():
-		return "empty"
-	var formatted := ""
-	var index := 0
-	for element in elements:
-		if max_elements != -1 and index > max_elements:
-			return formatted + delimiter + "..."
-		if formatted.length() > 0 :
-			formatted += delimiter
-		formatted += str(element)
-		index += 1
-	return formatted
-
-
 # Filters an array by given value
 static func array_filter_value(array :Array, filter_value) -> Array:
 	var filtered_array := Array()

--- a/addons/gdUnit4/src/core/parse/GdDefaultValueDecoder.gd
+++ b/addons/gdUnit4/src/core/parse/GdDefaultValueDecoder.gd
@@ -4,7 +4,7 @@ extends GdUnitSingleton
 
 
 var _decoders = {
-	TYPE_NIL: func(value): return "<null>",
+	TYPE_NIL: func(value): return "null",
 	TYPE_STRING: func(value): return '"%s"' % value,
 	TYPE_STRING_NAME: func(value): return '"%s"' % value,
 	TYPE_BOOL: func(value): return str(value).to_lower(),

--- a/addons/gdUnit4/src/core/parse/GdDefaultValueDecoder.gd
+++ b/addons/gdUnit4/src/core/parse/GdDefaultValueDecoder.gd
@@ -4,16 +4,18 @@ extends GdUnitSingleton
 
 
 var _decoders = {
-	TYPE_NIL: Callable(self, "_on_type_nill"),
-	TYPE_STRING: Callable(self, "_on_type_string"),
-	TYPE_STRING_NAME: Callable(self, "_on_type_string"),
-	TYPE_BOOL: Callable(self, "_on_type_bool"),
-	TYPE_RID: Callable(self, "_on_type_RID"),
-	TYPE_RECT2: Callable(self, "_on_decode_Rect2").bind(GdDefaultValueDecoder._regex("P: ?(\\(.+\\)), S: ?(\\(.+\\))")),
-	TYPE_RECT2I: Callable(self, "_on_decode_Rect2i").bind(GdDefaultValueDecoder._regex("P: ?(\\(.+\\)), S: ?(\\(.+\\))")),
-	TYPE_TRANSFORM2D: Callable(self, "_on_type_Transform2D"),
-	TYPE_TRANSFORM3D: Callable(self, "_on_type_Transform3D"),
-	TYPE_PACKED_COLOR_ARRAY: Callable(self, "_on_type_PackedColorArray"),
+	TYPE_NIL: func(value): return "<null>",
+	TYPE_STRING: func(value): return '"%s"' % value,
+	TYPE_STRING_NAME: func(value): return '"%s"' % value,
+	TYPE_BOOL: func(value): return str(value).to_lower(),
+	TYPE_FLOAT: func(value): return '%f' % value,
+	TYPE_COLOR: func(value): return "Color%s" % value,
+	TYPE_RID: _on_type_RID,
+	TYPE_RECT2: _on_decode_Rect2.bind(GdDefaultValueDecoder._regex("P: ?(\\(.+\\)), S: ?(\\(.+\\))")),
+	TYPE_RECT2I: _on_decode_Rect2i.bind(GdDefaultValueDecoder._regex("P: ?(\\(.+\\)), S: ?(\\(.+\\))")),
+	TYPE_TRANSFORM2D: _on_type_Transform2D,
+	TYPE_TRANSFORM3D: _on_type_Transform3D,
+	TYPE_PACKED_COLOR_ARRAY: _on_type_PackedColorArray,
 }
 
 static func _regex(pattern :String) -> RegEx:
@@ -26,24 +28,7 @@ static func _regex(pattern :String) -> RegEx:
 
 
 func get_decoder(type :int) -> Callable:
-	return _decoders.get(type)
-
-
-func _on_type_self(value :Variant) -> String:
-	return str(value)
-
-
-@warning_ignore("unused_parameter")
-func _on_type_nill(value :Variant) -> String:
-	return "null"
-
-
-func _on_type_string(value :Variant) -> String:
-	return "\"%s\"" % value
-
-
-func _on_type_bool(value :Variant) -> String:
-	return str(value).to_lower()
+	return _decoders.get(type, func(value): return '%s' % value)
 
 
 func _on_type_Transform2D(value :Variant) -> String:

--- a/addons/gdUnit4/test/asserts/GdUnitArrayAssertImplTest.gd
+++ b/addons/gdUnit4/test/asserts/GdUnitArrayAssertImplTest.gd
@@ -97,7 +97,7 @@ func test_is_equal_ignoring_case():
 		.is_failed() \
 		.has_message("""
 			Expecting:
-			 'This, is'
+			 '"This", "is"'
 			 but was
 			 '<null>'"""
 			.dedent().trim_prefix("\n"))
@@ -125,9 +125,9 @@ func test_is_not_equal_ignoring_case():
 		.is_failed() \
 		.has_message("""
 			Expecting:
-			 'This, is, a, Message'
+			 '"This", "is", "a", "Message"'
 			 not equal to (case insensitiv)
-			 'this, is, a, message'"""
+			 '"this", "is", "a", "message"'"""
 			.dedent().trim_prefix("\n"))
 
 
@@ -303,6 +303,46 @@ func test_contains_exactly_in_any_order():
 			.dedent().trim_prefix("\n"))
 
 
+func test_not_contains():
+	assert_array([]).not_contains([0])
+	assert_array([1, 2, 3, 4, 5]).not_contains([0])
+	assert_array([1, 2, 3, 4, 5]).not_contains([0, 6])
+	
+	assert_failure(func(): assert_array([1, 2, 3, 4, 5]).not_contains([5]))\
+		.is_failed() \
+		.has_message("""
+			Expecting:
+			 1, 2, 3, 4, 5
+			 do not contains
+			 5
+			 but found elements:
+			 5"""
+			.dedent().trim_prefix("\n")
+		)
+	assert_failure(func(): assert_array([1, 2, 3, 4, 5]).not_contains([1, 4, 6])) \
+		.is_failed() \
+		.has_message("""
+			Expecting:
+			 1, 2, 3, 4, 5
+			 do not contains
+			 1, 4, 6
+			 but found elements:
+			 1, 4"""
+			.dedent().trim_prefix("\n")
+		)
+	assert_failure(func(): assert_array([1, 2, 3, 4, 5]).not_contains([6, 4, 1])) \
+		.is_failed() \
+		.has_message("""
+			Expecting:
+			 1, 2, 3, 4, 5
+			 do not contains
+			 6, 4, 1
+			 but found elements:
+			 4, 1"""
+			.dedent().trim_prefix("\n")
+		)
+
+
 func test_fluent():
 	assert_array([])\
 		.has_size(0)\
@@ -351,11 +391,11 @@ func test_extract() -> void:
 			Expecting contains exactly elements:
 			 <null>
 			 do contains (in same order)
-			 AStar3D, Node
+			 "AStar3D", "Node"
 			but some elements where not expected:
 			 <null>
 			and could not find elements:
-			 AStar3D, Node"""
+			 "AStar3D", "Node\""""
 			.dedent().trim_prefix("\n"))
 
 

--- a/addons/gdUnit4/test/asserts/GdUnitPackedArrayAssertTest.gd
+++ b/addons/gdUnit4/test/asserts/GdUnitPackedArrayAssertTest.gd
@@ -6,13 +6,9 @@ const __source = 'res://addons/gdUnit4/src/asserts/GdUnitArrayAssertImpl.gd'
 
 # small value format helper
 func format_value(value) -> String:
-	if value is Color:
-		return "Color%s" % value
-	if value is float:
-		return "%f" % value
 	if GdObjects.is_array_type(value):
-		return ", ".join(Array(value))
-	return "%s" % value
+		return GdAssertMessages.array_to_string(value)
+	return GdAssertMessages._typed_value(value)
 
 
 @warning_ignore("unused_parameter")
@@ -231,6 +227,71 @@ func test_contains_exactly(_test :String, array, test_parameters = [
 			.replace("$B", format_value(array[3]))
 			.replace("$source", format_value(array))
 			.replace("$contains", format_value(shuffled))
+		)
+
+
+@warning_ignore("unused_parameter")
+func test_not_contains(_test :String, array, test_parameters = [
+	["Array", Array([1, 2, 3, 4, 5])],
+	["PackedByteArray", PackedByteArray([1, 2, 3, 4, 5])],
+	["PackedInt32Array", PackedInt32Array([1, 2, 3, 4, 5])],
+	["PackedInt64Array", PackedInt64Array([1, 2, 3, 4, 5])],
+	["PackedFloat32Array", PackedFloat32Array([1, 2, 3, 4, 5])],
+	["PackedFloat64Array", PackedFloat64Array([1, 2, 3, 4, 5])],
+	["PackedStringArray", PackedStringArray(["1", "2", "3", "4", "5"])],
+	["PackedVector2Array", PackedVector2Array([Vector2.ZERO, Vector2.LEFT, Vector2.RIGHT, Vector2.UP, Vector2.DOWN])],
+	["PackedVector3Array", PackedVector3Array([Vector3.ZERO, Vector3.LEFT, Vector3.RIGHT, Vector3.UP, Vector3.DOWN])],
+	["PackedColorArray", PackedColorArray([Color.RED, Color.GREEN, Color.BLUE, Color.YELLOW, Color.BLACK])] ]
+	) -> void:
+	
+	assert_array(array).not_contains([0])
+	assert_array(array).not_contains([0])
+	assert_array(array).not_contains([0, 6])
+	
+	var should_not_contain = [array[4]]
+	assert_failure(func(): assert_array(array).not_contains(should_not_contain))\
+		.is_failed() \
+		.has_message("""
+			Expecting:
+			 $current
+			 do not contains
+			 $not_contain
+			 but found elements:
+			 $found"""
+			.dedent().trim_prefix("\n")
+			.replace("$current", format_value(array))
+			.replace("$not_contain",  format_value(should_not_contain))
+			.replace("$found", format_value(array[4]))
+		)
+	should_not_contain = [array[0], array[3], 6]
+	assert_failure(func(): assert_array(array).not_contains(should_not_contain)) \
+		.is_failed() \
+		.has_message("""
+			Expecting:
+			 $current
+			 do not contains
+			 $not_contain
+			 but found elements:
+			 $found"""
+			.dedent().trim_prefix("\n")
+			.replace("$current", format_value(array))
+			.replace("$not_contain",  format_value(should_not_contain))
+			.replace("$found", format_value([array[0], array[3]]))
+		)
+	should_not_contain = [6, array[3], array[0]]
+	assert_failure(func(): assert_array(array).not_contains(should_not_contain)) \
+		.is_failed() \
+		.has_message("""
+			Expecting:
+			 $current
+			 do not contains
+			 $not_contain
+			 but found elements:
+			 $found"""
+			.dedent().trim_prefix("\n")
+			.replace("$current", format_value(array))
+			.replace("$not_contain",  format_value(should_not_contain))
+			.replace("$found", format_value([array[3], array[0]]))
 		)
 
 


### PR DESCRIPTION
`assert_array([1, 2, 3, 4, 5]).not_contains([0, 6])`

# Why
We want to check if an array does not contain certain values

# What
- Added missing validaiton `not_contains(expected)`
- Resolve error messages by formatting the values correctly