### PR TITLE
GD-164: Extend array assert by same validation functions

### DIFF
--- a/addons/gdUnit4/src/GdUnitArrayAssert.gd
+++ b/addons/gdUnit4/src/GdUnitArrayAssert.gd
@@ -66,25 +66,50 @@ func has_size(expectd: int) -> GdUnitArrayAssert:
 	return self
 
 
-## Verifies that the current Array contains the given values, in any order.
+## Verifies that the current Array contains the given values, in any order.[br]
+## The values are compared by deep parameter comparision, for object reference compare you have to use [method contains_same]
 @warning_ignore("unused_parameter")
 func contains(expected) -> GdUnitArrayAssert:
 	return self
 
 
-## Verifies that the current Array contains exactly only the given values and nothing else, in same order.
+## Verifies that the current Array contains exactly only the given values and nothing else, in same order.[br]
+## The values are compared by deep parameter comparision, for object reference compare you have to use [method contains_same_exactly]
 @warning_ignore("unused_parameter")
 func contains_exactly(expected) -> GdUnitArrayAssert:
 	return self
 
 
-## Verifies that the current Array contains exactly only the given values and nothing else, in any order.
+## Verifies that the current Array contains exactly only the given values and nothing else, in any order.[br]
+## The values are compared by deep parameter comparision, for object reference compare you have to use [method contains_same_exactly_in_any_order]
 @warning_ignore("unused_parameter")
 func contains_exactly_in_any_order(expected) -> GdUnitArrayAssert:
 	return self
 
 
+## Verifies that the current Array contains the given values, in any order.[br]
+## The values are compared by object reference, for deep parameter comparision use [method contains]
+@warning_ignore("unused_parameter")
+func contains_same(expected) -> GdUnitArrayAssert:
+	return self
+
+
+## Verifies that the current Array contains exactly only the given values and nothing else, in same order.[br]
+## The values are compared by object reference, for deep parameter comparision use [method contains_exactly]
+@warning_ignore("unused_parameter")
+func contains_same_exactly(expected) -> GdUnitArrayAssert:
+	return self
+
+
+## Verifies that the current Array contains exactly only the given values and nothing else, in any order.[br]
+## The values are compared by object reference, for deep parameter comparision use [method contains_exactly_in_any_order]
+@warning_ignore("unused_parameter")
+func contains_same_exactly_in_any_order(expected) -> GdUnitArrayAssert:
+	return self
+
+
 ## Verifies that the current Array do NOT contains the given values, in any order.[br]
+## The values are compared by deep parameter comparision, for object reference compare you have to use [method not_contains_same]
 ## [b]Example:[/b]
 ## [codeblock]
 ## # will succeed
@@ -94,6 +119,20 @@ func contains_exactly_in_any_order(expected) -> GdUnitArrayAssert:
 ## [/codeblock]
 @warning_ignore("unused_parameter")
 func not_contains(expected) -> GdUnitArrayAssert:
+	return self
+
+
+## Verifies that the current Array do NOT contains the given values, in any order.[br]
+## The values are compared by object reference, for deep parameter comparision use [method not_contains]
+## [b]Example:[/b]
+## [codeblock]
+## # will succeed
+## assert_array([1, 2, 3, 4, 5]).not_contains([6])
+## # will fail
+## assert_array([1, 2, 3, 4, 5]).not_contains([2, 6])
+## [/codeblock]
+@warning_ignore("unused_parameter")
+func not_contains_same(expected) -> GdUnitArrayAssert:
 	return self
 
 

--- a/addons/gdUnit4/src/GdUnitArrayAssert.gd
+++ b/addons/gdUnit4/src/GdUnitArrayAssert.gd
@@ -46,6 +46,19 @@ func is_empty() -> GdUnitArrayAssert:
 func is_not_empty() -> GdUnitArrayAssert:
 	return self
 
+## Verifies that the current Array is the same. [br]
+## Compares the current by object reference equals
+@warning_ignore("unused_parameter", "shadowed_global_identifier")
+func is_same(expected) -> GdUnitArrayAssert:
+	return self
+
+
+## Verifies that the current Array is NOT the same. [br]
+## Compares the current by object reference equals
+@warning_ignore("unused_parameter", "shadowed_global_identifier")
+func is_not_same(expected) -> GdUnitArrayAssert:
+	return self
+
 
 ## Verifies that the current Array has a size of given value.
 @warning_ignore("unused_parameter")

--- a/addons/gdUnit4/src/GdUnitTestSuite.gd
+++ b/addons/gdUnit4/src/GdUnitTestSuite.gd
@@ -227,10 +227,10 @@ func reset(obj) -> void:
 ##		# verify the signial is emitted
 ##		await assert_signal(emitter).is_emitted('my_signal')
 ##	[/codeblock]
-func monitor_signals(source :Object, auto_free := true) -> Object:
+func monitor_signals(source :Object, _auto_free := true) -> Object:
 	var signal_collector := GdUnitThreadManager.get_current_context().get_signal_collector()
 	signal_collector.register_emitter(source)
-	return auto_free(source) if auto_free else source
+	return auto_free(source) if _auto_free else source
 
 
 # === Argument matchers ========================================================
@@ -423,7 +423,7 @@ func tuple(arg0, arg1=GdUnitTuple.NO_ARG, arg2=GdUnitTuple.NO_ARG, arg3=GdUnitTu
 ## It checks the given value by type to fit to the best assert
 func assert_that(current) -> GdUnitAssert:
 	
-	if GdObjects.is_array_type(current):
+	if GdArrayTools.is_array_type(current):
 		return assert_array(current)
 	
 	match typeof(current):

--- a/addons/gdUnit4/src/GdUnitTuple.gd
+++ b/addons/gdUnit4/src/GdUnitTuple.gd
@@ -8,7 +8,7 @@ var __values :Array = Array()
 
 
 func _init(arg0,arg1,arg2=NO_ARG,arg3=NO_ARG,arg4=NO_ARG,arg5=NO_ARG,arg6=NO_ARG,arg7=NO_ARG,arg8=NO_ARG,arg9=NO_ARG):
-	__values = GdObjects.array_filter_value([arg0,arg1,arg2,arg3,arg4,arg5,arg6,arg7,arg8,arg9], NO_ARG)
+	__values = GdArrayTools.filter_value([arg0,arg1,arg2,arg3,arg4,arg5,arg6,arg7,arg8,arg9], NO_ARG)
 
 
 func values() -> Array:

--- a/addons/gdUnit4/src/asserts/GdAssertMessages.gd
+++ b/addons/gdUnit4/src/asserts/GdAssertMessages.gd
@@ -332,8 +332,10 @@ static func error_has_length(current, expected: int, compare_operator) -> String
 
 
 # - ArrayAssert specific messgaes ---------------------------------------------------
-static func error_arr_contains(current, expected :Array, not_expect :Array, not_found :Array) -> String:
-	var error := "%s\n %s\n do contains (in any order)\n %s" % [_error("Expecting contains elements:"), _colored_value(current, ", "), _colored_value(expected, ", ")]
+
+static func error_arr_contains(current, expected :Array, not_expect :Array, not_found :Array, by_reference :bool) -> String:
+	var failure_message = "Expecting contains SAME elements:" if by_reference else "Expecting contains elements:"
+	var error := "%s\n %s\n do contains (in any order)\n %s" % [_error(failure_message), _colored_value(current, ", "), _colored_value(expected, ", ")]
 	if not not_expect.is_empty():
 		error += "\nbut some elements where not expected:\n %s" % _colored_value(not_expect, ", ")
 	if not not_found.is_empty():
@@ -342,12 +344,13 @@ static func error_arr_contains(current, expected :Array, not_expect :Array, not_
 	return error
 
 
-static func error_arr_contains_exactly(current, expected, not_expect, not_found) -> String:
+static func error_arr_contains_exactly(current, expected, not_expect, not_found, by_reference :bool) -> String:
+	var failure_message = "Expecting contains SAME exactly elements:" if by_reference else "Expecting contains exactly elements:"
 	if not_expect.is_empty() and not_found.is_empty():
 		var diff := _find_first_diff(current, expected)
-		return "%s\n %s\n do contains (in same order)\n %s\n but has different order %s"  % [_error("Expecting contains exactly elements:"), _colored_value(current, ", "), _colored_value(expected, ", "), diff]
+		return "%s\n %s\n do contains (in same order)\n %s\n but has different order %s"  % [_error(failure_message), _colored_value(current, ", "), _colored_value(expected, ", "), diff]
 	
-	var error := "%s\n %s\n do contains (in same order)\n %s" % [_error("Expecting contains exactly elements:"), _colored_value(current, ", "), _colored_value(expected, ", ")]
+	var error := "%s\n %s\n do contains (in same order)\n %s" % [_error(failure_message), _colored_value(current, ", "), _colored_value(expected, ", ")]
 	if not not_expect.is_empty():
 		error += "\nbut some elements where not expected:\n %s" % _colored_value(not_expect, ", ")
 	if not not_found.is_empty():
@@ -356,8 +359,9 @@ static func error_arr_contains_exactly(current, expected, not_expect, not_found)
 	return error
 
 
-static func error_arr_contains_exactly_in_any_order(current, expected :Array, not_expect :Array, not_found :Array) -> String:
-	var error := "%s\n %s\n do contains exactly (in any order)\n %s" % [_error("Expecting contains exactly elements:"), _colored_value(current, ", "), _colored_value(expected, ", ")]
+static func error_arr_contains_exactly_in_any_order(current, expected :Array, not_expect :Array, not_found :Array, by_reference :bool) -> String:
+	var failure_message = "Expecting contains SAME exactly elements:" if by_reference else "Expecting contains exactly elements:"
+	var error := "%s\n %s\n do contains exactly (in any order)\n %s" % [_error(failure_message), _colored_value(current, ", "), _colored_value(expected, ", ")]
 	if not not_expect.is_empty():
 		error += "\nbut some elements where not expected:\n %s" % _colored_value(not_expect, ", ")
 	if not not_found.is_empty():
@@ -366,12 +370,12 @@ static func error_arr_contains_exactly_in_any_order(current, expected :Array, no
 	return error
 
 
-static func error_arr_not_contains(current :Array, expected :Array, found :Array) -> String:
-	var error := "%s\n %s\n do not contains\n %s" % [_error("Expecting:"), _colored_value(current, ", "), _colored_value(expected, ", ")]
+static func error_arr_not_contains(current :Array, expected :Array, found :Array, by_reference :bool) -> String:
+	var failure_message = "Expecting SAME:" if by_reference else "Expecting:"
+	var error := "%s\n %s\n do not contains\n %s" % [_error(failure_message), _colored_value(current, ", "), _colored_value(expected, ", ")]
 	if not found.is_empty():
 		error += "\n but found elements:\n %s" % _colored_value(found, ", ")
 	return error
-
 
 
 # - DictionaryAssert specific messages ----------------------------------------------

--- a/addons/gdUnit4/src/asserts/GdAssertMessages.gd
+++ b/addons/gdUnit4/src/asserts/GdAssertMessages.gd
@@ -111,7 +111,7 @@ static func _colored_value(value, _delimiter ="\n", detailed := false) -> String
 		TYPE_DICTIONARY:
 			return "'[color=%s]%s[/color]'" % [VALUE_COLOR, _format_dict(value)]
 		_:
-			if GdObjects.is_array_type(value):
+			if GdArrayTools.is_array_type(value):
 				return "'[color=%s]%s[/color]'" % [VALUE_COLOR, _typed_value(value)]
 			return "'[color=%s]%s[/color]'" % [VALUE_COLOR, value]
 

--- a/addons/gdUnit4/src/asserts/GdAssertMessages.gd
+++ b/addons/gdUnit4/src/asserts/GdAssertMessages.gd
@@ -67,30 +67,9 @@ static func _colored_array_div(characters :PackedByteArray) -> String:
 	result.append_array(format_chars(additional_chars, ADD_COLOR))
 	return result.get_string_from_utf8()
 
-const max_elements := 32
-
-static func array_to_string(elements :Array, encode_value := true) -> String:
-	var delemiter = ", "
-	if elements == null:
-		return "<null>"
-	if elements.is_empty():
-		return "empty"
-	var formatted := ""
-	var index := 0
-	for element in elements:
-		if max_elements != -1 and index > max_elements:
-			return formatted + delemiter + "..."
-		if formatted.length() > 0 :
-			formatted += delemiter
-		formatted += _typed_value(element) if encode_value else str(element)
-		index += 1
-	return formatted
-
 
 static func _typed_value(value) -> String:
-	if value == null:
-		return "<null>"
-	return GdDefaultValueDecoder.decode(typeof(value), value)
+	return GdDefaultValueDecoder.decode(value)
 
 
 static func _warning(error :String) -> String:
@@ -133,7 +112,7 @@ static func _colored_value(value, _delimiter ="\n", detailed := false) -> String
 			return "'[color=%s]%s[/color]'" % [VALUE_COLOR, _format_dict(value)]
 		_:
 			if GdObjects.is_array_type(value):
-				return "[color=%s]%s[/color]" % [VALUE_COLOR, array_to_string(value)]
+				return "'[color=%s]%s[/color]'" % [VALUE_COLOR, _typed_value(value)]
 			return "'[color=%s]%s[/color]'" % [VALUE_COLOR, value]
 
 
@@ -363,7 +342,7 @@ static func error_arr_contains(current, expected :Array, not_expect :Array, not_
 	return error
 
 
-static func error_arr_contains_exactly(current, expected :Array, not_expect :Array, not_found :Array) -> String:
+static func error_arr_contains_exactly(current, expected, not_expect, not_found) -> String:
 	if not_expect.is_empty() and not_found.is_empty():
 		var diff := _find_first_diff(current, expected)
 		return "%s\n %s\n do contains (in same order)\n %s\n but has different order %s"  % [_error("Expecting contains exactly elements:"), _colored_value(current, ", "), _colored_value(expected, ", "), diff]

--- a/addons/gdUnit4/src/asserts/GdUnitArrayAssertImpl.gd
+++ b/addons/gdUnit4/src/asserts/GdUnitArrayAssertImpl.gd
@@ -41,7 +41,7 @@ func override_failure_message(message :String) -> GdUnitArrayAssert:
 func __validate_value_type(value) -> bool:
 	return (
 		value == null
-		or GdObjects.is_array_type(value)
+		or GdArrayTools.is_array_type(value)
 	)
 
 
@@ -81,8 +81,8 @@ func _array_div(left :Array[Variant], right :Array[Variant], _same_order := fals
 		for index_e in right.size():
 			var e = right[index_e]
 			if GdObjects.equals(c, e):
-				GdObjects.array_erase_value(not_expect, e)
-				GdObjects.array_erase_value(not_found, c)
+				GdArrayTools.erase_value(not_expect, e)
+				GdArrayTools.erase_value(not_found, c)
 				break
 	return [not_expect, not_found]
 
@@ -100,14 +100,14 @@ func is_not_null() -> GdUnitArrayAssert:
 # Verifies that the current String is equal to the given one.
 func is_equal(expected) -> GdUnitArrayAssert:
 	if not __validate_value_type(expected):
-		return report_error("Unexpected type: <%s>\n You only allowed to verify against Array Types!" % GdObjects.typeof_as_string(expected))
+		return report_error("ERROR: expected value: <%s>\n is not a Array Type!" % GdObjects.typeof_as_string(expected))
 	var current_ = __current()
 	if current_ == null and expected != null:
 		return report_error(GdAssertMessages.error_equal(null, expected))
 	if not GdObjects.equals(current_, expected):
 		var diff := _array_equals_div(current_, expected)
-		var expected_as_list = GdDefaultValueDecoder.array_to_string(diff[0], false)
-		var current_as_list = GdDefaultValueDecoder.array_to_string(diff[1], false)
+		var expected_as_list = GdArrayTools.as_string(diff[0], false)
+		var current_as_list = GdArrayTools.as_string(diff[1], false)
 		var index_report = diff[2]
 		return report_error(GdAssertMessages.error_equal(expected_as_list, current_as_list, index_report))
 	return report_success()
@@ -116,14 +116,14 @@ func is_equal(expected) -> GdUnitArrayAssert:
 # Verifies that the current Array is equal to the given one, ignoring case considerations.
 func is_equal_ignoring_case(expected) -> GdUnitArrayAssert:
 	if not __validate_value_type(expected):
-		return report_error("Unexpected type: <%s>\n You only allowed to verify against Array Types!" % GdObjects.typeof_as_string(expected))
+		return report_error("ERROR: expected value: <%s>\n is not a Array Type!" % GdObjects.typeof_as_string(expected))
 	var current_ = __current()
 	if current_ == null and expected != null:
-		return report_error(GdAssertMessages.error_equal(null, GdDefaultValueDecoder.array_to_string(expected)))
+		return report_error(GdAssertMessages.error_equal(null, GdArrayTools.as_string(expected)))
 	if not GdObjects.equals(current_, expected, true):
 		var diff := _array_equals_div(current_, expected, true)
-		var expected_as_list := GdDefaultValueDecoder.array_to_string(diff[0])
-		var current_as_list := GdDefaultValueDecoder.array_to_string(diff[1])
+		var expected_as_list := GdArrayTools.as_string(diff[0])
+		var current_as_list := GdArrayTools.as_string(diff[1])
 		var index_report = diff[2]
 		return report_error(GdAssertMessages.error_equal(expected_as_list, current_as_list, index_report))
 	return report_success()
@@ -131,7 +131,7 @@ func is_equal_ignoring_case(expected) -> GdUnitArrayAssert:
 
 func is_not_equal(expected) -> GdUnitArrayAssert:
 	if not __validate_value_type(expected):
-		return report_error("Unexpected type: <%s>\n You only allowed to verify against Array Types!" % GdObjects.typeof_as_string(expected))
+		return report_error("ERROR: expected value: <%s>\n is not a Array Type!" % GdObjects.typeof_as_string(expected))
 	var current_ = __current()
 	if GdObjects.equals(current_, expected):
 		return report_error(GdAssertMessages.error_not_equal(current_, expected))
@@ -140,11 +140,11 @@ func is_not_equal(expected) -> GdUnitArrayAssert:
 
 func is_not_equal_ignoring_case(expected) -> GdUnitArrayAssert:
 	if not __validate_value_type(expected):
-		return report_error("Unexpected type: <%s>\n You only allowed to verify against Array Types!" % GdObjects.typeof_as_string(expected))
+		return report_error("ERROR: expected value: <%s>\n is not a Array Type!" % GdObjects.typeof_as_string(expected))
 	var current_ = __current()
 	if GdObjects.equals(current_, expected, true):
-		var c := GdDefaultValueDecoder.array_to_string(current_)
-		var e := GdDefaultValueDecoder.array_to_string(expected)
+		var c := GdArrayTools.as_string(current_)
+		var e := GdArrayTools.as_string(expected)
 		return report_error(GdAssertMessages.error_not_equal_case_insensetiv(c, e))
 	return report_success()
 
@@ -166,7 +166,7 @@ func is_not_empty() -> GdUnitArrayAssert:
 @warning_ignore("unused_parameter", "shadowed_global_identifier")
 func is_same(expected) -> GdUnitArrayAssert:
 	if not __validate_value_type(expected):
-		return report_error("Unexpected type: <%s>\n You only allowed to verify against Array Types!" % GdObjects.typeof_as_string(expected))
+		return report_error("ERROR: expected value: <%s>\n is not a Array Type!" % GdObjects.typeof_as_string(expected))
 	var current = __current()
 	if not is_same(current, expected):
 		report_error(GdAssertMessages.error_is_same(current, expected))
@@ -175,7 +175,7 @@ func is_same(expected) -> GdUnitArrayAssert:
 
 func is_not_same(expected) -> GdUnitArrayAssert:
 	if not __validate_value_type(expected):
-		return report_error("Unexpected type: <%s>\n You only allowed to verify against Array Types!" % GdObjects.typeof_as_string(expected))
+		return report_error("ERROR: expected value: <%s>\n is not a Array Type!" % GdObjects.typeof_as_string(expected))
 	var current = __current()
 	if is_same(current, expected):
 		report_error(GdAssertMessages.error_not_same(current, expected))
@@ -191,7 +191,7 @@ func has_size(expected: int) -> GdUnitArrayAssert:
 
 func contains(expected) -> GdUnitArrayAssert:
 	if not __validate_value_type(expected):
-		return report_error("Unexpected type: <%s>\n You only allowed to verify against Array Types!" % GdObjects.typeof_as_string(expected))
+		return report_error("ERROR: expected value: <%s>\n is not a Array Type!" % GdObjects.typeof_as_string(expected))
 	var current_ = __current()
 	if current_ == null:
 		return report_error(GdAssertMessages.error_arr_contains(current_, expected, [], expected))
@@ -205,15 +205,15 @@ func contains(expected) -> GdUnitArrayAssert:
 
 func contains_exactly(expected) -> GdUnitArrayAssert:
 	if not __validate_value_type(expected):
-		return report_error("Unexpected type: <%s>\n You only allowed to verify against Array Types!" % GdObjects.typeof_as_string(expected))
+		return report_error("ERROR: expected value: <%s>\n is not a Array Type!" % GdObjects.typeof_as_string(expected))
 	var current_ = __current()
 	if current_ == null:
 		return report_error(GdAssertMessages.error_arr_contains_exactly(current_, expected, [], expected))
 	# has same content in same order
-	if GdObjects.equals(current_, expected):
+	if GdObjects.equals(Array(current_), Array(expected)):
 		return report_success()
 	# check has same elements but in different order
-	if GdObjects.equals_sorted(current_, expected):
+	if GdObjects.equals_sorted(Array(current_), Array(expected)):
 		return report_error(GdAssertMessages.error_arr_contains_exactly(current_, expected, [], []))
 	# find the difference
 	var diffs := _array_div(current_, expected, true)
@@ -224,7 +224,7 @@ func contains_exactly(expected) -> GdUnitArrayAssert:
 
 func contains_exactly_in_any_order(expected) -> GdUnitArrayAssert:
 	if not __validate_value_type(expected):
-		return report_error("Unexpected type: <%s>\n You only allowed to verify against Array Types!" % GdObjects.typeof_as_string(expected))
+		return report_error("ERROR: expected value: <%s>\n is not a Array Type!" % GdObjects.typeof_as_string(expected))
 	var current_ = __current()
 	if current_ == null:
 		return report_error(GdAssertMessages.error_arr_contains_exactly_in_any_order(current_, expected, [], expected))
@@ -239,7 +239,7 @@ func contains_exactly_in_any_order(expected) -> GdUnitArrayAssert:
 
 func not_contains(expected) -> GdUnitArrayAssert:
 	if not __validate_value_type(expected):
-		return report_error("Unexpected type: <%s>\n You only allowed to verify against Array Types!" % GdObjects.typeof_as_string(expected))
+		return report_error("ERROR: expected value: <%s>\n is not a Array Type!" % GdObjects.typeof_as_string(expected))
 	var current_ = __current()
 	if current_ == null:
 		return report_error(GdAssertMessages.error_arr_contains_exactly_in_any_order(current_, expected, [], expected))
@@ -280,7 +280,7 @@ func extractv(
 	extr7 :GdUnitValueExtractor = null,
 	extr8 :GdUnitValueExtractor = null,
 	extr9 :GdUnitValueExtractor = null) -> GdUnitArrayAssert:
-	var extractors := GdObjects.array_filter_value([extr0, extr1, extr2, extr3, extr4, extr5, extr6, extr7, extr8, extr9], null)
+	var extractors :Variant = GdArrayTools.filter_value([extr0, extr1, extr2, extr3, extr4, extr5, extr6, extr7, extr8, extr9], null)
 	var extracted_elements := Array()
 	var current = __current()
 	if current == null:

--- a/addons/gdUnit4/src/asserts/GdUnitArrayAssertImpl.gd
+++ b/addons/gdUnit4/src/asserts/GdUnitArrayAssertImpl.gd
@@ -46,21 +46,12 @@ func __validate_value_type(value) -> bool:
 
 
 func __current() -> Variant:
-	var current = _current_value_provider.get_value()
-	if current == null or typeof(current) == TYPE_ARRAY:
-		return current
-	return Array(current)
+	return _current_value_provider.get_value()
 
 
-func __expected(expected) -> Variant:
-	if typeof(expected) == TYPE_ARRAY:
-		return expected
-	return Array(expected)
-
-
-func _array_equals_div(current :Array, expected :Array, case_sensitive :bool = false) -> Array:
-	var current_ := PackedStringArray(current)
-	var expected_ := PackedStringArray(expected)
+func _array_equals_div(current, expected, case_sensitive :bool = false) -> Array:
+	var current_ := PackedStringArray(Array(current))
+	var expected_ := PackedStringArray(Array(expected))
 	var index_report_ := Array()
 	for index in current_.size():
 		var c := current_[index]
@@ -75,14 +66,14 @@ func _array_equals_div(current :Array, expected :Array, case_sensitive :bool = f
 			current_[index] = GdAssertMessages.format_invalid(c)
 			index_report_.push_back({"index" : index, "current" :c, "expected": "<N/A>"})
 	
-	for index in range(current.size(), expected.size()):
+	for index in range(current.size(), expected_.size()):
 		var value := expected_[index]
 		expected_[index] = GdAssertMessages.format_invalid(value)
 		index_report_.push_back({"index" : index, "current" : "<N/A>", "expected": value})
 	return [current_, expected_, index_report_]
 
 
-func _array_div(left :Array, right :Array, _same_order := false) -> Array:
+func _array_div(left :Array[Variant], right :Array[Variant], _same_order := false) -> Array[Variant]:
 	var not_expect := left.duplicate(true)
 	var not_found := right.duplicate(true)
 	for index_c in left.size():
@@ -108,14 +99,15 @@ func is_not_null() -> GdUnitArrayAssert:
 
 # Verifies that the current String is equal to the given one.
 func is_equal(expected) -> GdUnitArrayAssert:
+	if not __validate_value_type(expected):
+		return report_error("Unexpected type: <%s>\n You only allowed to verify against Array Types!" % GdObjects.typeof_as_string(expected))
 	var current_ = __current()
-	var expected_ = __expected(expected)
-	if current_ == null and expected_ != null:
-		return report_error(GdAssertMessages.error_equal(null, GdAssertMessages.array_to_string(expected_)))
-	if not GdObjects.equals(current_, expected_):
-		var diff := _array_equals_div(current_, expected_)
-		var expected_as_list := GdAssertMessages.array_to_string(diff[0], false)
-		var current_as_list := GdAssertMessages.array_to_string(diff[1], false)
+	if current_ == null and expected != null:
+		return report_error(GdAssertMessages.error_equal(null, expected))
+	if not GdObjects.equals(current_, expected):
+		var diff := _array_equals_div(current_, expected)
+		var expected_as_list = GdDefaultValueDecoder.array_to_string(diff[0], false)
+		var current_as_list = GdDefaultValueDecoder.array_to_string(diff[1], false)
 		var index_report = diff[2]
 		return report_error(GdAssertMessages.error_equal(expected_as_list, current_as_list, index_report))
 	return report_success()
@@ -123,35 +115,36 @@ func is_equal(expected) -> GdUnitArrayAssert:
 
 # Verifies that the current Array is equal to the given one, ignoring case considerations.
 func is_equal_ignoring_case(expected) -> GdUnitArrayAssert:
+	if not __validate_value_type(expected):
+		return report_error("Unexpected type: <%s>\n You only allowed to verify against Array Types!" % GdObjects.typeof_as_string(expected))
 	var current_ = __current()
-	var expected_ = __expected(expected)
-	if current_ == null and expected_ != null:
-		return report_error(GdAssertMessages.error_equal(null, GdAssertMessages.array_to_string(expected_)))
-	if not GdObjects.equals(current_, expected_, true):
-		var diff := _array_equals_div(current_, expected_, true)
-		var expected_as_list := GdAssertMessages.array_to_string(diff[0], false)
-		var current_as_list := GdAssertMessages.array_to_string(diff[1], false)
+	if current_ == null and expected != null:
+		return report_error(GdAssertMessages.error_equal(null, GdDefaultValueDecoder.array_to_string(expected)))
+	if not GdObjects.equals(current_, expected, true):
+		var diff := _array_equals_div(current_, expected, true)
+		var expected_as_list := GdDefaultValueDecoder.array_to_string(diff[0])
+		var current_as_list := GdDefaultValueDecoder.array_to_string(diff[1])
 		var index_report = diff[2]
 		return report_error(GdAssertMessages.error_equal(expected_as_list, current_as_list, index_report))
 	return report_success()
 
 
 func is_not_equal(expected) -> GdUnitArrayAssert:
+	if not __validate_value_type(expected):
+		return report_error("Unexpected type: <%s>\n You only allowed to verify against Array Types!" % GdObjects.typeof_as_string(expected))
 	var current_ = __current()
-	var expected_ = __expected(expected)
-	if GdObjects.equals(current_, expected_):
-		var c := GdAssertMessages.array_to_string(current_)
-		var e := GdAssertMessages.array_to_string(expected_)
-		return report_error(GdAssertMessages.error_not_equal(c, e))
+	if GdObjects.equals(current_, expected):
+		return report_error(GdAssertMessages.error_not_equal(current_, expected))
 	return report_success()
 
 
 func is_not_equal_ignoring_case(expected) -> GdUnitArrayAssert:
+	if not __validate_value_type(expected):
+		return report_error("Unexpected type: <%s>\n You only allowed to verify against Array Types!" % GdObjects.typeof_as_string(expected))
 	var current_ = __current()
-	var expected_ = __expected(expected)
-	if GdObjects.equals(current_, expected_, true):
-		var c := GdAssertMessages.array_to_string(current_)
-		var e := GdAssertMessages.array_to_string(expected_)
+	if GdObjects.equals(current_, expected, true):
+		var c := GdDefaultValueDecoder.array_to_string(current_)
+		var e := GdDefaultValueDecoder.array_to_string(expected)
 		return report_error(GdAssertMessages.error_not_equal_case_insensetiv(c, e))
 	return report_success()
 
@@ -170,6 +163,25 @@ func is_not_empty() -> GdUnitArrayAssert:
 	return report_success()
 
 
+@warning_ignore("unused_parameter", "shadowed_global_identifier")
+func is_same(expected) -> GdUnitArrayAssert:
+	if not __validate_value_type(expected):
+		return report_error("Unexpected type: <%s>\n You only allowed to verify against Array Types!" % GdObjects.typeof_as_string(expected))
+	var current = __current()
+	if not is_same(current, expected):
+		report_error(GdAssertMessages.error_is_same(current, expected))
+	return self
+
+
+func is_not_same(expected) -> GdUnitArrayAssert:
+	if not __validate_value_type(expected):
+		return report_error("Unexpected type: <%s>\n You only allowed to verify against Array Types!" % GdObjects.typeof_as_string(expected))
+	var current = __current()
+	if is_same(current, expected):
+		report_error(GdAssertMessages.error_not_same(current, expected))
+	return self
+
+
 func has_size(expected: int) -> GdUnitArrayAssert:
 	var current_ = __current()
 	if current_ == null or current_.size() != expected:
@@ -178,74 +190,65 @@ func has_size(expected: int) -> GdUnitArrayAssert:
 
 
 func contains(expected) -> GdUnitArrayAssert:
+	if not __validate_value_type(expected):
+		return report_error("Unexpected type: <%s>\n You only allowed to verify against Array Types!" % GdObjects.typeof_as_string(expected))
 	var current_ = __current()
-	var expected_ = __expected(expected)
 	if current_ == null:
-		return report_error(GdAssertMessages.error_arr_contains(current_, expected_, [], expected_))
-	var diffs := _array_div(current_, expected_)
+		return report_error(GdAssertMessages.error_arr_contains(current_, expected, [], expected))
+	var diffs := _array_div(current_, expected)
 	#var not_expect := diffs[0] as Array
 	var not_found := diffs[1] as Array
 	if not not_found.is_empty():
-		return report_error(GdAssertMessages.error_arr_contains(current_, expected_, [], not_found))
+		return report_error(GdAssertMessages.error_arr_contains(current_, expected, [], not_found))
 	return report_success()
 
 
-func contains_exactly(expected :Array) -> GdUnitArrayAssert:
+func contains_exactly(expected) -> GdUnitArrayAssert:
+	if not __validate_value_type(expected):
+		return report_error("Unexpected type: <%s>\n You only allowed to verify against Array Types!" % GdObjects.typeof_as_string(expected))
 	var current_ = __current()
-	var expected_ = __expected(expected)
 	if current_ == null:
-		return report_error(GdAssertMessages.error_arr_contains_exactly(current_, expected_, [], expected_))
+		return report_error(GdAssertMessages.error_arr_contains_exactly(current_, expected, [], expected))
 	# has same content in same order
-	if GdObjects.equals(current_, expected_):
+	if GdObjects.equals(current_, expected):
 		return report_success()
 	# check has same elements but in different order
-	if GdObjects.equals_sorted(current_, expected_):
-		return report_error(GdAssertMessages.error_arr_contains_exactly(current_, expected_, [], []))
+	if GdObjects.equals_sorted(current_, expected):
+		return report_error(GdAssertMessages.error_arr_contains_exactly(current_, expected, [], []))
 	# find the difference
-	var diffs := _array_div(current_, expected_, true)
-	var not_expect := diffs[0] as Array
-	var not_found := diffs[1] as Array
-	return report_error(GdAssertMessages.error_arr_contains_exactly(current_, expected_, not_expect, not_found))
+	var diffs := _array_div(current_, expected, true)
+	var not_expect := diffs[0] as Array[Variant]
+	var not_found := diffs[1] as Array[Variant]
+	return report_error(GdAssertMessages.error_arr_contains_exactly(current_, expected, not_expect, not_found))
 
 
 func contains_exactly_in_any_order(expected) -> GdUnitArrayAssert:
+	if not __validate_value_type(expected):
+		return report_error("Unexpected type: <%s>\n You only allowed to verify against Array Types!" % GdObjects.typeof_as_string(expected))
 	var current_ = __current()
-	var expected_ = __expected(expected)
 	if current_ == null:
-		return report_error(GdAssertMessages.error_arr_contains_exactly_in_any_order(current_, expected_, [], expected_))
+		return report_error(GdAssertMessages.error_arr_contains_exactly_in_any_order(current_, expected, [], expected))
 	# find the difference
-	var diffs := _array_div(current_, expected_, false)
+	var diffs := _array_div(current_, expected, false)
 	var not_expect := diffs[0] as Array
 	var not_found := diffs[1] as Array
 	if not_expect.is_empty() and not_found.is_empty():
 		return report_success()
-	return report_error(GdAssertMessages.error_arr_contains_exactly_in_any_order(current_, expected_, not_expect, not_found))
+	return report_error(GdAssertMessages.error_arr_contains_exactly_in_any_order(current_, expected, not_expect, not_found))
 
 
 func not_contains(expected) -> GdUnitArrayAssert:
 	if not __validate_value_type(expected):
 		return report_error("Unexpected type: <%s>\n You only allowed to verify against Array Types!" % GdObjects.typeof_as_string(expected))
 	var current_ = __current()
-	var expected_ = __expected(expected)
 	if current_ == null:
-		return report_error(GdAssertMessages.error_arr_contains_exactly_in_any_order(current_, expected_, [], expected_))
-	var diffs := _array_div(current_, expected_)
+		return report_error(GdAssertMessages.error_arr_contains_exactly_in_any_order(current_, expected, [], expected))
+	var diffs := _array_div(current_, expected)
 	var found := diffs[0] as Array
 	if found.size() == current_.size():
 		return report_success()
-	var diffs2 := _array_div(expected_, diffs[1])
-	return report_error(GdAssertMessages.error_arr_not_contains(current_, expected_, diffs2[0]))
-
-
-@warning_ignore("shadowed_global_identifier")
-func is_same(expected) -> GdUnitAssert:
-	_base.is_same(expected)
-	return self
-
-
-func is_not_same(expected) -> GdUnitAssert:
-	_base.is_not_same(expected)
-	return self
+	var diffs2 := _array_div(expected, diffs[1])
+	return report_error(GdAssertMessages.error_arr_not_contains(current_, expected, diffs2[0]))
 
 
 func is_instanceof(expected) -> GdUnitAssert:
@@ -258,11 +261,11 @@ func extract(func_name :String, args := Array()) -> GdUnitArrayAssert:
 	var extractor := GdUnitFuncValueExtractor.new(func_name, args)
 	var current = __current()
 	if current == null:
-		extracted_elements.append(null)
+		_current_value_provider = DefaultValueProvider.new(null)
 	else:
 		for element in current:
 			extracted_elements.append(extractor.extract_value(element))
-	_current_value_provider = DefaultValueProvider.new(extracted_elements)
+		_current_value_provider = DefaultValueProvider.new(extracted_elements)
 	return self
 
 
@@ -281,7 +284,7 @@ func extractv(
 	var extracted_elements := Array()
 	var current = __current()
 	if current == null:
-		extracted_elements.append(null)
+		_current_value_provider = DefaultValueProvider.new(null)
 	else:
 		for element in __current():
 			var ev :Array[Variant] = [GdUnitTuple.NO_ARG, GdUnitTuple.NO_ARG, GdUnitTuple.NO_ARG, GdUnitTuple.NO_ARG, GdUnitTuple.NO_ARG, GdUnitTuple.NO_ARG, GdUnitTuple.NO_ARG, GdUnitTuple.NO_ARG, GdUnitTuple.NO_ARG, GdUnitTuple.NO_ARG]
@@ -293,5 +296,5 @@ func extractv(
 				extracted_elements.append(GdUnitTuple.new(ev[0], ev[1], ev[2], ev[3], ev[4], ev[5], ev[6], ev[7], ev[8], ev[9]))
 			else:
 				extracted_elements.append(ev[0])
-	_current_value_provider = DefaultValueProvider.new(extracted_elements)
+		_current_value_provider = DefaultValueProvider.new(extracted_elements)
 	return self

--- a/addons/gdUnit4/src/asserts/GdUnitArrayAssertImpl.gd
+++ b/addons/gdUnit4/src/asserts/GdUnitArrayAssertImpl.gd
@@ -1,8 +1,15 @@
 class_name GdUnitArrayAssertImpl
 extends GdUnitArrayAssert
 
+enum COMPARE_MODE {
+	OBJECT_REFERENCE,
+	PARAMETER_DEEP_TEST
+}
+
+
 var _base :GdUnitAssert
 var _current_value_provider :ValueProvider
+
 
 func _init(current):
 	_current_value_provider = DefaultValueProvider.new(current)
@@ -73,18 +80,85 @@ func _array_equals_div(current, expected, case_sensitive :bool = false) -> Array
 	return [current_, expected_, index_report_]
 
 
-func _array_div(left :Array[Variant], right :Array[Variant], _same_order := false) -> Array[Variant]:
+func _array_div(deep_check :COMPARE_MODE, left :Array[Variant], right :Array[Variant], _same_order := false) -> Array[Variant]:
 	var not_expect := left.duplicate(true)
 	var not_found := right.duplicate(true)
 	for index_c in left.size():
 		var c = left[index_c]
 		for index_e in right.size():
 			var e = right[index_e]
-			if GdObjects.equals(c, e):
+			if GdObjects.equals(c, e, false, deep_check == COMPARE_MODE.PARAMETER_DEEP_TEST):
 				GdArrayTools.erase_value(not_expect, e)
 				GdArrayTools.erase_value(not_found, c)
 				break
 	return [not_expect, not_found]
+
+
+
+func _contains(expected, compare_mode :COMPARE_MODE) -> GdUnitArrayAssert:
+	if not __validate_value_type(expected):
+		return report_error("ERROR: expected value: <%s>\n is not a Array Type!" % GdObjects.typeof_as_string(expected))
+	var by_reference := compare_mode == COMPARE_MODE.OBJECT_REFERENCE
+	var current_ = __current()
+	if current_ == null:
+		return report_error(GdAssertMessages.error_arr_contains(current_, expected, [], expected, by_reference))
+	var diffs := _array_div(compare_mode, current_, expected)
+	#var not_expect := diffs[0] as Array
+	var not_found := diffs[1] as Array
+	if not not_found.is_empty():
+		return report_error(GdAssertMessages.error_arr_contains(current_, expected, [], not_found, by_reference))
+	return report_success()
+
+
+func _contains_exactly(expected, compare_mode :COMPARE_MODE) -> GdUnitArrayAssert:
+	if not __validate_value_type(expected):
+		return report_error("ERROR: expected value: <%s>\n is not a Array Type!" % GdObjects.typeof_as_string(expected))
+	var by_reference := compare_mode == COMPARE_MODE.OBJECT_REFERENCE
+	var current_ = __current()
+	if current_ == null:
+		return report_error(GdAssertMessages.error_arr_contains_exactly(current_, expected, [], expected, by_reference))
+	# has same content in same order
+	if GdObjects.equals(Array(current_), Array(expected), false, !by_reference ):
+		return report_success()
+	# check has same elements but in different order
+	if GdObjects.equals_sorted(Array(current_), Array(expected), false, !by_reference):
+		return report_error(GdAssertMessages.error_arr_contains_exactly(current_, expected, [], [], by_reference))
+	# find the difference
+	var diffs := _array_div(compare_mode, current_, expected, true)
+	var not_expect := diffs[0] as Array[Variant]
+	var not_found := diffs[1] as Array[Variant]
+	return report_error(GdAssertMessages.error_arr_contains_exactly(current_, expected, not_expect, not_found, by_reference))
+
+
+func _contains_exactly_in_any_order(expected, compare_mode :COMPARE_MODE) -> GdUnitArrayAssert:
+	if not __validate_value_type(expected):
+		return report_error("ERROR: expected value: <%s>\n is not a Array Type!" % GdObjects.typeof_as_string(expected))
+	var by_reference := compare_mode == COMPARE_MODE.OBJECT_REFERENCE
+	var current_ = __current()
+	if current_ == null:
+		return report_error(GdAssertMessages.error_arr_contains_exactly_in_any_order(current_, expected, [], expected, by_reference))
+	# find the difference
+	var diffs := _array_div(compare_mode, current_, expected, false)
+	var not_expect := diffs[0] as Array
+	var not_found := diffs[1] as Array
+	if not_expect.is_empty() and not_found.is_empty():
+		return report_success()
+	return report_error(GdAssertMessages.error_arr_contains_exactly_in_any_order(current_, expected, not_expect, not_found, by_reference))
+
+
+func _not_contains(expected, compare_mode :COMPARE_MODE) -> GdUnitArrayAssert:
+	if not __validate_value_type(expected):
+		return report_error("ERROR: expected value: <%s>\n is not a Array Type!" % GdObjects.typeof_as_string(expected))
+	var by_reference := compare_mode == COMPARE_MODE.OBJECT_REFERENCE
+	var current_ = __current()
+	if current_ == null:
+		return report_error(GdAssertMessages.error_arr_contains_exactly_in_any_order(current_, expected, [], expected, by_reference))
+	var diffs := _array_div(compare_mode, current_, expected)
+	var found := diffs[0] as Array
+	if found.size() == current_.size():
+		return report_success()
+	var diffs2 := _array_div(compare_mode, expected, diffs[1])
+	return report_error(GdAssertMessages.error_arr_not_contains(current_, expected, diffs2[0], by_reference))
 
 
 func is_null() -> GdUnitArrayAssert:
@@ -190,65 +264,35 @@ func has_size(expected: int) -> GdUnitArrayAssert:
 
 
 func contains(expected) -> GdUnitArrayAssert:
-	if not __validate_value_type(expected):
-		return report_error("ERROR: expected value: <%s>\n is not a Array Type!" % GdObjects.typeof_as_string(expected))
-	var current_ = __current()
-	if current_ == null:
-		return report_error(GdAssertMessages.error_arr_contains(current_, expected, [], expected))
-	var diffs := _array_div(current_, expected)
-	#var not_expect := diffs[0] as Array
-	var not_found := diffs[1] as Array
-	if not not_found.is_empty():
-		return report_error(GdAssertMessages.error_arr_contains(current_, expected, [], not_found))
-	return report_success()
+	return _contains(expected, COMPARE_MODE.PARAMETER_DEEP_TEST)
 
 
 func contains_exactly(expected) -> GdUnitArrayAssert:
-	if not __validate_value_type(expected):
-		return report_error("ERROR: expected value: <%s>\n is not a Array Type!" % GdObjects.typeof_as_string(expected))
-	var current_ = __current()
-	if current_ == null:
-		return report_error(GdAssertMessages.error_arr_contains_exactly(current_, expected, [], expected))
-	# has same content in same order
-	if GdObjects.equals(Array(current_), Array(expected)):
-		return report_success()
-	# check has same elements but in different order
-	if GdObjects.equals_sorted(Array(current_), Array(expected)):
-		return report_error(GdAssertMessages.error_arr_contains_exactly(current_, expected, [], []))
-	# find the difference
-	var diffs := _array_div(current_, expected, true)
-	var not_expect := diffs[0] as Array[Variant]
-	var not_found := diffs[1] as Array[Variant]
-	return report_error(GdAssertMessages.error_arr_contains_exactly(current_, expected, not_expect, not_found))
+	return _contains_exactly(expected, COMPARE_MODE.PARAMETER_DEEP_TEST)
 
 
 func contains_exactly_in_any_order(expected) -> GdUnitArrayAssert:
-	if not __validate_value_type(expected):
-		return report_error("ERROR: expected value: <%s>\n is not a Array Type!" % GdObjects.typeof_as_string(expected))
-	var current_ = __current()
-	if current_ == null:
-		return report_error(GdAssertMessages.error_arr_contains_exactly_in_any_order(current_, expected, [], expected))
-	# find the difference
-	var diffs := _array_div(current_, expected, false)
-	var not_expect := diffs[0] as Array
-	var not_found := diffs[1] as Array
-	if not_expect.is_empty() and not_found.is_empty():
-		return report_success()
-	return report_error(GdAssertMessages.error_arr_contains_exactly_in_any_order(current_, expected, not_expect, not_found))
+	return _contains_exactly_in_any_order(expected, COMPARE_MODE.PARAMETER_DEEP_TEST)
+
+
+func contains_same(expected) -> GdUnitArrayAssert:
+	return _contains(expected, COMPARE_MODE.OBJECT_REFERENCE)
+
+
+func contains_same_exactly(expected) -> GdUnitArrayAssert:
+	return _contains_exactly(expected, COMPARE_MODE.OBJECT_REFERENCE)
+
+
+func contains_same_exactly_in_any_order(expected) -> GdUnitArrayAssert:
+	return _contains_exactly_in_any_order(expected, COMPARE_MODE.OBJECT_REFERENCE)
 
 
 func not_contains(expected) -> GdUnitArrayAssert:
-	if not __validate_value_type(expected):
-		return report_error("ERROR: expected value: <%s>\n is not a Array Type!" % GdObjects.typeof_as_string(expected))
-	var current_ = __current()
-	if current_ == null:
-		return report_error(GdAssertMessages.error_arr_contains_exactly_in_any_order(current_, expected, [], expected))
-	var diffs := _array_div(current_, expected)
-	var found := diffs[0] as Array
-	if found.size() == current_.size():
-		return report_success()
-	var diffs2 := _array_div(expected, diffs[1])
-	return report_error(GdAssertMessages.error_arr_not_contains(current_, expected, diffs2[0]))
+	return _not_contains(expected, COMPARE_MODE.PARAMETER_DEEP_TEST)
+
+
+func not_contains_same(expected) -> GdUnitArrayAssert:
+	return _not_contains(expected, COMPARE_MODE.OBJECT_REFERENCE)
 
 
 func is_instanceof(expected) -> GdUnitAssert:

--- a/addons/gdUnit4/src/asserts/GdUnitSignalAssertImpl.gd
+++ b/addons/gdUnit4/src/asserts/GdUnitSignalAssertImpl.gd
@@ -68,7 +68,7 @@ class SignalCollector extends RefCounted:
 	
 	# receives the signal from the emitter with all emitted signal arguments and additional the emitter and signal_name as last two arguements
 	func _on_signal_emmited( arg0=NO_ARG, arg1=NO_ARG, arg2=NO_ARG, arg3=NO_ARG, arg4=NO_ARG, arg5=NO_ARG, arg6=NO_ARG, arg7=NO_ARG, arg8=NO_ARG, arg9=NO_ARG, arg10=NO_ARG, arg11=NO_ARG):
-		var signal_args = GdObjects.array_filter_value([arg0,arg1,arg2,arg3,arg4,arg5,arg6,arg7,arg8,arg9,arg10,arg11], NO_ARG)
+		var signal_args = GdArrayTools.filter_value([arg0,arg1,arg2,arg3,arg4,arg5,arg6,arg7,arg8,arg9,arg10,arg11], NO_ARG)
 		# extract the emitter and signal_name from the last two arguments (see line 61 where is added)
 		var signal_name :String = signal_args.pop_back()
 		var emitter :Object = signal_args.pop_back()

--- a/addons/gdUnit4/src/core/GdArrayTools.gd
+++ b/addons/gdUnit4/src/core/GdArrayTools.gd
@@ -1,0 +1,101 @@
+## Small helper tool to work with Godot Arrays
+class_name GdArrayTools
+extends RefCounted
+
+
+const max_elements := 32
+const ARRAY_TYPES := [
+	TYPE_ARRAY,
+	TYPE_PACKED_BYTE_ARRAY,
+	TYPE_PACKED_INT32_ARRAY,
+	TYPE_PACKED_INT64_ARRAY,
+	TYPE_PACKED_FLOAT32_ARRAY,
+	TYPE_PACKED_FLOAT64_ARRAY,
+	TYPE_PACKED_STRING_ARRAY,
+	TYPE_PACKED_VECTOR2_ARRAY,
+	TYPE_PACKED_VECTOR3_ARRAY,
+	TYPE_PACKED_COLOR_ARRAY
+]
+
+
+static func is_array_type(value) -> bool:
+	return is_type_array(typeof(value))
+
+
+static func is_type_array(type :int) -> bool:
+	return  type in ARRAY_TYPES
+
+
+## Filters an array by given value[br]
+## If the given value not an array it returns null, will remove all occurence of given value.
+static func filter_value(array, value :Variant) -> Variant:
+	if not is_array_type(array):
+		return null
+	var filtered_array = array.duplicate()
+	var index :int = filtered_array.find(value)
+	while index != -1:
+		filtered_array.remove_at(index)
+		index = filtered_array.find(value)
+	return filtered_array
+
+
+## Erases a value from given array by using equals(l,r) to find the element to erase
+static func erase_value(array :Array, value) -> void:
+	for element in array:
+		if GdObjects.equals(element, value):
+			array.erase(element)
+
+
+## Scans for the array build in type on a untyped array[br]
+## Returns the buildin type by scan all values and returns the type if all values has the same type.
+## If the values has different types TYPE_VARIANT is returend
+static func scan_typed(array :Array) -> int:
+	if array.is_empty():
+		return TYPE_NIL
+	var actual_type := GdObjects.TYPE_VARIANT
+	for value in array:
+		var current_type := typeof(value)
+		if not actual_type in [GdObjects.TYPE_VARIANT, current_type]:
+			return GdObjects.TYPE_VARIANT
+		actual_type = current_type
+	return actual_type
+
+
+## Converts given array into a string presentation.[br]
+## This function is different to the original Godot str(<array>) implementation.
+## The string presentaion contains fullquallified typed informations.
+##[br]
+## Examples:
+## 	[codeblock]
+##		# will result in PackedString(["a", "b"])
+## 		GdArrayTools.as_string(PackedStringArray("a", "b"))
+##		# will result in PackedString(["a", "b"])
+##		GdArrayTools.as_string(PackedColorArray(Color.RED, COLOR.GREEN))
+## 	[/codeblock]
+static func as_string(elements :Variant, encode_value := true) -> String:
+	if not is_array_type(elements):
+		return "ERROR: Not an Array Type!"
+	var delemiter = ", "
+	if elements == null:
+		return "<null>"
+	if elements.is_empty():
+		return "<empty>"
+	var prefix := _typeof_as_string(elements) if encode_value else ""
+	var formatted := ""
+	var index := 0
+	for element in elements:
+		if max_elements != -1 and index > max_elements:
+			return prefix + "[" + formatted + delemiter + "...]" 
+		if formatted.length() > 0 :
+			formatted += delemiter
+		formatted += GdDefaultValueDecoder.decode(element) if encode_value else str(element)
+		index += 1
+	return prefix + "[" + formatted + "]"
+
+
+static func _typeof_as_string(value :Variant) -> String:
+	var type := typeof(value)
+	# for untyped array we retun empty string
+	if type == TYPE_ARRAY:
+		return ""
+	return GdObjects.typeof_as_string(value)

--- a/addons/gdUnit4/src/core/GdObjects.gd
+++ b/addons/gdUnit4/src/core/GdObjects.gd
@@ -131,12 +131,12 @@ const NOTIFICATION_AS_STRING_MAPPINGS := {
 }
 
 
-static func equals_sorted(obj_a :Array, obj_b :Array, case_sensitive :bool = false ) -> bool:
+static func equals_sorted(obj_a :Array, obj_b :Array, case_sensitive :bool = false, deep_check :bool = true ) -> bool:
 	var a := obj_a.duplicate()
 	var b := obj_b.duplicate()
 	a.sort()
 	b.sort()
-	return equals(a, b, case_sensitive)
+	return equals(a, b, case_sensitive, deep_check)
 
 
 # prototype of better object to dictionary

--- a/addons/gdUnit4/src/core/GdObjects.gd
+++ b/addons/gdUnit4/src/core/GdObjects.gd
@@ -320,23 +320,6 @@ static func is_primitive_type(value) -> bool:
 	return typeof(value) in [TYPE_BOOL, TYPE_STRING, TYPE_INT, TYPE_FLOAT]
 
 
-static func is_array_type(value) -> bool:
-	return is_type_array(typeof(value))
-
-
-static func is_type_array(type :int) -> bool:
-	return  type in [TYPE_ARRAY,
-		TYPE_PACKED_BYTE_ARRAY,
-		TYPE_PACKED_INT32_ARRAY,
-		TYPE_PACKED_INT64_ARRAY,
-		TYPE_PACKED_FLOAT32_ARRAY,
-		TYPE_PACKED_FLOAT64_ARRAY,
-		TYPE_PACKED_STRING_ARRAY,
-		TYPE_PACKED_VECTOR2_ARRAY,
-		TYPE_PACKED_VECTOR3_ARRAY,
-		TYPE_PACKED_COLOR_ARRAY]
-
-
 static func _is_type_equivalent(type_a, type_b) -> bool:
 	# don't test for TYPE_STRING_NAME equivalenz
 	if type_a == TYPE_STRING_NAME or type_b == TYPE_STRING_NAME:
@@ -663,22 +646,6 @@ static func default_value_by_type(type :int):
 	
 	push_error("Can't determine a default value for type: '%s', Please create a Bug issue and attach the stacktrace please." % type)
 	return null
-
-
-# Filters an array by given value
-static func array_filter_value(array :Array, filter_value) -> Array:
-	var filtered_array := Array()
-	for element in array:
-		if not equals(element, filter_value):
-			filtered_array.append(element)
-	return filtered_array
-
-
-# Erases a value from given array by using equals(l,r) to find the element to erase
-static func array_erase_value(array :Array, value) -> void:
-	for element in array:
-		if equals(element, value):
-			array.erase(element)
 
 
 static func find_nodes_by_class(root: Node, cls: String, recursive: bool = false) -> Array[Node]:

--- a/addons/gdUnit4/src/core/GdUnitSceneRunnerImpl.gd
+++ b/addons/gdUnit4/src/core/GdUnitSceneRunnerImpl.gd
@@ -207,13 +207,13 @@ func simulate_frames(frames: int, delta_milli :int = -1) -> GdUnitSceneRunner:
 
 
 func simulate_until_signal(signal_name :String, arg0=NO_ARG, arg1=NO_ARG, arg2=NO_ARG, arg3=NO_ARG, arg4=NO_ARG, arg5=NO_ARG, arg6=NO_ARG, arg7=NO_ARG, arg8=NO_ARG, arg9=NO_ARG) -> GdUnitSceneRunner:
-	var args = GdObjects.array_filter_value([arg0,arg1,arg2,arg3,arg4,arg5,arg6,arg7,arg8,arg9], NO_ARG)
+	var args = GdArrayTools.filter_value([arg0,arg1,arg2,arg3,arg4,arg5,arg6,arg7,arg8,arg9], NO_ARG)
 	await GdUnitAwaiter.await_signal_idle_frames(_current_scene, signal_name, args, 10000)
 	return self
 
 
 func simulate_until_object_signal(source :Object, signal_name :String, arg0=NO_ARG, arg1=NO_ARG, arg2=NO_ARG, arg3=NO_ARG, arg4=NO_ARG, arg5=NO_ARG, arg6=NO_ARG, arg7=NO_ARG, arg8=NO_ARG, arg9=NO_ARG) -> GdUnitSceneRunner:
-	var args = GdObjects.array_filter_value([arg0,arg1,arg2,arg3,arg4,arg5,arg6,arg7,arg8,arg9], NO_ARG)
+	var args = GdArrayTools.filter_value([arg0,arg1,arg2,arg3,arg4,arg5,arg6,arg7,arg8,arg9], NO_ARG)
 	await GdUnitAwaiter.await_signal_idle_frames(source, signal_name, args, 10000)
 	return self
 
@@ -249,7 +249,7 @@ func get_property(name :String):
 
 
 func invoke(name :String, arg0=NO_ARG, arg1=NO_ARG, arg2=NO_ARG, arg3=NO_ARG, arg4=NO_ARG, arg5=NO_ARG, arg6=NO_ARG, arg7=NO_ARG, arg8=NO_ARG, arg9=NO_ARG):
-	var args = GdObjects.array_filter_value([arg0,arg1,arg2,arg3,arg4,arg5,arg6,arg7,arg8,arg9], NO_ARG)
+	var args = GdArrayTools.filter_value([arg0,arg1,arg2,arg3,arg4,arg5,arg6,arg7,arg8,arg9], NO_ARG)
 	if _current_scene.has_method(name):
 		return _current_scene.callv(name, args)
 	return "The method '%s' not exist checked loaded scene." % name

--- a/addons/gdUnit4/src/core/GdUnitSignalAwaiter.gd
+++ b/addons/gdUnit4/src/core/GdUnitSignalAwaiter.gd
@@ -17,7 +17,7 @@ func _init(timeout_millis :int, wait_on_idle_frame := false):
 
 
 func _on_signal_emmited(arg0=NO_ARG, arg1=NO_ARG, arg2=NO_ARG, arg3=NO_ARG, arg4=NO_ARG, arg5=NO_ARG, arg6=NO_ARG, arg7=NO_ARG, arg8=NO_ARG, arg9=NO_ARG):
-	var signal_args := GdObjects.array_filter_value([arg0,arg1,arg2,arg3,arg4,arg5,arg6,arg7,arg8,arg9], NO_ARG)
+	var signal_args :Variant = GdArrayTools.filter_value([arg0,arg1,arg2,arg3,arg4,arg5,arg6,arg7,arg8,arg9], NO_ARG)
 	signal_emitted.emit(signal_args)
 
 

--- a/addons/gdUnit4/src/core/parse/GdDefaultValueDecoder.gd
+++ b/addons/gdUnit4/src/core/parse/GdDefaultValueDecoder.gd
@@ -2,7 +2,7 @@
 class_name GdDefaultValueDecoder 
 extends GdUnitSingleton
 
-
+@warning_ignore("unused_parameter")
 var _decoders = {
 	TYPE_NIL: func(value): return "<null>",
 	TYPE_STRING: func(value): return '"%s"' % value,
@@ -10,19 +10,23 @@ var _decoders = {
 	TYPE_BOOL: func(value): return str(value).to_lower(),
 	TYPE_FLOAT: func(value): return '%f' % value,
 	TYPE_COLOR: func(value): return "Color%s" % value,
-	TYPE_ARRAY: func(value): return "<empty>" if value.is_empty() else str(value),
-	TYPE_PACKED_BYTE_ARRAY: func(value): return "PackedByteArray(%s)" % GdDefaultValueDecoder.array_to_string(value),
-	TYPE_PACKED_STRING_ARRAY: func(value): return "PackedStringArray(%s)" % GdDefaultValueDecoder.array_to_string(value),
-	TYPE_PACKED_FLOAT32_ARRAY: func(value): return "PackedFloat32Array(%s)" % GdDefaultValueDecoder.array_to_string(value),
-	TYPE_PACKED_FLOAT64_ARRAY: func(value): return "PackedFloat64Array(%s)" % GdDefaultValueDecoder.array_to_string(value),
-	TYPE_PACKED_INT32_ARRAY: func(value): return "PackedInt32Array(%s)" % GdDefaultValueDecoder.array_to_string(value),
-	TYPE_PACKED_INT64_ARRAY: func(value): return "PackedInt64Array(%s)" % GdDefaultValueDecoder.array_to_string(value),
-	TYPE_PACKED_COLOR_ARRAY: func(value): return "PackedColorArray(%s)" % GdDefaultValueDecoder.array_to_string(value),
-	TYPE_PACKED_VECTOR2_ARRAY: func(value): return "PackedVector2Array(%s)" % GdDefaultValueDecoder.array_to_string(value),
-	TYPE_PACKED_VECTOR3_ARRAY: func(value): return "PackedVector3Array(%s)" % GdDefaultValueDecoder.array_to_string(value),
+	TYPE_ARRAY: func(value): return GdArrayTools.as_string(value),
+	TYPE_PACKED_BYTE_ARRAY: func(value): return GdArrayTools.as_string(value),
+	TYPE_PACKED_STRING_ARRAY: func(value): return GdArrayTools.as_string(value),
+	TYPE_PACKED_FLOAT32_ARRAY: func(value): return GdArrayTools.as_string(value),
+	TYPE_PACKED_FLOAT64_ARRAY: func(value): return GdArrayTools.as_string(value),
+	TYPE_PACKED_INT32_ARRAY: func(value): return GdArrayTools.as_string(value),
+	TYPE_PACKED_INT64_ARRAY: func(value): return GdArrayTools.as_string(value),
+	TYPE_PACKED_COLOR_ARRAY: func(value): return GdArrayTools.as_string(value),
+	TYPE_PACKED_VECTOR2_ARRAY: func(value): return GdArrayTools.as_string(value),
+	TYPE_PACKED_VECTOR3_ARRAY: func(value): return GdArrayTools.as_string(value),
 	TYPE_RID: _on_type_RID,
 	TYPE_VECTOR2: func(value): return "Vector2%s" % value,
+	TYPE_VECTOR2I: func(value): return "Vector2i%s" % value,
 	TYPE_VECTOR3: func(value): return "Vector3%s" % value,
+	TYPE_VECTOR3I: func(value): return "Vector3i%s" % value,
+	TYPE_VECTOR4: func(value): return "Vector4%s" % value,
+	TYPE_VECTOR4I: func(value): return "Vector4i%s" % value,
 	TYPE_RECT2: _on_decode_Rect2.bind(GdDefaultValueDecoder._regex("P: ?(\\(.+\\)), S: ?(\\(.+\\))")),
 	TYPE_RECT2I: _on_decode_Rect2i.bind(GdDefaultValueDecoder._regex("P: ?(\\(.+\\)), S: ?(\\(.+\\))")),
 	TYPE_TRANSFORM2D: _on_type_Transform2D,
@@ -40,26 +44,6 @@ static func _regex(pattern :String) -> RegEx:
 
 func get_decoder(type :int) -> Callable:
 	return _decoders.get(type, func(value): return '%s' % value)
-
-
-const max_elements := 32
-
-static func array_to_string(elements, encode_value := true) -> String:
-	var delemiter = ", "
-	if elements == null:
-		return "<null>"
-	if elements.is_empty():
-		return "<empty>"
-	var formatted := ""
-	var index := 0
-	for element in elements:
-		if max_elements != -1 and index > max_elements:
-			return "[" + formatted + delemiter + "...]" 
-		if formatted.length() > 0 :
-			formatted += delemiter
-		formatted += GdDefaultValueDecoder.decode(element) if encode_value else str(element)
-		index += 1
-	return "[" + formatted + "]"
 
 
 func _on_type_Transform2D(value :Variant) -> String:

--- a/addons/gdUnit4/src/core/parse/GdDefaultValueDecoder.gd
+++ b/addons/gdUnit4/src/core/parse/GdDefaultValueDecoder.gd
@@ -4,18 +4,29 @@ extends GdUnitSingleton
 
 
 var _decoders = {
-	TYPE_NIL: func(value): return "null",
+	TYPE_NIL: func(value): return "<null>",
 	TYPE_STRING: func(value): return '"%s"' % value,
 	TYPE_STRING_NAME: func(value): return '"%s"' % value,
 	TYPE_BOOL: func(value): return str(value).to_lower(),
 	TYPE_FLOAT: func(value): return '%f' % value,
 	TYPE_COLOR: func(value): return "Color%s" % value,
+	TYPE_ARRAY: func(value): return "<empty>" if value.is_empty() else str(value),
+	TYPE_PACKED_BYTE_ARRAY: func(value): return "PackedByteArray(%s)" % GdDefaultValueDecoder.array_to_string(value),
+	TYPE_PACKED_STRING_ARRAY: func(value): return "PackedStringArray(%s)" % GdDefaultValueDecoder.array_to_string(value),
+	TYPE_PACKED_FLOAT32_ARRAY: func(value): return "PackedFloat32Array(%s)" % GdDefaultValueDecoder.array_to_string(value),
+	TYPE_PACKED_FLOAT64_ARRAY: func(value): return "PackedFloat64Array(%s)" % GdDefaultValueDecoder.array_to_string(value),
+	TYPE_PACKED_INT32_ARRAY: func(value): return "PackedInt32Array(%s)" % GdDefaultValueDecoder.array_to_string(value),
+	TYPE_PACKED_INT64_ARRAY: func(value): return "PackedInt64Array(%s)" % GdDefaultValueDecoder.array_to_string(value),
+	TYPE_PACKED_COLOR_ARRAY: func(value): return "PackedColorArray(%s)" % GdDefaultValueDecoder.array_to_string(value),
+	TYPE_PACKED_VECTOR2_ARRAY: func(value): return "PackedVector2Array(%s)" % GdDefaultValueDecoder.array_to_string(value),
+	TYPE_PACKED_VECTOR3_ARRAY: func(value): return "PackedVector3Array(%s)" % GdDefaultValueDecoder.array_to_string(value),
 	TYPE_RID: _on_type_RID,
+	TYPE_VECTOR2: func(value): return "Vector2%s" % value,
+	TYPE_VECTOR3: func(value): return "Vector3%s" % value,
 	TYPE_RECT2: _on_decode_Rect2.bind(GdDefaultValueDecoder._regex("P: ?(\\(.+\\)), S: ?(\\(.+\\))")),
 	TYPE_RECT2I: _on_decode_Rect2i.bind(GdDefaultValueDecoder._regex("P: ?(\\(.+\\)), S: ?(\\(.+\\))")),
 	TYPE_TRANSFORM2D: _on_type_Transform2D,
 	TYPE_TRANSFORM3D: _on_type_Transform3D,
-	TYPE_PACKED_COLOR_ARRAY: _on_type_PackedColorArray,
 }
 
 static func _regex(pattern :String) -> RegEx:
@@ -31,6 +42,26 @@ func get_decoder(type :int) -> Callable:
 	return _decoders.get(type, func(value): return '%s' % value)
 
 
+const max_elements := 32
+
+static func array_to_string(elements, encode_value := true) -> String:
+	var delemiter = ", "
+	if elements == null:
+		return "<null>"
+	if elements.is_empty():
+		return "<empty>"
+	var formatted := ""
+	var index := 0
+	for element in elements:
+		if max_elements != -1 and index > max_elements:
+			return "[" + formatted + delemiter + "...]" 
+		if formatted.length() > 0 :
+			formatted += delemiter
+		formatted += GdDefaultValueDecoder.decode(element) if encode_value else str(element)
+		index += 1
+	return "[" + formatted + "]"
+
+
 func _on_type_Transform2D(value :Variant) -> String:
 	var transform := value as Transform2D
 	return "Transform2D(Vector2%s, Vector2%s, Vector2%s)" % [transform.x, transform.y, transform.origin]
@@ -39,15 +70,6 @@ func _on_type_Transform2D(value :Variant) -> String:
 func _on_type_Transform3D(value :Variant) -> String:
 	var transform :Transform3D = value
 	return "Transform3D(Vector3%s, Vector3%s, Vector3%s, Vector3%s)" % [transform.basis.x, transform.basis.y, transform.basis.z, transform.origin]
-
-
-func _on_type_PackedColorArray(value :Variant) -> String:
-	var array := value as PackedColorArray
-	if array.is_empty():
-		return "[]"
-	else:
-		push_error("TODO, implemnt compile array values")
-		return "invalid"
 
 
 @warning_ignore("unused_parameter")
@@ -71,7 +93,16 @@ func _on_decode_Rect2i(value :Variant, regEx :RegEx) -> String:
 	return "Rect2i()"
 
 
-static func decode(type :int, value :Variant) -> String:
+static func decode(value :Variant) -> String:
+	var type := typeof(value) 
+	var decoder :Callable = instance("GdUnitDefaultValueDecoders", func(): return GdDefaultValueDecoder.new()).get_decoder(type)
+	if decoder == null:
+		push_error("No value decoder registered for type '%d'! Please open a Bug issue at 'https://github.com/MikeSchulze/gdUnit4/issues/new/choose'." % type)
+		return "null"
+	return decoder.call(value)
+
+
+static func decode_typed(type :int, value :Variant) -> String:
 	var decoder :Callable = instance("GdUnitDefaultValueDecoders", func(): return GdDefaultValueDecoder.new()).get_decoder(type)
 	if decoder == null:
 		push_error("No value decoder registered for type '%d'! Please open a Bug issue at 'https://github.com/MikeSchulze/gdUnit4/issues/new/choose'." % type)

--- a/addons/gdUnit4/src/core/parse/GdFunctionDescriptor.gd
+++ b/addons/gdUnit4/src/core/parse/GdFunctionDescriptor.gd
@@ -255,19 +255,19 @@ static func _argument_default_value(arg :Dictionary, default_value) -> String:
 	var type := _argument_type(arg)
 	match type:
 		TYPE_NIL, TYPE_RID:
-			return GdDefaultValueDecoder.decode(type, default_value)
+			return GdDefaultValueDecoder.decode_typed(type, default_value)
 		TYPE_STRING:
-			return GdDefaultValueDecoder.decode(type, default_value)
+			return GdDefaultValueDecoder.decode_typed(type, default_value)
 		TYPE_STRING_NAME:
-			return GdDefaultValueDecoder.decode(type, default_value)
+			return GdDefaultValueDecoder.decode_typed(type, default_value)
 		TYPE_BOOL:
-			return GdDefaultValueDecoder.decode(type, default_value)
+			return GdDefaultValueDecoder.decode_typed(type, default_value)
 		TYPE_RECT2, TYPE_RECT2I:
-			return GdDefaultValueDecoder.decode(type, default_value)
+			return GdDefaultValueDecoder.decode_typed(type, default_value)
 		TYPE_TRANSFORM2D, TYPE_TRANSFORM3D:
-			return GdDefaultValueDecoder.decode(type, default_value)
+			return GdDefaultValueDecoder.decode_typed(type, default_value)
 		TYPE_PACKED_COLOR_ARRAY:
-			return GdDefaultValueDecoder.decode(type, default_value)
+			return GdDefaultValueDecoder.decode_typed(type, default_value)
 		TYPE_OBJECT:
 			if default_value == null:
 				return "null"

--- a/addons/gdUnit4/src/core/parse/GdFunctionDescriptor.gd
+++ b/addons/gdUnit4/src/core/parse/GdFunctionDescriptor.gd
@@ -254,11 +254,11 @@ static func _argument_default_value(arg :Dictionary, default_value) -> String:
 		return "null"
 	var type := _argument_type(arg)
 	match type:
-		TYPE_NIL, TYPE_RID:
+		TYPE_NIL:
+			return "null"
+		TYPE_RID:
 			return GdDefaultValueDecoder.decode_typed(type, default_value)
-		TYPE_STRING:
-			return GdDefaultValueDecoder.decode_typed(type, default_value)
-		TYPE_STRING_NAME:
+		TYPE_STRING, TYPE_STRING_NAME:
 			return GdDefaultValueDecoder.decode_typed(type, default_value)
 		TYPE_BOOL:
 			return GdDefaultValueDecoder.decode_typed(type, default_value)
@@ -266,15 +266,13 @@ static func _argument_default_value(arg :Dictionary, default_value) -> String:
 			return GdDefaultValueDecoder.decode_typed(type, default_value)
 		TYPE_TRANSFORM2D, TYPE_TRANSFORM3D:
 			return GdDefaultValueDecoder.decode_typed(type, default_value)
-		TYPE_PACKED_COLOR_ARRAY:
-			return GdDefaultValueDecoder.decode_typed(type, default_value)
 		TYPE_OBJECT:
 			if default_value == null:
 				return "null"
 	if GdObjects.is_primitive_type(default_value):
 		return str(default_value)
 	if GdArrayTools.is_type_array(type):
-		if default_value == null:
+		if default_value == null or default_value.is_empty():
 			return "[]"
-		return str(default_value)
+		return GdDefaultValueDecoder.decode_typed(type, default_value)
 	return "%s(%s)" % [GdObjects.type_as_string(type), str(default_value).trim_prefix("(").trim_suffix(")")]

--- a/addons/gdUnit4/src/core/parse/GdFunctionDescriptor.gd
+++ b/addons/gdUnit4/src/core/parse/GdFunctionDescriptor.gd
@@ -273,7 +273,7 @@ static func _argument_default_value(arg :Dictionary, default_value) -> String:
 				return "null"
 	if GdObjects.is_primitive_type(default_value):
 		return str(default_value)
-	if GdObjects.is_type_array(type):
+	if GdArrayTools.is_type_array(type):
 		if default_value == null:
 			return "[]"
 		return str(default_value)

--- a/addons/gdUnit4/src/extractors/GdUnitFuncValueExtractor.gd
+++ b/addons/gdUnit4/src/extractors/GdUnitFuncValueExtractor.gd
@@ -32,7 +32,7 @@ func extract_value(value):
 	if value == null:
 		return null
 	for func_name in func_names():
-		if GdObjects.is_array_type(value):
+		if GdArrayTools.is_array_type(value):
 			var values := Array()
 			for element in Array(value):
 				values.append(_call_func(element, func_name))
@@ -50,7 +50,7 @@ func extract_value(value):
 func _call_func(value, func_name :String):
 	# for array types we need to call explicit by function name, using funcref is only supported for Objects
 	# TODO extend to all array functions
-	if GdObjects.is_array_type(value) and func_name == "empty":
+	if GdArrayTools.is_array_type(value) and func_name == "empty":
 		return value.is_empty()
 	
 	if not (value is Object):

--- a/addons/gdUnit4/src/spy/GdUnitSpyBuilder.gd
+++ b/addons/gdUnit4/src/spy/GdUnitSpyBuilder.gd
@@ -40,7 +40,7 @@ static func get_class_info(clazz :Variant) -> Dictionary:
 
 
 static func spy_on_script(instance, function_excludes :PackedStringArray, debug_write) -> GDScript:
-	if GdObjects.is_array_type(instance):
+	if GdArrayTools.is_array_type(instance):
 		if GdUnitSettings.is_verbose_assert_errors():
 			push_error("Can't build spy checked type '%s'! Spy checked Container Built-In Type not supported!" % instance.get_class())
 		return null

--- a/addons/gdUnit4/test/GdUnitTestCaseTimingTest.gd
+++ b/addons/gdUnit4/test/GdUnitTestCaseTimingTest.gd
@@ -12,25 +12,25 @@ class TestCaseStatistics:
 	var _test_before_calls :int
 	var _test_after_calls :int
 	
-	func _init(before_calls := 0,after_calls := 0):
+	func _init(before_calls := 0, after_calls := 0):
 		_test_before_calls = before_calls
 		_test_after_calls = after_calls
+
 
 func before():
 	_test_values_current = {
 		"test_fast" : TestCaseStatistics.new(),
 		"test_2s" : TestCaseStatistics.new(),
-		"test_1m" : TestCaseStatistics.new(),
 		"test_multi_yielding" : TestCaseStatistics.new(),
 		"test_multi_yielding_with_fuzzer" : TestCaseStatistics.new()
 	}
 	_test_values_expected = {
 		"test_fast" : TestCaseStatistics.new(1, 1),
 		"test_2s" : TestCaseStatistics.new(1, 1),
-		"test_1m" : TestCaseStatistics.new(1, 1),
 		"test_multi_yielding" : TestCaseStatistics.new(1, 1),
 		"test_multi_yielding_with_fuzzer" : TestCaseStatistics.new(10 , 10)
 	}
+
 
 func after():
 	for test_case in _test_values_expected.keys():
@@ -43,30 +43,23 @@ func after():
 			.override_failure_message("Expect after_test called %s times but is %s for test case %s" % [expected._test_before_calls, current._test_before_calls, test_case])\
 			.is_equal(expected._test_after_calls)
 
+
 func before_test():
 	var current = _test_values_current[__active_test_case] as TestCaseStatistics
 	current._test_before_calls +=1
+
 
 func after_test():
 	var current = _test_values_current[__active_test_case] as TestCaseStatistics
 	current._test_after_calls +=1
 
-func test_fast():
-	var timer_start := Time.get_ticks_msec()
-	await get_tree().create_timer(0.200).timeout
-	# subtract an offset of 100ms because the time is not accurate
-	assert_int(Time.get_ticks_msec()-timer_start).is_between(10, 300)
 
 func test_2s():
 	var timer_start := Time.get_ticks_msec()
-	await get_tree().create_timer(2.0).timeout
+	await await_millis(2000)
 	# subtract an offset of 100ms because the time is not accurate
 	assert_int(Time.get_ticks_msec()-timer_start).is_between(2*SECOND-100, 2*SECOND+100)
 
-func test_1m():
-	var timer_start := Time.get_ticks_msec()
-	await get_tree().create_timer(60.0).timeout
-	assert_int(Time.get_ticks_msec()-timer_start).is_greater_equal(MINUTE-100)
 
 func test_multi_yielding():
 	var timer_start := Time.get_ticks_msec()
@@ -82,6 +75,7 @@ func test_multi_yielding():
 	await get_tree().create_timer(1.0).timeout
 	prints("Go")
 	assert_int(Time.get_ticks_msec()-timer_start).is_greater_equal(4*(SECOND-50))
+
 
 func test_multi_yielding_with_fuzzer(fuzzer := Fuzzers.rangei(0, 1000), fuzzer_iterations = 10):
 	if fuzzer.iteration_index() == 1:

--- a/addons/gdUnit4/test/asserts/GdUnitArrayAssertImplTest.gd
+++ b/addons/gdUnit4/test/asserts/GdUnitArrayAssertImplTest.gd
@@ -5,15 +5,16 @@ extends GdUnitTestSuite
 const __source = 'res://addons/gdUnit4/src/asserts/GdUnitArrayAssertImpl.gd'
 
 
-func test_is_null():
+
+func test_is_null() -> void:
 	assert_array(null).is_null()
 	
 	assert_failure(func(): assert_array([]).is_null()) \
 		.is_failed() \
-		.has_message("Expecting: '<null>' but was empty")
+		.has_message("Expecting: '<null>' but was '<empty>'")
 
 
-func test_is_not_null():
+func test_is_not_null() -> void:
 	assert_array([]).is_not_null()
 	
 	assert_failure(func(): assert_array(null).is_not_null()) \
@@ -33,9 +34,9 @@ func test_is_equal():
 		.is_failed() \
 		.has_message("""
 			Expecting:
-			 '1,    2, 3, 4'
+			 '[1,    2, 3, 4]'
 			 but was
-			 '1, 2222, 3, 4, 5, 6'
+			 '[1, 2222, 3, 4, 5, 6]'
 			
 			Differences found:
 			Index	Current	Expected	1	2222	2	4	5	<N/A>	5	6	<N/A>	"""
@@ -46,9 +47,9 @@ func test_is_equal():
 		.is_failed() \
 		.has_message("""
 			Expecting:
-			 '1,   2, 3, 4, 5, 6'
+			 '[1,   2, 3, 4, 5, 6]'
 			 but was
-			 '1, 222, 3, 4'
+			 '[1, 222, 3, 4]'
 			
 			Differences found:
 			Index	Current	Expected	1	222	2	4	<N/A>	5	5	<N/A>	6	"""
@@ -58,7 +59,7 @@ func test_is_equal():
 		.is_failed() \
 		.has_message("""
 			Expecting:
-			 '1, 2, 3'
+			 '[1, 2, 3]'
 			 but was
 			 '<null>'"""
 			.dedent().trim_prefix("\n"))
@@ -79,9 +80,9 @@ func test_is_equal_big_arrays():
 		.is_failed() \
 		.has_message("""
 			Expecting:
-			 '0, 1, 2, 3, 4, 5, 6, 7, 8, 9,      10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, ...'
+			 '[0, 1, 2, 3, 4, 5, 6, 7, 8, 9,      10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, ...]'
 			 but was
-			 '0, 1, 2, 3, 4, 5, 6, 7, 8, 9, invalid, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, ...'
+			 '[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, invalid, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, ...]'
 			
 			Differences found:
 			Index	Current	Expected	10	invalid	10	40	invalid	40	100	invalid	100	888	invalid	888	"""
@@ -97,7 +98,7 @@ func test_is_equal_ignoring_case():
 		.is_failed() \
 		.has_message("""
 			Expecting:
-			 '"This", "is"'
+			 '["This", "is"]'
 			 but was
 			 '<null>'"""
 			.dedent().trim_prefix("\n"))
@@ -111,9 +112,9 @@ func test_is_not_equal():
 		.is_failed() \
 		.has_message("""
 			Expecting:
-			 '1, 2, 3, 4, 5'
+			 '[1, 2, 3, 4, 5]'
 			 not equal to
-			 '1, 2, 3, 4, 5'"""
+			 '[1, 2, 3, 4, 5]'"""
 			.dedent().trim_prefix("\n"))
 
 
@@ -125,9 +126,9 @@ func test_is_not_equal_ignoring_case():
 		.is_failed() \
 		.has_message("""
 			Expecting:
-			 '"This", "is", "a", "Message"'
+			 '["This", "is", "a", "Message"]'
 			 not equal to (case insensitiv)
-			 '"this", "is", "a", "message"'"""
+			 '["this", "is", "a", "message"]'"""
 			.dedent().trim_prefix("\n"))
 
 
@@ -139,7 +140,7 @@ func test_is_empty():
 		.has_message("""
 			Expecting:
 			 must be empty but was
-			 1, 2, 3"""
+			 '[1, 2, 3]'"""
 			.dedent().trim_prefix("\n"))
 	assert_failure(func(): assert_array(null).is_empty()) \
 		.is_failed() \
@@ -157,6 +158,23 @@ func test_is_not_empty():
 	assert_failure(func(): assert_array([]).is_not_empty()) \
 		.is_failed() \
 		.has_message("Expecting:\n must not be empty")
+
+
+func test_is_same() -> void:
+	var value := [0]
+	assert_array(value).is_same(value)
+	
+	assert_failure(func(): assert_array(value).is_same(value.duplicate()))\
+		.is_failed()\
+		.has_message("Expecting:\n '[0]'\n to refer to the same object\n '[0]'")
+
+
+func test_is_not_same() -> void:
+	assert_array([0]).is_not_same([0])
+	var value := [0]
+	assert_failure(func(): assert_array(value).is_not_same(value))\
+		.is_failed()\
+		.has_message("Expecting: not same '[0]'")
 
 
 func test_has_size():
@@ -190,11 +208,11 @@ func test_contains():
 		.is_failed() \
 		.has_message("""
 			Expecting contains elements:
-			 1, 2, 3, 4, 5
+			 '[1, 2, 3, 4, 5]'
 			 do contains (in any order)
-			 2, 7, 6
+			 '[2, 7, 6]'
 			but could not find elements:
-			 7, 6"""
+			 '[7, 6]'"""
 			.dedent().trim_prefix("\n"))
 	assert_failure(func(): assert_array(null).contains([2, 7, 6])) \
 		.is_failed() \
@@ -202,9 +220,9 @@ func test_contains():
 			Expecting contains elements:
 			 '<null>'
 			 do contains (in any order)
-			 2, 7, 6
+			 '[2, 7, 6]'
 			but could not find elements:
-			 2, 7, 6"""
+			 '[2, 7, 6]'"""
 			.dedent().trim_prefix("\n"))
 
 
@@ -215,9 +233,9 @@ func test_contains_exactly():
 		.is_failed() \
 		.has_message("""
 			Expecting contains exactly elements:
-			 1, 2, 3, 4, 5
+			 '[1, 2, 3, 4, 5]'
 			 do contains (in same order)
-			 1, 4, 3, 2, 5
+			 '[1, 4, 3, 2, 5]'
 			 but has different order at position '1'
 			 '2' vs '4'"""
 			.dedent().trim_prefix("\n"))
@@ -227,11 +245,11 @@ func test_contains_exactly():
 		.is_failed() \
 		.has_message("""
 			Expecting contains exactly elements:
-			 1, 2, 3, 4, 5, 6, 7
+			 '[1, 2, 3, 4, 5, 6, 7]'
 			 do contains (in same order)
-			 1, 4, 3, 2, 5
+			 '[1, 4, 3, 2, 5]'
 			but some elements where not expected:
-			 6, 7"""
+			 '[6, 7]'"""
 			.dedent().trim_prefix("\n"))
 	
 	# should fail because the array contains less elements and in a different order
@@ -239,11 +257,11 @@ func test_contains_exactly():
 		.is_failed() \
 		.has_message("""
 			Expecting contains exactly elements:
-			 1, 2, 3, 4, 5
+			 '[1, 2, 3, 4, 5]'
 			 do contains (in same order)
-			 1, 4, 3, 2, 5, 6, 7
+			 '[1, 4, 3, 2, 5, 6, 7]'
 			but could not find elements:
-			 6, 7"""
+			 '[6, 7]'"""
 			.dedent().trim_prefix("\n"))
 	
 	assert_failure(func(): assert_array(null).contains_exactly([1, 4, 3])) \
@@ -252,9 +270,9 @@ func test_contains_exactly():
 			Expecting contains exactly elements:
 			 '<null>'
 			 do contains (in same order)
-			 1, 4, 3
+			 '[1, 4, 3]'
 			but could not find elements:
-			 1, 4, 3"""
+			 '[1, 4, 3]'"""
 			.dedent().trim_prefix("\n"))
 
 
@@ -268,13 +286,13 @@ func test_contains_exactly_in_any_order():
 		.is_failed() \
 		.has_message("""
 			Expecting contains exactly elements:
-			 1, 2, 6, 4, 5
+			 '[1, 2, 6, 4, 5]'
 			 do contains exactly (in any order)
-			 5, 3, 2, 4, 1, 9, 10
+			 '[5, 3, 2, 4, 1, 9, 10]'
 			but some elements where not expected:
-			 6
+			 '[6]'
 			and could not find elements:
-			 3, 9, 10"""
+			 '[3, 9, 10]'"""
 			.dedent().trim_prefix("\n"))
 	
 	#should fail because the array contains the same elements but in a different order
@@ -282,13 +300,13 @@ func test_contains_exactly_in_any_order():
 		.is_failed() \
 		.has_message("""
 			Expecting contains exactly elements:
-			 1, 2, 6, 9, 10, 4, 5
+			 '[1, 2, 6, 9, 10, 4, 5]'
 			 do contains exactly (in any order)
-			 5, 3, 2, 4, 1
+			 '[5, 3, 2, 4, 1]'
 			but some elements where not expected:
-			 6, 9, 10
+			 '[6, 9, 10]'
 			and could not find elements:
-			 3"""
+			 '[3]'"""
 			.dedent().trim_prefix("\n"))
 	
 	assert_failure(func(): assert_array(null).contains_exactly_in_any_order([1, 4, 3])) \
@@ -297,9 +315,9 @@ func test_contains_exactly_in_any_order():
 			Expecting contains exactly elements:
 			 '<null>'
 			 do contains exactly (in any order)
-			 1, 4, 3
+			 '[1, 4, 3]'
 			but could not find elements:
-			 1, 4, 3"""
+			 '[1, 4, 3]'"""
 			.dedent().trim_prefix("\n"))
 
 
@@ -312,33 +330,33 @@ func test_not_contains():
 		.is_failed() \
 		.has_message("""
 			Expecting:
-			 1, 2, 3, 4, 5
+			 '[1, 2, 3, 4, 5]'
 			 do not contains
-			 5
+			 '[5]'
 			 but found elements:
-			 5"""
+			 '[5]'"""
 			.dedent().trim_prefix("\n")
 		)
 	assert_failure(func(): assert_array([1, 2, 3, 4, 5]).not_contains([1, 4, 6])) \
 		.is_failed() \
 		.has_message("""
 			Expecting:
-			 1, 2, 3, 4, 5
+			 '[1, 2, 3, 4, 5]'
 			 do not contains
-			 1, 4, 6
+			 '[1, 4, 6]'
 			 but found elements:
-			 1, 4"""
+			 '[1, 4]'"""
 			.dedent().trim_prefix("\n")
 		)
 	assert_failure(func(): assert_array([1, 2, 3, 4, 5]).not_contains([6, 4, 1])) \
 		.is_failed() \
 		.has_message("""
 			Expecting:
-			 1, 2, 3, 4, 5
+			 '[1, 2, 3, 4, 5]'
 			 do not contains
-			 6, 4, 1
+			 '[6, 4, 1]'
 			 but found elements:
-			 4, 1"""
+			 '[4, 1]'"""
 			.dedent().trim_prefix("\n")
 		)
 
@@ -389,13 +407,11 @@ func test_extract() -> void:
 		.is_failed() \
 		.has_message("""
 			Expecting contains exactly elements:
-			 <null>
+			 '<null>'
 			 do contains (in same order)
-			 "AStar3D", "Node"
-			but some elements where not expected:
-			 <null>
-			and could not find elements:
-			 "AStar3D", "Node\""""
+			 '["AStar3D", "Node"]'
+			but could not find elements:
+			 '["AStar3D", "Node"]'"""
 			.dedent().trim_prefix("\n"))
 
 
@@ -467,13 +483,11 @@ func test_extractv() -> void:
 		.is_failed() \
 		.has_message("""
 			Expecting contains exactly elements:
-			 <null>
+			 '<null>'
 			 do contains (in same order)
-			 tuple([\"A\", 10, <null>]), tuple([\"B\", \"foo\", \"bar\"]), tuple([\"C\", 11, 42])
-			but some elements where not expected:
-			 <null>
-			and could not find elements:
-			 tuple([\"A\", 10, <null>]), tuple([\"B\", \"foo\", \"bar\"]), tuple([\"C\", 11, 42])"""
+			 '[tuple(["A", 10, <null>]), tuple(["B", "foo", "bar"]), tuple(["C", 11, 42])]'
+			but could not find elements:
+			 '[tuple(["A", 10, <null>]), tuple(["B", "foo", "bar"]), tuple(["C", 11, 42])]'"""
 			.dedent().trim_prefix("\n"))
 
 

--- a/addons/gdUnit4/test/asserts/GdUnitArrayAssertImplTest.gd
+++ b/addons/gdUnit4/test/asserts/GdUnitArrayAssertImplTest.gd
@@ -203,6 +203,10 @@ func test_contains():
 	assert_array([1, 2, 3, 4, 5]).contains([])
 	assert_array([1, 2, 3, 4, 5]).contains([5, 2])
 	assert_array([1, 2, 3, 4, 5]).contains([5, 4, 3, 2, 1])
+	var valueA := TestObj.new("A", 0)
+	var valueB := TestObj.new("B", 0)
+	assert_array([valueA, valueB]).contains([TestObj.new("A", 0)])
+	
 	# should fail because the array not contains 7 and 6
 	assert_failure(func(): assert_array([1, 2, 3, 4, 5]).contains([2, 7, 6])) \
 		.is_failed() \
@@ -214,6 +218,7 @@ func test_contains():
 			but could not find elements:
 			 '[7, 6]'"""
 			.dedent().trim_prefix("\n"))
+	
 	assert_failure(func(): assert_array(null).contains([2, 7, 6])) \
 		.is_failed() \
 		.has_message("""
@@ -224,10 +229,25 @@ func test_contains():
 			but could not find elements:
 			 '[2, 7, 6]'"""
 			.dedent().trim_prefix("\n"))
+	
+	assert_failure(func(): assert_array([valueA, valueB]).contains([TestObj.new("C", 0)])) \
+		.is_failed() \
+		.has_message("""
+			Expecting contains elements:
+			 '[class:A, class:B]'
+			 do contains (in any order)
+			 '[class:C]'
+			but could not find elements:
+			 '[class:C]'"""
+			.dedent().trim_prefix("\n"))
 
 
 func test_contains_exactly():
 	assert_array([1, 2, 3, 4, 5]).contains_exactly([1, 2, 3, 4, 5])
+	var valueA := TestObj.new("A", 0)
+	var valueB := TestObj.new("B", 0)
+	assert_array([valueA, valueB]).contains_exactly([TestObj.new("A", 0), valueB])
+	
 	# should fail because the array contains the same elements but in a different order
 	assert_failure(func(): assert_array([1, 2, 3, 4, 5]).contains_exactly([1, 4, 3, 2, 5])) \
 		.is_failed() \
@@ -274,12 +294,26 @@ func test_contains_exactly():
 			but could not find elements:
 			 '[1, 4, 3]'"""
 			.dedent().trim_prefix("\n"))
+	
+	assert_failure(func(): assert_array([valueA, valueB]).contains_exactly([valueB, TestObj.new("A", 0)])) \
+		.is_failed() \
+		.has_message("""
+			Expecting contains exactly elements:
+			 '[class:A, class:B]'
+			 do contains (in same order)
+			 '[class:B, class:A]'
+			 but has different order at position '0'
+			 'class:A' vs 'class:B'"""
+		.dedent().trim_prefix("\n"))
 
 
 func test_contains_exactly_in_any_order():
 	assert_array([1, 2, 3, 4, 5]).contains_exactly_in_any_order([1, 2, 3, 4, 5])
 	assert_array([1, 2, 3, 4, 5]).contains_exactly_in_any_order([5, 3, 2, 4, 1])
 	assert_array([1, 2, 3, 4, 5]).contains_exactly_in_any_order([5, 1, 2, 4, 3])
+	var valueA := TestObj.new("A", 0)
+	var valueB := TestObj.new("B", 0)
+	assert_array([valueA, valueB]).contains_exactly_in_any_order([valueB, TestObj.new("A", 0)])
 	
 	# should fail because the array contains not exactly the same elements in any order
 	assert_failure(func(): assert_array([1, 2, 6, 4, 5]).contains_exactly_in_any_order([5, 3, 2, 4, 1, 9, 10])) \
@@ -319,12 +353,95 @@ func test_contains_exactly_in_any_order():
 			but could not find elements:
 			 '[1, 4, 3]'"""
 			.dedent().trim_prefix("\n"))
+	
+	assert_failure(func():  assert_array([valueA, valueB]).contains_exactly_in_any_order([valueB, TestObj.new("C", 0)])) \
+		.is_failed() \
+		.has_message("""
+			Expecting contains exactly elements:
+			 '[class:A, class:B]'
+			 do contains exactly (in any order)
+			 '[class:B, class:C]'
+			but some elements where not expected:
+			 '[class:A]'
+			and could not find elements:
+			 '[class:C]'"""
+			.dedent().trim_prefix("\n"))
+
+
+func test_contains_same():
+	var valueA := TestObj.new("A", 0)
+	var valueB := TestObj.new("B", 0)
+	var valueC := TestObj.new("C", 0)
+	assert_array([valueA, valueB]).contains_same([valueA])
+	
+	assert_failure(func(): assert_array([valueA, valueB]).contains_same([TestObj.new("A", 0)])) \
+		.is_failed() \
+		.has_message("""
+			Expecting contains SAME elements:
+			 '[class:A, class:B]'
+			 do contains (in any order)
+			 '[class:A]'
+			but could not find elements:
+			 '[class:A]'"""
+			.dedent().trim_prefix("\n"))
+
+
+func test_contains_same_exactly():
+	var valueA := TestObj.new("A", 0)
+	var valueB := TestObj.new("B", 0)
+	assert_array([valueA, valueB]).contains_same_exactly([valueA, valueB])
+	
+	assert_failure(func(): assert_array([valueA, valueB]).contains_same_exactly([valueB, valueA])) \
+		.is_failed() \
+		.has_message("""
+			Expecting contains SAME exactly elements:
+			 '[class:A, class:B]'
+			 do contains (in same order)
+			 '[class:B, class:A]'
+			 but has different order at position '0'
+			 'class:A' vs 'class:B'"""
+		.dedent().trim_prefix("\n"))
+	
+	assert_failure(func(): assert_array([valueA, valueB]).contains_same_exactly([TestObj.new("A", 0), valueB])) \
+		.is_failed() \
+		.has_message("""
+			Expecting contains SAME exactly elements:
+			 '[class:A, class:B]'
+			 do contains (in same order)
+			 '[class:A, class:B]'
+			but some elements where not expected:
+			 '[class:A]'
+			and could not find elements:
+			 '[class:A]'"""
+			.dedent().trim_prefix("\n"))
+
+
+func test_contains_same_exactly_in_any_order():
+	var valueA := TestObj.new("A", 0)
+	var valueB := TestObj.new("B", 0)
+	assert_array([valueA, valueB]).contains_same_exactly_in_any_order([valueB, valueA])
+	
+	assert_failure(func():  assert_array([valueA, valueB]).contains_same_exactly_in_any_order([valueB, TestObj.new("A", 0)])) \
+		.is_failed() \
+		.has_message("""
+			Expecting contains SAME exactly elements:
+			 '[class:A, class:B]'
+			 do contains exactly (in any order)
+			 '[class:B, class:A]'
+			but some elements where not expected:
+			 '[class:A]'
+			and could not find elements:
+			 '[class:A]'"""
+			.dedent().trim_prefix("\n"))
 
 
 func test_not_contains():
 	assert_array([]).not_contains([0])
 	assert_array([1, 2, 3, 4, 5]).not_contains([0])
 	assert_array([1, 2, 3, 4, 5]).not_contains([0, 6])
+	var valueA := TestObj.new("A", 0)
+	var valueB := TestObj.new("B", 0)
+	assert_array([valueA, valueB]).not_contains([TestObj.new("C", 0)])
 	
 	assert_failure(func(): assert_array([1, 2, 3, 4, 5]).not_contains([5]))\
 		.is_failed() \
@@ -337,6 +454,7 @@ func test_not_contains():
 			 '[5]'"""
 			.dedent().trim_prefix("\n")
 		)
+	
 	assert_failure(func(): assert_array([1, 2, 3, 4, 5]).not_contains([1, 4, 6])) \
 		.is_failed() \
 		.has_message("""
@@ -348,6 +466,7 @@ func test_not_contains():
 			 '[1, 4]'"""
 			.dedent().trim_prefix("\n")
 		)
+	
 	assert_failure(func(): assert_array([1, 2, 3, 4, 5]).not_contains([6, 4, 1])) \
 		.is_failed() \
 		.has_message("""
@@ -357,6 +476,37 @@ func test_not_contains():
 			 '[6, 4, 1]'
 			 but found elements:
 			 '[4, 1]'"""
+			.dedent().trim_prefix("\n")
+		)
+	
+	assert_failure(func(): assert_array([valueA, valueB]).not_contains([TestObj.new("A", 0)])) \
+		.is_failed() \
+		.has_message("""
+			Expecting:
+			 '[class:A, class:B]'
+			 do not contains
+			 '[class:A]'
+			 but found elements:
+			 '[class:A]'"""
+			.dedent().trim_prefix("\n")
+		)
+
+
+func test_not_contains_same():
+	var valueA := TestObj.new("A", 0)
+	var valueB := TestObj.new("B", 0)
+	var valueC := TestObj.new("B", 0)
+	assert_array([valueA, valueB]).not_contains_same([valueC])
+	
+	assert_failure(func(): assert_array([valueA, valueB]).not_contains_same([valueB])) \
+		.is_failed() \
+		.has_message("""
+			Expecting SAME:
+			 '[class:A, class:B]'
+			 do not contains
+			 '[class:B]'
+			 but found elements:
+			 '[class:B]'"""
 			.dedent().trim_prefix("\n")
 		)
 
@@ -420,7 +570,7 @@ class TestObj:
 	var _value
 	var _x
 	
-	func _init(name :String,value,x = null):
+	func _init(name :String, value, x = null):
 		_name = name
 		_value = value
 		_x = x
@@ -460,7 +610,9 @@ class TestObj:
 	
 	func get_x9() -> String:
 		return "x9"
-
+	
+	func _to_string() -> String:
+		return "class:" + _name
 
 func test_extractv() -> void:
 	# single extract

--- a/addons/gdUnit4/test/asserts/GdUnitDictionaryAssertImplTest.gd
+++ b/addons/gdUnit4/test/asserts/GdUnitDictionaryAssertImplTest.gd
@@ -186,11 +186,11 @@ func test_contains_keys() -> void:
 		.is_failed() \
 		.has_message("""
 			Expecting keys:
-			 1, 3
+			 '[1, 3]'
 			 to contains:
-			 2
+			 '[2]'
 			 but can't find key's:
-			 2"""
+			 '[2]'"""
 			.dedent()
 			.trim_prefix("\n")
 		)
@@ -198,11 +198,11 @@ func test_contains_keys() -> void:
 		.is_failed() \
 		.has_message("""
 			Expecting keys:
-			 1, 3
+			 '[1, 3]'
 			 to contains:
-			 1, 4
+			 '[1, 4]'
 			 but can't find key's:
-			 4"""
+			 '[4]'"""
 			.dedent()
 			.trim_prefix("\n")
 		)
@@ -220,11 +220,11 @@ func test_contains_not_keys() -> void:
 		.is_failed() \
 		.has_message("""
 			Expecting keys:
-			 1, 2, 3
+			 '[1, 2, 3]'
 			 do not contains:
-			 2, 4
+			 '[2, 4]'
 			 but contains key's:
-			 2"""
+			 '[2]'"""
 			.dedent()
 			.trim_prefix("\n")
 		)
@@ -232,11 +232,11 @@ func test_contains_not_keys() -> void:
 		.is_failed() \
 		.has_message("""
 			Expecting keys:
-			 1, 2, 3
+			 '[1, 2, 3]'
 			 do not contains:
-			 1, 2, 3, 4
+			 '[1, 2, 3, 4]'
 			 but contains key's:
-			 1, 2, 3"""
+			 '[1, 2, 3]'"""
 			.dedent()
 			.trim_prefix("\n")
 		)

--- a/addons/gdUnit4/test/asserts/GdUnitPackedArrayAssertTest.gd
+++ b/addons/gdUnit4/test/asserts/GdUnitPackedArrayAssertTest.gd
@@ -74,7 +74,7 @@ func test_is_equal(_test :String, array, test_parameters = [
 			Index	Current	Expected	5	<N/A>	$value	"""
 			.dedent()
 			.trim_prefix("\n")
-			.replace("$value", str(array[2]) ) % [GdDefaultValueDecoder.array_to_string(other, false), GdDefaultValueDecoder.array_to_string(array, false)])
+			.replace("$value", str(array[2]) ) % [GdArrayTools.as_string(other, false), GdArrayTools.as_string(array, false)])
 
 
 @warning_ignore("unused_parameter")

--- a/addons/gdUnit4/test/asserts/GdUnitPackedArrayAssertTest.gd
+++ b/addons/gdUnit4/test/asserts/GdUnitPackedArrayAssertTest.gd
@@ -4,15 +4,9 @@ extends GdUnitTestSuite
 # TestSuite generated from
 const __source = 'res://addons/gdUnit4/src/asserts/GdUnitArrayAssertImpl.gd'
 
-# small value format helper
-func format_value(value) -> String:
-	if GdObjects.is_array_type(value):
-		return GdAssertMessages.array_to_string(value)
-	return GdAssertMessages._typed_value(value)
-
 
 @warning_ignore("unused_parameter")
-func test_is_null(_test :String, array, test_parameters = [
+func test_is_null(_test :String, value, test_parameters = [
 	["Array", Array()],
 	["PackedByteArray", PackedByteArray()],
 	["PackedInt32Array", PackedInt32Array()],
@@ -25,9 +19,9 @@ func test_is_null(_test :String, array, test_parameters = [
 	["PackedColorArray", PackedColorArray()] ]
 	) -> void:
 	assert_array(null).is_null()
-	assert_failure(func(): assert_array(array).is_null()) \
+	assert_failure(func(): assert_array(value).is_null()) \
 		.is_failed() \
-		.has_message("Expecting: '<null>' but was empty")
+		.has_message("Expecting: '<null>' but was '%s'" % GdDefaultValueDecoder.decode(value))
 
 
 @warning_ignore("unused_parameter")
@@ -49,6 +43,7 @@ func test_is_not_null(_test :String, array, test_parameters = [
 		.is_failed() \
 		.has_message("Expecting: not to be '<null>'")
 
+
 @warning_ignore("unused_parameter")
 func test_is_equal(_test :String, array, test_parameters = [
 	["Array", Array([1, 2, 3, 4, 5])],
@@ -68,7 +63,18 @@ func test_is_equal(_test :String, array, test_parameters = [
 	# should fail because the array not contains same elements and has diff size
 	other.append(array[2])
 	assert_failure(func(): assert_array(array).is_equal(other)) \
-		.is_failed()
+		.is_failed() \
+		.has_message("""
+			Expecting:
+			 '%s'
+			 but was
+			 '%s'
+			
+			Differences found:
+			Index	Current	Expected	5	<N/A>	$value	"""
+			.dedent()
+			.trim_prefix("\n")
+			.replace("$value", str(array[2]) ) % [GdDefaultValueDecoder.array_to_string(other, false), GdDefaultValueDecoder.array_to_string(array, false)])
 
 
 @warning_ignore("unused_parameter")
@@ -90,7 +96,14 @@ func test_is_not_equal(_test :String, array, test_parameters = [
 	assert_array(array).is_not_equal(other)
 	# should fail because the array  contains same elements
 	assert_failure(func(): assert_array(array).is_not_equal(array.duplicate())) \
-		.is_failed()
+		.is_failed() \
+		.has_message("""
+			Expecting:
+			 '%s'
+			 not equal to
+			 '%s'"""
+			.dedent()
+			.trim_prefix("\n") % [GdDefaultValueDecoder.decode(array), GdDefaultValueDecoder.decode(array)])
 
 
 @warning_ignore("unused_parameter")
@@ -113,7 +126,12 @@ func test_is_empty(_test :String, array, test_parameters = [
 	# should fail because the array is not empty
 	assert_failure(func(): assert_array(array).is_empty()) \
 		.is_failed() \
-		.starts_with_message("Expecting:\n must be empty but was")
+		.has_message("""
+			Expecting:
+			 must be empty but was
+			 '%s'"""
+			.dedent()
+			.trim_prefix("\n") % GdDefaultValueDecoder.decode(array))
 
 
 @warning_ignore("unused_parameter")
@@ -139,6 +157,52 @@ func test_is_not_empty(_test :String, array, test_parameters = [
 		.has_message("Expecting:\n must not be empty")
 
 
+func test_is_same(value, test_parameters = [
+	[[0]],
+	[PackedByteArray([0])],
+	[PackedFloat32Array([0.0])],
+	[PackedFloat64Array([0.0])],
+	[PackedInt32Array([0])],
+	[PackedInt64Array([0])],
+	[PackedStringArray([""])],
+	[PackedColorArray([Color.RED])],
+	[PackedVector2Array([Vector2.ZERO])],
+	[PackedVector3Array([Vector3.ZERO])],
+]) -> void:
+	assert_array(value).is_same(value)
+	
+	var v := GdDefaultValueDecoder.decode(value)
+	assert_failure(func(): assert_array(value).is_same(value.duplicate()))\
+		.is_failed()\
+		.has_message("""
+			Expecting:
+			 '%s'
+			 to refer to the same object
+			 '%s'"""
+			.dedent()
+			.trim_prefix("\n") % [v, v])
+
+
+@warning_ignore("unused_parameter")
+func test_is_not_same(value, test_parameters = [
+	[[0]],
+	[PackedByteArray([0])],
+	[PackedFloat32Array([0.0])],
+	[PackedFloat64Array([0.0])],
+	[PackedInt32Array([0])],
+	[PackedInt64Array([0])],
+	[PackedStringArray([""])],
+	[PackedColorArray([Color.RED])],
+	[PackedVector2Array([Vector2.ZERO])],
+	[PackedVector3Array([Vector3.ZERO])],
+]) -> void:
+	assert_array(value).is_not_same(value.duplicate())
+	
+	assert_failure(func(): assert_array(value).is_not_same(value))\
+		.is_failed()\
+		.has_message("Expecting: not same '%s'" % GdDefaultValueDecoder.decode(value))
+
+
 @warning_ignore("unused_parameter")
 func test_has_size(_test :String, array, test_parameters = [
 	["Array", Array([1, 2, 3, 4, 5])],
@@ -157,7 +221,13 @@ func test_has_size(_test :String, array, test_parameters = [
 	# should fail because the array has a size of 5
 	assert_failure(func(): assert_array(array).has_size(4)) \
 		.is_failed() \
-		.has_message("Expecting size:\n '4'\n but was\n '5'")
+		.has_message("""
+			Expecting size:
+			 '4'
+			 but was
+			 '5'"""
+			.dedent()
+			.trim_prefix("\n"))
 
 
 @warning_ignore("unused_parameter")
@@ -181,15 +251,15 @@ func test_contains(_test :String, array, test_parameters = [
 		.is_failed() \
 		.has_message("""
 			Expecting contains elements:
-			 $source
+			 '$source'
 			 do contains (in any order)
-			 $contains
+			 '$contains'
 			but could not find elements:
-			 7, 6"""
+			 '[7, 6]'"""
 			.dedent()
 			.trim_prefix("\n")
-			.replace("$source", format_value(array))
-			.replace("$contains", format_value(do_contains))
+			.replace("$source", GdDefaultValueDecoder.decode(array))
+			.replace("$contains", GdDefaultValueDecoder.decode(do_contains))
 		)
 
 
@@ -216,84 +286,18 @@ func test_contains_exactly(_test :String, array, test_parameters = [
 		.is_failed() \
 		.has_message("""
 			Expecting contains exactly elements:
-			 $source
+			 '$source'
 			 do contains (in same order)
-			 $contains
+			 '$contains'
 			 but has different order at position '1'
 			 '$A' vs '$B'"""
 			.dedent()
 			.trim_prefix("\n")
-			.replace("$A", format_value(array[1]))
-			.replace("$B", format_value(array[3]))
-			.replace("$source", format_value(array))
-			.replace("$contains", format_value(shuffled))
+			.replace("$A", GdDefaultValueDecoder.decode(array[1]))
+			.replace("$B", GdDefaultValueDecoder.decode(array[3]))
+			.replace("$source", GdDefaultValueDecoder.decode(array))
+			.replace("$contains", GdDefaultValueDecoder.decode(shuffled))
 		)
-
-
-@warning_ignore("unused_parameter")
-func test_not_contains(_test :String, array, test_parameters = [
-	["Array", Array([1, 2, 3, 4, 5])],
-	["PackedByteArray", PackedByteArray([1, 2, 3, 4, 5])],
-	["PackedInt32Array", PackedInt32Array([1, 2, 3, 4, 5])],
-	["PackedInt64Array", PackedInt64Array([1, 2, 3, 4, 5])],
-	["PackedFloat32Array", PackedFloat32Array([1, 2, 3, 4, 5])],
-	["PackedFloat64Array", PackedFloat64Array([1, 2, 3, 4, 5])],
-	["PackedStringArray", PackedStringArray(["1", "2", "3", "4", "5"])],
-	["PackedVector2Array", PackedVector2Array([Vector2.ZERO, Vector2.LEFT, Vector2.RIGHT, Vector2.UP, Vector2.DOWN])],
-	["PackedVector3Array", PackedVector3Array([Vector3.ZERO, Vector3.LEFT, Vector3.RIGHT, Vector3.UP, Vector3.DOWN])],
-	["PackedColorArray", PackedColorArray([Color.RED, Color.GREEN, Color.BLUE, Color.YELLOW, Color.BLACK])] ]
-	) -> void:
-	
-	assert_array(array).not_contains([0])
-	assert_array(array).not_contains([0])
-	assert_array(array).not_contains([0, 6])
-	
-	var should_not_contain = [array[4]]
-	assert_failure(func(): assert_array(array).not_contains(should_not_contain))\
-		.is_failed() \
-		.has_message("""
-			Expecting:
-			 $current
-			 do not contains
-			 $not_contain
-			 but found elements:
-			 $found"""
-			.dedent().trim_prefix("\n")
-			.replace("$current", format_value(array))
-			.replace("$not_contain",  format_value(should_not_contain))
-			.replace("$found", format_value(array[4]))
-		)
-	should_not_contain = [array[0], array[3], 6]
-	assert_failure(func(): assert_array(array).not_contains(should_not_contain)) \
-		.is_failed() \
-		.has_message("""
-			Expecting:
-			 $current
-			 do not contains
-			 $not_contain
-			 but found elements:
-			 $found"""
-			.dedent().trim_prefix("\n")
-			.replace("$current", format_value(array))
-			.replace("$not_contain",  format_value(should_not_contain))
-			.replace("$found", format_value([array[0], array[3]]))
-		)
-	should_not_contain = [6, array[3], array[0]]
-	assert_failure(func(): assert_array(array).not_contains(should_not_contain)) \
-		.is_failed() \
-		.has_message("""
-			Expecting:
-			 $current
-			 do not contains
-			 $not_contain
-			 but found elements:
-			 $found"""
-			.dedent().trim_prefix("\n")
-			.replace("$current", format_value(array))
-			.replace("$not_contain",  format_value(should_not_contain))
-			.replace("$found", format_value([array[3], array[0]]))
-		)
-
 
 @warning_ignore("unused_parameter")
 func test_override_failure_message(_test :String, array, test_parameters = [

--- a/addons/gdUnit4/test/core/GdArrayToolsTest.gd
+++ b/addons/gdUnit4/test/core/GdArrayToolsTest.gd
@@ -1,0 +1,152 @@
+# GdUnit generated TestSuite
+class_name GdArrayToolsTest
+extends GdUnitTestSuite
+@warning_ignore('unused_parameter')
+@warning_ignore('return_value_discarded')
+
+# TestSuite generated from
+const __source = 'res://addons/gdUnit4/src/core/GdArrayTools.gd'
+
+
+@warning_ignore('unused_parameter')
+func test_as_string(_test :String, value, expected :String, test_parameters = [
+	['Array', Array([1, 2]), '[1, 2]'],
+	['Array', Array([1.0, 2.212]), '[1.000000, 2.212000]'],
+	['Array', Array([true, false]), '[true, false]'],
+	['Array', Array(["1", "2"]), '["1", "2"]'],
+	['Array', Array([Vector2.ZERO, Vector2.LEFT]), '[Vector2(0, 0), Vector2(-1, 0)]'],
+	['Array', Array([Vector3.ZERO, Vector3.LEFT]), '[Vector3(0, 0, 0), Vector3(-1, 0, 0)]'],
+	['Array', Array([Color.RED, Color.GREEN]), '[Color(1, 0, 0, 1), Color(0, 1, 0, 1)]'],
+	['ArrayInt', Array([1, 2]) as Array[int], '[1, 2]'],
+	['ArrayFloat', Array([1.0, 2.212]) as Array[float], '[1.000000, 2.212000]'],
+	['ArrayBool', Array([true, false]) as Array[bool], '[true, false]'],
+	['ArrayString', Array(["1", "2"]) as Array[String], '["1", "2"]'],
+	['ArrayVector2', Array([Vector2.ZERO, Vector2.LEFT]) as Array[Vector2], '[Vector2(0, 0), Vector2(-1, 0)]'],
+	['ArrayVector2i', Array([Vector2i.ZERO, Vector2i.LEFT]) as Array[Vector2i], '[Vector2i(0, 0), Vector2i(-1, 0)]'],
+	['ArrayVector3', Array([Vector3.ZERO, Vector3.LEFT]) as Array[Vector3], '[Vector3(0, 0, 0), Vector3(-1, 0, 0)]'],
+	['ArrayVector3i', Array([Vector3i.ZERO, Vector3i.LEFT]) as Array[Vector3i], '[Vector3i(0, 0, 0), Vector3i(-1, 0, 0)]'],
+	['ArrayVector4', Array([Vector4.ZERO, Vector4.ONE]) as Array[Vector4], '[Vector4(0, 0, 0, 0), Vector4(1, 1, 1, 1)]'],
+	['ArrayVector4i', Array([Vector4i.ZERO, Vector4i.ONE]) as Array[Vector4i], '[Vector4i(0, 0, 0, 0), Vector4i(1, 1, 1, 1)]'],
+	['ArrayColor', Array([Color.RED, Color.GREEN]) as Array[Color], '[Color(1, 0, 0, 1), Color(0, 1, 0, 1)]'],
+	['PackedByteArray', PackedByteArray([1, 2]), 'PackedByteArray[1, 2]'],
+	['PackedInt32Array', PackedInt32Array([1, 2]), 'PackedInt32Array[1, 2]'],
+	['PackedInt64Array', PackedInt64Array([1, 2]), 'PackedInt64Array[1, 2]'],
+	['PackedFloat32Array', PackedFloat32Array([1, 2.212]), 'PackedFloat32Array[1.000000, 2.212000]'],
+	['PackedFloat64Array', PackedFloat64Array([1, 2.212]), 'PackedFloat64Array[1.000000, 2.212000]'],
+	['PackedStringArray', PackedStringArray([1, 2]), 'PackedStringArray["1", "2"]'],
+	['PackedVector2Array', PackedVector2Array([Vector2.ZERO, Vector2.LEFT]), 'PackedVector2Array[Vector2(0, 0), Vector2(-1, 0)]'],
+	['PackedVector3Array', PackedVector3Array([Vector3.ZERO, Vector3.LEFT]), 'PackedVector3Array[Vector3(0, 0, 0), Vector3(-1, 0, 0)]'],
+	['PackedColorArray', PackedColorArray([Color.RED, Color.GREEN]), 'PackedColorArray[Color(1, 0, 0, 1), Color(0, 1, 0, 1)]'],
+]) -> void:
+	
+	assert_that(GdArrayTools.as_string(value)).is_equal(expected)
+
+
+func test_as_string_simple_format():
+	var value := PackedStringArray(["a", "b"])
+	prints(GdArrayTools.as_string(value, false))
+	assert_that(GdArrayTools.as_string(value, false)).is_equal('[a, b]')
+
+
+func test_is_array_type(_test :String, value, expected :bool, test_parameters = [
+	['bool', true, false],
+	['int', 42, false],
+	['float', 1.21, false],
+	['String', "abc", false],
+	['Dictionary', {}, false],
+	['RefCounted', RefCounted.new(), false],
+	['Array', Array([1, 2]), true],
+	['Array', Array([1.0, 2.212]), true],
+	['Array', Array([true, false]), true],
+	['Array', Array(["1", "2"]), true],
+	['Array', Array([Vector2.ZERO, Vector2.LEFT]), true],
+	['Array', Array([Vector3.ZERO, Vector3.LEFT]), true],
+	['Array', Array([Color.RED, Color.GREEN]), true],
+	['ArrayInt', Array([1, 2]) as Array[int], true],
+	['ArrayFloat', Array([1.0, 2.212]) as Array[float], true],
+	['ArrayBool', Array([true, false]) as Array[bool], true],
+	['ArrayString', Array(["1", "2"]) as Array[String], true],
+	['ArrayVector2', Array([Vector2.ZERO, Vector2.LEFT]) as Array[Vector2], true],
+	['ArrayVector2i', Array([Vector2i.ZERO, Vector2i.LEFT]) as Array[Vector2i], true],
+	['ArrayVector3', Array([Vector3.ZERO, Vector3.LEFT]) as Array[Vector3], true],
+	['ArrayVector3i', Array([Vector3i.ZERO, Vector3i.LEFT]) as Array[Vector3i], true],
+	['ArrayVector4', Array([Vector4.ZERO, Vector4.ONE]) as Array[Vector4], true],
+	['ArrayVector4i', Array([Vector4i.ZERO, Vector4i.ONE]) as Array[Vector4i], true],
+	['ArrayColor', Array([Color.RED, Color.GREEN]) as Array[Color], true],
+	['PackedByteArray', PackedByteArray([1, 2]), true],
+	['PackedInt32Array', PackedInt32Array([1, 2]), true],
+	['PackedInt64Array', PackedInt64Array([1, 2]), true],
+	['PackedFloat32Array', PackedFloat32Array([1, 2.212]), true],
+	['PackedFloat64Array', PackedFloat64Array([1, 2.212]), true],
+	['PackedStringArray', PackedStringArray([1, 2]), true],
+	['PackedVector2Array', PackedVector2Array([Vector2.ZERO, Vector2.LEFT]), true],
+	['PackedVector3Array', PackedVector3Array([Vector3.ZERO, Vector3.LEFT]), true],
+	['PackedColorArray', PackedColorArray([Color.RED, Color.GREEN]), true],
+]) -> void:
+	
+	assert_that(GdArrayTools.is_array_type(value)).is_equal(expected)
+
+
+func test_is_type_array() -> void:
+	for type in [TYPE_NIL, TYPE_MAX]:
+		if type in [TYPE_ARRAY, TYPE_PACKED_COLOR_ARRAY]:
+			assert_that(GdArrayTools.is_type_array(type)).is_true()
+		else:
+			assert_that(GdArrayTools.is_type_array(type)).is_false()
+
+
+func test_filter_value(value, expected_type :int, test_parameters = [
+	[[1, 2, 3, 1], TYPE_ARRAY],
+	[Array([1, 2, 3, 1]) as Array[int], TYPE_ARRAY],
+	[PackedByteArray([1, 2, 3, 1]), TYPE_PACKED_BYTE_ARRAY],
+	[PackedInt32Array([1, 2, 3, 1]), TYPE_PACKED_INT32_ARRAY],
+	[PackedInt64Array([1, 2, 3, 1]), TYPE_PACKED_INT64_ARRAY],
+	[PackedFloat32Array([1.0, 2, 1.1, 1.0]), TYPE_PACKED_FLOAT32_ARRAY],
+	[PackedFloat64Array([1.0, 2, 1.1, 1.0]), TYPE_PACKED_FLOAT64_ARRAY],
+	[PackedStringArray(["1", "2", "3", "1"]), TYPE_PACKED_STRING_ARRAY],
+	[PackedVector2Array([Vector2.ZERO, Vector2.ONE, Vector2.DOWN, Vector2.ZERO]), TYPE_PACKED_VECTOR2_ARRAY],
+	[PackedVector3Array([Vector3.ZERO, Vector3.ONE, Vector3.DOWN, Vector3.ZERO]), TYPE_PACKED_VECTOR3_ARRAY],
+	[PackedColorArray([Color.RED, Color.GREEN, Color.BLUE, Color.RED]), TYPE_PACKED_COLOR_ARRAY]
+	]) -> void:
+	
+	var value_to_remove = value[0]
+	var result :Variant = GdArrayTools.filter_value(value, value_to_remove)
+	assert_array(result).not_contains([value_to_remove]).has_size(2)
+	assert_that(typeof(result)).is_equal(expected_type)
+
+
+func test_filter_value_() -> void:
+	assert_array(GdArrayTools.filter_value([], null)).is_empty()
+	assert_array(GdArrayTools.filter_value([], "")).is_empty()
+	
+	var current :Array = [null, "a", "b", null, "c", null]
+	var filtered :Variant= GdArrayTools.filter_value(current, null)
+	assert_array(filtered).contains_exactly(["a", "b", "c"])
+	# verify the source is not affected
+	assert_array(current).contains_exactly([null, "a", "b", null, "c", null])
+	
+	current = [null, "a", "xxx", null, "xx", null]
+	filtered = GdArrayTools.filter_value(current, "xxx")
+	assert_array(filtered).contains_exactly([null, "a", null, "xx", null])
+	# verify the source is not affected
+	assert_array(current).contains_exactly([null, "a", "xxx", null, "xx", null])
+
+
+func test_erase_value() -> void:
+	var current := []
+	GdArrayTools.erase_value(current, null)
+	assert_array(current).is_empty()
+	
+	current = [null]
+	GdArrayTools.erase_value(current, null)
+	assert_array(current).is_empty()
+	
+	current = [null, "a", "b", null, "c", null]
+	GdArrayTools.erase_value(current, null)
+	# verify the source is affected
+	assert_array(current).contains_exactly(["a", "b", "c"])
+
+
+func test_scan_typed() -> void:
+	assert_that(GdArrayTools.scan_typed([1, 2, 3])).is_equal(TYPE_INT)
+	assert_that(GdArrayTools.scan_typed([1, 2.2, 3])).is_equal(GdObjects.TYPE_VARIANT)

--- a/addons/gdUnit4/test/core/GdObjectsTest.gd
+++ b/addons/gdUnit4/test/core/GdObjectsTest.gd
@@ -152,17 +152,6 @@ func test_is_primitive_type():
 	assert_bool(GdObjects.is_primitive_type("")).is_true()
 	assert_bool(GdObjects.is_primitive_type(Vector2.ONE)).is_false()
 
-func test_is_array_type():
-	assert_bool(GdObjects.is_array_type([])).is_true()
-	assert_bool(GdObjects.is_array_type(Array())).is_true()
-	assert_bool(GdObjects.is_array_type(PackedByteArray())).is_true()
-	assert_bool(GdObjects.is_array_type(PackedColorArray())).is_true()
-	assert_bool(GdObjects.is_array_type(PackedInt32Array())).is_true()
-	assert_bool(GdObjects.is_array_type(PackedFloat32Array())).is_true()
-	assert_bool(GdObjects.is_array_type(PackedStringArray())).is_true()
-	assert_bool(GdObjects.is_array_type(PackedVector2Array())).is_true()
-	assert_bool(GdObjects.is_array_type(PackedVector3Array())).is_true()
-	assert_bool(GdObjects.is_array_type(false)).is_false()
 
 class TestClassForIsType:
 	var x
@@ -410,35 +399,6 @@ func test_is_public_script_class() -> void:
 	# inner classes not listed as public classes
 	assert_bool(GdObjects.is_public_script_class("CustomClass.InnerClassA")).is_false()
 
-func test_array_filter_value() -> void:
-	assert_array(GdObjects.array_filter_value([], null)).is_empty()
-	assert_array(GdObjects.array_filter_value([], "")).is_empty()
-	
-	var current :Array = [null, "a", "b", null, "c", null]
-	var filtered := GdObjects.array_filter_value(current, null)
-	assert_array(filtered).contains_exactly(["a", "b", "c"])
-	# verify the source is not affected
-	assert_array(current).contains_exactly([null, "a", "b", null, "c", null])
-	
-	current = [null, "a", "xxx", null, "xx", null]
-	filtered = GdObjects.array_filter_value(current, "xxx")
-	assert_array(filtered).contains_exactly([null, "a", null, "xx", null])
-	# verify the source is not affected
-	assert_array(current).contains_exactly([null, "a", "xxx", null, "xx", null])
-
-func test_array_erase_value() -> void:
-	var current := []
-	GdObjects.array_erase_value(current, null)
-	assert_array(current).is_empty()
-	
-	current = [null]
-	GdObjects.array_erase_value(current, null)
-	assert_array(current).is_empty()
-	
-	current = [null, "a", "b", null, "c", null]
-	GdObjects.array_erase_value(current, null)
-	# verify the source is affected
-	assert_array(current).contains_exactly(["a", "b", "c"])
 
 func test_is_instance_scene() -> void:
 	# checked none scene objects


### PR DESCRIPTION
# Why
We want to compare array elements by object reference.

# What
- assert_array now supports all array types
- added verifications
  - is_same
  - is_not_same
  - contains_same
  - contains_same_exactly
  - contains_same_exactly_in_any_order
  - not_contains_same
- improve the failure messages by printing typed arrays
- moved all array util functions into new class `GdArrayTools`
- small cleanups