### PR TITLE
GD-182: Fix `assert_vector.is_equal_approx`

### DIFF
--- a/addons/gdUnit4/src/asserts/GdUnitVectorAssertImpl.gd
+++ b/addons/gdUnit4/src/asserts/GdUnitVectorAssertImpl.gd
@@ -91,7 +91,28 @@ func is_not_equal(expected :Variant) -> GdUnitVectorAssert:
 func is_equal_approx(expected :Variant, approx :Variant) -> GdUnitVectorAssert:
 	if not _validate_is_vector_type(expected) or not _validate_is_vector_type(approx):
 		return self
-	return is_between(expected-approx, expected+approx)
+	var current = __current()
+	var from = expected - approx
+	var to = expected + approx
+	if current == null or (not _is_equal_approx(current, from, to)):
+		return report_error(GdAssertMessages.error_is_value(Comparator.BETWEEN_EQUAL, current, from, to))
+	return report_success()
+
+
+func _is_equal_approx(current, from, to) -> bool:
+	match typeof(current):
+		TYPE_VECTOR2, TYPE_VECTOR2I:
+			return ((current.x >= from.x and current.y >= from.y)
+				and (current.x <= to.x and current.y <= to.y))
+		TYPE_VECTOR3, TYPE_VECTOR3I:
+			return ((current.x >= from.x and current.y >= from.y and current.z >= from.z)
+				and (current.x <= to.x and current.y <= to.y and current.z <= to.z))
+		TYPE_VECTOR4, TYPE_VECTOR4I:
+			return ((current.x >= from.x and current.y >= from.y and current.z >= from.z and current.w >= from.w)
+				and (current.x <= to.x and current.y <= to.y and current.z <= to.z and current.w <= to.w))
+		_:
+			push_error("Missing implementation '_is_equal_approx' for vector type %s" % typeof(current))
+			return false
 
 
 func is_less(expected :Variant) -> GdUnitVectorAssert:

--- a/addons/gdUnit4/test/asserts/GdUnitVectorAssertImplTest.gd
+++ b/addons/gdUnit4/test/asserts/GdUnitVectorAssertImplTest.gd
@@ -113,7 +113,24 @@ func test_is_equal_approx() -> void:
 	assert_failure(func(): assert_vector(Vector2(1.2, 1.000001)).is_equal_approx(Vector3.ONE, Vector3(1.2, 1.000001, 1.0))) \
 		.is_failed() \
 		.has_message("Unexpected type comparison:\n Expecting type 'Vector2' but is 'Vector3'")
-
+	assert_failure(func(): assert_vector(Vector2(0.878431, 0.505882)).is_equal_approx(Vector2(0.878431, 0.105882), Vector2(0.000001, 0.000001))) \
+		.is_failed() \
+		.has_message("""
+			Expecting:
+			 '(0.878431, 0.505882)'
+			 in range between
+			 '(0.87843, 0.105881)' <> '(0.878432, 0.105883)'"""
+			.dedent().trim_prefix("\n")
+		)
+	assert_failure(func(): assert_vector(Vector3(0.0, 0.878431, 0.505882)).is_equal_approx(Vector3(0.0, 0.878431, 0.105882), Vector3(0.000001, 0.000001, 0.000001))) \
+		.is_failed() \
+		.has_message("""
+			Expecting:
+			 '(0, 0.878431, 0.505882)'
+			 in range between
+			 '(-0.000001, 0.87843, 0.105881)' <> '(0.000001, 0.878432, 0.105883)'"""
+			.dedent().trim_prefix("\n")
+		)
 
 func test_is_equal_approx_over_all_types(value, expected, approx, test_parameters = [
 	[Vector2(0.996, 1.004), Vector2.ONE, Vector2(0.004, 0.004)],


### PR DESCRIPTION
# Why
The validation uses the standard compare operators <= and >= where not pass to test for equal approx

# What
Add your own comparison to verify