### PR TITLE
GD-246: Reduce test-suite loading time

### DIFF
--- a/addons/gdUnit4/bin/GdUnitCmdTool.gd
+++ b/addons/gdUnit4/bin/GdUnitCmdTool.gd
@@ -1,6 +1,8 @@
 #!/usr/bin/env -S godot -s
 extends SceneTree
 
+const GdUnitTools := preload("res://addons/gdUnit4/src/core/GdUnitTools.gd")
+
 #warning-ignore-all:return_value_discarded
 class CLIRunner extends Node:
 	

--- a/addons/gdUnit4/bin/GdUnitCopyLog.gd
+++ b/addons/gdUnit4/bin/GdUnitCopyLog.gd
@@ -1,6 +1,8 @@
 #!/usr/bin/env -S godot -s
 extends MainLoop
 
+const GdUnitTools := preload("res://addons/gdUnit4/src/core/GdUnitTools.gd")
+
 const NO_LOG_TEMPLATE = """
 <!DOCTYPE html>
 <html>

--- a/addons/gdUnit4/plugin.gd
+++ b/addons/gdUnit4/plugin.gd
@@ -1,22 +1,11 @@
 @tool
 extends EditorPlugin
 
+const GdUnitTools := preload("res://addons/gdUnit4/src/core/GdUnitTools.gd")
+
 var _gd_inspector :Node
 var _server_node
 var _gd_console :Node
-
-
-# removes GdUnit classes inherits from Godot.Node from the node inspecor, ohterwise it takes very long to popup the dialog
-func _fixup_node_inspector() -> void:
-	var classes := PackedStringArray([
-		"GdUnitTestSuite",
-		"_TestCase",
-		"GdUnitInspecor",
-		"GdUnitExecutor",
-		"GdUnitTcpClient",
-		"GdUnitTcpServer"])
-	for clazz in classes:
-		remove_custom_type(clazz)
 
 
 func _enter_tree():
@@ -30,7 +19,6 @@ func _enter_tree():
 	add_control_to_bottom_panel(_gd_console, "gdUnitConsole")
 	_server_node = load("res://addons/gdUnit4/src/network/GdUnitServer.tscn").instantiate()
 	add_child(_server_node)
-	_fixup_node_inspector()
 	prints("Loading GdUnit4 Plugin success")
 	if GdUnitSettings.is_update_notification_enabled():
 		var update_tool = load("res://addons/gdUnit4/src/update/GdUnitUpdateNotify.tscn").instantiate()

--- a/addons/gdUnit4/src/GdUnitAssert.gd
+++ b/addons/gdUnit4/src/GdUnitAssert.gd
@@ -3,6 +3,32 @@ class_name GdUnitAssert
 extends RefCounted
 
 
+# Scans the current stack trace for the root cause to extract the line number
+static func _get_line_number() -> int:
+	var stack_trace := get_stack()
+	if stack_trace == null or stack_trace.is_empty():
+		return -1
+	for stack_info in stack_trace:
+		var function :String = stack_info.get("function")
+		# we catch helper asserts to skip over to return the correct line number
+		if function.begins_with("assert_"):
+			continue
+		if function.begins_with("test_"):
+			return stack_info.get("line")
+		var source :String = stack_info.get("source")
+		if source.is_empty() \
+			or source.begins_with("user://") \
+			or source.ends_with("GdUnitAssert.gd") \
+			or source.ends_with("AssertImpl.gd") \
+			or source.ends_with("GdUnitTestSuite.gd") \
+			or source.ends_with("GdUnitSceneRunnerImpl.gd") \
+			or source.ends_with("GdUnitObjectInteractions.gd") \
+			or source.ends_with("GdUnitAwaiter.gd"):
+			continue
+		return stack_info.get("line")
+	return -1
+
+
 ## Verifies that the current value is null.
 func is_null():
 	return self

--- a/addons/gdUnit4/src/GdUnitAwaiter.gd
+++ b/addons/gdUnit4/src/GdUnitAwaiter.gd
@@ -2,23 +2,27 @@ class_name GdUnitAwaiter
 extends RefCounted
 
 
+static func __gdunit_assert() -> GDScript:
+	return ResourceLoader.load("res://addons/gdUnit4/src/asserts/GdUnitAssertImpl.gd", "GDSript", ResourceLoader.CACHE_MODE_REUSE)
+
+
 # Waits for a specified signal in an interval of 50ms sent from the <source>, and terminates with an error after the specified timeout has elapsed.
 # source: the object from which the signal is emitted
 # signal_name: signal name
 # args: the expected signal arguments as an array
 # timeout: the timeout in ms, default is set to 2000ms
 static func await_signal_on(source :Object, signal_name :String, args :Array = [], timeout_millis :int = 2000) -> Variant:
-	var line_number := GdUnitAssertImpl._get_line_number()
+	var line_number := GdUnitAssert._get_line_number()
 	# fail fast if the given source instance invalid
 	if not is_instance_valid(source):
-		GdUnitAssertImpl.new(signal_name)\
+		__gdunit_assert().new(signal_name)\
 			.report_error(GdAssertMessages.error_await_signal_on_invalid_instance(source, signal_name, args), line_number)
 		return await await_idle_frame()
 	var awaiter := GdUnitSignalAwaiter.new(timeout_millis)
 	var value :Variant = await awaiter.on_signal(source, signal_name, args)
 	if awaiter.is_interrupted():
 		var failure = "await_signal_on(%s, %s) timed out after %sms" % [signal_name, args, timeout_millis]
-		GdUnitAssertImpl.new(signal_name).report_error(failure, line_number)
+		__gdunit_assert().new(signal_name).report_error(failure, line_number)
 	return value
 
 
@@ -28,17 +32,17 @@ static func await_signal_on(source :Object, signal_name :String, args :Array = [
 # args: the expected signal arguments as an array
 # timeout: the timeout in ms, default is set to 2000ms
 static func await_signal_idle_frames(source :Object, signal_name :String, args :Array = [], timeout_millis :int = 2000) -> Variant:
-	var line_number := GdUnitAssertImpl._get_line_number()
+	var line_number := GdUnitAssert._get_line_number()
 	# fail fast if the given source instance invalid
 	if not is_instance_valid(source):
-		GdUnitAssertImpl.new(signal_name)\
+		__gdunit_assert().new(signal_name)\
 			.report_error(GdAssertMessages.error_await_signal_on_invalid_instance(source, signal_name, args), line_number)
 		return await await_idle_frame()
 	var awaiter := GdUnitSignalAwaiter.new(timeout_millis, true)
 	var value :Variant = await awaiter.on_signal(source, signal_name, args)
 	if awaiter.is_interrupted():
 		var failure = "await_signal_idle_frames(%s, %s) timed out after %sms" % [signal_name, args, timeout_millis]
-		GdUnitAssertImpl.new(signal_name).report_error(failure, line_number)
+		__gdunit_assert().new(signal_name).report_error(failure, line_number)
 	return value
 
 

--- a/addons/gdUnit4/src/GdUnitAwaiter.gd
+++ b/addons/gdUnit4/src/GdUnitAwaiter.gd
@@ -1,9 +1,7 @@
 class_name GdUnitAwaiter
 extends RefCounted
 
-
-static func __gdunit_assert() -> GDScript:
-	return ResourceLoader.load("res://addons/gdUnit4/src/asserts/GdUnitAssertImpl.gd", "GDSript", ResourceLoader.CACHE_MODE_REUSE)
+const GdUnitAssertImpl = preload("res://addons/gdUnit4/src/asserts/GdUnitAssertImpl.gd")
 
 
 # Waits for a specified signal in an interval of 50ms sent from the <source>, and terminates with an error after the specified timeout has elapsed.
@@ -12,17 +10,22 @@ static func __gdunit_assert() -> GDScript:
 # args: the expected signal arguments as an array
 # timeout: the timeout in ms, default is set to 2000ms
 static func await_signal_on(source :Object, signal_name :String, args :Array = [], timeout_millis :int = 2000) -> Variant:
+	# fail fast if the given source instance invalid
 	var line_number := GdUnitAssert._get_line_number()
+	if not is_instance_valid(source):
+		GdUnitAssertImpl.new(signal_name)\
+			.report_error(GdAssertMessages.error_await_signal_on_invalid_instance(source, signal_name, args), line_number)
+		return await Engine.get_main_loop().process_frame
 	# fail fast if the given source instance invalid
 	if not is_instance_valid(source):
-		__gdunit_assert().new(signal_name)\
+		GdUnitAssertImpl.new(signal_name)\
 			.report_error(GdAssertMessages.error_await_signal_on_invalid_instance(source, signal_name, args), line_number)
 		return await await_idle_frame()
 	var awaiter := GdUnitSignalAwaiter.new(timeout_millis)
 	var value :Variant = await awaiter.on_signal(source, signal_name, args)
 	if awaiter.is_interrupted():
 		var failure = "await_signal_on(%s, %s) timed out after %sms" % [signal_name, args, timeout_millis]
-		__gdunit_assert().new(signal_name).report_error(failure, line_number)
+		GdUnitAssertImpl.new(signal_name).report_error(failure, line_number)
 	return value
 
 
@@ -35,14 +38,14 @@ static func await_signal_idle_frames(source :Object, signal_name :String, args :
 	var line_number := GdUnitAssert._get_line_number()
 	# fail fast if the given source instance invalid
 	if not is_instance_valid(source):
-		__gdunit_assert().new(signal_name)\
+		GdUnitAssertImpl.new(signal_name)\
 			.report_error(GdAssertMessages.error_await_signal_on_invalid_instance(source, signal_name, args), line_number)
 		return await await_idle_frame()
 	var awaiter := GdUnitSignalAwaiter.new(timeout_millis, true)
 	var value :Variant = await awaiter.on_signal(source, signal_name, args)
 	if awaiter.is_interrupted():
 		var failure = "await_signal_idle_frames(%s, %s) timed out after %sms" % [signal_name, args, timeout_millis]
-		__gdunit_assert().new(signal_name).report_error(failure, line_number)
+		GdUnitAssertImpl.new(signal_name).report_error(failure, line_number)
 	return value
 
 

--- a/addons/gdUnit4/src/GdUnitTestSuite.gd
+++ b/addons/gdUnit4/src/GdUnitTestSuite.gd
@@ -3,11 +3,11 @@
 ## You have to extend and implement your test cases as described[br]
 ## e.g MyTests.gd [br]
 ## [codeblock]
-## 	extends GdUnitTestSuite
-## 	# testcase
-## 	func test_testCaseA():
-## 	    assert_that("value").is_equal("value")
-## [/codeblock][br]
+##    extends GdUnitTestSuite
+##    # testcase
+##    func test_case_a():
+##       assert_that("value").is_equal("value")
+## [/codeblock]
 ## @tutorial:  https://mikeschulze.github.io/gdUnit4/faq/test-suite/
 
 @icon("res://addons/gdUnit4/src/ui/assets/TestSuite.svg")
@@ -23,25 +23,32 @@ var __is_skipped := false
 var __skip_reason :String = "Unknow."
 
 
-### Loads the given script and cache to improve the test-suite loading time
-func __load_gdscript(script_path :String) -> GDScript:
+### We now load all used asserts and tool scripts into the cache according to the principle of "lazy loading"
+### in order to noticeably reduce the loading time of the test suite.
+# We go this hard way to increase the loading performance to avoid reparsing all the used scripts
+# for more detailed info -> https://github.com/godotengine/godot/issues/67400
+func __lazy_load(script_path :String) -> GDScript:
 	return ResourceLoader.load(script_path, "GDScript", ResourceLoader.CACHE_MODE_REUSE)
 
 
 func __gdunit_assert() -> GDScript:
-	return __load_gdscript("res://addons/gdUnit4/src/asserts/GdUnitAssertImpl.gd")
+	return __lazy_load("res://addons/gdUnit4/src/asserts/GdUnitAssertImpl.gd")
 
 
 func __gdunit_tools() -> GDScript:
-	return __load_gdscript("res://addons/gdUnit4/src/core/GdUnitTools.gd")
+	return __lazy_load("res://addons/gdUnit4/src/core/GdUnitTools.gd")
 
 
 func __gdunit_awaiter() -> GDScript:
-	return __load_gdscript("res://addons/gdUnit4/src/GdUnitAwaiter.gd")
+	return __lazy_load("res://addons/gdUnit4/src/GdUnitAwaiter.gd")
 
 
 func __gdunit_argument_matchers():
-	return __load_gdscript("res://addons/gdUnit4/src/matchers/GdUnitArgumentMatchers.gd")
+	return __lazy_load("res://addons/gdUnit4/src/matchers/GdUnitArgumentMatchers.gd")
+
+
+func __gdunit_object_interactions():
+	return __lazy_load("res://addons/gdUnit4/src/core/GdUnitObjectInteractions.gd")
 
 
 ## This function is called before a test suite starts[br]
@@ -86,7 +93,7 @@ func error_as_string(error_number :int) -> String:
 
 ## A litle helper to auto freeing your created objects after test execution
 func auto_free(obj) -> Variant:
-	var GdUnitMemoryPool = __load_gdscript("res://addons/gdUnit4/src/core/GdUnitMemoryPool.gd")
+	var GdUnitMemoryPool = __lazy_load("res://addons/gdUnit4/src/core/GdUnitMemoryPool.gd")
 	return GdUnitMemoryPool.register_auto_free(obj, get_meta(GdUnitMemoryPool.META_PARAM))
 
 
@@ -138,19 +145,12 @@ func clear_push_errors() -> void:
 	__gdunit_tools().clear_push_errors()
 
 
-
 ## Waits for given signal is emited by the <source> until a specified timeout to fail[br]
 ## source: the object from which the signal is emitted[br]
 ## signal_name: signal name[br]
 ## args: the expected signal arguments as an array[br]
 ## timeout: the timeout in ms, default is set to 2000ms
 func await_signal_on(source :Object, signal_name :String, args :Array = [], timeout :int = 2000) -> Variant:
-	# fail fast if the given source instance invalid
-	if not is_instance_valid(source):
-		var GdUnitAssertImpl = __gdunit_assert()
-		GdUnitAssertImpl.new(signal_name)\
-			.report_error(GdAssertMessages.error_await_signal_on_invalid_instance(source, signal_name, args), GdUnitAssertImpl._get_line_number())
-		return await __gdunit_awaiter().await_idle_frame()
 	return await __gdunit_awaiter().await_signal_on(source, signal_name, args, timeout)
 
 
@@ -182,7 +182,7 @@ func await_millis(timeout :int):
 ##    var runner := scene_runner("res://foo/my_scne.tscn")
 ## [/codeblock]
 func scene_runner(scene, verbose := false) -> GdUnitSceneRunner:
-	return auto_free(GdUnitSceneRunnerImpl.new(scene, verbose))
+	return auto_free(__lazy_load("res://addons/gdUnit4/src/core/GdUnitSceneRunnerImpl.gd").new(scene, verbose))
 
 
 # === Mocking  & Spy ===========================================================
@@ -198,12 +198,12 @@ const RETURN_DEEP_STUB = GdUnitMock.RETURN_DEEP_STUB
 
 ## Creates a mock for given class name
 func mock(clazz, mock_mode := RETURN_DEFAULTS) -> Object:
-	return GdUnitMockBuilder.build(self, clazz, mock_mode)
+	return __lazy_load("res://addons/gdUnit4/src/mocking/GdUnitMockBuilder.gd").build(self, clazz, mock_mode)
 
 
 ## Creates a spy checked given object instance
-func spy(instance):
-	return GdUnitSpyBuilder.build(self, instance)
+func spy(instance) -> Object:
+	return __lazy_load("res://addons/gdUnit4/src/spy/GdUnitSpyBuilder.gd").build(self, instance)
 
 
 ## Configures a return value for the specified function and used arguments.[br]
@@ -218,22 +218,22 @@ func do_return(value) -> GdUnitMock:
 
 ## Verifies certain behavior happened at least once or exact number of times
 func verify(obj, times := 1):
-	return GdUnitObjectInteractions.verify(obj, times)
+	return __gdunit_object_interactions().verify(obj, times)
 
 
 ## Verifies no interactions is happen checked this mock or spy
 func verify_no_interactions(obj) -> GdUnitAssert:
-	return GdUnitObjectInteractions.verify_no_interactions(obj)
+	return __gdunit_object_interactions().verify_no_interactions(obj)
 
 
 ## Verifies the given mock or spy has any unverified interaction.
 func verify_no_more_interactions(obj) -> GdUnitAssert:
-	return GdUnitObjectInteractions.verify_no_more_interactions(obj)
+	return __gdunit_object_interactions().verify_no_more_interactions(obj)
 
 
 ## Resets the saved function call counters checked a mock or spy
 func reset(obj) -> void:
-	GdUnitObjectInteractions.reset(obj)
+	__gdunit_object_interactions().reset(obj)
 
 
 ## Starts monitoring the specified source to collect all transmitted signals.[br]
@@ -249,8 +249,10 @@ func reset(obj) -> void:
 ##		await assert_signal(emitter).is_emitted('my_signal')
 ##	[/codeblock]
 func monitor_signals(source :Object, _auto_free := true) -> Object:
-	var signal_collector := GdUnitThreadManager.get_current_context().get_signal_collector()
-	signal_collector.register_emitter(source)
+	__lazy_load("res://addons/gdUnit4/src/core/thread/GdUnitThreadManager.gd")\
+		.get_current_context()\
+		.get_signal_collector()\
+		.register_emitter(source)
 	return auto_free(source) if _auto_free else source
 
 
@@ -430,21 +432,21 @@ func any_class(clazz :Object) -> GdUnitArgumentMatcher:
 # === value extract utils ======================================================
 ## Builds an extractor by given function name and optional arguments
 func extr(func_name :String, args := Array()) -> GdUnitValueExtractor:
-	return __load_gdscript("res://addons/gdUnit4/src/extractors/GdUnitFuncValueExtractor.gd").new(func_name, args)
+	return __lazy_load("res://addons/gdUnit4/src/extractors/GdUnitFuncValueExtractor.gd").new(func_name, args)
 
 
 ## Constructs a tuple by given arguments
-func tuple(arg0:Variant,
-	arg1:Variant=NO_ARG,
-	arg2:Variant=NO_ARG,
-	arg3:Variant=NO_ARG,
-	arg4:Variant=NO_ARG,
-	arg5:Variant=NO_ARG,
-	arg6:Variant=NO_ARG,
-	arg7:Variant=NO_ARG,
-	arg8:Variant=NO_ARG,
-	arg9:Variant=NO_ARG) -> GdUnitTuple:
-	return __load_gdscript("res://addons/gdUnit4/src/GdUnitTuple.gd").new(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9)
+func tuple(arg0 :Variant,
+	arg1 :Variant=NO_ARG,
+	arg2 :Variant=NO_ARG,
+	arg3 :Variant=NO_ARG,
+	arg4 :Variant=NO_ARG,
+	arg5 :Variant=NO_ARG,
+	arg6 :Variant=NO_ARG,
+	arg7 :Variant=NO_ARG,
+	arg8 :Variant=NO_ARG,
+	arg9 :Variant=NO_ARG) -> GdUnitTuple:
+	return GdUnitTuple.new(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9)
 
 
 # === Asserts ==================================================================
@@ -452,10 +454,6 @@ func tuple(arg0:Variant,
 ## The common assertion tool to verify values.
 ## It checks the given value by type to fit to the best assert
 func assert_that(current) -> GdUnitAssert:
-	
-	if GdArrayTools.is_array_type(current):
-		return assert_array(current)
-	
 	match typeof(current):
 		TYPE_BOOL:
 			return assert_bool(current)
@@ -469,7 +467,9 @@ func assert_that(current) -> GdUnitAssert:
 			return assert_vector(current)
 		TYPE_DICTIONARY:
 			return assert_dict(current)
-		TYPE_ARRAY:
+		TYPE_ARRAY, TYPE_PACKED_BYTE_ARRAY, TYPE_PACKED_INT32_ARRAY, TYPE_PACKED_INT64_ARRAY,\
+		TYPE_PACKED_FLOAT32_ARRAY, TYPE_PACKED_FLOAT64_ARRAY, TYPE_PACKED_STRING_ARRAY,\
+		TYPE_PACKED_VECTOR2_ARRAY, TYPE_PACKED_VECTOR3_ARRAY, TYPE_PACKED_COLOR_ARRAY:
 			return assert_array(current)
 		TYPE_OBJECT, TYPE_NIL:
 			return assert_object(current)
@@ -479,22 +479,22 @@ func assert_that(current) -> GdUnitAssert:
 
 ## An assertion tool to verify boolean values.
 func assert_bool(current) -> GdUnitBoolAssert:
-	return __load_gdscript("res://addons/gdUnit4/src/asserts/GdUnitBoolAssertImpl.gd").new(current)
+	return __lazy_load("res://addons/gdUnit4/src/asserts/GdUnitBoolAssertImpl.gd").new(current)
 
 
 ## An assertion tool to verify String values.
 func assert_str(current) -> GdUnitStringAssert:
-	return __load_gdscript("res://addons/gdUnit4/src/asserts/GdUnitStringAssertImpl.gd").new(current)
+	return __lazy_load("res://addons/gdUnit4/src/asserts/GdUnitStringAssertImpl.gd").new(current)
 
 
 ## An assertion tool to verify integer values.
 func assert_int(current) -> GdUnitIntAssert:
-	return __load_gdscript("res://addons/gdUnit4/src/asserts/GdUnitIntAssertImpl.gd").new(current)
+	return __lazy_load("res://addons/gdUnit4/src/asserts/GdUnitIntAssertImpl.gd").new(current)
 
 
 ## An assertion tool to verify float values.
 func assert_float(current) -> GdUnitFloatAssert:
-	return __load_gdscript("res://addons/gdUnit4/src/asserts/GdUnitFloatAssertImpl.gd").new(current)
+	return __lazy_load("res://addons/gdUnit4/src/asserts/GdUnitFloatAssertImpl.gd").new(current)
 
 
 ## An assertion tool to verify Vector values.[br]
@@ -504,41 +504,41 @@ func assert_float(current) -> GdUnitFloatAssert:
 ##		assert_vector(Vector2(1.2, 1.000001)).is_equal(Vector2(1.2, 1.000001))
 ##     [/codeblock]
 func assert_vector(current) -> GdUnitVectorAssert:
-	return __load_gdscript("res://addons/gdUnit4/src/asserts/GdUnitVectorAssertImpl.gd").new(current)
+	return __lazy_load("res://addons/gdUnit4/src/asserts/GdUnitVectorAssertImpl.gd").new(current)
 
 
 ## An assertion tool to verify arrays.
 func assert_array(current) -> GdUnitArrayAssert:
-	return __load_gdscript("res://addons/gdUnit4/src/asserts/GdUnitArrayAssertImpl.gd").new(current)
+	return __lazy_load("res://addons/gdUnit4/src/asserts/GdUnitArrayAssertImpl.gd").new(current)
 
 
 ## An assertion tool to verify dictionaries.
 func assert_dict(current) -> GdUnitDictionaryAssert:
-	return __load_gdscript("res://addons/gdUnit4/src/asserts/GdUnitDictionaryAssertImpl.gd").new(current)
+	return __lazy_load("res://addons/gdUnit4/src/asserts/GdUnitDictionaryAssertImpl.gd").new(current)
 
 
 ## An assertion tool to verify FileAccess.
 func assert_file(current) -> GdUnitFileAssert:
-	return __load_gdscript("res://addons/gdUnit4/src/asserts/GdUnitFileAssertImpl.gd").new(current)
+	return __lazy_load("res://addons/gdUnit4/src/asserts/GdUnitFileAssertImpl.gd").new(current)
 
 
 ## An assertion tool to verify Objects.
 func assert_object(current) -> GdUnitObjectAssert:
-	return __load_gdscript("res://addons/gdUnit4/src/asserts/GdUnitObjectAssertImpl.gd").new(current)
+	return __lazy_load("res://addons/gdUnit4/src/asserts/GdUnitObjectAssertImpl.gd").new(current)
 
 
 func assert_result(current) -> GdUnitResultAssert:
-	return __load_gdscript("res://addons/gdUnit4/src/asserts/GdUnitResultAssertImpl.gd").new(current)
+	return __lazy_load("res://addons/gdUnit4/src/asserts/GdUnitResultAssertImpl.gd").new(current)
 
 
 ## An assertion tool that waits until a certain time for an expected function return value
 func assert_func(instance :Object, func_name :String, args := Array()) -> GdUnitFuncAssert:
-	return __load_gdscript("res://addons/gdUnit4/src/asserts/GdUnitFuncAssertImpl.gd").new(instance, func_name, args)
+	return __lazy_load("res://addons/gdUnit4/src/asserts/GdUnitFuncAssertImpl.gd").new(instance, func_name, args)
 
 
 ## An Assertion Tool to verify for emitted signals until a certain time.
 func assert_signal(instance :Object) -> GdUnitSignalAssert:
-	return __load_gdscript("res://addons/gdUnit4/src/asserts/GdUnitSignalAssertImpl.gd").new(instance)
+	return __lazy_load("res://addons/gdUnit4/src/asserts/GdUnitSignalAssertImpl.gd").new(instance)
 
 
 ## An assertion tool to test for failing assertions.[br]
@@ -549,7 +549,7 @@ func assert_signal(instance :Object) -> GdUnitSignalAssert:
 ##		    .has_message("Expecting:\n 'true'\n not equal to\n 'true'")
 ##     [/codeblock]
 func assert_failure(assertion :Callable) -> GdUnitFailureAssert:
-	return __load_gdscript("res://addons/gdUnit4/src/asserts/GdUnitFailureAssertImpl.gd").new().execute(assertion)
+	return __lazy_load("res://addons/gdUnit4/src/asserts/GdUnitFailureAssertImpl.gd").new().execute(assertion)
 
 
 ## An assertion tool to test for failing assertions.[br]
@@ -560,7 +560,7 @@ func assert_failure(assertion :Callable) -> GdUnitFailureAssert:
 ##		    .has_message("Expecting:\n 'true'\n not equal to\n 'true'")
 ##     [/codeblock]
 func assert_failure_await(assertion :Callable) -> GdUnitFailureAssert:
-	return await __load_gdscript("res://addons/gdUnit4/src/asserts/GdUnitFailureAssertImpl.gd").new().execute_and_await(assertion)
+	return await __lazy_load("res://addons/gdUnit4/src/asserts/GdUnitFailureAssertImpl.gd").new().execute_and_await(assertion)
 
 
 ## An assertion tool to verify for Godot errors.[br]
@@ -576,18 +576,7 @@ func assert_failure_await(assertion :Callable) -> GdUnitFailureAssert:
 ##		    .is_push_error('test error')
 ##     [/codeblock]
 func assert_error(current :Callable) -> GdUnitGodotErrorAssert:
-	return __load_gdscript("res://addons/gdUnit4/src/asserts/GdUnitGodotErrorAssertImpl.gd").new(current)
-
-
-## Utility to check if a test has failed in a particular line and if there is an error message
-func assert_failed_at(line_number :int, expected_failure :String) -> bool:
-	var is_failed = is_failure()
-	var last_failure = GdAssertReports.current_failure()
-	var last_failure_line = GdAssertReports.get_last_error_line_number()
-	assert_str(last_failure).is_equal(expected_failure)
-	assert_int(last_failure_line).is_equal(line_number)
-	GdAssertReports.expect_fail(true)
-	return is_failed
+	return __lazy_load("res://addons/gdUnit4/src/asserts/GdUnitGodotErrorAssertImpl.gd").new(current)
 
 
 func assert_not_yet_implemented():

--- a/addons/gdUnit4/src/GdUnitTestSuite.gd
+++ b/addons/gdUnit4/src/GdUnitTestSuite.gd
@@ -14,12 +14,34 @@
 class_name GdUnitTestSuite
 extends Node
 
-
-const NO_ARG = GdUnitConstants.NO_ARG
+const NO_ARG :Variant = GdUnitConstants.NO_ARG
 
 ### internal runtime variables that must not be overwritten!!!
+@warning_ignore("unused_private_class_variable")
 var __is_skipped := false
+@warning_ignore("unused_private_class_variable")
 var __skip_reason :String = "Unknow."
+
+
+### Loads the given script and cache to improve the test-suite loading time
+func __load_gdscript(script_path :String) -> GDScript:
+	return ResourceLoader.load(script_path, "GDScript", ResourceLoader.CACHE_MODE_REUSE)
+
+
+func __gdunit_assert() -> GDScript:
+	return __load_gdscript("res://addons/gdUnit4/src/asserts/GdUnitAssertImpl.gd")
+
+
+func __gdunit_tools() -> GDScript:
+	return __load_gdscript("res://addons/gdUnit4/src/core/GdUnitTools.gd")
+
+
+func __gdunit_awaiter() -> GDScript:
+	return __load_gdscript("res://addons/gdUnit4/src/GdUnitAwaiter.gd")
+
+
+func __gdunit_argument_matchers():
+	return __load_gdscript("res://addons/gdUnit4/src/matchers/GdUnitArgumentMatchers.gd")
 
 
 ## This function is called before a test suite starts[br]
@@ -59,11 +81,12 @@ func set_active_test_case(test_case :String) -> void:
 # Mapps Godot error number to a readable error message. See at ERROR
 # https://docs.godotengine.org/de/stable/classes/class_@globalscope.html#enum-globalscope-error
 func error_as_string(error_number :int) -> String:
-	return GdUnitTools.error_as_string(error_number)
+	return __gdunit_tools().error_as_string(error_number)
 
 
 ## A litle helper to auto freeing your created objects after test execution
 func auto_free(obj) -> Variant:
+	var GdUnitMemoryPool = __load_gdscript("res://addons/gdUnit4/src/core/GdUnitMemoryPool.gd")
 	return GdUnitMemoryPool.register_auto_free(obj, get_meta(GdUnitMemoryPool.META_PARAM))
 
 
@@ -71,48 +94,49 @@ func auto_free(obj) -> Variant:
 ## By default, an interrupted test is reported as an error.[br]
 ## This function allows you to change the message to Success when an interrupted error is reported.
 func discard_error_interupted_by_timeout() -> void:
-	GdUnitTools.register_expect_interupted_by_timeout(self, __active_test_case)
+	__gdunit_tools().register_expect_interupted_by_timeout(self, __active_test_case)
 
 
 ## Creates a new directory under the temporary directory *user://tmp*[br]
 ## Useful for storing data during test execution. [br]
 ## The directory is automatically deleted after test suite execution
 func create_temp_dir(relative_path :String) -> String:
-	return GdUnitTools.create_temp_dir(relative_path)
+	return __gdunit_tools().create_temp_dir(relative_path)
 
 
 ## Deletes the temporary base directory[br]
 ## Is called automatically after each execution of the test suite
 func clean_temp_dir():
-	GdUnitTools.clear_tmp()
+	__gdunit_tools().clear_tmp()
 
 
 ## Creates a new file under the temporary directory *user://tmp* + <relative_path>[br]
 ## with given name <file_name> and given file <mode> (default = File.WRITE)[br]
 ## If success the returned File is automatically closed after the execution of the test suite
 func create_temp_file(relative_path :String, file_name :String, mode := FileAccess.WRITE) -> FileAccess:
-	return GdUnitTools.create_temp_file(relative_path, file_name, mode)
+	return __gdunit_tools().create_temp_file(relative_path, file_name, mode)
 
 
 ## Reads a resource by given path <resource_path> into a PackedStringArray.
 func resource_as_array(resource_path :String) -> PackedStringArray:
-	return GdUnitTools.resource_as_array(resource_path)
+	return __gdunit_tools().resource_as_array(resource_path)
 
 
 ## Reads a resource by given path <resource_path> and returned the content as String.
 func resource_as_string(resource_path :String) -> String:
-	return GdUnitTools.resource_as_string(resource_path)
+	return __gdunit_tools().resource_as_string(resource_path)
 
 
 ## Reads a resource by given path <resource_path> and return Variand translated by str_to_var
 func resource_as_var(resource_path :String):
-	return str_to_var(GdUnitTools.resource_as_string(resource_path))
+	return str_to_var(__gdunit_tools().resource_as_string(resource_path))
 
 
 ## clears the debuger error list[br]
 ## PROTOTYPE!!!! Don't use it for now
 func clear_push_errors() -> void:
-	GdUnitTools.clear_push_errors()
+	__gdunit_tools().clear_push_errors()
+
 
 
 ## Waits for given signal is emited by the <source> until a specified timeout to fail[br]
@@ -123,15 +147,16 @@ func clear_push_errors() -> void:
 func await_signal_on(source :Object, signal_name :String, args :Array = [], timeout :int = 2000) -> Variant:
 	# fail fast if the given source instance invalid
 	if not is_instance_valid(source):
+		var GdUnitAssertImpl = __gdunit_assert()
 		GdUnitAssertImpl.new(signal_name)\
 			.report_error(GdAssertMessages.error_await_signal_on_invalid_instance(source, signal_name, args), GdUnitAssertImpl._get_line_number())
-		return await GdUnitAwaiter.await_idle_frame()
-	return await GdUnitAwaiter.await_signal_on(source, signal_name, args, timeout)
+		return await __gdunit_awaiter().await_idle_frame()
+	return await __gdunit_awaiter().await_signal_on(source, signal_name, args, timeout)
 
 
 ## Waits until the next idle frame
 func await_idle_frame():
-	await GdUnitAwaiter.await_idle_frame()
+	await __gdunit_awaiter().await_idle_frame()
 
 
 ## Waits for for a given amount of milliseconds[br]
@@ -142,7 +167,7 @@ func await_idle_frame():
 ## [/codeblock][br]
 ## use this waiter and not `await get_tree().create_timer().timeout to prevent errors when a test case is timed out
 func await_millis(timeout :int):
-	await GdUnitAwaiter.await_millis(timeout)
+	await __gdunit_awaiter().await_millis(timeout)
 
 
 ## Creates a new scene runner to allow simulate interactions checked a scene.[br]
@@ -232,37 +257,37 @@ func monitor_signals(source :Object, _auto_free := true) -> Object:
 # === Argument matchers ========================================================
 ## Argument matcher to match any argument
 func any() -> GdUnitArgumentMatcher:
-	return GdUnitArgumentMatchers.any()
+	return __gdunit_argument_matchers().any()
 
 
 ## Argument matcher to match any boolean value
 func any_bool() -> GdUnitArgumentMatcher:
-	return GdUnitArgumentMatchers.by_type(TYPE_BOOL)
+	return __gdunit_argument_matchers().by_type(TYPE_BOOL)
 
 
 ## Argument matcher to match any integer value
 func any_int() -> GdUnitArgumentMatcher:
-	return GdUnitArgumentMatchers.by_type(TYPE_INT)
+	return __gdunit_argument_matchers().by_type(TYPE_INT)
 
 
 ## Argument matcher to match any float value
 func any_float() -> GdUnitArgumentMatcher:
-	return GdUnitArgumentMatchers.by_type(TYPE_FLOAT)
+	return __gdunit_argument_matchers().by_type(TYPE_FLOAT)
 
 
 ## Argument matcher to match any string value
 func any_string() -> GdUnitArgumentMatcher:
-	return GdUnitArgumentMatchers.by_type(TYPE_STRING)
+	return __gdunit_argument_matchers().by_type(TYPE_STRING)
 
 
 ## Argument matcher to match any Color value
 func any_color() -> GdUnitArgumentMatcher:
-	return GdUnitArgumentMatchers.by_type(TYPE_COLOR)
+	return __gdunit_argument_matchers().by_type(TYPE_COLOR)
 
 
 ## Argument matcher to match any Vector typed value
 func any_vector() -> GdUnitArgumentMatcher:
-	return GdUnitArgumentMatchers.by_types([
+	return __gdunit_argument_matchers().by_types([
 		TYPE_VECTOR2,
 		TYPE_VECTOR2I,
 		TYPE_VECTOR3,
@@ -274,143 +299,152 @@ func any_vector() -> GdUnitArgumentMatcher:
 
 ## Argument matcher to match any Vector2 value
 func any_vector2() -> GdUnitArgumentMatcher:
-	return GdUnitArgumentMatchers.by_type(TYPE_VECTOR2)
+	return __gdunit_argument_matchers().by_type(TYPE_VECTOR2)
 
 
 ## Argument matcher to match any Vector2i value
 func any_vector2i() -> GdUnitArgumentMatcher:
-	return GdUnitArgumentMatchers.by_type(TYPE_VECTOR2I)
+	return __gdunit_argument_matchers().by_type(TYPE_VECTOR2I)
 
 
 ## Argument matcher to match any Vector3 value
 func any_vector3() -> GdUnitArgumentMatcher:
-	return GdUnitArgumentMatchers.by_type(TYPE_VECTOR3)
+	return __gdunit_argument_matchers().by_type(TYPE_VECTOR3)
 
 
 ## Argument matcher to match any Vector3i value
 func any_vector3i() -> GdUnitArgumentMatcher:
-	return GdUnitArgumentMatchers.by_type(TYPE_VECTOR3I)
+	return __gdunit_argument_matchers().by_type(TYPE_VECTOR3I)
 
 
 ## Argument matcher to match any Vector4 value
 func any_vector4() -> GdUnitArgumentMatcher:
-	return GdUnitArgumentMatchers.by_type(TYPE_VECTOR4)
+	return __gdunit_argument_matchers().by_type(TYPE_VECTOR4)
 
 
 ## Argument matcher to match any Vector3i value
 func any_vector4i() -> GdUnitArgumentMatcher:
-	return GdUnitArgumentMatchers.by_type(TYPE_VECTOR4I)
+	return __gdunit_argument_matchers().by_type(TYPE_VECTOR4I)
 
 
 ## Argument matcher to match any Rect2 value
 func any_rect2() -> GdUnitArgumentMatcher:
-	return GdUnitArgumentMatchers.by_type(TYPE_RECT2)
+	return __gdunit_argument_matchers().by_type(TYPE_RECT2)
 
 
 ## Argument matcher to match any Plane value
 func any_plane() -> GdUnitArgumentMatcher:
-	return GdUnitArgumentMatchers.by_type(TYPE_PLANE)
+	return __gdunit_argument_matchers().by_type(TYPE_PLANE)
 
 
 ## Argument matcher to match any Quaternion value
 func any_quat() -> GdUnitArgumentMatcher:
-	return GdUnitArgumentMatchers.by_type(TYPE_QUATERNION)
+	return __gdunit_argument_matchers().by_type(TYPE_QUATERNION)
 
 
 ## Argument matcher to match any AABB value
 func any_aabb() -> GdUnitArgumentMatcher:
-	return GdUnitArgumentMatchers.by_type(TYPE_AABB)
+	return __gdunit_argument_matchers().by_type(TYPE_AABB)
 
 
 ## Argument matcher to match any Basis value
 func any_basis() -> GdUnitArgumentMatcher:
-	return GdUnitArgumentMatchers.by_type(TYPE_BASIS)
+	return __gdunit_argument_matchers().by_type(TYPE_BASIS)
 
 
 ## Argument matcher to match any Transform3D value
 func any_transform() -> GdUnitArgumentMatcher:
-	return GdUnitArgumentMatchers.by_type(TYPE_TRANSFORM3D)
+	return __gdunit_argument_matchers().by_type(TYPE_TRANSFORM3D)
 
 
 ## Argument matcher to match any Transform2D value
 func any_transform_2d() -> GdUnitArgumentMatcher:
-	return GdUnitArgumentMatchers.by_type(TYPE_TRANSFORM2D)
+	return __gdunit_argument_matchers().by_type(TYPE_TRANSFORM2D)
 
 
 ## Argument matcher to match any NodePath value
 func any_node_path() -> GdUnitArgumentMatcher:
-	return GdUnitArgumentMatchers.by_type(TYPE_NODE_PATH)
+	return __gdunit_argument_matchers().by_type(TYPE_NODE_PATH)
 
 
 ## Argument matcher to match any RID value
 func any_rid() -> GdUnitArgumentMatcher:
-	return GdUnitArgumentMatchers.by_type(TYPE_RID)
+	return __gdunit_argument_matchers().by_type(TYPE_RID)
 
 
 ## Argument matcher to match any Object value
 func any_object() -> GdUnitArgumentMatcher:
-	return GdUnitArgumentMatchers.by_type(TYPE_OBJECT)
+	return __gdunit_argument_matchers().by_type(TYPE_OBJECT)
 
 
 ## Argument matcher to match any Dictionary value
 func any_dictionary() -> GdUnitArgumentMatcher:
-	return GdUnitArgumentMatchers.by_type(TYPE_DICTIONARY)
+	return __gdunit_argument_matchers().by_type(TYPE_DICTIONARY)
 
 
 ## Argument matcher to match any Array value
 func any_array() -> GdUnitArgumentMatcher:
-	return GdUnitArgumentMatchers.by_type(TYPE_ARRAY)
+	return __gdunit_argument_matchers().by_type(TYPE_ARRAY)
 
 
 ## Argument matcher to match any PackedByteArray value
 func any_pool_byte_array() -> GdUnitArgumentMatcher:
-	return GdUnitArgumentMatchers.by_type(TYPE_PACKED_BYTE_ARRAY)
+	return __gdunit_argument_matchers().by_type(TYPE_PACKED_BYTE_ARRAY)
 
 
 ## Argument matcher to match any PackedInt32Array value
 func any_pool_int_array() -> GdUnitArgumentMatcher:
-	return GdUnitArgumentMatchers.by_type(TYPE_PACKED_INT32_ARRAY)
+	return __gdunit_argument_matchers().by_type(TYPE_PACKED_INT32_ARRAY)
 
 
 ## Argument matcher to match any PackedFloat32Array value
 func any_pool_float_array() -> GdUnitArgumentMatcher:
-	return GdUnitArgumentMatchers.by_type(TYPE_PACKED_FLOAT32_ARRAY)
+	return __gdunit_argument_matchers().by_type(TYPE_PACKED_FLOAT32_ARRAY)
 
 
 ## Argument matcher to match any PackedStringArray value
 func any_pool_string_array() -> GdUnitArgumentMatcher:
-	return GdUnitArgumentMatchers.by_type(TYPE_PACKED_STRING_ARRAY)
+	return __gdunit_argument_matchers().by_type(TYPE_PACKED_STRING_ARRAY)
 
 
 ## Argument matcher to match any PackedVector2Array value
 func any_pool_vector2_array() -> GdUnitArgumentMatcher:
-	return GdUnitArgumentMatchers.by_type(TYPE_PACKED_VECTOR2_ARRAY)
+	return __gdunit_argument_matchers().by_type(TYPE_PACKED_VECTOR2_ARRAY)
 
 
 ## Argument matcher to match any PackedVector3Array value
 func any_pool_vector3_array() -> GdUnitArgumentMatcher:
-	return GdUnitArgumentMatchers.by_type(TYPE_PACKED_VECTOR3_ARRAY)
+	return __gdunit_argument_matchers().by_type(TYPE_PACKED_VECTOR3_ARRAY)
 
 
 ## Argument matcher to match any PackedColorArray value
 func any_pool_color_array() -> GdUnitArgumentMatcher:
-	return GdUnitArgumentMatchers.by_type(TYPE_PACKED_COLOR_ARRAY)
+	return __gdunit_argument_matchers().by_type(TYPE_PACKED_COLOR_ARRAY)
 
 
 ## Argument matcher to match any instance of given class
 func any_class(clazz :Object) -> GdUnitArgumentMatcher:
-	return GdUnitArgumentMatchers.any_class(clazz)
+	return __gdunit_argument_matchers().any_class(clazz)
 
 
 # === value extract utils ======================================================
 ## Builds an extractor by given function name and optional arguments
 func extr(func_name :String, args := Array()) -> GdUnitValueExtractor:
-	return GdUnitFuncValueExtractor.new(func_name, args)
+	return __load_gdscript("res://addons/gdUnit4/src/extractors/GdUnitFuncValueExtractor.gd").new(func_name, args)
 
 
 ## Constructs a tuple by given arguments
-func tuple(arg0, arg1=GdUnitTuple.NO_ARG, arg2=GdUnitTuple.NO_ARG, arg3=GdUnitTuple.NO_ARG, arg4=GdUnitTuple.NO_ARG, arg5=GdUnitTuple.NO_ARG, arg6=GdUnitTuple.NO_ARG, arg7=GdUnitTuple.NO_ARG, arg8=GdUnitTuple.NO_ARG, arg9=GdUnitTuple.NO_ARG) -> GdUnitTuple:
-	return GdUnitTuple.new(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9)
+func tuple(arg0:Variant,
+	arg1:Variant=NO_ARG,
+	arg2:Variant=NO_ARG,
+	arg3:Variant=NO_ARG,
+	arg4:Variant=NO_ARG,
+	arg5:Variant=NO_ARG,
+	arg6:Variant=NO_ARG,
+	arg7:Variant=NO_ARG,
+	arg8:Variant=NO_ARG,
+	arg9:Variant=NO_ARG) -> GdUnitTuple:
+	return __load_gdscript("res://addons/gdUnit4/src/GdUnitTuple.gd").new(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9)
 
 
 # === Asserts ==================================================================
@@ -440,27 +474,27 @@ func assert_that(current) -> GdUnitAssert:
 		TYPE_OBJECT, TYPE_NIL:
 			return assert_object(current)
 		_:
-			return GdUnitAssertImpl.new(current)
+			return __gdunit_assert().new(current)
 
 
 ## An assertion tool to verify boolean values.
 func assert_bool(current) -> GdUnitBoolAssert:
-	return GdUnitBoolAssertImpl.new(current)
+	return __load_gdscript("res://addons/gdUnit4/src/asserts/GdUnitBoolAssertImpl.gd").new(current)
 
 
 ## An assertion tool to verify String values.
 func assert_str(current) -> GdUnitStringAssert:
-	return GdUnitStringAssertImpl.new(current)
+	return __load_gdscript("res://addons/gdUnit4/src/asserts/GdUnitStringAssertImpl.gd").new(current)
 
 
 ## An assertion tool to verify integer values.
 func assert_int(current) -> GdUnitIntAssert:
-	return GdUnitIntAssertImpl.new(current)
+	return __load_gdscript("res://addons/gdUnit4/src/asserts/GdUnitIntAssertImpl.gd").new(current)
 
 
 ## An assertion tool to verify float values.
 func assert_float(current) -> GdUnitFloatAssert:
-	return GdUnitFloatAssertImpl.new(current)
+	return __load_gdscript("res://addons/gdUnit4/src/asserts/GdUnitFloatAssertImpl.gd").new(current)
 
 
 ## An assertion tool to verify Vector values.[br]
@@ -470,55 +504,41 @@ func assert_float(current) -> GdUnitFloatAssert:
 ##		assert_vector(Vector2(1.2, 1.000001)).is_equal(Vector2(1.2, 1.000001))
 ##     [/codeblock]
 func assert_vector(current) -> GdUnitVectorAssert:
-	return GdUnitVectorAssertImpl.new(current)
-
-
-## An assertion tool to verify Vector2 values.[br]
-## This function is [b]deprecated[/b] you have to use [method assert_vector] instead
-func assert_vector2(current) -> GdUnitVectorAssert:
-	push_warning("assert_vector2 is deprecated, Use 'assert_vector' instead.")
-	return assert_vector(current)
-
-
-## An assertion tool to verify Vector3 values.[br]
-## This function is [b]deprecated[/b] you have to use [method assert_vector] instead
-func assert_vector3(current) -> GdUnitVectorAssert:
-	push_warning("assert_vector3 is deprecated, Use 'assert_vector' instead.")
-	return assert_vector(current)
+	return __load_gdscript("res://addons/gdUnit4/src/asserts/GdUnitVectorAssertImpl.gd").new(current)
 
 
 ## An assertion tool to verify arrays.
 func assert_array(current) -> GdUnitArrayAssert:
-	return GdUnitArrayAssertImpl.new(current)
+	return __load_gdscript("res://addons/gdUnit4/src/asserts/GdUnitArrayAssertImpl.gd").new(current)
 
 
 ## An assertion tool to verify dictionaries.
 func assert_dict(current) -> GdUnitDictionaryAssert:
-	return GdUnitDictionaryAssertImpl.new(current)
+	return __load_gdscript("res://addons/gdUnit4/src/asserts/GdUnitDictionaryAssertImpl.gd").new(current)
 
 
 ## An assertion tool to verify FileAccess.
 func assert_file(current) -> GdUnitFileAssert:
-	return GdUnitFileAssertImpl.new(current)
+	return __load_gdscript("res://addons/gdUnit4/src/asserts/GdUnitFileAssertImpl.gd").new(current)
 
 
 ## An assertion tool to verify Objects.
 func assert_object(current) -> GdUnitObjectAssert:
-	return GdUnitObjectAssertImpl.new(current)
+	return __load_gdscript("res://addons/gdUnit4/src/asserts/GdUnitObjectAssertImpl.gd").new(current)
 
 
 func assert_result(current) -> GdUnitResultAssert:
-	return GdUnitResultAssertImpl.new(current)
+	return __load_gdscript("res://addons/gdUnit4/src/asserts/GdUnitResultAssertImpl.gd").new(current)
 
 
 ## An assertion tool that waits until a certain time for an expected function return value
 func assert_func(instance :Object, func_name :String, args := Array()) -> GdUnitFuncAssert:
-	return GdUnitFuncAssertImpl.new(instance, func_name, args)
+	return __load_gdscript("res://addons/gdUnit4/src/asserts/GdUnitFuncAssertImpl.gd").new(instance, func_name, args)
 
 
 ## An Assertion Tool to verify for emitted signals until a certain time.
 func assert_signal(instance :Object) -> GdUnitSignalAssert:
-	return GdUnitSignalAssertImpl.new(instance)
+	return __load_gdscript("res://addons/gdUnit4/src/asserts/GdUnitSignalAssertImpl.gd").new(instance)
 
 
 ## An assertion tool to test for failing assertions.[br]
@@ -529,7 +549,7 @@ func assert_signal(instance :Object) -> GdUnitSignalAssert:
 ##		    .has_message("Expecting:\n 'true'\n not equal to\n 'true'")
 ##     [/codeblock]
 func assert_failure(assertion :Callable) -> GdUnitFailureAssert:
-	return GdUnitFailureAssertImpl.new().execute(assertion)
+	return __load_gdscript("res://addons/gdUnit4/src/asserts/GdUnitFailureAssertImpl.gd").new().execute(assertion)
 
 
 ## An assertion tool to test for failing assertions.[br]
@@ -540,7 +560,7 @@ func assert_failure(assertion :Callable) -> GdUnitFailureAssert:
 ##		    .has_message("Expecting:\n 'true'\n not equal to\n 'true'")
 ##     [/codeblock]
 func assert_failure_await(assertion :Callable) -> GdUnitFailureAssert:
-	return await GdUnitFailureAssertImpl.new().execute_and_await(assertion)
+	return await __load_gdscript("res://addons/gdUnit4/src/asserts/GdUnitFailureAssertImpl.gd").new().execute_and_await(assertion)
 
 
 ## An assertion tool to verify for Godot errors.[br]
@@ -556,7 +576,7 @@ func assert_failure_await(assertion :Callable) -> GdUnitFailureAssert:
 ##		    .is_push_error('test error')
 ##     [/codeblock]
 func assert_error(current :Callable) -> GdUnitGodotErrorAssert:
-	return GdUnitGodotErrorAssertImpl.new(current)
+	return __load_gdscript("res://addons/gdUnit4/src/asserts/GdUnitGodotErrorAssertImpl.gd").new(current)
 
 
 ## Utility to check if a test has failed in a particular line and if there is an error message
@@ -571,11 +591,11 @@ func assert_failed_at(line_number :int, expected_failure :String) -> bool:
 
 
 func assert_not_yet_implemented():
-	GdUnitAssertImpl.new(null).test_fail()
+	__gdunit_assert().new(null).test_fail()
 
 
 func fail(message :String):
-	GdUnitAssertImpl.new(null).report_error(message)
+	__gdunit_assert().new(null).report_error(message)
 
 
 # --- internal stuff do not override!!!

--- a/addons/gdUnit4/src/GdUnitTuple.gd
+++ b/addons/gdUnit4/src/GdUnitTuple.gd
@@ -8,15 +8,15 @@ var __values :Array = Array()
 
 
 func _init(arg0:Variant,
-	arg1:Variant=NO_ARG,
-	arg2:Variant=NO_ARG,
-	arg3:Variant=NO_ARG,
-	arg4:Variant=NO_ARG,
-	arg5:Variant=NO_ARG,
-	arg6:Variant=NO_ARG,
-	arg7:Variant=NO_ARG,
-	arg8:Variant=NO_ARG,
-	arg9:Variant=NO_ARG):
+	arg1 :Variant=NO_ARG,
+	arg2 :Variant=NO_ARG,
+	arg3 :Variant=NO_ARG,
+	arg4 :Variant=NO_ARG,
+	arg5 :Variant=NO_ARG,
+	arg6 :Variant=NO_ARG,
+	arg7 :Variant=NO_ARG,
+	arg8 :Variant=NO_ARG,
+	arg9 :Variant=NO_ARG):
 	__values = GdArrayTools.filter_value([arg0,arg1,arg2,arg3,arg4,arg5,arg6,arg7,arg8,arg9], NO_ARG)
 
 

--- a/addons/gdUnit4/src/GdUnitTuple.gd
+++ b/addons/gdUnit4/src/GdUnitTuple.gd
@@ -7,7 +7,16 @@ const NO_ARG :Variant = GdUnitConstants.NO_ARG
 var __values :Array = Array()
 
 
-func _init(arg0,arg1,arg2=NO_ARG,arg3=NO_ARG,arg4=NO_ARG,arg5=NO_ARG,arg6=NO_ARG,arg7=NO_ARG,arg8=NO_ARG,arg9=NO_ARG):
+func _init(arg0:Variant,
+	arg1:Variant=NO_ARG,
+	arg2:Variant=NO_ARG,
+	arg3:Variant=NO_ARG,
+	arg4:Variant=NO_ARG,
+	arg5:Variant=NO_ARG,
+	arg6:Variant=NO_ARG,
+	arg7:Variant=NO_ARG,
+	arg8:Variant=NO_ARG,
+	arg9:Variant=NO_ARG):
 	__values = GdArrayTools.filter_value([arg0,arg1,arg2,arg3,arg4,arg5,arg6,arg7,arg8,arg9], NO_ARG)
 
 

--- a/addons/gdUnit4/src/asserts/GdUnitArrayAssertImpl.gd
+++ b/addons/gdUnit4/src/asserts/GdUnitArrayAssertImpl.gd
@@ -1,5 +1,5 @@
-class_name GdUnitArrayAssertImpl
 extends GdUnitArrayAssert
+
 
 var _base :GdUnitAssert
 var _current_value_provider :ValueProvider
@@ -7,7 +7,7 @@ var _current_value_provider :ValueProvider
 
 func _init(current):
 	_current_value_provider = DefaultValueProvider.new(current)
-	_base = GdUnitAssertImpl.new(current)
+	_base = ResourceLoader.load("res://addons/gdUnit4/src/asserts/GdUnitAssertImpl.gd", "GDScript", ResourceLoader.CACHE_MODE_REUSE).new(current)
 	# save the actual assert instance on the current thread context
 	GdUnitThreadManager.get_current_context().set_assert(self)
 	if not __validate_value_type(current):
@@ -50,6 +50,12 @@ func __current() -> Variant:
 	return _current_value_provider.get_value()
 
 
+func max_length(left, right) -> int:
+	var ls = str(left).length()
+	var rs = str(right).length()
+	return rs if ls < rs else ls
+
+
 func _array_equals_div(current, expected, case_sensitive :bool = false) -> Array:
 	var current_ := PackedStringArray(Array(current))
 	var expected_ := PackedStringArray(Array(expected))
@@ -59,7 +65,7 @@ func _array_equals_div(current, expected, case_sensitive :bool = false) -> Array
 		if index < expected_.size():
 			var e := expected_[index]
 			if not GdObjects.equals(c, e, case_sensitive):
-				var length := GdUnitTools.max_length(c, e)
+				var length := max_length(c, e)
 				current_[index] = GdAssertMessages.format_invalid(c.lpad(length))
 				expected_[index] = e.lpad(length)
 				index_report_.push_back({"index" : index, "current" :c, "expected": e})
@@ -293,7 +299,7 @@ func is_instanceof(expected) -> GdUnitAssert:
 
 func extract(func_name :String, args := Array()) -> GdUnitArrayAssert:
 	var extracted_elements := Array()
-	var extractor := GdUnitFuncValueExtractor.new(func_name, args)
+	var extractor :GdUnitValueExtractor = ResourceLoader.load("res://addons/gdUnit4/src/extractors/GdUnitFuncValueExtractor.gd", "GDScript", ResourceLoader.CACHE_MODE_REUSE).new(func_name, args)
 	var current = __current()
 	if current == null:
 		_current_value_provider = DefaultValueProvider.new(null)

--- a/addons/gdUnit4/src/asserts/GdUnitAssertImpl.gd
+++ b/addons/gdUnit4/src/asserts/GdUnitAssertImpl.gd
@@ -1,33 +1,9 @@
-class_name GdUnitAssertImpl
 extends GdUnitAssert
 
 
 var _current :Variant
 var _current_error_message :String = ""
 var _custom_failure_message :String = ""
-
-
-# Scans the current stack trace for the root cause to extract the line number
-static func _get_line_number() -> int:
-	var stack_trace := get_stack()
-	if stack_trace == null or stack_trace.is_empty():
-		return -1
-	for stack_info in stack_trace:
-		var function :String = stack_info.get("function")
-		# we catch helper asserts to skip over to return the correct line number
-		if function.begins_with("assert_"):
-			continue
-		var source :String = stack_info.get("source")
-		if source.is_empty() \
-			or source.begins_with("user://") \
-			or source.ends_with("AssertImpl.gd") \
-			or source.ends_with("GdUnitTestSuite.gd") \
-			or source.ends_with("GdUnitSceneRunnerImpl.gd") \
-			or source.ends_with("GdUnitObjectInteractions.gd") \
-			or source.ends_with("GdUnitAwaiter.gd"):
-			continue
-		return stack_info.get("line")
-	return -1
 
 
 func _init(current :Variant):
@@ -55,7 +31,7 @@ func report_success() -> GdUnitAssert:
 
 
 func report_error(error_message :String, failure_line_number: int = -1) -> GdUnitAssert:
-	var line_number := failure_line_number if failure_line_number != -1 else GdUnitAssertImpl._get_line_number()
+	var line_number := failure_line_number if failure_line_number != -1 else GdUnitAssert._get_line_number()
 	GdAssertReports.set_last_error_line_number(line_number)
 	_current_error_message = error_message if _custom_failure_message.is_empty() else _custom_failure_message
 	GdAssertReports.report_error(_current_error_message, line_number)
@@ -64,10 +40,6 @@ func report_error(error_message :String, failure_line_number: int = -1) -> GdUni
 
 func test_fail():
 	return report_error(GdAssertMessages.error_not_implemented())
-
-
-static func _normalize_bbcode(message :String) -> String:
-	return GdUnitTools.richtext_normalize(message).replace("\r", "")
 
 
 func override_failure_message(message :String):

--- a/addons/gdUnit4/src/asserts/GdUnitBoolAssertImpl.gd
+++ b/addons/gdUnit4/src/asserts/GdUnitBoolAssertImpl.gd
@@ -1,10 +1,10 @@
-class_name GdUnitBoolAssertImpl
 extends GdUnitBoolAssert
 
-var _base: GdUnitAssertImpl
+var _base: GdUnitAssert
+
 
 func _init(current):
-	_base = GdUnitAssertImpl.new(current)
+	_base = ResourceLoader.load("res://addons/gdUnit4/src/asserts/GdUnitAssertImpl.gd", "GDScript", ResourceLoader.CACHE_MODE_REUSE).new(current)
 	# save the actual assert instance on the current thread context
 	GdUnitThreadManager.get_current_context().set_assert(self)
 	if not _base.__validate_value_type(current, TYPE_BOOL):

--- a/addons/gdUnit4/src/asserts/GdUnitDictionaryAssertImpl.gd
+++ b/addons/gdUnit4/src/asserts/GdUnitDictionaryAssertImpl.gd
@@ -1,11 +1,10 @@
-class_name GdUnitDictionaryAssertImpl
 extends GdUnitDictionaryAssert
 
 var _base :GdUnitAssert
 
 
 func _init(current):
-	_base = GdUnitAssertImpl.new(current)
+	_base = ResourceLoader.load("res://addons/gdUnit4/src/asserts/GdUnitAssertImpl.gd", "GDScript", ResourceLoader.CACHE_MODE_REUSE).new(current)
 	# save the actual assert instance on the current thread context
 	GdUnitThreadManager.get_current_context().set_assert(self)
 	if not _base.__validate_value_type(current, TYPE_DICTIONARY):

--- a/addons/gdUnit4/src/asserts/GdUnitFailureAssertImpl.gd
+++ b/addons/gdUnit4/src/asserts/GdUnitFailureAssertImpl.gd
@@ -1,5 +1,6 @@
-class_name GdUnitFailureAssertImpl
 extends GdUnitFailureAssert
+
+const GdUnitTools := preload("res://addons/gdUnit4/src/core/GdUnitTools.gd")
 
 var _is_failed := false
 var _failure_message :String
@@ -75,7 +76,7 @@ func has_line(expected :int) -> GdUnitFailureAssert:
 
 func has_message(expected :String) -> GdUnitFailureAssert:
 	var expected_error := GdUnitTools.normalize_text(expected)
-	var current_error := GdUnitAssertImpl._normalize_bbcode(_failure_message)
+	var current_error := GdUnitTools.normalize_text(GdUnitTools.richtext_normalize(_failure_message))
 	if current_error != expected_error:
 		var diffs := GdDiffTool.string_diff(current_error, expected_error)
 		var current := GdAssertMessages._colored_array_div(diffs[1])
@@ -85,7 +86,7 @@ func has_message(expected :String) -> GdUnitFailureAssert:
 
 func starts_with_message(expected :String) -> GdUnitFailureAssert:
 	var expected_error := GdUnitTools.normalize_text(expected)
-	var current_error := GdUnitAssertImpl._normalize_bbcode(_failure_message)
+	var current_error := GdUnitTools.normalize_text(GdUnitTools.richtext_normalize(_failure_message))
 	if current_error.find(expected_error) != 0:
 		var diffs := GdDiffTool.string_diff(current_error, expected_error)
 		var current := GdAssertMessages._colored_array_div(diffs[1])
@@ -94,7 +95,7 @@ func starts_with_message(expected :String) -> GdUnitFailureAssert:
 
 
 func _report_error(error_message :String, failure_line_number: int = -1) -> GdUnitAssert:
-	var line_number := failure_line_number if failure_line_number != -1 else GdUnitAssertImpl._get_line_number()
+	var line_number := failure_line_number if failure_line_number != -1 else GdUnitAssert._get_line_number()
 	GdAssertReports.report_error(error_message, line_number)
 	return self
 

--- a/addons/gdUnit4/src/asserts/GdUnitFileAssertImpl.gd
+++ b/addons/gdUnit4/src/asserts/GdUnitFileAssertImpl.gd
@@ -1,12 +1,12 @@
-class_name GdUnitFileAssertImpl
 extends GdUnitFileAssert
 
+const GdUnitTools := preload("res://addons/gdUnit4/src/core/GdUnitTools.gd")
 
 var _base: GdUnitAssert
 
 
 func _init(current):
-	_base = GdUnitAssertImpl.new(current)
+	_base = ResourceLoader.load("res://addons/gdUnit4/src/asserts/GdUnitAssertImpl.gd", "GDScript", ResourceLoader.CACHE_MODE_REUSE).new(current)
 	# save the actual assert instance on the current thread context
 	GdUnitThreadManager.get_current_context().set_assert(self)
 	if not _base.__validate_value_type(current, TYPE_STRING):
@@ -89,5 +89,6 @@ func contains_exactly(expected_rows :Array) -> GdUnitFileAssert:
 		var source_code = GdScriptParser.to_unix_format(instance.get_script().source_code)
 		GdUnitTools.free_instance(instance)
 		var rows := Array(source_code.split("\n"))
-		GdUnitArrayAssertImpl.new(rows).contains_exactly(expected_rows)
+		ResourceLoader.load("res://addons/gdUnit4/src/asserts/GdUnitArrayAssertImpl.gd", "GDScript", ResourceLoader.CACHE_MODE_REUSE).new(rows)\
+			.contains_exactly(expected_rows)
 	return self

--- a/addons/gdUnit4/src/asserts/GdUnitFloatAssertImpl.gd
+++ b/addons/gdUnit4/src/asserts/GdUnitFloatAssertImpl.gd
@@ -1,10 +1,10 @@
-class_name GdUnitFloatAssertImpl
 extends GdUnitFloatAssert
 
 var _base: GdUnitAssert
 
+
 func _init(current):
-	_base = GdUnitAssertImpl.new(current)
+	_base = ResourceLoader.load("res://addons/gdUnit4/src/asserts/GdUnitAssertImpl.gd", "GDScript", ResourceLoader.CACHE_MODE_REUSE).new(current)
 	# save the actual assert instance on the current thread context
 	GdUnitThreadManager.get_current_context().set_assert(self)
 	if not _base.__validate_value_type(current, TYPE_FLOAT):

--- a/addons/gdUnit4/src/asserts/GdUnitFuncAssertImpl.gd
+++ b/addons/gdUnit4/src/asserts/GdUnitFuncAssertImpl.gd
@@ -1,7 +1,8 @@
-class_name GdUnitFuncAssertImpl
 extends GdUnitFuncAssert
 
 signal value_provided(value)
+
+const GdUnitTools := preload("res://addons/gdUnit4/src/core/GdUnitTools.gd")
 
 const DEFAULT_TIMEOUT := 2000
 
@@ -16,7 +17,7 @@ var _sleep_timer :Timer = null
 
 
 func _init(instance :Object, func_name :String, args := Array()):
-	_line_number = GdUnitAssertImpl._get_line_number()
+	_line_number = GdUnitAssert._get_line_number()
 	GdAssertReports.reset_last_error_line_number()
 	# save the actual assert instance on the current thread context
 	GdUnitThreadManager.get_current_context().set_assert(self)

--- a/addons/gdUnit4/src/asserts/GdUnitGodotErrorAssertImpl.gd
+++ b/addons/gdUnit4/src/asserts/GdUnitGodotErrorAssertImpl.gd
@@ -1,6 +1,4 @@
-class_name GdUnitGodotErrorAssertImpl
 extends GdUnitGodotErrorAssert
-
 
 var _current_error_message :String
 var _callable :Callable
@@ -37,7 +35,7 @@ func _report_success() -> GdUnitAssert:
 
 
 func _report_error(error_message :String, failure_line_number: int = -1) -> GdUnitAssert:
-	var line_number := failure_line_number if failure_line_number != -1 else GdUnitAssertImpl._get_line_number()
+	var line_number := failure_line_number if failure_line_number != -1 else GdUnitAssert._get_line_number()
 	_current_error_message = error_message
 	GdAssertReports.report_error(error_message, line_number)
 	return self

--- a/addons/gdUnit4/src/asserts/GdUnitIntAssertImpl.gd
+++ b/addons/gdUnit4/src/asserts/GdUnitIntAssertImpl.gd
@@ -1,10 +1,10 @@
-class_name GdUnitIntAssertImpl
 extends GdUnitIntAssert
 
 var _base: GdUnitAssert
 
+
 func _init(current):
-	_base = GdUnitAssertImpl.new(current)
+	_base = ResourceLoader.load("res://addons/gdUnit4/src/asserts/GdUnitAssertImpl.gd", "GDScript", ResourceLoader.CACHE_MODE_REUSE).new(current)
 	# save the actual assert instance on the current thread context
 	GdUnitThreadManager.get_current_context().set_assert(self)
 	if not _base.__validate_value_type(current, TYPE_INT):

--- a/addons/gdUnit4/src/asserts/GdUnitObjectAssertImpl.gd
+++ b/addons/gdUnit4/src/asserts/GdUnitObjectAssertImpl.gd
@@ -1,11 +1,10 @@
-class_name GdUnitObjectAssertImpl
 extends GdUnitObjectAssert
 
 var _base :GdUnitAssert
 
 
 func _init(current):
-	_base = GdUnitAssertImpl.new(current)
+	_base = ResourceLoader.load("res://addons/gdUnit4/src/asserts/GdUnitAssertImpl.gd", "GDScript", ResourceLoader.CACHE_MODE_REUSE).new(current)
 	# save the actual assert instance on the current thread context
 	GdUnitThreadManager.get_current_context().set_assert(self)
 	if (current != null

--- a/addons/gdUnit4/src/asserts/GdUnitResultAssertImpl.gd
+++ b/addons/gdUnit4/src/asserts/GdUnitResultAssertImpl.gd
@@ -1,10 +1,10 @@
-class_name GdUnitResultAssertImpl
 extends GdUnitResultAssert
 
 var _base :GdUnitAssert
 
+
 func _init(current):
-	_base = GdUnitAssertImpl.new(current)
+	_base = ResourceLoader.load("res://addons/gdUnit4/src/asserts/GdUnitAssertImpl.gd", "GDScript", ResourceLoader.CACHE_MODE_REUSE).new(current)
 	# save the actual assert instance on the current thread context
 	GdUnitThreadManager.get_current_context().set_assert(self)
 	if not __validate_value_type(current):

--- a/addons/gdUnit4/src/asserts/GdUnitSignalAssertImpl.gd
+++ b/addons/gdUnit4/src/asserts/GdUnitSignalAssertImpl.gd
@@ -1,10 +1,8 @@
-class_name GdUnitSignalAssertImpl
 extends GdUnitSignalAssert
 
 const DEFAULT_TIMEOUT := 2000
-const NO_ARG = GdUnitConstants.NO_ARG
 
-var _signal_collector :GdUnitSignalAssertImpl.SignalCollector
+var _signal_collector :GdUnitSignalCollector
 var _emitter :Object
 var _current_error_message :String = ""
 var _custom_failure_message :String = ""
@@ -13,113 +11,12 @@ var _timeout := DEFAULT_TIMEOUT
 var _interrupted := false
 
 
-# It connects to all signals of given emitter and collects received signals and arguments
-# The collected signals are cleand finally when the emitter is freed.
-class SignalCollector extends RefCounted:
-	const SIGNAL_BLACK_LIST = []#["tree_exiting", "tree_exited", "child_exiting_tree"]
-	
-	# {
-	#	emitter<Object> : {
-	#		signal_name<String> : [signal_args<Array>],
-	#		...
-	#	}
-	# }
-	var _collected_signals :Dictionary = {}
-	
-	
-	func clear() -> void:
-		for emitter in _collected_signals.keys():
-			if is_instance_valid(emitter):
-				unregister_emitter(emitter)
-	
-	
-	# connect to all possible signals defined by the emitter
-	# prepares the signal collection to store received signals and arguments
-	func register_emitter(emitter :Object):
-		if is_instance_valid(emitter):
-			# check emitter is already registerd
-			if _collected_signals.has(emitter):
-				return
-			_collected_signals[emitter] = Dictionary()
-			# connect to 'tree_exiting' of the emitter to finally release all acquired resources/connections.
-			if emitter is Node and !emitter.tree_exiting.is_connected(unregister_emitter):
-				emitter.tree_exiting.connect(unregister_emitter.bind(emitter))
-			# connect to all signals of the emitter we want to collect
-			for signal_def in emitter.get_signal_list():
-				var signal_name = signal_def["name"]
-				# set inital collected to empty
-				if not is_signal_collecting(emitter, signal_name):
-					_collected_signals[emitter][signal_name] = Array()
-				if SIGNAL_BLACK_LIST.find(signal_name) != -1:
-					continue
-				if !emitter.is_connected(signal_name, _on_signal_emmited):
-					var err := emitter.connect(signal_name, _on_signal_emmited.bind(emitter, signal_name))
-					if err != OK:
-						push_error("Can't connect to signal %s on %s. Error: %s" % [signal_name, emitter, error_string(err)])
-	
-	
-	# unregister all acquired resources/connections, otherwise it ends up in orphans
-	# is called when the emitter is removed from the parent
-	func unregister_emitter(emitter :Object):
-		if is_instance_valid(emitter):
-			for signal_def in emitter.get_signal_list():
-				var signal_name = signal_def["name"]
-				if emitter.is_connected(signal_name, _on_signal_emmited):
-					emitter.disconnect(signal_name, _on_signal_emmited.bind(emitter, signal_name))
-			_collected_signals.erase(emitter)
-	
-	
-	# receives the signal from the emitter with all emitted signal arguments and additional the emitter and signal_name as last two arguements
-	func _on_signal_emmited( arg0=NO_ARG, arg1=NO_ARG, arg2=NO_ARG, arg3=NO_ARG, arg4=NO_ARG, arg5=NO_ARG, arg6=NO_ARG, arg7=NO_ARG, arg8=NO_ARG, arg9=NO_ARG, arg10=NO_ARG, arg11=NO_ARG):
-		var signal_args = GdArrayTools.filter_value([arg0,arg1,arg2,arg3,arg4,arg5,arg6,arg7,arg8,arg9,arg10,arg11], NO_ARG)
-		# extract the emitter and signal_name from the last two arguments (see line 61 where is added)
-		var signal_name :String = signal_args.pop_back()
-		var emitter :Object = signal_args.pop_back()
-		# prints("_on_signal_emmited:", emitter, signal_name, signal_args)
-		if is_signal_collecting(emitter, signal_name):
-			_collected_signals[emitter][signal_name].append(signal_args)
-	
-	
-	func reset_received_signals(emitter :Object):
-		# _debug_signal_list("before claer");
-		if _collected_signals.has(emitter):
-			for signal_name in _collected_signals[emitter]:
-				_collected_signals[emitter][signal_name].clear()
-		# _debug_signal_list("after claer");
-	
-	
-	func is_signal_collecting(emitter :Object, signal_name :String) -> bool:
-		return _collected_signals.has(emitter) and _collected_signals[emitter].has(signal_name)
-	
-	
-	func match(emitter :Object, signal_name :String, args :Array) -> bool:
-		#prints("match", signal_name,  _collected_signals[emitter][signal_name]);
-		if _collected_signals.is_empty() or not _collected_signals.has(emitter):
-			return false
-		for received_args in _collected_signals[emitter][signal_name]:
-			# prints("testing", signal_name, received_args, "vs", args)
-			if GdObjects.equals(received_args, args):
-				return true
-		return false
-	
-	
-	func _debug_signal_list(message :String):
-		prints("-----", message, "-------")
-		prints("senders {")
-		for emitter in _collected_signals:
-			prints("\t", emitter)
-			for signal_name in _collected_signals[emitter]:
-				var args = _collected_signals[emitter][signal_name]
-				prints("\t\t", signal_name, args)
-		prints("}")
-
-
 func _init(emitter :Object):
 	# save the actual assert instance on the current thread context
 	var context := GdUnitThreadManager.get_current_context()
 	context.set_assert(self)
 	_signal_collector = context.get_signal_collector()
-	_line_number = GdUnitAssertImpl._get_line_number()
+	_line_number = GdUnitAssert._get_line_number()
 	_emitter =  emitter
 	GdAssertReports.reset_last_error_line_number()
 
@@ -130,7 +27,7 @@ func report_success() -> GdUnitAssert:
 
 
 func report_warning(message :String) -> GdUnitAssert:
-	GdAssertReports.report_warning(message, GdUnitAssertImpl._get_line_number())
+	GdAssertReports.report_warning(message, GdUnitAssert._get_line_number())
 	return self
 
 
@@ -171,13 +68,13 @@ func is_signal_exists(signal_name :String) -> GdUnitSignalAssert:
 
 # Verifies that given signal is emitted until waiting time
 func is_emitted(name :String, args := []) -> GdUnitSignalAssert:
-	_line_number = GdUnitAssertImpl._get_line_number()
+	_line_number = GdUnitAssert._get_line_number()
 	return await _wail_until_signal(name, args, false)
 
 
 # Verifies that given signal is NOT emitted until waiting time
 func is_not_emitted(name :String, args := []) -> GdUnitSignalAssert:
-	_line_number = GdUnitAssertImpl._get_line_number()
+	_line_number = GdUnitAssert._get_line_number()
 	return await _wail_until_signal(name, args, true)
 
 

--- a/addons/gdUnit4/src/asserts/GdUnitStringAssertImpl.gd
+++ b/addons/gdUnit4/src/asserts/GdUnitStringAssertImpl.gd
@@ -1,11 +1,10 @@
-class_name GdUnitStringAssertImpl
 extends GdUnitStringAssert
 
 var _base :GdUnitAssert
 
 
 func _init(current):
-	_base = GdUnitAssertImpl.new(current)
+	_base = ResourceLoader.load("res://addons/gdUnit4/src/asserts/GdUnitAssertImpl.gd", "GDScript", ResourceLoader.CACHE_MODE_REUSE).new(current)
 	# save the actual assert instance on the current thread context
 	GdUnitThreadManager.get_current_context().set_assert(self)
 	if not _base.__validate_value_type(current, TYPE_STRING):

--- a/addons/gdUnit4/src/asserts/GdUnitVectorAssertImpl.gd
+++ b/addons/gdUnit4/src/asserts/GdUnitVectorAssertImpl.gd
@@ -1,4 +1,3 @@
-class_name GdUnitVectorAssertImpl
 extends GdUnitVectorAssert
 
 var _base: GdUnitAssert
@@ -6,7 +5,7 @@ var _current_type :int
 
 
 func _init(current :Variant):
-	_base = GdUnitAssertImpl.new(current)
+	_base = ResourceLoader.load("res://addons/gdUnit4/src/asserts/GdUnitAssertImpl.gd", "GDScript", ResourceLoader.CACHE_MODE_REUSE).new(current)
 	# save the actual assert instance on the current thread context
 	GdUnitThreadManager.get_current_context().set_assert(self)
 	if not _validate_value_type(current):

--- a/addons/gdUnit4/src/core/GdObjects.gd
+++ b/addons/gdUnit4/src/core/GdObjects.gd
@@ -2,6 +2,8 @@
 class_name GdObjects
 extends Resource
 
+const GdUnitTools := preload("res://addons/gdUnit4/src/core/GdUnitTools.gd")
+
 const TYPE_VOID 	= TYPE_MAX + 1000
 const TYPE_VARARG 	= TYPE_MAX + 1001
 const TYPE_VARIANT	= TYPE_MAX + 1002

--- a/addons/gdUnit4/src/core/GdUnitExecutor.gd
+++ b/addons/gdUnit4/src/core/GdUnitExecutor.gd
@@ -2,6 +2,8 @@ extends Node
 
 signal ExecutionCompleted()
 
+const GdUnitTools := preload("res://addons/gdUnit4/src/core/GdUnitTools.gd")
+const GdUnitMemoryPool = preload("res://addons/gdUnit4/src/core/GdUnitMemoryPool.gd")
 
 const INIT = 0
 const STAGE_TEST_SUITE_BEFORE = GdUnitReportCollector.STAGE_TEST_SUITE_BEFORE
@@ -126,7 +128,7 @@ func suite_after(test_suite :GdUnitTestSuite):
 		skip_count = 0
 		@warning_ignore("redundant_await")
 		await test_suite.after()
-		GdUnitTools.append_array(reports, _report_collector.get_reports(STAGE_TEST_SUITE_AFTER))
+		reports.append_array(_report_collector.get_reports(STAGE_TEST_SUITE_AFTER))
 		_memory_pool.free_pool()
 		_memory_pool.monitor_stop()
 		orphan_nodes = _memory_pool.orphan_nodes()

--- a/addons/gdUnit4/src/core/GdUnitMemoryPool.gd
+++ b/addons/gdUnit4/src/core/GdUnitMemoryPool.gd
@@ -1,4 +1,3 @@
-class_name GdUnitMemoryPool 
 extends GdUnitSingleton
 
 const META_PARAM := "MEMORY_POOL"
@@ -85,7 +84,8 @@ func monitor_stop() -> void:
 
 
 func free_pool() -> void:
-	GdUnitMemoryPool.run_auto_free(_current)
+	@warning_ignore("static_called_on_instance")
+	run_auto_free(_current)
 
 
 func get_monitor(pool_id :POOL) -> GdUnitMemMonitor:

--- a/addons/gdUnit4/src/core/GdUnitObjectInteractions.gd
+++ b/addons/gdUnit4/src/core/GdUnitObjectInteractions.gd
@@ -9,7 +9,7 @@ static func verify(obj :Object, times):
 
 
 static func verify_no_interactions(obj :Object) -> GdUnitAssert:
-	var gd_assert := GdUnitAssertImpl.new("")
+	var gd_assert = ResourceLoader.load("res://addons/gdUnit4/src/asserts/GdUnitAssertImpl.gd", "GDScript", ResourceLoader.CACHE_MODE_REUSE).new("")
 	if not _is_mock_or_spy(obj, "__verify"):
 		return gd_assert.report_success()
 	var summary :Dictionary = obj.__verify_no_interactions()
@@ -19,7 +19,7 @@ static func verify_no_interactions(obj :Object) -> GdUnitAssert:
 
 
 static func verify_no_more_interactions(obj :Object) -> GdUnitAssert:
-	var gd_assert := GdUnitAssertImpl.new("")
+	var gd_assert = ResourceLoader.load("res://addons/gdUnit4/src/asserts/GdUnitAssertImpl.gd", "GDScript", ResourceLoader.CACHE_MODE_REUSE).new("")
 	if not _is_mock_or_spy(obj, "__verify_no_more_interactions"):
 		return gd_assert
 	var summary :Dictionary = obj.__verify_no_more_interactions()

--- a/addons/gdUnit4/src/core/GdUnitObjectInteractionsTemplate.gd
+++ b/addons/gdUnit4/src/core/GdUnitObjectInteractionsTemplate.gd
@@ -1,5 +1,7 @@
 class_name GdUnitObjectInteractionsTemplate
 
+const GdUnitAssertImpl := preload("res://addons/gdUnit4/src/asserts/GdUnitAssertImpl.gd")
+
 var __expected_interactions :int = -1
 var __saved_interactions := Dictionary()
 var __verified_interactions := Array()

--- a/addons/gdUnit4/src/core/GdUnitRunnerConfig.gd
+++ b/addons/gdUnit4/src/core/GdUnitRunnerConfig.gd
@@ -1,6 +1,8 @@
 class_name GdUnitRunnerConfig
 extends Resource
 
+const GdUnitTools := preload("res://addons/gdUnit4/src/core/GdUnitTools.gd")
+
 const CONFIG_VERSION = "1.0"
 const VERSION = "version"
 const INCLUDED = "included"

--- a/addons/gdUnit4/src/core/GdUnitSceneRunnerImpl.gd
+++ b/addons/gdUnit4/src/core/GdUnitSceneRunnerImpl.gd
@@ -2,6 +2,11 @@
 class_name GdUnitSceneRunnerImpl
 extends GdUnitSceneRunner
 
+
+var GdUnitMemoryPool := ResourceLoader.load("res://addons/gdUnit4/src/core/GdUnitMemoryPool.gd", "GDScript", ResourceLoader.CACHE_MODE_REUSE)
+var GdUnitFuncAssertImpl := ResourceLoader.load("res://addons/gdUnit4/src/asserts/GdUnitFuncAssertImpl.gd", "GDScript", ResourceLoader.CACHE_MODE_REUSE)
+
+
 # mapping of mouse buttons and his masks
 const MAP_MOUSE_BUTTON_MASKS := {
 	MOUSE_BUTTON_LEFT : MOUSE_BUTTON_MASK_LEFT,

--- a/addons/gdUnit4/src/core/GdUnitSettings.gd
+++ b/addons/gdUnit4/src/core/GdUnitSettings.gd
@@ -254,7 +254,7 @@ static func save_property(name :String, value) -> void:
 static func save() -> void:
 	var err := ProjectSettings.save()
 	if err != OK:
-		push_error("Save GdUnit3 settings failed : %s" % GdUnitTools.error_as_string(err))
+		push_error("Save GdUnit3 settings failed : %s" % error_string(err))
 		return
 
 

--- a/addons/gdUnit4/src/core/GdUnitSignalCollector.gd
+++ b/addons/gdUnit4/src/core/GdUnitSignalCollector.gd
@@ -1,0 +1,102 @@
+# It connects to all signals of given emitter and collects received signals and arguments
+# The collected signals are cleand finally when the emitter is freed.
+class_name GdUnitSignalCollector
+extends RefCounted
+
+const NO_ARG :Variant = GdUnitConstants.NO_ARG
+const SIGNAL_BLACK_LIST = []#["tree_exiting", "tree_exited", "child_exiting_tree"]
+
+# {
+#	emitter<Object> : {
+#		signal_name<String> : [signal_args<Array>],
+#		...
+#	}
+# }
+var _collected_signals :Dictionary = {}
+
+
+func clear() -> void:
+	for emitter in _collected_signals.keys():
+		if is_instance_valid(emitter):
+			unregister_emitter(emitter)
+
+
+# connect to all possible signals defined by the emitter
+# prepares the signal collection to store received signals and arguments
+func register_emitter(emitter :Object):
+	if is_instance_valid(emitter):
+		# check emitter is already registerd
+		if _collected_signals.has(emitter):
+			return
+		_collected_signals[emitter] = Dictionary()
+		# connect to 'tree_exiting' of the emitter to finally release all acquired resources/connections.
+		if emitter is Node and !emitter.tree_exiting.is_connected(unregister_emitter):
+			emitter.tree_exiting.connect(unregister_emitter.bind(emitter))
+		# connect to all signals of the emitter we want to collect
+		for signal_def in emitter.get_signal_list():
+			var signal_name = signal_def["name"]
+			# set inital collected to empty
+			if not is_signal_collecting(emitter, signal_name):
+				_collected_signals[emitter][signal_name] = Array()
+			if SIGNAL_BLACK_LIST.find(signal_name) != -1:
+				continue
+			if !emitter.is_connected(signal_name, _on_signal_emmited):
+				var err := emitter.connect(signal_name, _on_signal_emmited.bind(emitter, signal_name))
+				if err != OK:
+					push_error("Can't connect to signal %s on %s. Error: %s" % [signal_name, emitter, error_string(err)])
+
+
+# unregister all acquired resources/connections, otherwise it ends up in orphans
+# is called when the emitter is removed from the parent
+func unregister_emitter(emitter :Object):
+	if is_instance_valid(emitter):
+		for signal_def in emitter.get_signal_list():
+			var signal_name = signal_def["name"]
+			if emitter.is_connected(signal_name, _on_signal_emmited):
+				emitter.disconnect(signal_name, _on_signal_emmited.bind(emitter, signal_name))
+		_collected_signals.erase(emitter)
+
+
+# receives the signal from the emitter with all emitted signal arguments and additional the emitter and signal_name as last two arguements
+func _on_signal_emmited( arg0=NO_ARG, arg1=NO_ARG, arg2=NO_ARG, arg3=NO_ARG, arg4=NO_ARG, arg5=NO_ARG, arg6=NO_ARG, arg7=NO_ARG, arg8=NO_ARG, arg9=NO_ARG, arg10=NO_ARG, arg11=NO_ARG):
+	var signal_args = GdArrayTools.filter_value([arg0,arg1,arg2,arg3,arg4,arg5,arg6,arg7,arg8,arg9,arg10,arg11], NO_ARG)
+	# extract the emitter and signal_name from the last two arguments (see line 61 where is added)
+	var signal_name :String = signal_args.pop_back()
+	var emitter :Object = signal_args.pop_back()
+	# prints("_on_signal_emmited:", emitter, signal_name, signal_args)
+	if is_signal_collecting(emitter, signal_name):
+		_collected_signals[emitter][signal_name].append(signal_args)
+
+
+func reset_received_signals(emitter :Object):
+	# _debug_signal_list("before claer");
+	if _collected_signals.has(emitter):
+		for signal_name in _collected_signals[emitter]:
+			_collected_signals[emitter][signal_name].clear()
+	# _debug_signal_list("after claer");
+
+
+func is_signal_collecting(emitter :Object, signal_name :String) -> bool:
+	return _collected_signals.has(emitter) and _collected_signals[emitter].has(signal_name)
+
+
+func match(emitter :Object, signal_name :String, args :Array) -> bool:
+	#prints("match", signal_name,  _collected_signals[emitter][signal_name]);
+	if _collected_signals.is_empty() or not _collected_signals.has(emitter):
+		return false
+	for received_args in _collected_signals[emitter][signal_name]:
+		# prints("testing", signal_name, received_args, "vs", args)
+		if GdObjects.equals(received_args, args):
+			return true
+	return false
+
+
+func _debug_signal_list(message :String):
+	prints("-----", message, "-------")
+	prints("senders {")
+	for emitter in _collected_signals:
+		prints("\t", emitter)
+		for signal_name in _collected_signals[emitter]:
+			var args = _collected_signals[emitter][signal_name]
+			prints("\t\t", signal_name, args)
+	prints("}")

--- a/addons/gdUnit4/src/core/GdUnitSingleton.gd
+++ b/addons/gdUnit4/src/core/GdUnitSingleton.gd
@@ -8,6 +8,7 @@ class_name GdUnitSingleton
 extends RefCounted
 
 
+const GdUnitTools := preload("res://addons/gdUnit4/src/core/GdUnitTools.gd")
 const MEATA_KEY := "GdUnitSingletons"
 
 

--- a/addons/gdUnit4/src/core/GdUnitTestSuiteScanner.gd
+++ b/addons/gdUnit4/src/core/GdUnitTestSuiteScanner.gd
@@ -49,9 +49,12 @@ func _scan_test_suites(dir :DirAccess, collected_suites :Array[Node]) -> Array[N
 			if sub_dir != null:
 				_scan_test_suites(sub_dir, collected_suites)
 		else:
+			var time = LocalTime.now()
 			var test_suite := _parse_is_test_suite(resource_path)
 			if test_suite:
 				collected_suites.append(test_suite)
+			if time.elapsed_since_ms() > 300:
+				push_warning("Scanning of test-suite '%s' took more than 300ms: " % resource_path, time.elapsed_since())
 		file_name = dir.get_next()
 	return collected_suites
 

--- a/addons/gdUnit4/src/core/GdUnitTools.gd
+++ b/addons/gdUnit4/src/core/GdUnitTools.gd
@@ -1,4 +1,3 @@
-class_name GdUnitTools
 extends RefCounted
 
 const GDUNIT_TEMP := "user://tmp"
@@ -9,15 +8,18 @@ static func temp_dir() -> String:
 		DirAccess.make_dir_recursive_absolute(GDUNIT_TEMP)
 	return GDUNIT_TEMP
 
+
 static func create_temp_dir(folder_name :String) -> String:
 	var new_folder = temp_dir() + "/" + folder_name
 	if not DirAccess.dir_exists_absolute(new_folder):
 		DirAccess.make_dir_recursive_absolute(new_folder)
 	return new_folder
 
+
 static func clear_tmp():
 	delete_directory(GDUNIT_TEMP)
-	
+
+
 # Creates a new file under 
 static func create_temp_file(relative_path :String, file_name :String, mode := FileAccess.WRITE) -> FileAccess:
 	var file_path := create_temp_dir(relative_path) + "/" + file_name
@@ -26,8 +28,10 @@ static func create_temp_file(relative_path :String, file_name :String, mode := F
 		push_error("Error creating temporary file at: %s, %s" % [file_path, error_as_string(FileAccess.get_open_error())])
 	return file
 
+
 static func current_dir() -> String:
 	return ProjectSettings.globalize_path("res://")
+
 
 static func delete_directory(path :String, only_content := false) -> void:
 	var dir := DirAccess.open(path)
@@ -102,6 +106,7 @@ static func copy_directory(from_dir :String, to_dir :String, recursive :bool = f
 		push_error("Directory not found: " + from_dir)
 		return false
 
+
 # scans given path for sub directories by given prefix and returns the highest index numer
 # e.g. <prefix_%d>
 static func find_last_path_index(path :String, prefix :String) -> int:
@@ -120,6 +125,7 @@ static func find_last_path_index(path :String, prefix :String) -> int:
 			if iteration > last_iteration:
 				last_iteration = iteration
 	return last_iteration
+
 
 static func delete_path_index_lower_equals_than(path :String, prefix :String, index :int) -> int:
 	var dir := DirAccess.open(path)
@@ -154,6 +160,7 @@ static func scan_dir(path :String) -> PackedStringArray:
 		content.append(next)
 	return content
 
+
 static func resource_as_array(resource_path :String) -> PackedStringArray:
 	var file := FileAccess.open(resource_path, FileAccess.READ)
 	if file == null:
@@ -163,6 +170,7 @@ static func resource_as_array(resource_path :String) -> PackedStringArray:
 	while not file.eof_reached():
 		file_content.append(file.get_line())
 	return file_content
+
 
 static func resource_as_string(resource_path :String) -> String:
 	var file := FileAccess.open(resource_path, FileAccess.READ)
@@ -178,20 +186,15 @@ static func normalize_text(text :String) -> String:
 
 static func richtext_normalize(input :String) -> String:
 	return GdUnitSingleton.instance("regex_richtext", func _regex_richtext() -> RegEx:
-		return GdUnitTools.to_regex("\\[/?(b|color|bgcolor|right|table|cell).*?\\]") ).sub(input, "", true)
-
-
-static func max_length(left, right) -> int:
-	var ls = str(left).length()
-	var rs = str(right).length()
-	return rs if ls < rs else ls
+		return to_regex("\\[/?(b|color|bgcolor|right|table|cell).*?\\]") )\
+	.sub(input, "", true).replace("\r", "")
 
 
 static func to_regex(pattern :String) -> RegEx:
 	var regex := RegEx.new()
 	var err := regex.compile(pattern)
 	if err != OK:
-		push_error("Can't compiling regx '%s'.\n ERROR: %s" % [pattern, GdUnitTools.error_as_string(err)])
+		push_error("Can't compiling regx '%s'.\n ERROR: %s" % [pattern, error_string(err)])
 	return regex
 
 
@@ -281,26 +284,20 @@ static func make_qualified_path(path :String) -> String:
 			return "res:/" + path
 	return path
 
+
 static func error_as_string(error_number :int) -> String:
 	return error_string(error_number)
-	
+
+
 static func clear_push_errors() -> void:
 	var runner = Engine.get_meta("GdUnitRunner")
 	if runner != null:
 		runner.clear_push_errors()
 
+
 static func register_expect_interupted_by_timeout(test_suite :Node, test_case_name :String) -> void:
 	var test_case = test_suite.find_child(test_case_name, false, false)
 	test_case.expect_to_interupt()
-
-static func append_array(array, append :Array) -> void:
-	var major :int = Engine.get_version_info()["major"]
-	var minor :int = Engine.get_version_info()["minor"]
-	if major >= 3 and minor >= 3:
-		array.append_array(append)
-	else:
-		for element in append:
-			array.append(element)
 
 
 static func extract_zip(zip_package :String, dest_path :String) -> Result:

--- a/addons/gdUnit4/src/core/command/GdUnitCommandHandler.gd
+++ b/addons/gdUnit4/src/core/command/GdUnitCommandHandler.gd
@@ -5,6 +5,8 @@ signal gdunit_runner_start()
 signal gdunit_runner_stop(client_id :int)
 
 
+const GdUnitTools := preload("res://addons/gdUnit4/src/core/GdUnitTools.gd")
+
 const CMD_RUN_OVERALL = "Debug Overall TestSuites"
 const CMD_RUN_TESTCASE = "Run TestCases"
 const CMD_RUN_TESTCASE_DEBUG = "Run TestCases (Debug)"

--- a/addons/gdUnit4/src/core/parse/GdScriptParser.gd
+++ b/addons/gdUnit4/src/core/parse/GdScriptParser.gd
@@ -1,6 +1,7 @@
 class_name GdScriptParser
 extends RefCounted
 
+const GdUnitTools := preload("res://addons/gdUnit4/src/core/GdUnitTools.gd")
 
 const ALLOWED_CHARACTERS := "0123456789_abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ\""
 

--- a/addons/gdUnit4/src/core/parse/GdUnitExpressionRunner.gd
+++ b/addons/gdUnit4/src/core/parse/GdUnitExpressionRunner.gd
@@ -16,7 +16,7 @@ func execute(src_script :GDScript, expression :String) -> Variant:
 		.replace("${clazz_path}", resource_path)\
 		.replace("$expression", expression)
 	script.reload(false)
-	var runner := script.new()
+	var runner :Variant = script.new()
 	if runner.has_method("queue_free"):
 		runner.queue_free()
 	return runner.__run_expression()

--- a/addons/gdUnit4/src/core/report/GdUnitReportCollector.gd
+++ b/addons/gdUnit4/src/core/report/GdUnitReportCollector.gd
@@ -52,7 +52,7 @@ func get_reports(execution_states :int) -> Array[GdUnitReport]:
 	var reports :Array[GdUnitReport] = []
 	for state in ALL_REPORT_STATES:
 		if execution_states&state == state:
-			GdUnitTools.append_array(reports, get_reports_by_state(state))
+			reports.append_array(get_reports_by_state(state))
 	return reports
 
 

--- a/addons/gdUnit4/src/core/thread/GdUnitThreadContext.gd
+++ b/addons/gdUnit4/src/core/thread/GdUnitThreadContext.gd
@@ -1,15 +1,14 @@
 class_name GdUnitThreadContext
 extends RefCounted
 
-
 var _thread :Thread
 var _assert :GdUnitAssert
-var _signal_collector :GdUnitSignalAssertImpl.SignalCollector
+var _signal_collector :GdUnitSignalCollector
 
 
 func _init(thread :Thread = null):
 	_thread = thread
-	_signal_collector = GdUnitSignalAssertImpl.SignalCollector.new()
+	_signal_collector = GdUnitSignalCollector.new()
 
 
 func init() -> void:
@@ -31,7 +30,7 @@ func get_assert() -> GdUnitAssert:
 	return _assert
 
 
-func get_signal_collector() -> GdUnitSignalAssertImpl.SignalCollector:
+func get_signal_collector() -> GdUnitSignalCollector:
 	return _signal_collector
 
 

--- a/addons/gdUnit4/src/extractors/GdUnitFuncValueExtractor.gd
+++ b/addons/gdUnit4/src/extractors/GdUnitFuncValueExtractor.gd
@@ -1,5 +1,4 @@
 # This class defines a value extractor by given function name and args
-class_name GdUnitFuncValueExtractor
 extends GdUnitValueExtractor
 
 var _func_names :Array

--- a/addons/gdUnit4/src/mocking/GdUnitMockBuilder.gd
+++ b/addons/gdUnit4/src/mocking/GdUnitMockBuilder.gd
@@ -1,9 +1,13 @@
 class_name GdUnitMockBuilder
 extends GdUnitClassDoubler
 
+const GdUnitTools := preload("res://addons/gdUnit4/src/core/GdUnitTools.gd")
+const GdUnitMemoryPool = preload("res://addons/gdUnit4/src/core/GdUnitMemoryPool.gd")
+
 
 # holds mocker runtime configuration
 const KEY_REPORT_PUSH_ERRORS = "report_push_errors"
+
 
 # only for testing
 static func do_push_errors(enabled :bool) -> void:

--- a/addons/gdUnit4/src/monitor/ErrorLogEntry.gd
+++ b/addons/gdUnit4/src/monitor/ErrorLogEntry.gd
@@ -1,11 +1,15 @@
 extends RefCounted
 class_name ErrorLogEntry
 
+
 enum TYPE {
 	SCRIPT_ERROR,
 	PUSH_ERROR,
 	PUSH_WARNING
 }
+
+
+const GdUnitTools := preload("res://addons/gdUnit4/src/core/GdUnitTools.gd")
 
 const PATTERN_SCRIPT_ERROR := "USER SCRIPT ERROR:"
 const PATTERN_PUSH_ERROR := "USER ERROR:"

--- a/addons/gdUnit4/src/mono/GdUnit3MonoAPI.gd
+++ b/addons/gdUnit4/src/mono/GdUnit3MonoAPI.gd
@@ -1,6 +1,9 @@
 extends RefCounted
 class_name GdUnit3MonoAPI
 
+const GdUnitTools := preload("res://addons/gdUnit4/src/core/GdUnitTools.gd")
+
+
 static func instance() :
 	return null#GdUnitSingleton.get_or_create_singleton("GdUnit3MonoAPI", "res://addons/gdUnit4/src/mono/GdUnit3MonoAPI.cs")
 

--- a/addons/gdUnit4/src/report/GdUnitReportSummary.gd
+++ b/addons/gdUnit4/src/report/GdUnitReportSummary.gd
@@ -1,6 +1,8 @@
 class_name GdUnitReportSummary
 extends RefCounted
 
+const GdUnitTools := preload("res://addons/gdUnit4/src/core/GdUnitTools.gd")
+
 const CHARACTERS_TO_ENCODE := {
 	'<' : '&lt;',
 	'>' : '&gt;'

--- a/addons/gdUnit4/src/report/JUnitXmlReport.gd
+++ b/addons/gdUnit4/src/report/JUnitXmlReport.gd
@@ -3,6 +3,8 @@
 class_name JUnitXmlReport
 extends RefCounted
 
+const GdUnitTools := preload("res://addons/gdUnit4/src/core/GdUnitTools.gd")
+
 const ATTR_CLASSNAME := "classname"
 const ATTR_ERRORS := "errors"
 const ATTR_FAILURES := "failures"

--- a/addons/gdUnit4/src/spy/GdUnitSpyBuilder.gd
+++ b/addons/gdUnit4/src/spy/GdUnitSpyBuilder.gd
@@ -5,7 +5,7 @@ const GdUnitTools := preload("res://addons/gdUnit4/src/core/GdUnitTools.gd")
 const GdUnitMemoryPool = preload("res://addons/gdUnit4/src/core/GdUnitMemoryPool.gd")
 
 
-static func build(caller :Object, to_spy, debug_write = false):
+static func build(caller :Object, to_spy, debug_write = false) -> Object:
 	var memory_pool :GdUnitMemoryPool.POOL = caller.get_meta(GdUnitMemoryPool.META_PARAM)
 	if GdObjects.is_singleton(to_spy):
 		push_error("Spy on a Singleton is not allowed! '%s'" % to_spy.get_class())

--- a/addons/gdUnit4/src/spy/GdUnitSpyBuilder.gd
+++ b/addons/gdUnit4/src/spy/GdUnitSpyBuilder.gd
@@ -1,6 +1,9 @@
 class_name GdUnitSpyBuilder
 extends GdUnitClassDoubler
 
+const GdUnitTools := preload("res://addons/gdUnit4/src/core/GdUnitTools.gd")
+const GdUnitMemoryPool = preload("res://addons/gdUnit4/src/core/GdUnitMemoryPool.gd")
+
 
 static func build(caller :Object, to_spy, debug_write = false):
 	var memory_pool :GdUnitMemoryPool.POOL = caller.get_meta(GdUnitMemoryPool.META_PARAM)

--- a/addons/gdUnit4/src/ui/settings/GdUnitSettingsDialog.gd
+++ b/addons/gdUnit4/src/ui/settings/GdUnitSettingsDialog.gd
@@ -2,6 +2,8 @@
 extends Window
 
 const EAXAMPLE_URL := "https://github.com/MikeSchulze/gdUnit4-examples/archive/refs/heads/master.zip"
+
+const GdUnitTools := preload("res://addons/gdUnit4/src/core/GdUnitTools.gd")
 const GdUnitUpdateClient = preload("res://addons/gdUnit4/src/update/GdUnitUpdateClient.gd")
 
 @onready var _update_client :GdUnitUpdateClient = $GdUnitUpdateClient

--- a/addons/gdUnit4/src/update/GdUnitUpdate.gd
+++ b/addons/gdUnit4/src/update/GdUnitUpdate.gd
@@ -1,7 +1,9 @@
 @tool
 extends ConfirmationDialog
 
-const GdUnitUpdateClient = preload("res://addons/gdUnit4/src/update/GdUnitUpdateClient.gd")
+const GdUnitTools := preload("res://addons/gdUnit4/src/core/GdUnitTools.gd")
+const GdUnitUpdateClient := preload("res://addons/gdUnit4/src/update/GdUnitUpdateClient.gd")
+
 const spinner_icon := "res://addons/gdUnit4/src/ui/assets/spinner.tres"
 
 
@@ -219,7 +221,7 @@ func download_release() -> void:
 	_update_client.queue_free()
 	if response.code() != 200:
 		push_warning("Update information cannot be retrieved from GitHub! \n Error code: %d : %s" % [response.code(), response.response()])
-		await message_h4("Update failed! Try it later again.", Color.RED)
+		message_h4("Update failed! Try it later again.", Color.RED)
 		await get_tree().create_timer(3).timeout
 		return
 

--- a/addons/gdUnit4/test/GdUnitAwaiterTest.gd
+++ b/addons/gdUnit4/test/GdUnitAwaiterTest.gd
@@ -19,6 +19,17 @@ func after_test():
 			node.stop()
 			node.free()
 
+
+## Utility to check if a test has failed in a particular line and if there is an error message
+func assert_failed_at(line_number :int, expected_failure :String) -> bool:
+	var is_failed = is_failure()
+	var last_failure = GdAssertReports.current_failure()
+	var last_failure_line = GdAssertReports.get_last_error_line_number()
+	assert_str(last_failure).is_equal(expected_failure)
+	assert_int(last_failure_line).is_equal(line_number)
+	return is_failed
+
+
 func install_signal_emitter(signal_name :String, signal_args: Array = [], time_out : float = 0.020):
 	var timer := Timer.new()
 	add_child(timer)

--- a/addons/gdUnit4/test/GdUnitScanTestSuitePerformanceTest.gd
+++ b/addons/gdUnit4/test/GdUnitScanTestSuitePerformanceTest.gd
@@ -6,8 +6,8 @@ func test_load_performance() -> void:
 	prints("Scan for test suites.")
 	var test_suites := GdUnitTestSuiteScanner.new().scan("res://addons/gdUnit4/test/")
 	assert_int(time.elapsed_since_ms())\
-		.override_failure_message("Expecting the loading time overall is less than 15s")\
-		.is_less(15*1000)
+		.override_failure_message("Expecting the loading time overall is less than 10s")\
+		.is_less(10*1000)
 	prints("Scanning of %d test suites took" % test_suites.size(), time.elapsed_since())
 	for ts in test_suites:
 		ts.free()

--- a/addons/gdUnit4/test/GdUnitScanTestSuitePerformanceTest.gd
+++ b/addons/gdUnit4/test/GdUnitScanTestSuitePerformanceTest.gd
@@ -1,0 +1,13 @@
+extends GdUnitTestSuite
+
+
+func test_load_performance() -> void:
+	var time = LocalTime.now()
+	prints("Scan for test suites.")
+	var test_suites := GdUnitTestSuiteScanner.new().scan("res://addons/gdUnit4/test/")
+	assert_int(time.elapsed_since_ms())\
+		.override_failure_message("Expecting the loading time overall is less than 15s")\
+		.is_less(15*1000)
+	prints("Scanning of %d test suites took" % test_suites.size(), time.elapsed_since())
+	for ts in test_suites:
+		ts.free()

--- a/addons/gdUnit4/test/GdUnitTestResourceLoader.gd
+++ b/addons/gdUnit4/test/GdUnitTestResourceLoader.gd
@@ -1,6 +1,8 @@
 class_name GdUnitTestResourceLoader
 extends RefCounted
 
+const GdUnitTools := preload("res://addons/gdUnit4/src/core/GdUnitTools.gd")
+
 enum {
 	GD_SUITE,
 	CS_SUITE

--- a/addons/gdUnit4/test/GdUnitTestSuitePerformanceTest.gd
+++ b/addons/gdUnit4/test/GdUnitTestSuitePerformanceTest.gd
@@ -3,11 +3,11 @@ extends GdUnitTestSuite
 
 func test_testsuite_loading_performance():
 	var time := LocalTime.now()
-	var reload_counter := 50
+	var reload_counter := 100
 	for i in range(1, reload_counter):
 		ResourceLoader.load("res://addons/gdUnit4/src/GdUnitTestSuite.gd", "GDScript", ResourceLoader.CACHE_MODE_IGNORE)
-	var error_message := "Expecting the loading time of test-suite is less than 100ms\n But was %s" % (time.elapsed_since_ms() / reload_counter)
+	var error_message := "Expecting the loading time of test-suite is less than 50ms\n But was %s" % (time.elapsed_since_ms() / reload_counter)
 	assert_int(time.elapsed_since_ms()/ reload_counter)\
 		.override_failure_message(error_message)\
-		.is_less(100)
+		.is_less(50)
 	prints("loading takes %d ms" % (time.elapsed_since_ms() / reload_counter))

--- a/addons/gdUnit4/test/GdUnitTestSuitePerformanceTest.gd
+++ b/addons/gdUnit4/test/GdUnitTestSuitePerformanceTest.gd
@@ -1,0 +1,13 @@
+extends GdUnitTestSuite
+
+
+func test_testsuite_loading_performance():
+	var time := LocalTime.now()
+	var reload_counter := 50
+	for i in range(1, reload_counter):
+		ResourceLoader.load("res://addons/gdUnit4/src/GdUnitTestSuite.gd", "GDScript", ResourceLoader.CACHE_MODE_IGNORE)
+	var error_message := "Expecting the loading time of test-suite is less than 100ms\n But was %s" % (time.elapsed_since_ms() / reload_counter)
+	assert_int(time.elapsed_since_ms()/ reload_counter)\
+		.override_failure_message(error_message)\
+		.is_less(100)
+	prints("loading takes %d ms" % (time.elapsed_since_ms() / reload_counter))

--- a/addons/gdUnit4/test/GdUnitTestSuiteTest.gd
+++ b/addons/gdUnit4/test/GdUnitTestSuiteTest.gd
@@ -4,6 +4,7 @@ extends GdUnitTestSuite
 
 # TestSuite generated from
 const __source = 'res://addons/gdUnit4/src/GdUnitTestSuite.gd'
+const GdUnitAssertImpl = preload("res://addons/gdUnit4/src/asserts/GdUnitAssertImpl.gd")
 
 var _events :Array[GdUnitEvent] = []
 

--- a/addons/gdUnit4/test/asserts/GdUnitArrayAssertImplTest.gd
+++ b/addons/gdUnit4/test/asserts/GdUnitArrayAssertImplTest.gd
@@ -5,7 +5,6 @@ extends GdUnitTestSuite
 const __source = 'res://addons/gdUnit4/src/asserts/GdUnitArrayAssertImpl.gd'
 
 
-
 func test_is_null() -> void:
 	assert_array(null).is_null()
 	
@@ -371,7 +370,7 @@ func test_contains_exactly_in_any_order():
 func test_contains_same():
 	var valueA := TestObj.new("A", 0)
 	var valueB := TestObj.new("B", 0)
-	var valueC := TestObj.new("C", 0)
+	
 	assert_array([valueA, valueB]).contains_same([valueA])
 	
 	assert_failure(func(): assert_array([valueA, valueB]).contains_same([TestObj.new("A", 0)])) \

--- a/addons/gdUnit4/test/asserts/GdUnitAssertImplTest.gd
+++ b/addons/gdUnit4/test/asserts/GdUnitAssertImplTest.gd
@@ -6,7 +6,7 @@ extends GdUnitTestSuite
 const __source = 'res://addons/gdUnit4/src/asserts/GdUnitAssertImpl.gd'
 
 func before():
-	assert_int(GdUnitAssertImpl._get_line_number()).is_equal(9)
+	assert_int(GdUnitAssert._get_line_number()).is_equal(9)
 	assert_failure(func(): assert_int(10).is_equal(42)) \
 		.is_failed() \
 		.has_line(10) \

--- a/addons/gdUnit4/test/asserts/GdUnitFailureAssertImplTest.gd
+++ b/addons/gdUnit4/test/asserts/GdUnitFailureAssertImplTest.gd
@@ -52,28 +52,28 @@ func test_assert_failure_on_assert(test_name :String, assert_type, value, test_p
 ]) -> void:
 	var  instance := assert_failure(func(): assert_that(value))
 	assert_object(last_assert()).is_instanceof(assert_type)
-	assert_object(instance).is_instanceof(GdUnitFailureAssertImpl)
+	assert_object(instance).is_instanceof(GdUnitFailureAssert)
 
 
 func test_assert_failure_on_assert_file() -> void:
 	var  instance := assert_failure(func(): assert_file("res://foo.gd"))
 	assert_object(last_assert()).is_instanceof(GdUnitFileAssert)
-	assert_object(instance).is_instanceof(GdUnitFailureAssertImpl)
+	assert_object(instance).is_instanceof(GdUnitFailureAssert)
 
 
 func test_assert_failure_on_assert_func() -> void:
 	var  instance := assert_failure(func(): assert_func(RefCounted.new(), "_to_string"))
 	assert_object(last_assert()).is_instanceof(GdUnitFuncAssert)
-	assert_object(instance).is_instanceof(GdUnitFailureAssertImpl)
+	assert_object(instance).is_instanceof(GdUnitFailureAssert)
 
 
 func test_assert_failure_on_assert_signal() -> void:
 	var  instance := assert_failure(func(): assert_signal(null))
 	assert_object(last_assert()).is_instanceof(GdUnitSignalAssert)
-	assert_object(instance).is_instanceof(GdUnitFailureAssertImpl)
+	assert_object(instance).is_instanceof(GdUnitFailureAssert)
 
 
 func test_assert_failure_on_assert_result() -> void:
 	var  instance := assert_failure(func(): assert_result(null))
 	assert_object(last_assert()).is_instanceof(GdUnitResultAssert)
-	assert_object(instance).is_instanceof(GdUnitFailureAssertImpl)
+	assert_object(instance).is_instanceof(GdUnitFailureAssert)

--- a/addons/gdUnit4/test/asserts/GdUnitFuncAssertImplTest.gd
+++ b/addons/gdUnit4/test/asserts/GdUnitFuncAssertImplTest.gd
@@ -6,6 +6,7 @@ extends GdUnitTestSuite
 
 # TestSuite generated from
 const __source = 'res://addons/gdUnit4/src/asserts/GdUnitFuncAssertImpl.gd'
+const GdUnitTools = preload("res://addons/gdUnit4/src/core/GdUnitTools.gd")
 
 
 # we need to skip await fail test because of an bug in Godot 4.0 stable
@@ -19,8 +20,8 @@ func verify_failed(cb :Callable) -> GdUnitStringAssert:
 	await cb.call()
 	GdAssertReports.expect_fail(false)
 	
-	var a :GdUnitFuncAssertImpl = GdUnitThreadManager.get_current_context().get_assert()
-	return assert_str( GdUnitAssertImpl._normalize_bbcode(a._failure_message()))
+	var a :GdUnitFuncAssert = GdUnitThreadManager.get_current_context().get_assert()
+	return assert_str(GdUnitTools.richtext_normalize(a._failure_message()))
 
 
 class TestValueProvider:

--- a/addons/gdUnit4/test/asserts/GdUnitPackedArrayAssertTest.gd
+++ b/addons/gdUnit4/test/asserts/GdUnitPackedArrayAssertTest.gd
@@ -157,6 +157,7 @@ func test_is_not_empty(_test :String, array, test_parameters = [
 		.has_message("Expecting:\n must not be empty")
 
 
+@warning_ignore("unused_parameter")
 func test_is_same(value, test_parameters = [
 	[[0]],
 	[PackedByteArray([0])],

--- a/addons/gdUnit4/test/asserts/GdUnitPackedArrayAssertTest.gd
+++ b/addons/gdUnit4/test/asserts/GdUnitPackedArrayAssertTest.gd
@@ -6,6 +6,23 @@ const __source = 'res://addons/gdUnit4/src/asserts/GdUnitArrayAssertImpl.gd'
 
 
 @warning_ignore("unused_parameter")
+func test_is_array_assert(_test :String, array, test_parameters = [
+	["Array", Array()],
+	["PackedByteArray", PackedByteArray()],
+	["PackedInt32Array", PackedInt32Array()],
+	["PackedInt64Array", PackedInt64Array()],
+	["PackedFloat32Array", PackedFloat32Array()],
+	["PackedFloat64Array", PackedFloat64Array()],
+	["PackedStringArray", PackedStringArray()],
+	["PackedVector2Array", PackedVector2Array()],
+	["PackedVector3Array", PackedVector3Array()],
+	["PackedColorArray", PackedColorArray()] ]
+	) -> void:
+	var assert_ = assert_that(array)
+	assert_object(assert_).is_instanceof(GdUnitArrayAssert)
+
+
+@warning_ignore("unused_parameter")
 func test_is_null(_test :String, value, test_parameters = [
 	["Array", Array()],
 	["PackedByteArray", PackedByteArray()],
@@ -37,7 +54,7 @@ func test_is_not_null(_test :String, array, test_parameters = [
 	["PackedVector3Array", PackedVector3Array()],
 	["PackedColorArray", PackedColorArray()] ]
 	) -> void:
-	assert_array(PackedByteArray()).is_not_null()
+	assert_array(array).is_not_null()
 	
 	assert_failure(func(): assert_array(null).is_not_null()) \
 		.is_failed() \

--- a/addons/gdUnit4/test/asserts/GdUnitSignalAssertImplTest.gd
+++ b/addons/gdUnit4/test/asserts/GdUnitSignalAssertImplTest.gd
@@ -6,6 +6,7 @@ extends GdUnitTestSuite
 
 # TestSuite generated from
 const __source = 'res://addons/gdUnit4/src/asserts/GdUnitSignalAssertImpl.gd'
+const GdUnitTools = preload("res://addons/gdUnit4/src/core/GdUnitTools.gd")
 
 
 class TestEmitter extends Node:
@@ -47,8 +48,8 @@ func verify_failed(cb :Callable) -> GdUnitStringAssert:
 	await cb.call()
 	GdAssertReports.expect_fail(false)
 	
-	var a :GdUnitSignalAssertImpl = GdUnitThreadManager.get_current_context().get_assert()
-	return assert_str( GdUnitAssertImpl._normalize_bbcode(a._failure_message()))
+	var a :GdUnitSignalAssert = GdUnitThreadManager.get_current_context().get_assert()
+	return assert_str(GdUnitTools.richtext_normalize(a._failure_message()))
 
 
 func test_invalid_arg() -> void:

--- a/addons/gdUnit4/test/asserts/GdUnitVectorAssertImplTest.gd
+++ b/addons/gdUnit4/test/asserts/GdUnitVectorAssertImplTest.gd
@@ -19,12 +19,14 @@ var _test_seta =[
 ]
 
 
+@warning_ignore("unused_parameter")
 func test_supported_types(value, test_parameters = _test_seta):
 	assert_object(assert_vector(value))\
 		.is_not_null()\
 		.is_instanceof(GdUnitVectorAssert)
 
 
+@warning_ignore("unused_parameter")
 func test_unsupported_types(value, details :String, test_parameters =[
 	[true, 'bool'],
 	[42, 'int'],
@@ -36,6 +38,7 @@ func test_unsupported_types(value, details :String, test_parameters =[
 		.has_message("GdUnitVectorAssert error, the type <%s> is not supported." % details)
 
 
+@warning_ignore("unused_parameter")
 func test_is_null(value, test_parameters = _test_seta):
 	if value == null:
 		assert_vector(null).is_null()
@@ -45,6 +48,7 @@ func test_is_null(value, test_parameters = _test_seta):
 			.starts_with_message("Expecting: '<null>' but was '%s'" % value)
 
 
+@warning_ignore("unused_parameter")
 func test_is_not_null(value, test_parameters = _test_seta):
 	if value == null:
 		assert_failure(func(): assert_vector(null).is_not_null()) \
@@ -54,6 +58,7 @@ func test_is_not_null(value, test_parameters = _test_seta):
 		assert_vector(value).is_not_null()
 
 
+@warning_ignore("unused_parameter")
 func test_is_equal() -> void:
 	assert_vector(Vector2.ONE).is_equal(Vector2.ONE)
 	assert_vector(Vector2.LEFT).is_equal(Vector2.LEFT)
@@ -73,6 +78,7 @@ func test_is_equal() -> void:
 		.has_message("Unexpected type comparison:\n Expecting type 'Vector2' but is 'Vector3'")
 
 
+@warning_ignore("unused_parameter")
 func test_is_equal_over_all_types(value, test_parameters = _test_seta) -> void:
 	assert_vector(value).is_equal(value)
 
@@ -91,6 +97,7 @@ func test_is_not_equal() -> void:
 		.has_message("Unexpected type comparison:\n Expecting type 'Vector2' but is 'Vector3'")
 
 
+@warning_ignore("unused_parameter")
 func test_is_not_equal_over_all_types(value, test_parameters = _test_seta) -> void:
 	var expected = Vector2.LEFT if value == null else value * 2
 	assert_vector(value).is_not_equal(expected)
@@ -132,6 +139,8 @@ func test_is_equal_approx() -> void:
 			.dedent().trim_prefix("\n")
 		)
 
+
+@warning_ignore("unused_parameter")
 func test_is_equal_approx_over_all_types(value, expected, approx, test_parameters = [
 	[Vector2(0.996, 1.004), Vector2.ONE, Vector2(0.004, 0.004)],
 	[Vector2i(9, 11), Vector2i(10, 10), Vector2i(1, 1)],
@@ -161,6 +170,7 @@ func test_is_less() -> void:
 		.has_message("Unexpected type comparison:\n Expecting type 'Vector2' but is 'Vector3'")
 
 
+@warning_ignore("unused_parameter")
 func test_is_less_over_all_types(value, expected, test_parameters = [
 	[Vector2(1.0, 1.0), Vector2(1.0001, 1.0001)],
 	[Vector2i(1, 1), Vector2i(2, 1)],
@@ -191,6 +201,7 @@ func test_is_less_equal() -> void:
 		.has_message("Unexpected type comparison:\n Expecting type 'Vector2' but is 'Vector3'")
 
 
+@warning_ignore("unused_parameter")
 func test_is_less_equal_over_all_types(value, expected, test_parameters = [
 	[Vector2(1.0, 1.0), Vector2(1.0001, 1.0001)],
 	[Vector2(1.0, 1.0), Vector2(1.0, 1.0)],
@@ -226,6 +237,7 @@ func test_is_greater() -> void:
 		.has_message("Unexpected type comparison:\n Expecting type 'Vector2' but is 'Vector3'")
 
 
+@warning_ignore("unused_parameter")
 func test_is_greater_over_all_types(value, expected, test_parameters = [
 	[Vector2(1.0001, 1.0001), Vector2(1.0, 1.0)],
 	[Vector2i(2, 1), Vector2i(1, 1)],
@@ -257,6 +269,7 @@ func test_is_greater_equal() -> void:
 		.has_message("Unexpected type comparison:\n Expecting type 'Vector2' but is 'Vector3'")
 
 
+@warning_ignore("unused_parameter")
 func test_is_greater_equal_over_all_types(value, expected, test_parameters = [
 	[Vector2(1.0001, 1.0001), Vector2(1.0, 1.0)],
 	[Vector2(1.0, 1.0), Vector2(1.0, 1.0)],
@@ -289,6 +302,7 @@ func test_is_between(fuzzer = Fuzzers.rangev2(Vector2.ZERO, Vector2.ONE)):
 		.has_message("Unexpected type comparison:\n Expecting type 'Vector2' but is 'Vector3'")
 
 
+@warning_ignore("unused_parameter")
 func test_is_between_over_all_types(value, from, to, test_parameters = [
 	[Vector2(1.2, 1.2), Vector2(1.0, 1.0), Vector2(1.2, 1.2)],
 	[Vector2i(1, 1), Vector2i(1, 1), Vector2i(2, 2)],
@@ -313,6 +327,7 @@ func test_is_not_between(fuzzer = Fuzzers.rangev2(Vector2.ONE, Vector2.ONE*2)):
 		.has_message("Unexpected type comparison:\n Expecting type 'Vector2' but is 'Vector3'")
 
 
+@warning_ignore("unused_parameter")
 func test_is_not_between_over_all_types(value, from, to, test_parameters = [
 	[Vector2(3.2, 1.2), Vector2(1.0, 1.0), Vector2(1.2, 1.2)],
 	[Vector2i(3, 1), Vector2i(1, 1), Vector2i(2, 2)],

--- a/addons/gdUnit4/test/core/GdArrayToolsTest.gd
+++ b/addons/gdUnit4/test/core/GdArrayToolsTest.gd
@@ -48,6 +48,7 @@ func test_as_string_simple_format():
 	assert_that(GdArrayTools.as_string(value, false)).is_equal('[a, b]')
 
 
+@warning_ignore("unused_parameter")
 func test_is_array_type(_test :String, value, expected :bool, test_parameters = [
 	['bool', true, false],
 	['int', 42, false],
@@ -95,6 +96,7 @@ func test_is_type_array() -> void:
 			assert_that(GdArrayTools.is_type_array(type)).is_false()
 
 
+@warning_ignore("unused_parameter")
 func test_filter_value(value, expected_type :int, test_parameters = [
 	[[1, 2, 3, 1], TYPE_ARRAY],
 	[Array([1, 2, 3, 1]) as Array[int], TYPE_ARRAY],

--- a/addons/gdUnit4/test/core/GdUnitExecutorTest.gd
+++ b/addons/gdUnit4/test/core/GdUnitExecutorTest.gd
@@ -8,6 +8,7 @@ signal test_execution_completed()
 const __source = 'res://addons/gdUnit4/src/core/GdUnitExecutor.gd'
 
 const GdUnitExecutor = preload("res://addons/gdUnit4/src/core/GdUnitExecutor.gd")
+const GdUnitTools := preload("res://addons/gdUnit4/src/core/GdUnitTools.gd")
 
 const SUCCEEDED = true
 const FAILED = false
@@ -72,7 +73,7 @@ func filter_failures(events :Array) -> Array:
 
 
 func flating_message(message :String) -> String:
-	return GdUnitAssertImpl._normalize_bbcode(message)
+	return GdUnitTools.richtext_normalize(message)
 
 
 func assert_event_reports2(events :Array[GdUnitEvent], reports1 :Array, reports2 :Array) -> void:

--- a/addons/gdUnit4/test/core/GdUnitMemoryPoolTest.gd
+++ b/addons/gdUnit4/test/core/GdUnitMemoryPoolTest.gd
@@ -4,6 +4,8 @@ extends GdUnitTestSuite
 
 # TestSuite generated from
 const __source = 'res://addons/gdUnit4/src/core/GdUnitMemoryPool.gd'
+const GdUnitMemoryPool = preload("res://addons/gdUnit4/src/core/GdUnitMemoryPool.gd")
+
 
 var _pool :GdUnitMemoryPool
 var _source :Object

--- a/addons/gdUnit4/test/core/GdUnitSceneRunnerTest.gd
+++ b/addons/gdUnit4/test/core/GdUnitSceneRunnerTest.gd
@@ -5,7 +5,6 @@ extends GdUnitTestSuite
 # TestSuite generated from
 const __source = 'res://addons/gdUnit4/src/core/GdUnitSceneRunnerImpl.gd'
 
-
 # loads the test runner and register for auto freeing after test 
 func load_test_scene() -> Node:
 	return auto_free(load("res://addons/gdUnit4/test/mocker/resources/scenes/TestScene.tscn").instantiate())
@@ -18,6 +17,17 @@ func before():
 
 func after():
 	Engine.set_max_fps(0)
+
+
+## Utility to check if a test has failed in a particular line and if there is an error message
+func assert_failed_at(line_number :int, expected_failure :String) -> bool:
+	var is_failed = is_failure()
+	var last_failure = GdAssertReports.current_failure()
+	var last_failure_line = GdAssertReports.get_last_error_line_number()
+	assert_str(last_failure).is_equal(expected_failure)
+	assert_int(last_failure_line).is_equal(line_number)
+	GdAssertReports.expect_fail(true)
+	return is_failed
 
 
 func test_get_property() -> void:

--- a/addons/gdUnit4/test/core/GdUnitTestSuiteBuilderTest.gd
+++ b/addons/gdUnit4/test/core/GdUnitTestSuiteBuilderTest.gd
@@ -4,6 +4,9 @@
 class_name GdUnitTestSuiteBuilderTest
 extends GdUnitTestSuite
 
+const GdUnitTools := preload("res://addons/gdUnit4/src/core/GdUnitTools.gd")
+
+
 # TestSuite generated from
 const __source = 'res://addons/gdUnit4/src/core/GdUnitTestSuiteBuilder.gd'
 

--- a/addons/gdUnit4/test/core/GdUnitTestSuiteScannerTest.gd
+++ b/addons/gdUnit4/test/core/GdUnitTestSuiteScannerTest.gd
@@ -9,11 +9,11 @@ const __source = 'res://addons/gdUnit4/src/core/GdUnitTestSuiteScanner.gd'
 
 func before_test():
 	ProjectSettings.set_setting(GdUnitSettings.TEST_SITE_NAMING_CONVENTION, GdUnitSettings.NAMING_CONVENTIONS.AUTO_DETECT)
-	GdUnitTools.clear_tmp()
+	clean_temp_dir()
 
 
 func after():
-	GdUnitTools.clear_tmp()
+	clean_temp_dir()
 
 
 func resolve_path(source_file :String) -> String:
@@ -97,7 +97,7 @@ func test_test_case_exists():
 
 
 func test_create_test_suite_pascal_case_path():
-	var temp_dir := GdUnitTools.create_temp_dir("TestSuiteScannerTest")
+	var temp_dir := create_temp_dir("TestSuiteScannerTest")
 	# checked source with class_name is set
 	var source_path := "res://addons/gdUnit4/test/core/resources/naming_conventions/PascalCaseWithClassName.gd"
 	var suite_path := temp_dir + "/test/MyClassTest1.gd"
@@ -139,7 +139,7 @@ func test_create_test_suite_pascal_case_path():
 
 
 func test_create_test_suite_snake_case_path():
-	var temp_dir := GdUnitTools.create_temp_dir("TestSuiteScannerTest")
+	var temp_dir := create_temp_dir("TestSuiteScannerTest")
 	# checked source with class_name is set
 	var source_path :="res://addons/gdUnit4/test/core/resources/naming_conventions/snake_case_with_class_name.gd"
 	var suite_path := temp_dir + "/test/my_class_test1.gd"
@@ -182,7 +182,7 @@ func test_create_test_suite_snake_case_path():
 
 func test_create_test_case():
 	# store test class checked temp dir
-	var tmp_path := GdUnitTools.create_temp_dir("TestSuiteScannerTest")
+	var tmp_path := create_temp_dir("TestSuiteScannerTest")
 	var source_path := "res://addons/gdUnit4/test/resources/core/Person.gd"
 	# generate new test suite with test 'test_last_name()'
 	var test_suite_path = tmp_path + "/test/PersonTest.gd"
@@ -234,7 +234,7 @@ func test_build_test_suite_path() -> void:
 	assert_str(GdUnitTestSuiteScanner.resolve_test_suite_path("res://addons/plugin/src/foo/bar/new_script.gd")).is_equal("res://addons/plugin/test/foo/bar/new_script_test.gd")
 	
 	# checked user temp folder
-	var tmp_path := GdUnitTools.create_temp_dir("projectX/entity")
+	var tmp_path := create_temp_dir("projectX/entity")
 	var source_path := tmp_path + "/Person.gd"
 	assert_str(GdUnitTestSuiteScanner.resolve_test_suite_path(source_path)).is_equal("user://tmp/test/projectX/entity/PersonTest.gd")
 
@@ -328,10 +328,6 @@ func test__to_naming_convention() -> void:
 
 func test_is_script_format_supported() -> void:
 	assert_bool(GdUnitTestSuiteScanner._is_script_format_supported("res://exampe.gd")).is_true()
-	if GdUnitTools.is_mono_supported():
-		assert_bool(GdUnitTestSuiteScanner._is_script_format_supported("res://exampe.cs")).is_true()
-	else:
-		assert_bool(GdUnitTestSuiteScanner._is_script_format_supported("res://exampe.cs")).is_false()
 	assert_bool(GdUnitTestSuiteScanner._is_script_format_supported("res://exampe.gdns")).is_false()
 	assert_bool(GdUnitTestSuiteScanner._is_script_format_supported("res://exampe.vs")).is_false()
 	assert_bool(GdUnitTestSuiteScanner._is_script_format_supported("res://exampe.tres")).is_false()

--- a/addons/gdUnit4/test/core/GdUnitToolsTest.gd
+++ b/addons/gdUnit4/test/core/GdUnitToolsTest.gd
@@ -2,6 +2,8 @@
 class_name GdUnitToolsTest
 extends GdUnitTestSuite
 
+const GdUnitTools := preload("res://addons/gdUnit4/src/core/GdUnitTools.gd")
+
 # TestSuite generated from
 const __source = 'res://addons/gdUnit4/src/core/GdUnitTools.gd'
 var file_to_save :String

--- a/addons/gdUnit4/test/core/ParameterizedTestCaseTest.gd
+++ b/addons/gdUnit4/test/core/ParameterizedTestCaseTest.gd
@@ -177,6 +177,7 @@ func test_with_string_paramset(
 
 
 # https://github.com/MikeSchulze/gdUnit4/issues/213
+@warning_ignore("unused_parameter")
 func test_with_string_contains_brackets(
 	test_index :int,
 	value :String,

--- a/addons/gdUnit4/test/extractors/GdUnitFuncValueExtractorTest.gd
+++ b/addons/gdUnit4/test/extractors/GdUnitFuncValueExtractorTest.gd
@@ -4,6 +4,8 @@ extends GdUnitTestSuite
 
 # TestSuite generated from
 const __source = 'res://addons/gdUnit4/src/extractors/GdUnitFuncValueExtractor.gd'
+const GdUnitFuncValueExtractor = preload("res://addons/gdUnit4/src/extractors/GdUnitFuncValueExtractor.gd")
+
 
 class TestNode extends Resource:
 	var _parent = null

--- a/addons/gdUnit4/test/mocker/GdUnitMockerTest.gd
+++ b/addons/gdUnit4/test/mocker/GdUnitMockerTest.gd
@@ -1,7 +1,12 @@
 class_name GdUnitMockerTest
 extends GdUnitTestSuite
 
+
+const GdUnitMemoryPool = preload("res://addons/gdUnit4/src/core/GdUnitMemoryPool.gd")
+
+
 var resource_path := "res://addons/gdUnit4/test/mocker/resources/"
+
 
 func before():
 	# disable error pushing for testing

--- a/addons/gdUnit4/test/mocker/resources/scenes/TestScene.gd
+++ b/addons/gdUnit4/test/mocker/resources/scenes/TestScene.gd
@@ -11,6 +11,7 @@ const COLOR_CYCLE := [Color.ROYAL_BLUE, Color.CHARTREUSE, Color.YELLOW_GREEN]
 @warning_ignore("unused_private_class_variable")
 @export var _initial_color := Color.RED
 
+@warning_ignore("unused_private_class_variable")
 var _nullable :Object
 
 func _ready():

--- a/addons/gdUnit4/test/monitor/GodotGdErrorMonitorTest.gd
+++ b/addons/gdUnit4/test/monitor/GodotGdErrorMonitorTest.gd
@@ -58,7 +58,7 @@ func test_scan_for_push_errors() -> void:
 	var entry := ErrorLogEntry.new(ErrorLogEntry.TYPE.PUSH_ERROR, -1,
 		"this is an error",
 		"at: push_error (core/variant/variant_utility.cpp:880)")
-	var expected_report := monitor._to_report(entry)
+	var expected_report := GodotGdErrorMonitor._to_report(entry)
 	assert_array(monitor.reports()).contains_exactly([expected_report])
 
 
@@ -78,7 +78,7 @@ func test_scan_for_script_errors() -> void:
 	var entry := ErrorLogEntry.new(ErrorLogEntry.TYPE.PUSH_ERROR, 22,
 		"Trying to call a function on a previously freed instance.",
 		"at: GdUnitScriptTypeTest.test_xx (res://addons/gdUnit4/test/GdUnitScriptTypeTest.gd:22)")
-	var expected_report := monitor._to_report(entry)
+	var expected_report := GodotGdErrorMonitor._to_report(entry)
 	assert_array(monitor.reports()).contains_exactly([expected_report])
 
 

--- a/addons/gdUnit4/test/mono/GdUnit3MonoAPITest.gd
+++ b/addons/gdUnit4/test/mono/GdUnit3MonoAPITest.gd
@@ -4,6 +4,9 @@
 class_name GdUnit3MonoAPITest
 extends GdUnitTestSuite
 
+const GdUnitTools := preload("res://addons/gdUnit4/src/core/GdUnitTools.gd")
+
+
 # TestSuite generated from
 const __source = 'res://addons/gdUnit4/src/mono/GdUnit3MonoAPI.gd'
 var _example_source_cs :String

--- a/addons/gdUnit4/test/network/GdUnitTcpServerTest.gd
+++ b/addons/gdUnit4/test/network/GdUnitTcpServerTest.gd
@@ -64,14 +64,14 @@ func test_receive_packages() -> void:
 
 
 # TODO refactor out and provide as public interface to can be reuse on other tests
-class GdUnitSignalCollector:
-	var _signalCollector :GdUnitSignalAssertImpl.SignalCollector
+class TestGdUnitSignalCollector:
+	var _signalCollector :GdUnitSignalCollector
 	var _emitter :Variant
 	
 	
 	func _init(emitter :Variant):
 		_emitter = emitter
-		_signalCollector = GdUnitSignalAssertImpl.SignalCollector.new()
+		_signalCollector = GdUnitSignalCollector.new()
 		_signalCollector.register_emitter(emitter)
 	
 	
@@ -84,5 +84,5 @@ class GdUnitSignalCollector:
 			_signalCollector.unregister_emitter(_emitter)
 
 
-func signal_collector(instance :Variant) -> GdUnitSignalCollector:
-	return GdUnitSignalCollector.new(instance)
+func signal_collector(instance :Variant) -> TestGdUnitSignalCollector:
+	return TestGdUnitSignalCollector.new(instance)

--- a/addons/gdUnit4/test/network/GdUnitTcpServerTest.gd
+++ b/addons/gdUnit4/test/network/GdUnitTcpServerTest.gd
@@ -48,7 +48,7 @@ func test_receive_packages() -> void:
 	var test_server :GdUnitTcpServer = auto_free(GdUnitTcpServer.new())
 	test_server.add_child(connection)
 	# create a signal collector to catch all signals emitted on the test server during `receive_packages()`
-	var signal_collector := signal_collector(test_server)
+	var signal_collector_ := signal_collector(test_server)
 	
 	# mock send RPCMessage
 	var data := DLM + RPCMessage.of("Test Message").serialize() + DLM
@@ -60,7 +60,7 @@ func test_receive_packages() -> void:
 	connection.receive_packages()
 	
 	# expect the RPCMessage is received and emitted
-	assert_that(signal_collector.is_emitted("rpc_data", [RPCMessage.of("Test Message")])).is_true()
+	assert_that(signal_collector_.is_emitted("rpc_data", [RPCMessage.of("Test Message")])).is_true()
 
 
 # TODO refactor out and provide as public interface to can be reuse on other tests

--- a/addons/gdUnit4/test/spy/GdUnitSpyTest.gd
+++ b/addons/gdUnit4/test/spy/GdUnitSpyTest.gd
@@ -2,6 +2,9 @@ class_name GdUnitSpyTest
 extends GdUnitTestSuite
 
 
+const GdUnitMemoryPool = preload("res://addons/gdUnit4/src/core/GdUnitMemoryPool.gd")
+
+
 func test_spy_instance_id_is_unique():
 	var m1  = spy(RefCounted.new())
 	var m2  = spy(RefCounted.new())
@@ -111,7 +114,7 @@ func test_spy_class_with_custom_formattings() -> void:
 	verify_no_more_interactions(do_spy)
 	assert_failure(func(): verify_no_interactions(do_spy))\
 		.is_failed() \
-		.has_line(112)
+		.has_line(115)
 
 
 func test_spy_copied_class_members():
@@ -220,7 +223,7 @@ func test_verify_fail():
 			.dedent().trim_prefix("\n")
 	assert_failure(func(): verify(spy_node, 1).set_process(true)) \
 		.is_failed() \
-		.has_line(221) \
+		.has_line(224) \
 		.has_message(expected_error)
 
 
@@ -247,7 +250,7 @@ func test_verify_func_interaction_wiht_PackedStringArray_fail():
 			.dedent().trim_prefix("\n")
 	assert_failure(func(): verify(spy_instance, 1).set_values([])) \
 		.is_failed() \
-		.has_line(248) \
+		.has_line(251) \
 		.has_message(expected_error)
 	
 	reset(spy_instance)
@@ -265,7 +268,7 @@ func test_verify_func_interaction_wiht_PackedStringArray_fail():
 			.dedent().trim_prefix("\n")
 	assert_failure(func(): verify(spy_instance, 1).set_values([])) \
 		.is_failed() \
-		.has_line(266) \
+		.has_line(269) \
 		.has_message(expected_error)
 
 
@@ -313,7 +316,7 @@ func test_verify_no_interactions_fails():
 	# it should fail because we have interactions
 	assert_failure(func(): verify_no_interactions(spy_node)) \
 		.is_failed() \
-		.has_line(314) \
+		.has_line(317) \
 		.has_message(expected_error)
 
 
@@ -368,7 +371,7 @@ func test_verify_no_more_interactions_but_has():
 			.dedent().trim_prefix("\n")
 	assert_failure(func(): verify_no_more_interactions(spy_node)) \
 		.is_failed() \
-		.has_line(369) \
+		.has_line(372) \
 		.has_message(expected_error)
 
 

--- a/addons/gdUnit4/test/update/bbcodeView.gd
+++ b/addons/gdUnit4/test/update/bbcodeView.gd
@@ -1,7 +1,8 @@
 extends Control
 
-const GdMarkDownReader = preload("res://addons/gdUnit4/src/update/GdMarkDownReader.gd")
-const GdUnitUpdateClient = preload("res://addons/gdUnit4/src/update/GdUnitUpdateClient.gd")
+const GdUnitTools := preload("res://addons/gdUnit4/src/core/GdUnitTools.gd")
+const GdMarkDownReader := preload("res://addons/gdUnit4/src/update/GdMarkDownReader.gd")
+const GdUnitUpdateClient := preload("res://addons/gdUnit4/src/update/GdUnitUpdateClient.gd")
 
 @onready var _input :TextEdit = $HSplitContainer/TextEdit
 @onready var _text :RichTextLabel = $HSplitContainer/RichTextLabel


### PR DESCRIPTION
# Why
The load time of the test suite is extremely increased compared to Godot3.
# What
Reduces the parsing/loading time of a test-suite by switching to "lazy loading" of all used asserts and tools.


# Performance Results
* Loading of a single TestSuite class reduced from 156ms to 38ms
![image](https://github.com/MikeSchulze/gdUnit4/assets/347037/39d362b0-b76f-431b-a4d0-9933f202db42)



* Loading over all TestSuites (94)  reduced from 22s  to 9s
![image](https://github.com/MikeSchulze/gdUnit4/assets/347037/be94994d-79bd-4956-8064-1e0521c76e5a)
