### PR TITLE
GD-173: ProgressBar displays an incorrect progress counter when executing parameterized tests.

### DIFF
--- a/addons/gdUnit4/src/ui/parts/InspectorProgressBar.tscn
+++ b/addons/gdUnit4/src/ui/parts/InspectorProgressBar.tscn
@@ -6,41 +6,29 @@
 bg_color = Color(0, 0.392157, 0, 1)
 
 [node name="ProgressBar" type="ProgressBar"]
-custom_minimum_size = Vector2i(0, 20)
+custom_minimum_size = Vector2(0, 20)
 anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
-offset_right = -1148.0
-offset_bottom = -644.0
 grow_horizontal = 2
 grow_vertical = 2
-size_flags_horizontal = 11
 size_flags_vertical = 9
 theme_override_styles/fill = SubResource("StyleBoxFlat_ayfir")
-min_value = -1.0
 max_value = 0.0
-value = -1.0
 rounded = true
-allow_lesser = true
+allow_greater = true
 show_percentage = false
 script = ExtResource("1")
 
 [node name="Label" type="Label" parent="."]
 use_parent_material = true
 layout_mode = 1
-anchors_preset = 8
-anchor_left = 0.5
-anchor_top = 0.5
-anchor_right = 0.5
-anchor_bottom = 0.5
-offset_left = -10.0
-offset_top = -7.0
-offset_right = 10.0
-offset_bottom = 7.0
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
 size_flags_vertical = 3
-text = "0:0"
 horizontal_alignment = 1
 vertical_alignment = 1
 max_lines_visible = 1

--- a/addons/gdUnit4/test/ui/parts/InspectorProgressBarTest.gd
+++ b/addons/gdUnit4/test/ui/parts/InspectorProgressBarTest.gd
@@ -1,0 +1,84 @@
+# GdUnit generated TestSuite
+class_name InspectorProgressBarTest
+extends GdUnitTestSuite
+@warning_ignore('unused_parameter')
+@warning_ignore('return_value_discarded')
+
+# TestSuite generated from
+const __source = 'res://addons/gdUnit4/src/ui/parts/InspectorProgressBar.gd'
+
+var _runner :GdUnitSceneRunner
+var _progress :ProgressBar
+var _status :Label
+var _style :StyleBoxFlat
+
+
+func before_test():
+	_runner = scene_runner('res://addons/gdUnit4/src/ui/parts/InspectorProgressBar.tscn')
+	_progress = _runner.get_property("bar")
+	_status = _runner.get_property("status")
+	_style = _runner.get_property("style")
+	# inital state
+	assert_that(_status.text).is_equal("0:0")
+	assert_that(_progress.value).is_equal(0)
+	assert_that(_progress.max_value).is_equal(0)
+	_runner.invoke("_on_gdunit_event", GdUnitInit.new(10, 42))
+
+
+func test_progress_init() -> void:
+	_runner.invoke("_on_gdunit_event", GdUnitInit.new(10, 230))
+	assert_that(_progress.value).is_equal(0)
+	assert_that(_progress.max_value).is_equal(230)
+	assert_that(_status.text).is_equal("0:230")
+	assert_that(_style.bg_color).is_equal(Color.DARK_GREEN)
+
+
+func test_progress_success() -> void:
+	_runner.invoke("_on_gdunit_event", GdUnitInit.new(10, 42))
+	var expected_progess_index := 0
+	# simulate execution of 20 success test runs
+	for index in 20:
+		_runner.invoke("_on_gdunit_event", GdUnitEvent.new().test_after("res://test/testA.gd", "TestSuiteA", "test_a%d" % index, {}))
+		expected_progess_index += 1
+		assert_that(_progress.value).is_equal(expected_progess_index)
+		assert_that(_status.text).is_equal("%d:42" % expected_progess_index)
+		assert_that(_style.bg_color).is_equal(Color.DARK_GREEN)
+	
+	# simulate execution of parameterized test with 10 iterations
+	for index in 10:
+		_runner.invoke("_on_gdunit_event", GdUnitEvent.new().test_after("res://test/testA.gd", "TestSuiteA", "test_parameterized:%d (params)" % index, {}))
+		assert_that(_progress.value).is_equal(expected_progess_index)
+	# final test end event
+	_runner.invoke("_on_gdunit_event", GdUnitEvent.new().test_after("res://test/testA.gd", "TestSuiteA", "test_parameterized", {}))
+	# we expect only one progress step after a parameterized test has been executed, regardless of the iterations
+	expected_progess_index += 1
+	assert_that(_progress.value).is_equal(expected_progess_index)
+	assert_that(_status.text).is_equal("%d:42" % expected_progess_index)
+	assert_that(_style.bg_color).is_equal(Color.DARK_GREEN)
+	
+	# verify the max progress state is not affected
+	assert_that(_progress.max_value).is_equal(42)
+
+
+@warning_ignore("unused_parameter")
+func test_progress_failed(test_name :String, is_failed :bool, is_error :bool, expected_color :Color, test_parameters = [
+	["test_a", false, false, Color.DARK_GREEN],
+	["test_b", false, false, Color.DARK_GREEN],
+	["test_c", false, false, Color.DARK_GREEN],
+	["test_d", true, false, Color.DARK_RED],
+	["test_e", true, false, Color.DARK_RED],
+]) -> void:
+	var statistics = {
+		GdUnitEvent.ORPHAN_NODES: 0,
+		GdUnitEvent.ELAPSED_TIME: 100,
+		GdUnitEvent.WARNINGS: false,
+		GdUnitEvent.ERRORS: is_error,
+		GdUnitEvent.ERROR_COUNT:  1 if is_error else 0,
+		GdUnitEvent.FAILED: is_failed,
+		GdUnitEvent.FAILED_COUNT: 1 if is_failed else 0,
+		GdUnitEvent.SKIPPED: false,
+		GdUnitEvent.SKIPPED_COUNT: 0,
+	}
+	
+	_runner.invoke("_on_gdunit_event", GdUnitEvent.new().test_after("res://test/testA.gd", "TestSuiteA", test_name, statistics))
+	assert_that(_style.bg_color).is_equal(expected_color)


### PR DESCRIPTION

# Why
An incorrect progress counter was displayed when executing parameterized tests.

# What
- The progress counter increases only at the end of the test and test iterrations are not counted now
- cleanup a bit the progress scene
- add test coverage for the progress bar