### PR TITLE
GD-224: Update project to Godot 4.1.1

### DIFF
--- a/.github/actions/publish-test-report/action.yml
+++ b/.github/actions/publish-test-report/action.yml
@@ -22,9 +22,3 @@ runs:
         path: 'reports/**/results.xml'
         reporter: java-junit
         fail-on-error: 'false'
-
-    - name: 'Upload Test Artifacts'
-      uses: actions/upload-artifact@v3
-      with:
-        name: test_artifact_${{ inputs.report-name }}
-        path: 'reports/**'

--- a/.github/actions/publish-test-report/action.yml
+++ b/.github/actions/publish-test-report/action.yml
@@ -22,3 +22,9 @@ runs:
         path: 'reports/**/results.xml'
         reporter: java-junit
         fail-on-error: 'false'
+
+    - name: 'Upload Test Artifacts'
+      uses: actions/upload-artifact@v3
+      with:
+        name: test_artifact_${{ inputs.report-name }}
+        path: 'reports/**'

--- a/.github/actions/upload-test-report/action.yml
+++ b/.github/actions/upload-test-report/action.yml
@@ -13,4 +13,7 @@ runs:
       uses: actions/upload-artifact@v3
       with:
         name: test_report_${{ inputs.report-name }}
-        path: reports/**
+        path: |
+          reports/**
+          /var/lib/systemd/coredump/**
+          /var/log/syslog

--- a/.github/workflows/ci-dev.yml
+++ b/.github/workflows/ci-dev.yml
@@ -21,7 +21,7 @@ jobs:
       fail-fast: false
       max-parallel: 10
       matrix:
-        godot-version: ['4.0.1', '4.0.2', '4.0.3']
+        godot-version: ['4.0.1', '4.0.2', '4.0.3', '4.1']
 
     name: "CI on Godot 🐧 v${{ matrix.godot-version }}"
     uses: ./.github/workflows/unit-tests.yml

--- a/.github/workflows/ci-dev.yml
+++ b/.github/workflows/ci-dev.yml
@@ -21,7 +21,7 @@ jobs:
       fail-fast: false
       max-parallel: 10
       matrix:
-        godot-version: ['4.0.1', '4.0.2', '4.0.3', '4.1']
+        godot-version: ['4.0.1', '4.0.2', '4.0.3', '4.1', '4.1.1']
 
     name: "CI on Godot 🐧 v${{ matrix.godot-version }}"
     uses: ./.github/workflows/unit-tests.yml

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -22,7 +22,7 @@ jobs:
       fail-fast: false
       max-parallel: 10
       matrix:
-        godot-version: ['4.0.1', '4.0.2', '4.0.3', '4.1']
+        godot-version: ['4.0.1', '4.0.2', '4.0.3', '4.1', '4.1.1']
 
     name: "CI on Godot 🐧 v${{ matrix.godot-version }}"
     uses: ./.github/workflows/unit-tests.yml

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -22,7 +22,7 @@ jobs:
       fail-fast: false
       max-parallel: 10
       matrix:
-        godot-version: ['4.0.1', '4.0.2', '4.0.3']
+        godot-version: ['4.0.1', '4.0.2', '4.0.3', '4.1']
 
     name: "CI on Godot 🐧 v${{ matrix.godot-version }}"
     uses: ./.github/workflows/unit-tests.yml

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 ---
 <h1 align="center">GdUnit4</h1>
-<p align="center">This version of GdUnit4 is based on Godot <strong>v4.0.3.stable.official [5222a99f5]</strong> (master branch)</p>
+<p align="center">This version of GdUnit4 is based on Godot <strong>v4.1.stable.official [970459615]</strong> (master branch)</p>
 </h2>
 
 
@@ -15,6 +15,7 @@
   <img src="https://img.shields.io/badge/Godot-v4.0.1-%23478cbf?logo=godot-engine&logoColor=cyian&color=green">
   <img src="https://img.shields.io/badge/Godot-v4.0.2-%23478cbf?logo=godot-engine&logoColor=cyian&color=green">
   <img src="https://img.shields.io/badge/Godot-v4.0.3-%23478cbf?logo=godot-engine&logoColor=cyian&color=green">
+  <img src="https://img.shields.io/badge/Godot-v4.1-%23478cbf?logo=godot-engine&logoColor=cyian&color=green">
 </p>
 
 <p align="center"><a href="https://github.com/MikeSchulze/gdUnit4"><img src="https://github.com/MikeSchulze/gdUnit4/blob/master/assets/gdUnit4-animated.gif" width="100%"/></p><br/>

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 ---
 <h1 align="center">GdUnit4</h1>
-<p align="center">This version of GdUnit4 is based on Godot <strong>v4.1.stable.official [970459615]</strong> (master branch)</p>
+<p align="center">This version of GdUnit4 is based on Godot <strong>v4.1.1.stable.official [bd6af8e0e]</strong> (master branch)</p>
 </h2>
 
 
@@ -16,6 +16,7 @@
   <img src="https://img.shields.io/badge/Godot-v4.0.2-%23478cbf?logo=godot-engine&logoColor=cyian&color=green">
   <img src="https://img.shields.io/badge/Godot-v4.0.3-%23478cbf?logo=godot-engine&logoColor=cyian&color=green">
   <img src="https://img.shields.io/badge/Godot-v4.1-%23478cbf?logo=godot-engine&logoColor=cyian&color=green">
+  <img src="https://img.shields.io/badge/Godot-v4.1.1-%23478cbf?logo=godot-engine&logoColor=cyian&color=green">
 </p>
 
 <p align="center"><a href="https://github.com/MikeSchulze/gdUnit4"><img src="https://github.com/MikeSchulze/gdUnit4/blob/master/assets/gdUnit4-animated.gif" width="100%"/></p><br/>

--- a/addons/gdUnit4/bin/ProjectScanner.gd
+++ b/addons/gdUnit4/bin/ProjectScanner.gd
@@ -11,8 +11,11 @@ func _initialize():
 
 
 func _finalize():
-	prints("Finalize scanner ..")
+	if Engine.get_version_info().hex < 0x40100 or Engine.get_version_info().hex > 0x40101:
+		print("Finalize scanner ..")
 	scanner.free()
+	if Engine.get_version_info().hex < 0x40100 or Engine.get_version_info().hex > 0x40101:
+		prints("done")
 
 
 class ProjectScanner extends Node:
@@ -48,7 +51,7 @@ class ProjectScanner extends Node:
 			_console.prints_color("======================================", Color.CORNFLOWER_BLUE)
 			_console.new_line()
 			await get_tree().process_frame
-			get_tree().quit()
+			get_tree().quit(0)
 	
 	
 	func scan_project() -> void:

--- a/addons/gdUnit4/plugin.gd
+++ b/addons/gdUnit4/plugin.gd
@@ -50,4 +50,5 @@ func _exit_tree():
 	GdUnitTools.dispose_all()
 	if Engine.has_meta("GdUnitEditorPlugin"):
 		Engine.remove_meta("GdUnitEditorPlugin")
-	prints("Unload GdUnit4 Plugin success")
+	if Engine.get_version_info().hex < 0x40100 or Engine.get_version_info().hex > 0x40101:
+		prints("Unload GdUnit4 Plugin success")

--- a/addons/gdUnit4/src/asserts/GdUnitFuncAssertImpl.gd
+++ b/addons/gdUnit4/src/asserts/GdUnitFuncAssertImpl.gd
@@ -16,8 +16,6 @@ var _sleep_timer :Timer = null
 
 
 func _init(instance :Object, func_name :String, args := Array()):
-	# temporary workaround to hold the instance see https://github.com/godotengine/godot/issues/73889
-	GdUnitTools.register_assert(self)
 	_line_number = GdUnitAssertImpl._get_line_number()
 	GdAssertReports.reset_last_error_line_number()
 	# save the actual assert instance on the current thread context
@@ -29,16 +27,9 @@ func _init(instance :Object, func_name :String, args := Array()):
 		_current_value_provider = CallBackValueProvider.new(instance, func_name, args)
 
 
-func _to_string():
-	return "GdUnitFuncAssertImpl" + str(get_instance_id())
-
-
 func _notification(_what):
 	if is_instance_valid(self):
 		dispose()
-	# temporary workaround to hold the instance see https://github.com/godotengine/godot/issues/73889
-	while is_instance_valid(self) and get_reference_count() > 1:
-		unreference()
 
 
 func report_success() -> GdUnitAssert:

--- a/addons/gdUnit4/src/core/GdUnitTools.gd
+++ b/addons/gdUnit4/src/core/GdUnitTools.gd
@@ -248,24 +248,9 @@ static func release_timers():
 				node.free()
 
 
-
-static func register_assert(value):
-	var asserts :Array = GdUnitSingleton.instance("GdUnitAsserts", func(): return [])
-	asserts.push_back(value)
-
-
-static func release_asserts():
-	var asserts :Array = GdUnitSingleton.instance("GdUnitAsserts", func(): return [])
-	for index in range(asserts.size()-1, -1, -1):
-		var assert_ = asserts[index]
-		assert_.notification(Object.NOTIFICATION_PREDELETE)
-		asserts.remove_at(index)
-
-
 # the finally cleaup unfreed resources and singletons
 static func dispose_all():
 	release_timers()
-	release_asserts()
 	GdUnitSignals.dispose()
 	GdUnitSingleton.dispose()
 

--- a/project.godot
+++ b/project.godot
@@ -20,6 +20,7 @@ default_bus_layout=""
 
 [debug]
 
+file_logging/enable_file_logging=true
 gdscript/warnings/unused_signal=false
 gdscript/warnings/return_value_discarded=false
 

--- a/project.godot
+++ b/project.godot
@@ -11,7 +11,7 @@ config_version=5
 [application]
 
 config/name="gdUnit4"
-config/features=PackedStringArray("4.0")
+config/features=PackedStringArray("4.1")
 config/icon="res://icon.png"
 
 [audio]


### PR DESCRIPTION
# Why
We want to support the latest Godot version v4.1.1


# What
- update project to v4.1.1
- add Godot 4.1, 4.1.1 to ci-pr and ci-dev workflows
- update README.md
- fix crash by remove the temporary workaround introduced by https://github.com/MikeSchulze/gdUnit4/pull/137
- fix crash by do not print messages on plugin `_exit_tree` (https://github.com/godotengine/godot/issues/79379)
```
malloc(): mismatching next->prev_size (unsorted)
Aborted (core dumped)
Error: Process completed with exit code 134.
```
