### PR TITLE
GD-103: Add monitor signals for a source to collect emitted signals

### DIFF
--- a/addons/gdUnit4/src/GdUnitTestSuite.gd
+++ b/addons/gdUnit4/src/GdUnitTestSuite.gd
@@ -215,6 +215,24 @@ func reset(obj) -> void:
 	GdUnitObjectInteractions.reset(obj)
 
 
+## Starts monitoring the specified source to collect all transmitted signals.[br]
+## The collected signals can then be checked with 'assert_signal'.[br]
+## By default, the specified source is automatically released when the test ends.
+## You can control this behavior by setting auto_free to false if you do not want the source to be automatically freed.[br]
+## Usage:
+##	[codeblock]
+##		var emitter := monitor_signals(MyEmitter.new())
+##		# call the function to send the signal
+##		emitter.do_it()
+##		# verify the signial is emitted
+##		await assert_signal(emitter).is_emitted('my_signal')
+##	[/codeblock]
+func monitor_signals(source :Object, auto_free := true) -> Object:
+	var signal_collector := GdUnitThreadManager.get_current_context().get_signal_collector()
+	signal_collector.register_emitter(source)
+	return auto_free(source) if auto_free else source
+
+
 # === Argument matchers ========================================================
 ## Argument matcher to match any argument
 func any() -> GdUnitArgumentMatcher:

--- a/addons/gdUnit4/src/asserts/GdUnitSignalAssertImpl.gd
+++ b/addons/gdUnit4/src/asserts/GdUnitSignalAssertImpl.gd
@@ -4,19 +4,18 @@ extends GdUnitSignalAssert
 const DEFAULT_TIMEOUT := 2000
 const NO_ARG = GdUnitConstants.NO_ARG
 
+var _signal_collector :GdUnitSignalAssertImpl.SignalCollector
 var _emitter :Object
 var _current_error_message :String = ""
 var _custom_failure_message :String = ""
 var _line_number := -1
 var _timeout := DEFAULT_TIMEOUT
 var _interrupted := false
-var _signal_collector :SignalCollector = SignalCollector.instance("SignalCollector", func(): return SignalCollector.new())
 
 
-# This is an singelton implementation and reused for each GdUnitSignalAssert
 # It connects to all signals of given emitter and collects received signals and arguments
 # The collected signals are cleand finally when the emitter is freed.
-class SignalCollector extends GdUnitSingleton:
+class SignalCollector extends RefCounted:
 	const SIGNAL_BLACK_LIST = []#["tree_exiting", "tree_exited", "child_exiting_tree"]
 	
 	# {
@@ -26,6 +25,12 @@ class SignalCollector extends GdUnitSingleton:
 	#	}
 	# }
 	var _collected_signals :Dictionary = {}
+	
+	
+	func clear() -> void:
+		for emitter in _collected_signals:
+			if is_instance_valid(emitter):
+				unregister_emitter(emitter)
 	
 	
 	# connect to all possible signals defined by the emitter
@@ -56,8 +61,8 @@ class SignalCollector extends GdUnitSingleton:
 	# unregister all acquired resources/connections, otherwise it ends up in orphans
 	# is called when the emitter is removed from the parent
 	func unregister_emitter(emitter :Object):
-		GdUnitTools._release_connections(emitter)
 		if is_instance_valid(emitter):
+			GdUnitTools._release_connections(emitter)
 			_collected_signals.erase(emitter)
 	
 	
@@ -67,17 +72,17 @@ class SignalCollector extends GdUnitSingleton:
 		# extract the emitter and signal_name from the last two arguments (see line 61 where is added)
 		var signal_name :String = signal_args.pop_back()
 		var emitter :Object = signal_args.pop_back()
-		#prints("_on_signal_emmited:", emitter, signal_name, signal_args)
+		# prints("_on_signal_emmited:", emitter, signal_name, signal_args)
 		if is_signal_collecting(emitter, signal_name):
 			_collected_signals[emitter][signal_name].append(signal_args)
 	
 	
 	func reset_received_signals(emitter :Object):
-		#_debug_signal_list("before claer");
-		if _collected_signals.has(emitter) or not _collected_signals.has(emitter):
+		# _debug_signal_list("before claer");
+		if _collected_signals.has(emitter):
 			for signal_name in _collected_signals[emitter]:
 				_collected_signals[emitter][signal_name].clear()
-		#_debug_signal_list("after claer");
+		# _debug_signal_list("after claer");
 	
 	
 	func is_signal_collecting(emitter :Object, signal_name :String) -> bool:
@@ -89,7 +94,7 @@ class SignalCollector extends GdUnitSingleton:
 		if _collected_signals.is_empty() or not _collected_signals.has(emitter):
 			return false
 		for received_args in _collected_signals[emitter][signal_name]:
-			#prints("testing", signal_name, received_args, "vs", args)
+			# prints("testing", signal_name, received_args, "vs", args)
 			if GdObjects.equals(received_args, args):
 				return true
 		return false
@@ -108,7 +113,9 @@ class SignalCollector extends GdUnitSingleton:
 
 func _init(emitter :Object):
 	# save the actual assert instance on the current thread context
-	GdUnitThreadManager.get_current_context().set_assert(self)
+	var context := GdUnitThreadManager.get_current_context()
+	context.set_assert(self)
+	_signal_collector = context.get_signal_collector()
 	_line_number = GdUnitAssertImpl._get_line_number()
 	_emitter =  emitter
 	GdAssertReports.reset_last_error_line_number()

--- a/addons/gdUnit4/src/core/GdUnitExecutor.gd
+++ b/addons/gdUnit4/src/core/GdUnitExecutor.gd
@@ -285,13 +285,14 @@ func execute(test_suite :GdUnitTestSuite):
 
 
 func Execute(test_suite :GdUnitTestSuite) -> void:
+	var context := GdUnitThreadManager.get_current_context()
+	context.init()
 	# stop checked first error if fail fast enabled
 	if _fail_fast and _total_test_failed > 0:
 		test_suite.free()
 		await get_tree().process_frame
 		ExecutionCompleted.emit()
 		return
-	
 	var ts := test_suite
 	await suite_before(ts, ts.get_child_count())
 	
@@ -327,6 +328,7 @@ func Execute(test_suite :GdUnitTestSuite) -> void:
 				
 	await suite_after(ts)
 	ts.free()
+	context.clear()
 	ExecutionCompleted.emit()
 
 

--- a/addons/gdUnit4/src/core/thread/GdUnitThreadContext.gd
+++ b/addons/gdUnit4/src/core/thread/GdUnitThreadContext.gd
@@ -4,10 +4,21 @@ extends RefCounted
 
 var _thread :Thread
 var _assert :GdUnitAssert
+var _signal_collector :GdUnitSignalAssertImpl.SignalCollector
 
 
 func _init(thread :Thread = null):
 	_thread = thread
+	_signal_collector = GdUnitSignalAssertImpl.SignalCollector.new()
+
+
+func init() -> void:
+	clear()
+
+func clear() -> void:
+	_assert = null
+	if is_instance_valid(_signal_collector):
+		_signal_collector.clear()
 
 
 func set_assert(value :GdUnitAssert) -> GdUnitThreadContext:
@@ -17,6 +28,10 @@ func set_assert(value :GdUnitAssert) -> GdUnitThreadContext:
 
 func get_assert() -> GdUnitAssert:
 	return _assert
+
+
+func get_signal_collector() -> GdUnitSignalAssertImpl.SignalCollector:
+	return _signal_collector
 
 
 func _to_string() -> String:


### PR DESCRIPTION
# Why
I want to test all emitted signals over the lifetime of a source.

# What
- Added new tool `monitor_signals(<source>)` to collect all emitted signals.
- Existing SignalCollector converted from singleton to a RefCounted instance, the signal collector is now thread-context-bound