### PR TITLE
GD-3: `GdScriptParser` use match instead of if/else

### DIFF
--- a/addons/gdUnit4/src/core/parse/GdScriptParser.gd
+++ b/addons/gdUnit4/src/core/parse/GdScriptParser.gd
@@ -356,19 +356,19 @@ func _process_values(left: Token, token_stack: Array, operator: Token) -> Token:
 		var lvalue = left.value()
 		var value = null
 		var next_token_ = token_stack.pop_front() as Token
-	
-		if operator == OPERATOR_ADD:
-			value =  lvalue + next_token_.value()
-		elif operator == OPERATOR_SUB:
-			value =  lvalue - next_token_.value()
-		elif operator == OPERATOR_MUL:
-			value =  lvalue * next_token_.value()
-		elif operator == OPERATOR_DIV:
-			value =  lvalue / next_token_.value()
-		elif operator == OPERATOR_REMAINDER:
-			value =  lvalue & next_token_.value()
-		else:
-			assert(false, "Unsupported operator %s" % operator)
+		match operator:
+			OPERATOR_ADD:
+				value =  lvalue + next_token_.value()
+			OPERATOR_SUB:
+				value =  lvalue - next_token_.value()
+			OPERATOR_MUL:
+				value =  lvalue * next_token_.value()
+			OPERATOR_DIV:
+				value =  lvalue / next_token_.value()
+			OPERATOR_REMAINDER:
+				value =  lvalue & next_token_.value()
+			_:
+				assert(false, "Unsupported operator %s" % operator)
 		return Variable.new( str(value))
 	return operator
 
@@ -447,40 +447,40 @@ func parse_arguments(input: String) -> Array[GdFunctionArgument]:
 			while current_index < len(input):
 				token = next_token(input, current_index)
 				current_index += token._consumed
-				#match token:
 				if token.is_skippable():
 					continue
-				elif token == TOKEN_ARGUMENT_TYPE:
-					token = next_token(input, current_index)
-					if token == TOKEN_SPACE:
-						current_index += token._consumed
+				match token:
+					TOKEN_ARGUMENT_TYPE:
 						token = next_token(input, current_index)
-					arg_type = GdObjects.string_as_typeof(token._token)
-				elif token == TOKEN_ARGUMENT_TYPE_ASIGNMENT:
-					arg_value = _parse_end_function(input.substr(current_index), true)
-					current_index += arg_value.length()
-				elif token == TOKEN_ARGUMENT_ASIGNMENT:
-					token = next_token(input, current_index)
-					arg_value = _parse_end_function(input.substr(current_index), true)
-					current_index += arg_value.length()
-				elif token == TOKEN_BRACKET_OPEN:
-					bracket += 1
-					# if value a function?
-					if bracket > 1:
-						# complete the argument value
-						var func_begin = input.substr(current_index-TOKEN_BRACKET_OPEN._consumed)
-						var func_body = _parse_end_function(func_begin)
-						arg_value += func_body
-						# fix parse index to end of value
-						current_index += func_body.length() - TOKEN_BRACKET_OPEN._consumed - TOKEN_BRACKET_CLOSE._consumed
-				elif token == TOKEN_BRACKET_CLOSE:
-					bracket -= 1
-					# end of function
-					if bracket == 0:
-						break
-				elif token == TOKEN_ARGUMENT_SEPARATOR:
-					if bracket <= 1:
-						break
+						if token == TOKEN_SPACE:
+							current_index += token._consumed
+							token = next_token(input, current_index)
+						arg_type = GdObjects.string_as_typeof(token._token)
+					TOKEN_ARGUMENT_TYPE_ASIGNMENT:
+						arg_value = _parse_end_function(input.substr(current_index), true)
+						current_index += arg_value.length()
+					TOKEN_ARGUMENT_ASIGNMENT:
+						token = next_token(input, current_index)
+						arg_value = _parse_end_function(input.substr(current_index), true)
+						current_index += arg_value.length()
+					TOKEN_BRACKET_OPEN:
+						bracket += 1
+						# if value a function?
+						if bracket > 1:
+							# complete the argument value
+							var func_begin = input.substr(current_index-TOKEN_BRACKET_OPEN._consumed)
+							var func_body = _parse_end_function(func_begin)
+							arg_value += func_body
+							# fix parse index to end of value
+							current_index += func_body.length() - TOKEN_BRACKET_OPEN._consumed - TOKEN_BRACKET_CLOSE._consumed
+					TOKEN_BRACKET_CLOSE:
+						bracket -= 1
+						# end of function
+						if bracket == 0:
+							break
+					TOKEN_ARGUMENT_SEPARATOR:
+						if bracket <= 1:
+							break
 			arg_value = arg_value.lstrip(" ")
 			if arg_type == TYPE_NIL and arg_value != GdFunctionArgument.UNDEFINED:
 				if arg_value.begins_with("Color."):

--- a/addons/gdUnit4/test/core/resources/SoundData.txt
+++ b/addons/gdUnit4/test/core/resources/SoundData.txt
@@ -1,4 +1,5 @@
 class SoundData:
 @warning_ignore("unused_private_class_variable")
 var _sample :String
+@warning_ignore("unused_private_class_variable")
 var _randomnes :float

--- a/addons/gdUnit4/test/mocker/resources/AdvancedTestClass.gd
+++ b/addons/gdUnit4/test/mocker/resources/AdvancedTestClass.gd
@@ -5,6 +5,7 @@ extends Resource
 class SoundData:
 	@warning_ignore("unused_private_class_variable")
 	var _sample :String
+	@warning_ignore("unused_private_class_variable")
 	var _randomnes :float
 	
 class AtmosphereData:


### PR DESCRIPTION
# Why
I dit a replacement of exist mach variable patterns by if/else to based on Godot issue https://github.com/godotengine/godot/issues/66999

# What
- Replace back the if/else by match construct
- fix a warning of unused variable at `AdvancedTestClass`


