### PR TITLE
WIP: Make spinner preloaded.

### DIFF
--- a/addons/gdUnit4/src/ui/parts/InspectorTreeMainPanel.gd
+++ b/addons/gdUnit4/src/ui/parts/InspectorTreeMainPanel.gd
@@ -14,7 +14,7 @@ signal run_testsuite
 @onready var _context_menu_debug := $contextMenu/items/debug
 
 # tree icons
-@onready var ICON_SPINNER = load("res://addons/gdUnit4/src/ui/assets/spinner.tres")
+@onready var ICON_SPINNER = preload("res://addons/gdUnit4/src/ui/assets/spinner.tres")
 @onready var ICON_TEST_DEFAULT = load_resized_texture("res://addons/gdUnit4/src/ui/assets/TestCase.svg")
 @onready var ICON_TEST_SUCCESS = load_resized_texture("res://addons/gdUnit4/src/ui/assets/TestCaseSuccess.svg")
 @onready var ICON_TEST_FAILED = load_resized_texture("res://addons/gdUnit4/src/ui/assets/TestCaseFailed.svg")

--- a/addons/gdUnit4/src/update/GdUnitUpdateNotify.gd
+++ b/addons/gdUnit4/src/update/GdUnitUpdateNotify.gd
@@ -5,7 +5,7 @@ signal request_completed(response)
 
 const GdMarkDownReader = preload("res://addons/gdUnit4/src/update/GdMarkDownReader.gd")
 const GdUnitUpdateClient = preload("res://addons/gdUnit4/src/update/GdUnitUpdateClient.gd")
-const spinner_icon := "res://addons/gdUnit4/src/ui/assets/spinner.tres"
+const spinner_icon := preload("res://addons/gdUnit4/src/ui/assets/spinner.tres")
 
 @onready var _md_reader :GdMarkDownReader = GdMarkDownReader.new()
 @onready var _update_client :GdUnitUpdateClient = $GdUnitUpdateClient


### PR DESCRIPTION
In making sense of https://github.com/godotengine/godot/issues/72273 and other I noticed there is nowhere **preload**ed.

This PR is not OK as I changed the **string** into a **preload**.

This PR could fix the spinner resource, but needs testing.

I also notices lots of **load**s instead of **preload**s .. is there a reason for using load instead of preload?