### PR TITLE
GD-168: Renamed mock function `checked` back to original named `on`

### DIFF
--- a/addons/gdUnit4/src/GdUnitTestSuite.gd
+++ b/addons/gdUnit4/src/GdUnitTestSuite.gd
@@ -185,7 +185,12 @@ func spy(instance):
 	return GdUnitSpyBuilder.build(self, instance)
 
 
-## Configures a return value for the specified function and used arguments.
+## Configures a return value for the specified function and used arguments.[br]
+## [b]Example:
+## 	[codeblock]
+## 		# overrides the return value of myMock.is_selected() to false
+## 		do_return(false).on(myMock).is_selected()
+## 	[/codeblock]
 func do_return(value) -> GdUnitMock:
 	return GdUnitMock.new(value)
 

--- a/addons/gdUnit4/src/mocking/GdUnitMock.gd
+++ b/addons/gdUnit4/src/mocking/GdUnitMock.gd
@@ -16,10 +16,21 @@ func _init(value):
 	_value = value
 
 
-func checked(obj :Object):
+## Selects the mock to work on, used in combination with [method GdUnitTestSuite.do_return][br]
+## Example:
+## 	[codeblock]
+## 		do_return(false).on(myMock).is_selected()
+## 	[/codeblock]
+func on(obj :Object) -> Object:
 	if not GdUnitMock._is_mock_or_spy( obj, "__do_return"):
 		return obj
 	return obj.__do_return(_value)
+
+
+## [color=yellow]`checked` is obsolete, use `on` instead [/color]
+func  checked(obj :Object) -> Object:
+	push_warning("Using a deprecated function 'checked' use `on` instead")
+	return on(obj)
 
 
 static func _is_mock_or_spy(obj :Object, func_sig :String) -> bool:

--- a/addons/gdUnit4/test/core/GdUnitCommandHandlerTest.gd
+++ b/addons/gdUnit4/test/core/GdUnitCommandHandlerTest.gd
@@ -11,11 +11,11 @@ func test__check_test_run_stopped_manually() -> void:
 	inspector._client_id = 1
 	
 	# simulate no test is running
-	do_return(false).checked(inspector).is_test_running_but_stop_pressed()
+	do_return(false).on(inspector).is_test_running_but_stop_pressed()
 	inspector.check_test_run_stopped_manually()
 	verify(inspector, 0).cmd_stop(any_int())
 	
 	# simulate the test runner was manually stopped by the editor
-	do_return(true).checked(inspector).is_test_running_but_stop_pressed()
+	do_return(true).on(inspector).is_test_running_but_stop_pressed()
 	inspector.check_test_run_stopped_manually()
 	verify(inspector, 1).cmd_stop(inspector._client_id)

--- a/addons/gdUnit4/test/mocker/GdUnitMockerTest.gd
+++ b/addons/gdUnit4/test/mocker/GdUnitMockerTest.gd
@@ -119,7 +119,7 @@ func test_mock_Node():
 	# test mocked function returns default typed value
 	assert_that(mocked_node.get_child_count()).is_equal(0)
 	# now mock return value for function 'foo' to 'overwriten value'
-	do_return(24).checked(mocked_node).get_child_count()
+	do_return(24).on(mocked_node).get_child_count()
 	# verify the return value is overwritten
 	assert_that(mocked_node.get_child_count()).is_equal(24)
 
@@ -231,13 +231,13 @@ func test_mock_custom_class_by_class_name():
 	assert_that(m.foo()).is_equal("")
 	
 	# now mock return value for function 'foo' to 'overwriten value'
-	do_return("overriden value").checked(m).foo()
+	do_return("overriden value").on(m).foo()
 	# verify the return value is overwritten
 	assert_that(m.foo()).is_equal("overriden value")
 	
 	# now mock return values by custom arguments
-	do_return("arg_1").checked(m).bar(1)
-	do_return("arg_2").checked(m).bar(2)
+	do_return("arg_1").on(m).bar(1)
+	do_return("arg_2").on(m).bar(2)
 	
 	assert_that(m.bar(1)).is_equal("arg_1")
 	assert_that(m.bar(2)).is_equal("arg_2")
@@ -253,13 +253,13 @@ func test_mock_custom_class_by_resource_path():
 	assert_that(m.foo()).is_equal("")
 	
 	# now mock return value for function 'foo' to 'overwriten value'
-	do_return("overriden value").checked(m).foo()
+	do_return("overriden value").on(m).foo()
 	# verify the return value is overwritten
 	assert_that(m.foo()).is_equal("overriden value")
 	
 	# now mock return values by custom arguments
-	do_return("arg_1").checked(m).bar(1)
-	do_return("arg_2").checked(m).bar(2)
+	do_return("arg_1").on(m).bar(1)
+	do_return("arg_2").on(m).bar(2)
 	
 	assert_that(m.bar(1)).is_equal("arg_1")
 	assert_that(m.bar(2)).is_equal("arg_2")
@@ -271,7 +271,7 @@ func test_mock_custom_class_func_foo_use_real_func():
 	# test mocked function returns value from real function
 	assert_that(m.foo()).is_equal("foo")
 	# now mock return value for function 'foo' to 'overwriten value'
-	do_return("overridden value").checked(m).foo()
+	do_return("overridden value").on(m).foo()
 	# verify the return value is overwritten
 	assert_that(m.foo()).is_equal("overridden value")
 
@@ -282,7 +282,7 @@ func test_mock_custom_class_void_func():
 	# test mocked void function returns null by default
 	assert_that(m.foo_void()).is_null()
 	# try now mock return value for a void function. results into an error
-	do_return("overridden value").checked(m).foo_void()
+	do_return("overridden value").on(m).foo_void()
 	# verify it has no affect for void func
 	assert_that(m.foo_void()).is_null()
 
@@ -293,7 +293,7 @@ func test_mock_custom_class_void_func_real_func():
 	# test mocked void function returns null by default
 	assert_that(m.foo_void()).is_null()
 	# try now mock return value for a void function. results into an error
-	do_return("overridden value").checked(m).foo_void()
+	do_return("overridden value").on(m).foo_void()
 	# verify it has no affect for void func
 	assert_that(m.foo_void()).is_null()
 
@@ -330,7 +330,7 @@ func test_mock_custom_class_func_foo_full_test():
 	verify(m, 0).foo()
 	assert_that(m.foo()).is_equal("")
 	verify(m, 1).foo()
-	do_return("new value").checked(m).foo()
+	do_return("new value").on(m).foo()
 	verify(m, 1).foo()
 	assert_that(m.foo()).is_equal("new value")
 	verify(m, 2).foo()
@@ -342,7 +342,7 @@ func test_mock_custom_class_func_foo_full_test_real_func():
 	verify(m, 0).foo()
 	assert_that(m.foo()).is_equal("foo")
 	verify(m, 1).foo()
-	do_return("new value").checked(m).foo()
+	do_return("new value").on(m).foo()
 	verify(m, 1).foo()
 	assert_that(m.foo()).is_equal("new value")
 	verify(m, 2).foo()
@@ -360,7 +360,7 @@ func test_mock_custom_class_func_bar():
 	verify(m, 0).bar(23)
 	
 	# now mock return value for function 'bar' with args [10] to 'overwriten value'
-	do_return("overridden value").checked(m).bar(10)
+	do_return("overridden value").on(m).bar(10)
 	# verify the return value is overwritten
 	assert_that(m.bar(10)).is_equal("overridden value")
 	# finally verify function call times
@@ -381,7 +381,7 @@ func test_mock_custom_class_func_bar_real_func():
 	verify(m, 0).bar(23)
 	
 	# now mock return value for function 'bar' with args [10] to 'overwriten value'
-	do_return("overridden value").checked(m).bar(10)
+	do_return("overridden value").on(m).bar(10)
 	# verify the return value is overwritten
 	assert_that(m.bar(10)).is_equal("overridden value")
 	# verify the real implementation is used
@@ -452,9 +452,9 @@ func test_mock_custom_class_extends_other_custom_class():
 	verify(m, 1).bar2()
 	
 	# override returns
-	do_return("abc1").checked(m).foo()
-	do_return("abc2").checked(m).foo2()
-	do_return("abc3").checked(m).bar2()
+	do_return("abc1").on(m).foo()
+	do_return("abc2").on(m).foo2()
+	do_return("abc3").on(m).bar2()
 	
 	assert_that(m.foo()).is_equal("abc1")
 	assert_that(m.foo2()).is_equal("abc2")
@@ -481,9 +481,9 @@ func test_mock_custom_class_extends_other_custom_class_call_real_func():
 	verify(m, 1).bar2()
 	
 	# override returns
-	do_return("abc1").checked(m).foo()
-	do_return("abc2").checked(m).foo2()
-	do_return("abc3").checked(m).bar2()
+	do_return("abc1").on(m).foo()
+	do_return("abc2").on(m).foo2()
+	do_return("abc3").on(m).bar2()
 	
 	assert_that(m.foo()).is_equal("abc1")
 	assert_that(m.foo2()).is_equal("abc2")
@@ -584,7 +584,7 @@ func test_mock_advanced_func_path():
 	verify(m, 1).a()
 	
 	# call select again wiht overriden return value for func a()
-	do_return("overridden a func").checked(m).a()
+	do_return("overridden a func").on(m).a()
 	assert_that(m.select(AdvancedTestClass.A)).is_equal("overridden a func")
 	
 	# verify at this time select() and a() is called two times
@@ -633,7 +633,7 @@ func test_example_do_return():
 	# is return 0 by default
 	mocked_node.get_child_count()
 	# configure to return 10 when 'get_child_count()' is called
-	do_return(10).checked(mocked_node).get_child_count()
+	do_return(10).on(mocked_node).get_child_count()
 	# will now return 10
 	mocked_node.get_child_count()
 	
@@ -642,9 +642,9 @@ func test_example_do_return():
 	assert_object(node).is_null()
 	
 	# configure to return a mocked 'Camera3D' for child 0
-	do_return(mock(Camera3D)).checked(mocked_node).get_child(0)
+	do_return(mock(Camera3D)).on(mocked_node).get_child(0)
 	# configure to return a mocked 'Area3D' for child 1
-	do_return(mock(Area3D)).checked(mocked_node).get_child(1)
+	do_return(mock(Area3D)).on(mocked_node).get_child(1)
 	
 	# will now return the Camera3D node
 	var node0 = mocked_node.get_child(0)

--- a/addons/gdUnit4/test/monitor/GodotGdErrorMonitorTest.gd
+++ b/addons/gdUnit4/test/monitor/GodotGdErrorMonitorTest.gd
@@ -31,14 +31,14 @@ func test_parse_push_error_line_number() -> void:
 func test_scan_for_push_errors() -> void:
 	var monitor := mock(GodotGdErrorMonitor, CALL_REAL_FUNC) as GodotGdErrorMonitor
 	monitor._report_enabled = true
-	do_return(error_report.dedent().split('\n')).checked(monitor)._collect_log_entries()
+	do_return(error_report.dedent().split('\n')).on(monitor)._collect_log_entries()
 	
 	# with disabled push_error reporting
-	do_return(false).checked(monitor)._is_report_push_errors()
+	do_return(false).on(monitor)._is_report_push_errors()
 	assert_array(monitor.reports()).is_empty()
 	
 	# with enabled push_error reporting
-	do_return(true).checked(monitor)._is_report_push_errors()
+	do_return(true).on(monitor)._is_report_push_errors()
 	
 	var expected_report := GodotGdErrorMonitor._report_user_error("USER ERROR: this is an error", "at: push_error (core/variant/variant_utility.cpp:880)")
 	assert_array(monitor.reports()).contains_exactly([expected_report])
@@ -47,14 +47,14 @@ func test_scan_for_push_errors() -> void:
 func test_scan_for_script_errors() -> void:
 	var monitor := mock(GodotGdErrorMonitor, CALL_REAL_FUNC) as GodotGdErrorMonitor
 	monitor._report_enabled = true
-	do_return(script_error.dedent().split('\n')).checked(monitor)._collect_log_entries()
+	do_return(script_error.dedent().split('\n')).on(monitor)._collect_log_entries()
 	
 	# with disabled push_error reporting
-	do_return(false).checked(monitor)._is_report_script_errors()
+	do_return(false).on(monitor)._is_report_script_errors()
 	assert_array(monitor.reports()).is_empty()
 	
 	# with enabled push_error reporting
-	do_return(true).checked(monitor)._is_report_script_errors()
+	do_return(true).on(monitor)._is_report_script_errors()
 	
 	var expected_report := GodotGdErrorMonitor._report_runtime_error("USER SCRIPT ERROR: Trying to call a function on a previously freed instance.",\
 		"at: GdUnitScriptTypeTest.test_xx (res://addons/gdUnit4/test/GdUnitScriptTypeTest.gd:22)")

--- a/addons/gdUnit4/test/network/GdUnitTcpServerTest.gd
+++ b/addons/gdUnit4/test/network/GdUnitTcpServerTest.gd
@@ -13,7 +13,7 @@ func test_read_next_data_packages() -> void:
 	var server = mock(TCPServer)
 	var stream = mock(StreamPeerTCP)
 	
-	do_return(stream).checked(server).take_connection()
+	do_return(stream).on(server).take_connection()
 	
 	var connection :GdUnitTcpServer.TcpConnection = auto_free(GdUnitTcpServer.TcpConnection.new(server))
 	
@@ -42,7 +42,7 @@ func test_receive_packages() -> void:
 	var server = mock(TCPServer)
 	var stream = mock(StreamPeerTCP)
 	
-	do_return(stream).checked(server).take_connection()
+	do_return(stream).on(server).take_connection()
 	
 	var connection :GdUnitTcpServer.TcpConnection = auto_free(GdUnitTcpServer.TcpConnection.new(server))
 	var test_server :GdUnitTcpServer = auto_free(GdUnitTcpServer.new())
@@ -53,8 +53,8 @@ func test_receive_packages() -> void:
 	# mock send RPCMessage
 	var data := DLM + RPCMessage.of("Test Message").serialize() + DLM
 	var package_data = [0, data.to_ascii_buffer()]
-	do_return(data.length()).checked(stream).get_available_bytes()
-	do_return(package_data).checked(stream).get_partial_data(data.length())
+	do_return(data.length()).on(stream).get_available_bytes()
+	do_return(package_data).on(stream).get_partial_data(data.length())
 	
 	# do receive next packages
 	connection.receive_packages()


### PR DESCRIPTION
# Why
The fuction GdUnitMock.on() was renamed to `checked` during migration to Godot4 This was a mistake and must be reverted.

# What
Re-addet the `on` function and set `checked` to deprecated