### PR TITLE
GD-186: Report `push_error` as failure is not working if custom `log_path` is configured

### DIFF
--- a/addons/gdUnit4/src/monitor/GdUnitMonitor.gd
+++ b/addons/gdUnit4/src/monitor/GdUnitMonitor.gd
@@ -1,6 +1,6 @@
 # GdUnit Monitoring Base Class
 class_name GdUnitMonitor
-extends Resource
+extends RefCounted
 
 var _id :String
 

--- a/addons/gdUnit4/src/monitor/GodotGdErrorMonitor.gd
+++ b/addons/gdUnit4/src/monitor/GodotGdErrorMonitor.gd
@@ -14,7 +14,7 @@ var _report_force : bool
 func _init(force := false):
 	super("GodotGdErrorMonitor")
 	_report_force = force
-	_godot_log_file = GdUnitSettings.get_log_path().get_base_dir() + "/godot.log"
+	_godot_log_file = GdUnitSettings.get_log_path()
 
 
 func start():

--- a/addons/gdUnit4/test/monitor/GodotGdErrorMonitorTest.gd
+++ b/addons/gdUnit4/test/monitor/GodotGdErrorMonitorTest.gd
@@ -59,3 +59,35 @@ func test_scan_for_script_errors() -> void:
 	var expected_report := GodotGdErrorMonitor._report_runtime_error("USER SCRIPT ERROR: Trying to call a function on a previously freed instance.",\
 		"at: GdUnitScriptTypeTest.test_xx (res://addons/gdUnit4/test/GdUnitScriptTypeTest.gd:22)")
 	assert_array(monitor.reports()).contains_exactly([expected_report])
+
+
+func test_custom_log_path() -> void:
+	# save original log_path
+	var log_path :String = ProjectSettings.get_setting("debug/file_logging/log_path")
+	# set custom log path
+	var custom_log_path := "user://logs/test-run.log"
+	FileAccess.open(custom_log_path, FileAccess.WRITE).store_line("test-log")
+	ProjectSettings.set_setting("debug/file_logging/log_path", custom_log_path)
+	var monitor := GodotGdErrorMonitor.new()
+	
+	assert_that(monitor._godot_log_file).is_equal(custom_log_path)
+	# restore orignal log_path
+	ProjectSettings.set_setting("debug/file_logging/log_path", log_path)
+
+
+func test_integration_test() -> void:
+	var monitor := GodotGdErrorMonitor.new(true)
+	# no errors reported
+	monitor.start()
+	monitor.stop()
+	assert_array(monitor.reports()).is_empty()
+	
+	# push error
+	monitor.start()
+	push_error("Test GodotGdErrorMonitor 'push_error' reporting")
+	monitor.stop()
+	assert_array(monitor.reports()).is_not_empty()
+	if not monitor.reports().is_empty():
+		assert_str(monitor.reports()[0].message()).contains("Test GodotGdErrorMonitor 'push_error' reporting")
+	else:
+		fail("Expect reporting push_error")


### PR DESCRIPTION
# Why
When a user configures a custom log_path, the push_error notifications are not tracked.


# What
- using full log_path instead of customized log path building.
- add integration test coverage
- create the monitor only at test execution