### PR TITLE
GD-221: Fix GdUnit Inspector button bar run status issues when a scene is open

### DIFF
--- a/addons/gdUnit4/src/GdUnitSceneRunner.gd
+++ b/addons/gdUnit4/src/GdUnitSceneRunner.gd
@@ -172,6 +172,7 @@ func get_property(name :String) -> Variant:
 ## [member name] : name of property[br]
 ## [member value] : value of property[br]
 ## [member return] : true|false depending on valid property name.
+@warning_ignore("unused_parameter")
 func set_property(name :String, value :Variant) -> bool:
 	return false
 

--- a/addons/gdUnit4/src/core/command/GdUnitCommandHandler.gd
+++ b/addons/gdUnit4/src/core/command/GdUnitCommandHandler.gd
@@ -208,7 +208,6 @@ func cmd_run(debug :bool) -> void:
 	# before start we have to save all changes
 	ScriptEditorControls.save_all_open_script()
 	gdunit_runner_start.emit()
-	_is_running = true
 	_current_runner_process_id = -1
 	_running_debug_mode = debug
 	if debug:
@@ -276,6 +275,7 @@ static func scan_test_directorys(base_directory :String, test_suite_paths :Packe
 
 func run_debug_mode():
 	_editor_interface.play_custom_scene("res://addons/gdUnit4/src/core/GdUnitRunner.tscn")
+	_is_running = true
 
 
 func run_release_mode():
@@ -287,6 +287,7 @@ func run_release_mode():
 	arguments.append(ProjectSettings.globalize_path("res://"))
 	arguments.append("res://addons/gdUnit4/src/core/GdUnitRunner.tscn")
 	_current_runner_process_id = OS.create_process(OS.get_executable_path(), arguments, false);
+	_is_running = true
 
 
 func script_editor() -> ScriptEditor:

--- a/addons/gdUnit4/src/ui/parts/InspectorToolBar.gd
+++ b/addons/gdUnit4/src/ui/parts/InspectorToolBar.gd
@@ -57,6 +57,7 @@ func init_shortcuts(command_handler :GdUnitCommandHandler) -> void:
 	# register for shortcut changes
 	GdUnitSignals.instance().gdunit_settings_changed.connect(_on_settings_changed.bind(command_handler))
 
+
 func _on_runoverall_pressed(debug := false):
 	run_overall_pressed.emit(debug)
 


### PR DESCRIPTION
# Why
The button bar did not adjust the execution state when the test was running and a scene was open in the editor.

# What
There was an error in handling the current status of the test execution. We perform a periodic `check_test_run_stopped_manually` to ensure that we eventually stop when the test is manually stopped. With this check, we test for `_is_running==true`, but the status was set to true too early.
- set status _is_running is now only set to true when the testrunner is started and not before.
- fix warning `unused_parameter` at SceneRunner#set_property
