### PR TITLE
GD-181: Don't allow spy on singletons

### DIFF
--- a/addons/gdUnit4/src/core/GdObjects.gd
+++ b/addons/gdUnit4/src/core/GdObjects.gd
@@ -414,6 +414,15 @@ static func is_gd_testsuite(script :Script) -> bool:
 	return false
 
 
+static func is_singleton(value :Variant) -> bool:
+	if not is_instance_valid(value) or is_native_class(value):
+		return false
+	for name in Engine.get_singleton_list():
+		if value.is_class(name):
+			return true
+	return false
+
+
 static func is_instance(value :Variant) -> bool:
 	if not is_instance_valid(value) or is_native_class(value):
 		return false

--- a/addons/gdUnit4/src/monitor/GodotGdErrorMonitor.gd
+++ b/addons/gdUnit4/src/monitor/GodotGdErrorMonitor.gd
@@ -8,15 +8,17 @@ const USER_PUSH_ERROR := "USER ERROR:"
 var _godot_log_file :String
 var _eof :int
 var _report_enabled := false
+var _report_force : bool
 
 
-func _init():
+func _init(force := false):
 	super("GodotGdErrorMonitor")
+	_report_force = force
 	_godot_log_file = GdUnitSettings.get_log_path().get_base_dir() + "/godot.log"
 
 
 func start():
-	_report_enabled = is_reporting_enabled()
+	_report_enabled = _report_force or is_reporting_enabled()
 	if _report_enabled:
 		var file = FileAccess.open(_godot_log_file, FileAccess.READ)
 		if file:
@@ -86,8 +88,8 @@ static func _parse_error_line_number(error :String) -> int:
 
 
 func _is_report_push_errors() -> bool:
-	return GdUnitSettings.is_report_push_errors()
+	return _report_force or GdUnitSettings.is_report_push_errors()
 
 
 func _is_report_script_errors() -> bool:
-	return GdUnitSettings.is_report_script_errors()
+	return _report_force or GdUnitSettings.is_report_script_errors()

--- a/addons/gdUnit4/src/spy/GdUnitSpyBuilder.gd
+++ b/addons/gdUnit4/src/spy/GdUnitSpyBuilder.gd
@@ -4,7 +4,9 @@ extends GdUnitClassDoubler
 
 static func build(caller :Object, to_spy, debug_write = false):
 	var memory_pool :GdUnitMemoryPool.POOL = caller.get_meta(GdUnitMemoryPool.META_PARAM)
-	
+	if GdObjects.is_singleton(to_spy):
+		push_error("Spy on a Singleton is not allowed! '%s'" % to_spy.get_class())
+		return null
 	# if resource path load it before
 	if GdObjects.is_scene_resource_path(to_spy):
 		if not FileAccess.file_exists(to_spy):

--- a/addons/gdUnit4/test/core/GdObjectsTest.gd
+++ b/addons/gdUnit4/test/core/GdObjectsTest.gd
@@ -187,8 +187,23 @@ func test_is_type():
 	assert_bool(GdObjects.is_type(TestClassForIsType.new())).is_false()
 	assert_bool(GdObjects.is_type(auto_free(CustomClass.InnerClassC.new()))).is_false()
 
+
+func test_is_singleton() -> void:
+	for singleton_name in Engine.get_singleton_list():
+		var singleton = Engine.get_singleton(singleton_name)
+		assert_bool(GdObjects.is_singleton(singleton)) \
+			.override_failure_message("Expect to a singleton: '%s' Instance: %s, Class: %s" % [singleton_name, singleton, singleton.get_class()]) \
+			.is_true()
+	# false tests
+	assert_bool(GdObjects.is_singleton(10)).is_false()
+	assert_bool(GdObjects.is_singleton(true)).is_false()
+	assert_bool(GdObjects.is_singleton(Node)).is_false()
+	assert_bool(GdObjects.is_singleton(auto_free(Node.new()))).is_false()
+
+
 func _is_instance(value) -> bool:
 	return GdObjects.is_instance(auto_free(value))
+
 
 func test_is_instance_true():
 	assert_bool(_is_instance(RefCounted.new())).is_true()

--- a/addons/gdUnit4/test/spy/GdUnitSpyTest.gd
+++ b/addons/gdUnit4/test/spy/GdUnitSpyTest.gd
@@ -220,7 +220,7 @@ func test_verify_fail():
 			.dedent().trim_prefix("\n")
 	assert_failure(func(): verify(spy_node, 1).set_process(true)) \
 		.is_failed() \
-		.has_line(207) \
+		.has_line(221) \
 		.has_message(expected_error)
 
 
@@ -247,7 +247,7 @@ func test_verify_func_interaction_wiht_PackedStringArray_fail():
 			.dedent().trim_prefix("\n")
 	assert_failure(func(): verify(spy_instance, 1).set_values([])) \
 		.is_failed() \
-		.has_line(234) \
+		.has_line(248) \
 		.has_message(expected_error)
 	
 	reset(spy_instance)
@@ -265,7 +265,7 @@ func test_verify_func_interaction_wiht_PackedStringArray_fail():
 			.dedent().trim_prefix("\n")
 	assert_failure(func(): verify(spy_instance, 1).set_values([])) \
 		.is_failed() \
-		.has_line(252) \
+		.has_line(266) \
 		.has_message(expected_error)
 
 
@@ -313,7 +313,7 @@ func test_verify_no_interactions_fails():
 	# it should fail because we have interactions
 	assert_failure(func(): verify_no_interactions(spy_node)) \
 		.is_failed() \
-		.has_line(300) \
+		.has_line(314) \
 		.has_message(expected_error)
 
 
@@ -368,7 +368,7 @@ func test_verify_no_more_interactions_but_has():
 			.dedent().trim_prefix("\n")
 	assert_failure(func(): verify_no_more_interactions(spy_node)) \
 		.is_failed() \
-		.has_line(355) \
+		.has_line(369) \
 		.has_message(expected_error)
 
 

--- a/addons/gdUnit4/test/spy/GdUnitSpyTest.gd
+++ b/addons/gdUnit4/test/spy/GdUnitSpyTest.gd
@@ -166,6 +166,20 @@ func test_spy_on_inner_class():
 	verify(spy_instance, 1).set_data(AdvancedTestClass.AtmosphereData.SMOKY, 1.3)
 
 
+func test_spy_on_singleton():
+	# setup monitor to collect expected push_error notifications
+	var monitor := GodotGdErrorMonitor.new(true)
+	monitor.start()
+	# We not allow to spy on a singleton
+	var spy_node = spy(Input)
+	await await_idle_frame()
+	monitor.stop()
+	assert_object(spy_node).is_null()
+	assert_array(monitor.reports()).has_size(1)
+	if not is_failure():
+		assert_str(monitor.reports()[0].message()).contains("Spy on a Singleton is not allowed! 'Input'")
+
+
 func test_example_verify():
 	var instance :Node = auto_free(Node.new())
 	var spy_node = spy(instance)


### PR DESCRIPTION
# Why
When a tester try to spy on a singleton an parser error is shown, but it should push an error do inform is not allowed to spy on a singleton

# What
Added validation on spy builder to verify if the given instance a singleton and stop building a spy on it