### PR TITLE
GD-222: Fix error on SignalCollector when emitter is not a Node

### DIFF
--- a/addons/gdUnit4/src/asserts/GdUnitSignalAssertImpl.gd
+++ b/addons/gdUnit4/src/asserts/GdUnitSignalAssertImpl.gd
@@ -28,7 +28,7 @@ class SignalCollector extends RefCounted:
 	
 	
 	func clear() -> void:
-		for emitter in _collected_signals:
+		for emitter in _collected_signals.keys():
 			if is_instance_valid(emitter):
 				unregister_emitter(emitter)
 	
@@ -42,7 +42,7 @@ class SignalCollector extends RefCounted:
 				return
 			_collected_signals[emitter] = Dictionary()
 			# connect to 'tree_exiting' of the emitter to finally release all acquired resources/connections.
-			if !emitter.tree_exiting.is_connected(unregister_emitter):
+			if emitter is Node and !emitter.tree_exiting.is_connected(unregister_emitter):
 				emitter.tree_exiting.connect(unregister_emitter.bind(emitter))
 			# connect to all signals of the emitter we want to collect
 			for signal_def in emitter.get_signal_list():
@@ -62,7 +62,10 @@ class SignalCollector extends RefCounted:
 	# is called when the emitter is removed from the parent
 	func unregister_emitter(emitter :Object):
 		if is_instance_valid(emitter):
-			GdUnitTools._release_connections(emitter)
+			for signal_def in emitter.get_signal_list():
+				var signal_name = signal_def["name"]
+				if emitter.is_connected(signal_name, _on_signal_emmited):
+					emitter.disconnect(signal_name, _on_signal_emmited.bind(emitter, signal_name))
 			_collected_signals.erase(emitter)
 	
 	

--- a/addons/gdUnit4/test/asserts/GdUnitSignalAssertImplTest.gd
+++ b/addons/gdUnit4/test/asserts/GdUnitSignalAssertImplTest.gd
@@ -184,3 +184,25 @@ func test_monitor_signals() -> void:
 	# now verify emitter b
 	emitter_b.do_emit_a()
 	await assert_signal(emitter_b).wait_until(50).is_emitted('my_signal_a')
+
+
+class ExampleResource extends Resource:
+	@export var title := "Title":
+		set(new_value):
+			title = new_value
+			changed.emit()
+	
+	
+	func change_title(p_title: String) -> void:
+		title = p_title
+
+
+func test_monitor_signals_on_resource_set() -> void:
+	var sut = ExampleResource.new()
+	var emitter := monitor_signals(sut)
+	
+	sut.change_title("Some title")
+	
+	# title change should emit "changed" signal
+	await assert_signal(emitter).is_emitted("changed")
+	assert_str(sut.title).is_equal("Some title")

--- a/addons/gdUnit4/test/core/GdUnitSignalAwaiterTest.gd
+++ b/addons/gdUnit4/test/core/GdUnitSignalAwaiterTest.gd
@@ -20,6 +20,7 @@ class Monster extends Node:
 		emit_signal("move", _pos)
 		emit_signal("slide", _pos, 1 , 2)
 
+
 func test_on_signal_with_single_arg() -> void:
 	var monster = auto_free(Monster.new())
 	add_child(monster)
@@ -27,12 +28,14 @@ func test_on_signal_with_single_arg() -> void:
 	assert_float(signal_arg).is_equal(1.0)
 	remove_child(monster)
 
+
 func test_on_signal_with_many_args() -> void:
 	var monster = auto_free(Monster.new())
 	add_child(monster)
 	var signal_args = await await_signal_on(monster, "slide", [1.0, 1, 2])
 	assert_array(signal_args).is_equal([1.0, 1, 2])
 	remove_child(monster)
+
 
 func test_on_signal_fail() -> void:
 	GdAssertReports.expect_fail()


### PR DESCRIPTION
# Why
When try to use the `monitor_signals` on a Resource it fails by a `Invalid get index 'tree_exiting' (on base: 'Resource (ExampleResource)').`

# What
- fixed by test is given emitter from type `Node` before connect to `tree_exiting`
- relase at testsuite end all monitored connected signal
