### PR TITLE
GD-197: Show test errors in full.

### DIFF
--- a/addons/gdUnit4/src/ui/parts/InspectorTreePanel.tscn
+++ b/addons/gdUnit4/src/ui/parts/InspectorTreePanel.tscn
@@ -38,11 +38,12 @@ size_flags_vertical = 11
 
 [node name="report_template" type="RichTextLabel" parent="report"]
 use_parent_material = true
+clip_contents = false
 layout_mode = 2
 size_flags_horizontal = 3
-size_flags_vertical = 11
 focus_mode = 2
 bbcode_enabled = true
+fit_content = true
 selection_enabled = true
 
 [node name="ScrollContainer" type="ScrollContainer" parent="report"]
@@ -66,8 +67,8 @@ anchor_right = 1.0
 anchor_bottom = 1.0
 offset_left = 4.0
 offset_top = 4.0
-offset_right = -1053.0
-offset_bottom = -572.0
+offset_right = -4.0
+offset_bottom = -4.0
 grow_horizontal = 2
 grow_vertical = 2
 size_flags_horizontal = 3


### PR DESCRIPTION
It would be cool to see the first error in full. This helps fixing the first bug faster.

## Before

![image](https://github.com/MikeSchulze/gdUnit4/assets/371014/608fc0dc-8f1f-409c-8c7d-fcd844706aec)

## After

![image](https://github.com/MikeSchulze/gdUnit4/assets/371014/ec926774-8bb5-46f9-a1fa-5db348026c2a)

## Scene

(not sure this one helps)
![image](https://github.com/MikeSchulze/gdUnit4/assets/371014/564f5073-29c7-4c76-9cd9-920d038c4de9)
