### PR TITLE
GD-234: CmdTool report failures for all test hooks

### DIFF
--- a/addons/gdUnit4/bin/GdUnitCmdTool.gd
+++ b/addons/gdUnit4/bin/GdUnitCmdTool.gd
@@ -27,7 +27,6 @@ class CLIRunner extends Node:
 	var _runner_config := GdUnitRunnerConfig.new()
 	var _console := CmdConsole.new()
 	var _cs_executor
-	var _rtf :RichTextLabel
 	var _cmd_options: = CmdOptions.new([
 			CmdOption.new("-a, --add", "-a <directory|path of testsuite>", "Adds the given test suite or directory to the execution pipeline.", TYPE_STRING),
 			CmdOption.new("-i, --ignore", "-i <testsuite_name|testsuite_name:test-name>", "Adds the given test suite or test case to the ignore list.", TYPE_STRING),
@@ -62,8 +61,6 @@ class CLIRunner extends Node:
 			push_error("Error checked startup, can't connect executor for 'send_event'")
 			quit(RETURN_ERROR)
 		add_child(_executor)
-		_rtf = RichTextLabel.new()
-		add_child(_rtf)
 	
 	
 	func _process(_delta):
@@ -93,14 +90,8 @@ class CLIRunner extends Node:
 	func quit(code :int) -> void:
 		if is_instance_valid(_executor):
 			_executor.free()
-		if is_instance_valid(_rtf):
-			_rtf.free()
 		GdUnitTools.dispose_all()
 		await get_tree().physics_frame
-		prints("-Orphan nodes report-----------------------")
-		Window.print_orphan_nodes()
-		prints("-SceneTree report-----------------------")
-		get_tree().root.print_tree_pretty()
 		get_tree().quit(code)
 	
 	
@@ -308,7 +299,7 @@ class CLIRunner extends Node:
 			GdUnitEvent.STOP:
 				var report_path := _report.write()
 				_report.delete_history(_report_max)
-				JUnitXmlReport.new(_report._report_path, _report.iteration(), _rtf).write(_report)
+				JUnitXmlReport.new(_report._report_path, _report.iteration()).write(_report)
 				_console.prints_color("Total test suites: %s" % _report.suite_count(), Color.DARK_SALMON)
 				_console.prints_color("Total test cases:  %s" % _report.test_count(), Color.DARK_SALMON)
 				_console.prints_color("Total time:        %s" % LocalTime.elapsed(_report.duration()), Color.DARK_SALMON)
@@ -316,17 +307,26 @@ class CLIRunner extends Node:
 			GdUnitEvent.TESTSUITE_BEFORE:
 				_report.add_testsuite_report(GdUnitTestSuiteReport.new(event.resource_path(), event.suite_name()))
 			GdUnitEvent.TESTSUITE_AFTER:
-				_report.update_test_suite_report(event.resource_path(), event.elapsed_time())
+				_report.update_test_suite_report(
+					event.resource_path(),
+					event.elapsed_time(),
+					event.is_error(),
+					event.is_failed(),
+					event.is_warning(),
+					event.is_skipped(),
+					event.failed_count(),
+					event.orphan_nodes(),
+					event.reports())
 			GdUnitEvent.TESTCASE_BEFORE:
-				_report.add_testcase_report(event.resource_path(), GdUnitTestCaseReport.new(_rtf, event.resource_path(), event.suite_name(), event.test_name()))
+				_report.add_testcase_report(event.resource_path(), GdUnitTestCaseReport.new(event.resource_path(), event.suite_name(), event.test_name()))
 			GdUnitEvent.TESTCASE_AFTER:
 				var test_report := GdUnitTestCaseReport.new(
-					_rtf,
 					event.resource_path(),
 					event.suite_name(),
 					event.test_name(),
 					event.is_error(),
 					event.is_failed(),
+					event.failed_count(),
 					event.orphan_nodes(),
 					event.is_skipped(),
 					event.reports(),
@@ -358,17 +358,17 @@ class CLIRunner extends Node:
 				_print_status(event)
 				_print_failure_report(event.reports())
 			GdUnitEvent.TESTSUITE_AFTER:
+				_print_failure_report(event.reports())
 				_print_status(event)
 				_console.prints_color("	| %d total | %d error | %d failed | %d skipped | %d orphans |\n" % [_report.test_count(), _report.error_count(), _report.failure_count(), _report.skipped_count(), _report.orphan_count()], Color.ANTIQUE_WHITE)
 	
 	
 	func _print_failure_report(reports :Array) -> void:
 		for report in reports:
-			_rtf.clear()
-			_rtf.parse_bbcode(report._to_string())
 			if report.is_failure() or report.is_error() or report.is_warning() or report.is_skipped():
 				_console.prints_color("	Report:", Color.DARK_TURQUOISE, CmdConsole.BOLD|CmdConsole.UNDERLINE)
-				for line in _rtf.get_parsed_text().split("\n"):
+				var text = GdUnitTools.richtext_normalize(report._to_string())
+				for line in text.split("\n"):
 					_console.prints_color("		%s" % line, Color.DARK_TURQUOISE)
 		_console.new_line()
 	
@@ -397,3 +397,8 @@ func _initialize():
 func _finalize():
 	prints("Finallize ..")
 	_cli_runner.free()
+	prints("-Orphan nodes report-----------------------")
+	Window.print_orphan_nodes()
+	prints("-SceneTree report-----------------------")
+	root.print_tree_pretty()
+	prints("Finallize .. done")

--- a/addons/gdUnit4/src/asserts/GdUnitAssertImpl.gd
+++ b/addons/gdUnit4/src/asserts/GdUnitAssertImpl.gd
@@ -67,12 +67,7 @@ func test_fail():
 
 
 static func _normalize_bbcode(message :String) -> String:
-	var rtl := RichTextLabel.new()
-	rtl.bbcode_enabled = true
-	rtl.append_text(message if message else "")
-	var normalized = rtl.get_parsed_text()
-	rtl.free()
-	return normalized.replace("\r", "")
+	return GdUnitTools.richtext_normalize(message).replace("\r", "")
 
 
 func override_failure_message(message :String):

--- a/addons/gdUnit4/src/core/GdUnitTools.gd
+++ b/addons/gdUnit4/src/core/GdUnitTools.gd
@@ -3,6 +3,8 @@ extends RefCounted
 
 const GDUNIT_TEMP := "user://tmp"
 
+static var regex_richtext = GdUnitTools.to_regex("\\[/?(b|color|bgcolor|right|table|cell).*?\\]")
+
 static func temp_dir() -> String:
 	if not DirAccess.dir_exists_absolute(GDUNIT_TEMP):
 		DirAccess.make_dir_recursive_absolute(GDUNIT_TEMP)
@@ -170,8 +172,13 @@ static func resource_as_string(resource_path :String) -> String:
 		return ""
 	return file.get_as_text(true)
 
+
 static func normalize_text(text :String) -> String:
 	return text.replace("\r", "");
+
+
+static func richtext_normalize(input :String) -> String:
+	return regex_richtext.sub(input, "", true)
 
 
 static func max_length(left, right) -> int:

--- a/addons/gdUnit4/src/core/GdUnitTools.gd
+++ b/addons/gdUnit4/src/core/GdUnitTools.gd
@@ -3,7 +3,6 @@ extends RefCounted
 
 const GDUNIT_TEMP := "user://tmp"
 
-static var regex_richtext = GdUnitTools.to_regex("\\[/?(b|color|bgcolor|right|table|cell).*?\\]")
 
 static func temp_dir() -> String:
 	if not DirAccess.dir_exists_absolute(GDUNIT_TEMP):
@@ -178,7 +177,8 @@ static func normalize_text(text :String) -> String:
 
 
 static func richtext_normalize(input :String) -> String:
-	return regex_richtext.sub(input, "", true)
+	return GdUnitSingleton.instance("regex_richtext", func _regex_richtext() -> RegEx:
+		return GdUnitTools.to_regex("\\[/?(b|color|bgcolor|right|table|cell).*?\\]") ).sub(input, "", true)
 
 
 static func max_length(left, right) -> int:

--- a/addons/gdUnit4/src/core/thread/GdUnitThreadManager.gd
+++ b/addons/gdUnit4/src/core/thread/GdUnitThreadManager.gd
@@ -11,7 +11,8 @@ func _init():
 
 
 func _notification(what):
-	prints("_notification", what)
+	# prints("_notification", what)
+	pass
 
 
 static func instance() -> GdUnitThreadManager:

--- a/addons/gdUnit4/src/report/GdUnitByPathReport.gd
+++ b/addons/gdUnit4/src/report/GdUnitByPathReport.gd
@@ -2,16 +2,16 @@ class_name GdUnitByPathReport
 extends GdUnitReportSummary
 
 
-func _init(path :String,reports :Array):
+func _init(path :String, reports :Array[GdUnitReportSummary]):
 	_resource_path = path
 	_reports = reports
 
 
-static func sort_reports_by_path(reports :Array) -> Dictionary:
+static func sort_reports_by_path(reports :Array[GdUnitReportSummary]) -> Dictionary:
 	var by_path := Dictionary()
 	for report in reports:
 		var suite_path :String = report.path()
-		var suite_report :Array = by_path.get(suite_path, Array())
+		var suite_report :Array[GdUnitReportSummary] = by_path.get(suite_path, [] as Array[GdUnitReportSummary])
 		suite_report.append(report)
 		by_path[suite_path] = suite_report
 	return by_path
@@ -38,7 +38,7 @@ func write(report_dir :String) -> String:
 	return output_path
 
 
-static func apply_testsuite_reports(report_dir :String, template :String, reports :Array) -> String:
+static func apply_testsuite_reports(report_dir :String, template :String, reports :Array[GdUnitReportSummary]) -> String:
 	var table_records := PackedStringArray()
 	
 	for report in reports:

--- a/addons/gdUnit4/src/report/GdUnitHtmlPatterns.gd
+++ b/addons/gdUnit4/src/report/GdUnitHtmlPatterns.gd
@@ -25,6 +25,18 @@ const TABLE_RECORD_PATH = """
 								</tr>
 """
 
+
+const TABLE_REPORT_TESTSUITE = """
+								<tr>
+									<td class="${report_state}">TestSuite hooks</td>
+									<td>n/a</td>
+									<td>${orphan_count}</td>
+									<td>${duration}</td>
+									<td class="report-column">${failure-report}</td>
+								</tr>
+"""
+
+
 const TABLE_RECORD_TESTCASE = """
 								<tr>
 									<td class="${report_state}">${testcase_name}</td>
@@ -58,12 +70,8 @@ const BREADCRUMP_PATH_LINK = "${breadcrumb_path_link}"
 const BUILD_DATE = "${buid_date}"
 
 
-#static func current_date2() -> String:
-#	return "{day}.{month}.{year}   {hour}:{minute}:{second}".format(OS.get_datetime())
-
 static func current_date() -> String:
 	return Time.get_datetime_string_from_system(true, true)
-	#return "%02d.%02d.%04d   %02d:%02d:%02d" % [date["day"], date["month"], date["year"], date["hour"], date["minute"], date["second"]]
 
 
 static func build(template :String, report :GdUnitReportSummary, report_link :String) -> String:

--- a/addons/gdUnit4/src/report/GdUnitHtmlReport.gd
+++ b/addons/gdUnit4/src/report/GdUnitHtmlReport.gd
@@ -22,10 +22,23 @@ func add_testcase_report(resource_path :String, suite_report :GdUnitTestCaseRepo
 			report.add_report(suite_report)
 
 
-func update_test_suite_report(resource_path :String, duration :int) -> void:
+func update_test_suite_report(
+	resource_path :String,
+	duration :int,
+	is_error :bool,
+	is_failed: bool,
+	is_warning :bool,
+	is_skipped :bool,
+	failed_count :int,
+	orphan_count :int,
+	reports :Array = []) -> void:
+	
 	for report in _reports:
 		if report.resource_path() == resource_path:
 			report.set_duration(duration)
+			report.set_failed(is_failed, failed_count)
+			report.set_orphans(orphan_count)
+			report.set_reports(reports)
 
 
 func update_testcase_report(resource_path :String, test_report :GdUnitTestCaseReport):

--- a/addons/gdUnit4/src/report/GdUnitReportSummary.gd
+++ b/addons/gdUnit4/src/report/GdUnitReportSummary.gd
@@ -14,7 +14,7 @@ var _error_count := 0
 var _orphan_count := 0
 var _skipped_count := 0
 var _duration := 0
-var _reports:Array = Array()
+var _reports :Array[GdUnitReportSummary] = []
 
 
 func name() -> String:
@@ -104,7 +104,10 @@ func calculate_state(p_error_count :int, p_failure_count :int, p_orphan_count :i
 func calculate_succes_rate(p_test_count :int, p_error_count :int, p_failure_count :int) -> String:
 	if p_failure_count == 0:
 		return "100%"
-	return "%d" % ((p_test_count-p_failure_count-p_error_count) * 100.0 / p_test_count) + "%"
+	var count = p_test_count-p_failure_count-p_error_count
+	if count < 0:
+		return "0%"
+	return "%d" % (( 0 if count < 0 else count) * 100.0 / p_test_count) + "%"
 
 
 func create_summary(_report_dir :String) -> String:
@@ -115,3 +118,12 @@ func html_encode(value :String) -> String:
 	for key in CHARACTERS_TO_ENCODE.keys():
 		value =value.replace(key, CHARACTERS_TO_ENCODE[key])
 	return value
+
+
+func convert_rtf_to_html(bbcode :String) -> String:
+	var as_text: = GdUnitTools.richtext_normalize(bbcode)
+	var converted := PackedStringArray()
+	var lines := as_text.split("\n")
+	for line in lines:
+		converted.append("<p>%s</p>" % line)
+	return "\n".join(converted)

--- a/addons/gdUnit4/src/report/GdUnitTestCaseReport.gd
+++ b/addons/gdUnit4/src/report/GdUnitTestCaseReport.gd
@@ -3,27 +3,25 @@ extends GdUnitReportSummary
 
 var _suite_name :String
 var _failure_reports :Array
-var _rtf :RichTextLabel
 
-
-func _init(rtf :RichTextLabel,
+func _init(
 		p_resource_path :String,
 		p_suite_name :String,
 		test_name :String,
 		is_error := false,
 		is_failed := false,
-		orphans :int = 0,
+		failed_count :int = 0,
+		orphan_count :int = 0,
 		is_skipped := false,
 		failure_reports :Array = [],
 		p_duration :int = 0):
-	_rtf = rtf
 	_resource_path = p_resource_path
 	_suite_name = p_suite_name
 	_name = test_name
 	_test_count = 1
 	_error_count = is_error
-	_failure_count = is_failed
-	_orphan_count = orphans
+	_failure_count = failed_count
+	_orphan_count = orphan_count
 	_skipped_count = is_skipped
 	_failure_reports = failure_reports
 	_duration = p_duration
@@ -39,17 +37,6 @@ func failure_report() -> String:
 		var report: GdUnitReport = r
 		html_report += convert_rtf_to_html(report._to_string())
 	return html_report
-
-
-func convert_rtf_to_html(bbcode :String) -> String:
-	_rtf.clear()
-	_rtf.parse_bbcode(bbcode)
-	var as_text: = _rtf.get_parsed_text()
-	var converted := PackedStringArray()
-	var lines := as_text.split("\n")
-	for line in lines:
-		converted.append("<p>%s</p>" % line)
-	return "\n".join(converted)
 
 
 func create_record(_report_dir :String) -> String:

--- a/addons/gdUnit4/src/report/JUnitXmlReport.gd
+++ b/addons/gdUnit4/src/report/JUnitXmlReport.gd
@@ -21,13 +21,11 @@ const HEADER := '<?xml version="1.0" encoding="UTF-8" ?>\n'
 
 var _report_path :String
 var _iteration :int
-var _rtf :RichTextLabel
 
 
-func _init(path :String,iteration :int,rtf :RichTextLabel):
+func _init(path :String,iteration :int):
 	_iteration = iteration
 	_report_path = path
-	_rtf = rtf
 
 
 func write(report :GdUnitReportSummary) -> String:
@@ -109,9 +107,7 @@ func build_reports(testReport :GdUnitTestCaseReport) -> Array:
 
 
 func convert_rtf_to_text(bbcode :String) -> String:
-	_rtf.clear()
-	_rtf.parse_bbcode(bbcode)
-	return _rtf.text
+	return GdUnitTools.richtext_normalize(bbcode)
 
 
 static func to_type(type :int) -> String:

--- a/addons/gdUnit4/test/GdUnitTestCaseTimingTest.gd
+++ b/addons/gdUnit4/test/GdUnitTestCaseTimingTest.gd
@@ -19,13 +19,11 @@ class TestCaseStatistics:
 
 func before():
 	_test_values_current = {
-		"test_fast" : TestCaseStatistics.new(),
 		"test_2s" : TestCaseStatistics.new(),
 		"test_multi_yielding" : TestCaseStatistics.new(),
 		"test_multi_yielding_with_fuzzer" : TestCaseStatistics.new()
 	}
 	_test_values_expected = {
-		"test_fast" : TestCaseStatistics.new(1, 1),
 		"test_2s" : TestCaseStatistics.new(1, 1),
 		"test_multi_yielding" : TestCaseStatistics.new(1, 1),
 		"test_multi_yielding_with_fuzzer" : TestCaseStatistics.new(10 , 10)

--- a/addons/gdUnit4/test/core/GdUnitToolsTest.gd
+++ b/addons/gdUnit4/test/core/GdUnitToolsTest.gd
@@ -247,3 +247,19 @@ func test_free_instance() -> void:
 	var node := Node.new()
 	node.free()
 	assert_that(GdUnitTools.free_instance(node)).is_false()
+
+
+func test_richtext_normalize() -> void:
+	assert_that(GdUnitTools.richtext_normalize("")).is_equal("")
+	assert_that(GdUnitTools.richtext_normalize("This is a Color Message")).is_equal("This is a Color Message")
+	
+	var message = """
+		[color=green]line [/color][color=aqua]11:[/color] [color=#CD5C5C]Expecting:[/color]
+			must be empty but was
+		'[color=#1E90FF]after[/color]'
+		"""
+	assert_that(GdUnitTools.richtext_normalize(message)).is_equal("""
+		line 11: Expecting:
+			must be empty but was
+		'after'
+		""")


### PR DESCRIPTION
# Why
The cmd tool was not reporting failures from test hooks e.g `after` and the test was reported as success

# What
- failures during test hooks are now reported and the suite is marked as failed
- fix html test report, add Test hook failures if occurs
- replace usage of RichTextLabel to normalize bbcode and replaced by regex replacement
