### PR TITLE
GD-233: Fix font loading error on linux systems

### DIFF
--- a/addons/gdUnit4/src/ui/GdUnitFonts.gd
+++ b/addons/gdUnit4/src/ui/GdUnitFonts.gd
@@ -9,8 +9,8 @@ const FONT_MONO_ITALIC      = "res://addons/gdUnit4/src/update/assets/fonts/stat
 
 static func init_fonts(item: CanvasItem) -> float:
 	# add a default fallback font
-	item.set("theme_override_fonts/font", create_font(FONT_MONO, 16))
-	item.set("theme_override_fonts/normal_font", create_font(FONT_MONO, 16))
+	item.set("theme_override_fonts/font", load_and_resize_font(FONT_MONO, 16))
+	item.set("theme_override_fonts/normal_font", load_and_resize_font(FONT_MONO, 16))
 	item.set("theme_override_font_sizes/font_size", 16)
 	if Engine.is_editor_hint():
 		var plugin :EditorPlugin = Engine.get_meta("GdUnitEditorPlugin")
@@ -18,11 +18,11 @@ static func init_fonts(item: CanvasItem) -> float:
 		var scale_factor :=  plugin.get_editor_interface().get_editor_scale()
 		var font_size = settings.get_setting("interface/editor/main_font_size")
 		font_size *= scale_factor
-		var font_mono := create_font(FONT_MONO, font_size)
+		var font_mono := load_and_resize_font(FONT_MONO, font_size)
 		item.set("theme_override_fonts/normal_font", font_mono)
-		item.set("theme_override_fonts/bold_font", create_font(FONT_MONO_BOLT, font_size))
-		item.set("theme_override_fonts/italics_font", create_font(FONT_MONO_ITALIC, font_size))
-		item.set("theme_override_fonts/bold_italics_font", create_font(FONT_MONO_BOLT_ITALIC, font_size))
+		item.set("theme_override_fonts/bold_font", load_and_resize_font(FONT_MONO_BOLT, font_size))
+		item.set("theme_override_fonts/italics_font", load_and_resize_font(FONT_MONO_ITALIC, font_size))
+		item.set("theme_override_fonts/bold_italics_font", load_and_resize_font(FONT_MONO_BOLT_ITALIC, font_size))
 		item.set("theme_override_fonts/mono_font", font_mono)
 		item.set("theme_override_font_sizes/font_size", font_size)
 		item.set("theme_override_font_sizes/normal_font_size", font_size)
@@ -33,8 +33,12 @@ static func init_fonts(item: CanvasItem) -> float:
 		return font_size
 	return 16.0
 
-static func create_font(font_resource: String, size: float) -> Font:
-	var font := FontFile.new()
-	font.font_data = load(font_resource)
-	font.fixed_size = int(size)
-	return font
+
+static func load_and_resize_font(font_resource: String, size: float) -> Font:
+	var font :FontFile = ResourceLoader.load(font_resource, "FontFile")
+	if font == null:
+		push_error("Can't load font '%s'" % font_resource)
+		return null
+	var resized_font = font.duplicate()
+	resized_font.fixed_size = int(size)
+	return resized_font

--- a/addons/gdUnit4/test/ui/GdUnitFontsTest.gd
+++ b/addons/gdUnit4/test/ui/GdUnitFontsTest.gd
@@ -1,0 +1,17 @@
+# GdUnit generated TestSuite
+class_name GdUnitFontsTest
+extends GdUnitTestSuite
+@warning_ignore('unused_parameter')
+@warning_ignore('return_value_discarded')
+
+# TestSuite generated from
+const __source = 'res://addons/gdUnit4/src/ui/GdUnitFonts.gd'
+
+
+func test_load_and_resize_font() -> void:
+	var font8 = GdUnitFonts.load_and_resize_font(GdUnitFonts.FONT_MONO, 8)
+	var font16 = GdUnitFonts.load_and_resize_font(GdUnitFonts.FONT_MONO, 16)
+	
+	assert_object(font8).is_not_null().is_not_same(font16)
+	assert_that(font8.fixed_size).is_equal(8)
+	assert_that(font16.fixed_size).is_equal(16)


### PR DESCRIPTION
# Why
We see an error `res://addons/gdUnit4/src/ui/GdUnitFonts.gd:38 - Invalid set index 'font_data' (on base: 'FontFile') with value of type 'FontFile'.` on linux systems when activating the plugin

# What
The property `font_data` was removed and the error was just ignored.
- Rewrite the font loader by load the font and duplicate and set the new font size.
- Renamed to better related name
- Add test coverage


