### PR TITLE
Respect log file renaming

### DIFF
--- a/addons/gdUnit4/src/monitor/GodotGdErrorMonitor.gd
+++ b/addons/gdUnit4/src/monitor/GodotGdErrorMonitor.gd
@@ -14,7 +14,7 @@ var _report_force : bool
 func _init(force := false):
 	super("GodotGdErrorMonitor")
 	_report_force = force
-	_godot_log_file = GdUnitSettings.get_log_path().get_base_dir() + "/godot.log"
+	_godot_log_file = GdUnitSettings.get_log_path()
 
 
 func start():


### PR DESCRIPTION
Currently if the log file is renamed tests will fail to run, this is a result of getting the log file path, then calling `get_base_dir()` on it and appending "/godot.log". Thus, ignoring any custom log file name and overwriting it with godot.log, since the path being returned to us is already an absolute path to the log file we can just use that and it will respect the users settings.