### PR TITLE
GD-172: Cleanup GdUnit asserts by remove obsolete `ValueProvider`

### DIFF
--- a/addons/gdUnit4/src/asserts/GdUnitArrayAssertImpl.gd
+++ b/addons/gdUnit4/src/asserts/GdUnitArrayAssertImpl.gd
@@ -2,8 +2,10 @@ class_name GdUnitArrayAssertImpl
 extends GdUnitArrayAssert
 
 var _base :GdUnitAssert
+var _current_value_provider :ValueProvider
 
 func _init(current):
+	_current_value_provider = DefaultValueProvider.new(current)
 	_base = GdUnitAssertImpl.new(current)
 	# save the actual assert instance on the current thread context
 	GdUnitThreadManager.get_current_context().set_assert(self)
@@ -38,14 +40,13 @@ func override_failure_message(message :String) -> GdUnitArrayAssert:
 
 func __validate_value_type(value) -> bool:
 	return (
-		value is ValueProvider
-		or value == null
+		value == null
 		or GdObjects.is_array_type(value)
 	)
 
 
 func __current() -> Variant:
-	var current = _base.__current()
+	var current = _current_value_provider.get_value()
 	if current == null or typeof(current) == TYPE_ARRAY:
 		return current
 	return Array(current)
@@ -261,7 +262,7 @@ func extract(func_name :String, args := Array()) -> GdUnitArrayAssert:
 	else:
 		for element in current:
 			extracted_elements.append(extractor.extract_value(element))
-	_base._current_value_provider = DefaultValueProvider.new(extracted_elements)
+	_current_value_provider = DefaultValueProvider.new(extracted_elements)
 	return self
 
 
@@ -292,5 +293,5 @@ func extractv(
 				extracted_elements.append(GdUnitTuple.new(ev[0], ev[1], ev[2], ev[3], ev[4], ev[5], ev[6], ev[7], ev[8], ev[9]))
 			else:
 				extracted_elements.append(ev[0])
-	_base._current_value_provider = DefaultValueProvider.new(extracted_elements)
+	_current_value_provider = DefaultValueProvider.new(extracted_elements)
 	return self

--- a/addons/gdUnit4/src/asserts/GdUnitAssertImpl.gd
+++ b/addons/gdUnit4/src/asserts/GdUnitAssertImpl.gd
@@ -2,7 +2,7 @@ class_name GdUnitAssertImpl
 extends GdUnitAssert
 
 
-var _current_value_provider :ValueProvider
+var _current :Variant
 var _current_error_message :String = ""
 var _custom_failure_message :String = ""
 
@@ -31,9 +31,9 @@ static func _get_line_number() -> int:
 
 
 func _init(current :Variant):
+	_current = current
 	# save the actual assert instance on the current thread context
 	GdUnitThreadManager.get_current_context().set_assert(self)
-	_current_value_provider = current if current is ValueProvider else DefaultValueProvider.new(current)
 	GdAssertReports.reset_last_error_line_number()
 
 
@@ -42,11 +42,11 @@ func _failure_message() -> String:
 
 
 func __current() -> Variant:
-	return _current_value_provider.get_value()
+	return _current
 
 
 func __validate_value_type(value, type :Variant.Type) -> bool:
-	return value is ValueProvider or value == null or typeof(value) == type
+	return value == null or typeof(value) == type
 
 
 func report_success() -> GdUnitAssert:

--- a/addons/gdUnit4/src/asserts/GdUnitObjectAssertImpl.gd
+++ b/addons/gdUnit4/src/asserts/GdUnitObjectAssertImpl.gd
@@ -8,12 +8,11 @@ func _init(current):
 	_base = GdUnitAssertImpl.new(current)
 	# save the actual assert instance on the current thread context
 	GdUnitThreadManager.get_current_context().set_assert(self)
-	if current is ValueProvider or current == null:
-		return
-	if _base.__validate_value_type(current, TYPE_BOOL)\
-		or _base.__validate_value_type(current, TYPE_INT)\
-		or _base.__validate_value_type(current, TYPE_FLOAT)\
-		or _base.__validate_value_type(current, TYPE_STRING):
+	if (current != null
+		and (_base.__validate_value_type(current, TYPE_BOOL)
+		or _base.__validate_value_type(current, TYPE_INT)
+		or _base.__validate_value_type(current, TYPE_FLOAT)
+		or _base.__validate_value_type(current, TYPE_STRING))):
 			report_error("GdUnitObjectAssert inital error, unexpected type <%s>" % GdObjects.typeof_as_string(current))
 
 

--- a/addons/gdUnit4/src/asserts/GdUnitResultAssertImpl.gd
+++ b/addons/gdUnit4/src/asserts/GdUnitResultAssertImpl.gd
@@ -19,7 +19,7 @@ func _notification(event):
 
 
 func __validate_value_type(value) -> bool:
-	return value is ValueProvider or value == null or value is Result
+	return value == null or value is Result
 
 
 func __current() -> Result:

--- a/addons/gdUnit4/test/asserts/GdUnitArrayAssertImplTest.gd
+++ b/addons/gdUnit4/test/asserts/GdUnitArrayAssertImplTest.gd
@@ -544,17 +544,6 @@ func test_override_failure_message() -> void:
 		.has_message("Custom failure message")
 
 
-var _value = 0
-func next_value() -> Array:
-	_value += 1
-	return [_value]
-
-
-func test_with_value_provider() -> void:
-	assert_array(CallBackValueProvider.new(self, "next_value"))\
-		.is_equal([1]).is_equal([2]).is_equal([3])
-
-
 # tests if an assert fails the 'is_failure' reflects the failure status
 func test_is_failure() -> void:
 	# initial is false

--- a/addons/gdUnit4/test/asserts/GdUnitAssertImplTest.gd
+++ b/addons/gdUnit4/test/asserts/GdUnitAssertImplTest.gd
@@ -115,23 +115,3 @@ func test_override_failure_message() -> void:
 		.is_failed() \
 		.has_line(112) \
 		.has_message("Custom failure message")
-
-
-func test_construct_with_value() -> void:
-	var assert_imp := GdUnitAssertImpl.new("a value")
-	assert_bool(assert_imp._current_value_provider is DefaultValueProvider).is_true()
-	assert_str(assert_imp.__current()).is_equal("a value")
-
-
-var _value = 0
-func next_value() -> int:
-	_value += 1
-	return _value
-
-
-func test_construct_with_value_provider() -> void:
-	var assert_imp := GdUnitAssertImpl.new(CallBackValueProvider.new(self, "next_value"))
-	assert_bool(assert_imp._current_value_provider is CallBackValueProvider).is_true()
-	assert_int(assert_imp.__current()).is_equal(1)
-	assert_int(assert_imp.__current()).is_equal(2)
-	assert_int(assert_imp.__current()).is_equal(3)

--- a/addons/gdUnit4/test/asserts/GdUnitBoolAssertImplTest.gd
+++ b/addons/gdUnit4/test/asserts/GdUnitBoolAssertImplTest.gd
@@ -93,17 +93,6 @@ func test_override_failure_message() -> void:
 		.has_message("Custom failure message")
 
 
-var _value = 0
-func next_value() -> bool:
-	_value += 1
-	return true if _value == 1 else false
-
-
-func test_with_value_provider() -> void:
-	assert_bool(CallBackValueProvider.new(self, "next_value"))\
-		.is_true().is_false().is_false()
-
-
 # tests if an assert fails the 'is_failure' reflects the failure status
 func test_is_failure() -> void:
 	# initial is false

--- a/addons/gdUnit4/test/asserts/GdUnitDictionaryAssertImplTest.gd
+++ b/addons/gdUnit4/test/asserts/GdUnitDictionaryAssertImplTest.gd
@@ -272,17 +272,6 @@ func test_override_failure_message() -> void:
 		.has_message("Custom failure message")
 
 
-var _value = 0
-func next_value() -> Dictionary:
-	_value += 1
-	return { "key_%d" % _value : _value}
-
-
-func test_with_value_provider() -> void:
-	assert_dict(CallBackValueProvider.new(self, "next_value"))\
-		.is_equal({"key_1" : 1}).is_equal({"key_2" : 2}).is_equal({"key_3" : 3})
-
-
 # tests if an assert fails the 'is_failure' reflects the failure status
 func test_is_failure() -> void:
 	# initial is false

--- a/addons/gdUnit4/test/asserts/GdUnitFloatAssertImplTest.gd
+++ b/addons/gdUnit4/test/asserts/GdUnitFloatAssertImplTest.gd
@@ -220,17 +220,6 @@ func test_override_failure_message() -> void:
 		.has_message("Custom failure message")
 
 
-var _value :float = 0
-func next_value() -> float:
-	_value += 1.1
-	return _value
-
-
-func test_with_value_provider() -> void:
-	assert_float(CallBackValueProvider.new(self, "next_value"))\
-		.is_equal(1.1).is_equal(2.2)
-
-
 # tests if an assert fails the 'is_failure' reflects the failure status
 func test_is_failure() -> void:
 	# initial is false

--- a/addons/gdUnit4/test/asserts/GdUnitIntAssertImplTest.gd
+++ b/addons/gdUnit4/test/asserts/GdUnitIntAssertImplTest.gd
@@ -216,17 +216,6 @@ func test_override_failure_message() -> void:
 		.has_message("Custom failure message")
 
 
-var _value := 0
-func next_value() -> int:
-	_value += 1
-	return _value
-
-
-func test_with_value_provider() -> void:
-	assert_int(CallBackValueProvider.new(self, "next_value"))\
-		.is_equal(1).is_equal(2).is_equal(3)
-
-
 # tests if an assert fails the 'is_failure' reflects the failure status
 func test_is_failure() -> void:
 	# initial is false

--- a/addons/gdUnit4/test/asserts/GdUnitObjectAssertImplTest.gd
+++ b/addons/gdUnit4/test/asserts/GdUnitObjectAssertImplTest.gd
@@ -138,18 +138,6 @@ func test_override_failure_message() -> void:
 		.has_message("Custom failure message")
 
 
-var _index = -1
-var _values := [RefCounted.new(), RefCounted.new(), RefCounted.new()]
-func next_value() -> Object:
-	_index += 1
-	return _values[_index]
-
-
-func test_with_value_provider() -> void:
-	assert_object(CallBackValueProvider.new(self, "next_value"))\
-		.is_equal(_values[0]).is_equal(_values[1]).is_equal(_values[2])
-
-
 # tests if an assert fails the 'is_failure' reflects the failure status
 func test_is_failure() -> void:
 	# initial is false

--- a/addons/gdUnit4/test/asserts/GdUnitPackedArrayAssertTest.gd
+++ b/addons/gdUnit4/test/asserts/GdUnitPackedArrayAssertTest.gd
@@ -314,14 +314,3 @@ func test_override_failure_message(_test :String, array, test_parameters = [
 			.is_null()) \
 		.is_failed() \
 		.has_message("Custom failure message")
-
-
-var _value = 0
-func next_value() -> PackedByteArray:
-	_value += 1
-	return PackedByteArray([_value])
-
-
-func test_with_value_provider() -> void:
-	assert_array(CallBackValueProvider.new(self, "next_value"))\
-		.is_equal([1]).is_equal([2]).is_equal([3])

--- a/addons/gdUnit4/test/asserts/GdUnitResultAssertImplTest.gd
+++ b/addons/gdUnit4/test/asserts/GdUnitResultAssertImplTest.gd
@@ -124,18 +124,6 @@ func test_override_failure_message() -> void:
 		.has_message("Custom failure message")
 
 
-var _index = -1
-var _values := [Result.success(""), Result.error("error"), Result.warn("warn")]
-func next_value() -> Result:
-	_index += 1
-	return _values[_index]
-
-
-func test_with_value_provider() -> void:
-	assert_result(CallBackValueProvider.new(self, "next_value"))\
-		.is_success().is_error().is_warning()
-
-
 # tests if an assert fails the 'is_failure' reflects the failure status
 func test_is_failure() -> void:
 	# initial is false

--- a/addons/gdUnit4/test/asserts/GdUnitStringAssertImplTest.gd
+++ b/addons/gdUnit4/test/asserts/GdUnitStringAssertImplTest.gd
@@ -254,17 +254,6 @@ func test_override_failure_message() -> void:
 		.has_message("Custom failure message")
 
 
-var _value := 0
-func next_value() -> String:
-	_value += 1
-	return "value_%d" % _value
-
-
-func test_with_value_provider() -> void:
-	assert_str(CallBackValueProvider.new(self, "next_value"))\
-		.is_equal("value_1").is_equal("value_2").is_equal("value_3")
-
-
 # tests if an assert fails the 'is_failure' reflects the failure status
 func test_is_failure() -> void:
 	# initial is false


### PR DESCRIPTION
# Why
We used a `DefaultValueProvider` by default for all assert implementations but never a custom one except for assert_array and assert_func. This was a holdover from previous refactorings.

# What
Removed the use of the ValueProvider from the normal assert and cleaned up the tests.