### PR TITLE
:bug: fix icon scaling

### DIFF
--- a/addons/gdUnit4/src/ui/assets/PlayDebug.svg.import
+++ b/addons/gdUnit4/src/ui/assets/PlayDebug.svg.import
@@ -5,6 +5,7 @@ type="CompressedTexture2D"
 uid="uid://tkrsqx2oxw6o"
 path="res://.godot/imported/PlayDebug.svg-d3618ec14e2e4cb6b467c3249916f8dd.ctex"
 metadata={
+"has_editor_variant": true,
 "vram_texture": false
 }
 
@@ -33,5 +34,5 @@ process/hdr_clamp_exposure=false
 process/size_limit=0
 detect_3d/compress_to=1
 svg/scale=1.0
-editor/scale_with_editor_scale=false
-editor/convert_colors_with_editor_theme=false
+editor/scale_with_editor_scale=true
+editor/convert_colors_with_editor_theme=true

--- a/addons/gdUnit4/src/ui/assets/PlayOverall.svg.import
+++ b/addons/gdUnit4/src/ui/assets/PlayOverall.svg.import
@@ -5,6 +5,7 @@ type="CompressedTexture2D"
 uid="uid://de1q5raia84bn"
 path="res://.godot/imported/PlayOverall.svg-d07157735d6bab5d74465733e8213328.ctex"
 metadata={
+"has_editor_variant": true,
 "vram_texture": false
 }
 
@@ -33,5 +34,5 @@ process/hdr_clamp_exposure=false
 process/size_limit=0
 detect_3d/compress_to=1
 svg/scale=1.0
-editor/scale_with_editor_scale=false
-editor/convert_colors_with_editor_theme=false
+editor/scale_with_editor_scale=true
+editor/convert_colors_with_editor_theme=true

--- a/addons/gdUnit4/src/ui/assets/TestCase.svg.import
+++ b/addons/gdUnit4/src/ui/assets/TestCase.svg.import
@@ -5,6 +5,7 @@ type="CompressedTexture2D"
 uid="uid://chwatiivlcovb"
 path="res://.godot/imported/TestCase.svg-f6ee172ad0e725d3612bec1b6f3c8078.ctex"
 metadata={
+"has_editor_variant": true,
 "vram_texture": false
 }
 
@@ -33,5 +34,5 @@ process/hdr_clamp_exposure=false
 process/size_limit=0
 detect_3d/compress_to=1
 svg/scale=1.0
-editor/scale_with_editor_scale=false
-editor/convert_colors_with_editor_theme=false
+editor/scale_with_editor_scale=true
+editor/convert_colors_with_editor_theme=true

--- a/addons/gdUnit4/src/ui/assets/TestCaseError.svg.import
+++ b/addons/gdUnit4/src/ui/assets/TestCaseError.svg.import
@@ -5,6 +5,7 @@ type="CompressedTexture2D"
 uid="uid://bafys3jjkjhqw"
 path="res://.godot/imported/TestCaseError.svg-373307086979f3f0e012eb3660cc91ec.ctex"
 metadata={
+"has_editor_variant": true,
 "vram_texture": false
 }
 
@@ -33,5 +34,5 @@ process/hdr_clamp_exposure=false
 process/size_limit=0
 detect_3d/compress_to=1
 svg/scale=1.0
-editor/scale_with_editor_scale=false
-editor/convert_colors_with_editor_theme=false
+editor/scale_with_editor_scale=true
+editor/convert_colors_with_editor_theme=true

--- a/addons/gdUnit4/src/ui/assets/TestCaseFailed.svg.import
+++ b/addons/gdUnit4/src/ui/assets/TestCaseFailed.svg.import
@@ -5,6 +5,7 @@ type="CompressedTexture2D"
 uid="uid://b4ej20o0cedro"
 path="res://.godot/imported/TestCaseFailed.svg-df47525fd14d5e4149690cacd8eb08db.ctex"
 metadata={
+"has_editor_variant": true,
 "vram_texture": false
 }
 
@@ -33,5 +34,5 @@ process/hdr_clamp_exposure=false
 process/size_limit=0
 detect_3d/compress_to=1
 svg/scale=1.0
-editor/scale_with_editor_scale=false
-editor/convert_colors_with_editor_theme=false
+editor/scale_with_editor_scale=true
+editor/convert_colors_with_editor_theme=true

--- a/addons/gdUnit4/src/ui/assets/TestCaseSuccess.svg.import
+++ b/addons/gdUnit4/src/ui/assets/TestCaseSuccess.svg.import
@@ -5,6 +5,7 @@ type="CompressedTexture2D"
 uid="uid://4yciagtse0nx"
 path="res://.godot/imported/TestCaseSuccess.svg-aaf852c6aeda68c93a410c7480502895.ctex"
 metadata={
+"has_editor_variant": true,
 "vram_texture": false
 }
 
@@ -33,5 +34,5 @@ process/hdr_clamp_exposure=false
 process/size_limit=0
 detect_3d/compress_to=1
 svg/scale=1.0
-editor/scale_with_editor_scale=false
-editor/convert_colors_with_editor_theme=false
+editor/scale_with_editor_scale=true
+editor/convert_colors_with_editor_theme=true

--- a/addons/gdUnit4/src/ui/assets/TestSuite.svg.import
+++ b/addons/gdUnit4/src/ui/assets/TestSuite.svg.import
@@ -5,6 +5,7 @@ type="CompressedTexture2D"
 uid="uid://bo6xbdqouosbs"
 path="res://.godot/imported/TestSuite.svg-f3ba31540dedae19e6c1b7b050a1b5d7.ctex"
 metadata={
+"has_editor_variant": true,
 "vram_texture": false
 }
 
@@ -33,5 +34,5 @@ process/hdr_clamp_exposure=false
 process/size_limit=0
 detect_3d/compress_to=1
 svg/scale=1.0
-editor/scale_with_editor_scale=false
-editor/convert_colors_with_editor_theme=false
+editor/scale_with_editor_scale=true
+editor/convert_colors_with_editor_theme=true

--- a/addons/gdUnit4/src/ui/assets/clock.svg.import
+++ b/addons/gdUnit4/src/ui/assets/clock.svg.import
@@ -5,6 +5,7 @@ type="CompressedTexture2D"
 uid="uid://dmu35vmwstrwg"
 path="res://.godot/imported/clock.svg-b16f5d68e1dedc017f1ce1df1e590248.ctex"
 metadata={
+"has_editor_variant": true,
 "vram_texture": false
 }
 
@@ -33,5 +34,5 @@ process/hdr_clamp_exposure=false
 process/size_limit=0
 detect_3d/compress_to=1
 svg/scale=1.0
-editor/scale_with_editor_scale=false
-editor/convert_colors_with_editor_theme=false
+editor/scale_with_editor_scale=true
+editor/convert_colors_with_editor_theme=true

--- a/addons/gdUnit4/src/ui/assets/errors.svg.import
+++ b/addons/gdUnit4/src/ui/assets/errors.svg.import
@@ -5,6 +5,7 @@ type="CompressedTexture2D"
 uid="uid://bftg23n8uymlk"
 path="res://.godot/imported/errors.svg-53aa38a5c5d3309095cd34f36952f16b.ctex"
 metadata={
+"has_editor_variant": true,
 "vram_texture": false
 }
 
@@ -33,5 +34,5 @@ process/hdr_clamp_exposure=false
 process/size_limit=0
 detect_3d/compress_to=1
 svg/scale=1.0
-editor/scale_with_editor_scale=false
-editor/convert_colors_with_editor_theme=false
+editor/scale_with_editor_scale=true
+editor/convert_colors_with_editor_theme=true

--- a/addons/gdUnit4/src/ui/assets/failures.svg.import
+++ b/addons/gdUnit4/src/ui/assets/failures.svg.import
@@ -5,6 +5,7 @@ type="CompressedTexture2D"
 uid="uid://davt5rxc7ao4s"
 path="res://.godot/imported/failures.svg-8659a946adf9b0616e867a8bf0855d3d.ctex"
 metadata={
+"has_editor_variant": true,
 "vram_texture": false
 }
 
@@ -33,5 +34,5 @@ process/hdr_clamp_exposure=false
 process/size_limit=0
 detect_3d/compress_to=1
 svg/scale=1.0
-editor/scale_with_editor_scale=false
-editor/convert_colors_with_editor_theme=false
+editor/scale_with_editor_scale=true
+editor/convert_colors_with_editor_theme=true

--- a/addons/gdUnit4/src/ui/assets/orphan/TestCaseError1.svg.import
+++ b/addons/gdUnit4/src/ui/assets/orphan/TestCaseError1.svg.import
@@ -5,6 +5,7 @@ type="CompressedTexture2D"
 uid="uid://bdl7p3rf6wpfw"
 path="res://.godot/imported/TestCaseError1.svg-43d13ea25f9f8c66fecf5a0ab4a752ad.ctex"
 metadata={
+"has_editor_variant": true,
 "vram_texture": false
 }
 
@@ -33,5 +34,5 @@ process/hdr_clamp_exposure=false
 process/size_limit=0
 detect_3d/compress_to=1
 svg/scale=1.0
-editor/scale_with_editor_scale=false
-editor/convert_colors_with_editor_theme=false
+editor/scale_with_editor_scale=true
+editor/convert_colors_with_editor_theme=true

--- a/addons/gdUnit4/src/ui/assets/orphan/TestCaseError2.svg.import
+++ b/addons/gdUnit4/src/ui/assets/orphan/TestCaseError2.svg.import
@@ -5,6 +5,7 @@ type="CompressedTexture2D"
 uid="uid://fqf674gwq375"
 path="res://.godot/imported/TestCaseError2.svg-27dc52b88f226d741b1f9c1294295841.ctex"
 metadata={
+"has_editor_variant": true,
 "vram_texture": false
 }
 
@@ -33,5 +34,5 @@ process/hdr_clamp_exposure=false
 process/size_limit=0
 detect_3d/compress_to=1
 svg/scale=1.0
-editor/scale_with_editor_scale=false
-editor/convert_colors_with_editor_theme=false
+editor/scale_with_editor_scale=true
+editor/convert_colors_with_editor_theme=true

--- a/addons/gdUnit4/src/ui/assets/orphan/TestCaseFailed.svg.import
+++ b/addons/gdUnit4/src/ui/assets/orphan/TestCaseFailed.svg.import
@@ -5,6 +5,7 @@ type="CompressedTexture2D"
 uid="uid://bqvlmgi6qpre0"
 path="res://.godot/imported/TestCaseFailed.svg-151182f42f6b32bd8c6dc168e9469b54.ctex"
 metadata={
+"has_editor_variant": true,
 "vram_texture": false
 }
 
@@ -33,5 +34,5 @@ process/hdr_clamp_exposure=false
 process/size_limit=0
 detect_3d/compress_to=1
 svg/scale=1.0
-editor/scale_with_editor_scale=false
-editor/convert_colors_with_editor_theme=false
+editor/scale_with_editor_scale=true
+editor/convert_colors_with_editor_theme=true

--- a/addons/gdUnit4/src/ui/assets/orphan/TestCaseFailed1.svg.import
+++ b/addons/gdUnit4/src/ui/assets/orphan/TestCaseFailed1.svg.import
@@ -5,6 +5,7 @@ type="CompressedTexture2D"
 uid="uid://deo4r8koimsfd"
 path="res://.godot/imported/TestCaseFailed1.svg-32464e8f6fa7f74ad74a7534dfaba019.ctex"
 metadata={
+"has_editor_variant": true,
 "vram_texture": false
 }
 
@@ -33,5 +34,5 @@ process/hdr_clamp_exposure=false
 process/size_limit=0
 detect_3d/compress_to=1
 svg/scale=1.0
-editor/scale_with_editor_scale=false
-editor/convert_colors_with_editor_theme=false
+editor/scale_with_editor_scale=true
+editor/convert_colors_with_editor_theme=true

--- a/addons/gdUnit4/src/ui/assets/orphan/TestCaseFailed2.svg.import
+++ b/addons/gdUnit4/src/ui/assets/orphan/TestCaseFailed2.svg.import
@@ -5,6 +5,7 @@ type="CompressedTexture2D"
 uid="uid://ctl52ddcptdxb"
 path="res://.godot/imported/TestCaseFailed2.svg-aa38e10f09edf43b31b1c0a4caf549c5.ctex"
 metadata={
+"has_editor_variant": true,
 "vram_texture": false
 }
 
@@ -33,5 +34,5 @@ process/hdr_clamp_exposure=false
 process/size_limit=0
 detect_3d/compress_to=1
 svg/scale=1.0
-editor/scale_with_editor_scale=false
-editor/convert_colors_with_editor_theme=false
+editor/scale_with_editor_scale=true
+editor/convert_colors_with_editor_theme=true

--- a/addons/gdUnit4/src/ui/assets/orphan/TestCaseSuccess1.svg.import
+++ b/addons/gdUnit4/src/ui/assets/orphan/TestCaseSuccess1.svg.import
@@ -5,6 +5,7 @@ type="CompressedTexture2D"
 uid="uid://bufumcx0iq38d"
 path="res://.godot/imported/TestCaseSuccess1.svg-3eadebb620a3275b67f53d505bc0f96b.ctex"
 metadata={
+"has_editor_variant": true,
 "vram_texture": false
 }
 
@@ -33,5 +34,5 @@ process/hdr_clamp_exposure=false
 process/size_limit=0
 detect_3d/compress_to=1
 svg/scale=1.0
-editor/scale_with_editor_scale=false
-editor/convert_colors_with_editor_theme=false
+editor/scale_with_editor_scale=true
+editor/convert_colors_with_editor_theme=true

--- a/addons/gdUnit4/src/ui/assets/orphan/TestCaseSuccess2.svg.import
+++ b/addons/gdUnit4/src/ui/assets/orphan/TestCaseSuccess2.svg.import
@@ -5,6 +5,7 @@ type="CompressedTexture2D"
 uid="uid://clj5nj84vnocn"
 path="res://.godot/imported/TestCaseSuccess2.svg-7767c6ebe7bd14d031b8c87b24e08595.ctex"
 metadata={
+"has_editor_variant": true,
 "vram_texture": false
 }
 
@@ -33,5 +34,5 @@ process/hdr_clamp_exposure=false
 process/size_limit=0
 detect_3d/compress_to=1
 svg/scale=1.0
-editor/scale_with_editor_scale=false
-editor/convert_colors_with_editor_theme=false
+editor/scale_with_editor_scale=true
+editor/convert_colors_with_editor_theme=true

--- a/addons/gdUnit4/src/ui/assets/orphan/orphan_green.svg.import
+++ b/addons/gdUnit4/src/ui/assets/orphan/orphan_green.svg.import
@@ -5,6 +5,7 @@ type="CompressedTexture2D"
 uid="uid://cqrikobu314r3"
 path="res://.godot/imported/orphan_green.svg-9ce01031b489dea619e91196cb66dce9.ctex"
 metadata={
+"has_editor_variant": true,
 "vram_texture": false
 }
 
@@ -33,5 +34,5 @@ process/hdr_clamp_exposure=false
 process/size_limit=0
 detect_3d/compress_to=1
 svg/scale=1.0
-editor/scale_with_editor_scale=false
-editor/convert_colors_with_editor_theme=false
+editor/scale_with_editor_scale=true
+editor/convert_colors_with_editor_theme=true

--- a/addons/gdUnit4/src/ui/assets/orphan/orphan_red1.svg.import
+++ b/addons/gdUnit4/src/ui/assets/orphan/orphan_red1.svg.import
@@ -5,6 +5,7 @@ type="CompressedTexture2D"
 uid="uid://da6s7yd3mpcbp"
 path="res://.godot/imported/orphan_red1.svg-8ddad0e8a9c8884f19621c8f733ce341.ctex"
 metadata={
+"has_editor_variant": true,
 "vram_texture": false
 }
 
@@ -33,5 +34,5 @@ process/hdr_clamp_exposure=false
 process/size_limit=0
 detect_3d/compress_to=1
 svg/scale=1.0
-editor/scale_with_editor_scale=false
-editor/convert_colors_with_editor_theme=false
+editor/scale_with_editor_scale=true
+editor/convert_colors_with_editor_theme=true

--- a/addons/gdUnit4/src/ui/assets/orphan/orphan_red2.svg.import
+++ b/addons/gdUnit4/src/ui/assets/orphan/orphan_red2.svg.import
@@ -5,6 +5,7 @@ type="CompressedTexture2D"
 uid="uid://cnvenq5hici48"
 path="res://.godot/imported/orphan_red2.svg-3ab7610a37b37b2e46ca7faaba5a2c40.ctex"
 metadata={
+"has_editor_variant": true,
 "vram_texture": false
 }
 
@@ -33,5 +34,5 @@ process/hdr_clamp_exposure=false
 process/size_limit=0
 detect_3d/compress_to=1
 svg/scale=1.0
-editor/scale_with_editor_scale=false
-editor/convert_colors_with_editor_theme=false
+editor/scale_with_editor_scale=true
+editor/convert_colors_with_editor_theme=true

--- a/addons/gdUnit4/src/ui/assets/orphan/orphan_red3.svg.import
+++ b/addons/gdUnit4/src/ui/assets/orphan/orphan_red3.svg.import
@@ -5,6 +5,7 @@ type="CompressedTexture2D"
 uid="uid://cbnqfoh4n6bj5"
 path="res://.godot/imported/orphan_red3.svg-2f1ae0a474446c730d13e401878da7f2.ctex"
 metadata={
+"has_editor_variant": true,
 "vram_texture": false
 }
 
@@ -33,5 +34,5 @@ process/hdr_clamp_exposure=false
 process/size_limit=0
 detect_3d/compress_to=1
 svg/scale=1.0
-editor/scale_with_editor_scale=false
-editor/convert_colors_with_editor_theme=false
+editor/scale_with_editor_scale=true
+editor/convert_colors_with_editor_theme=true

--- a/addons/gdUnit4/src/ui/assets/orphan/orphan_red4.svg.import
+++ b/addons/gdUnit4/src/ui/assets/orphan/orphan_red4.svg.import
@@ -5,6 +5,7 @@ type="CompressedTexture2D"
 uid="uid://bjm3fxk3ieapk"
 path="res://.godot/imported/orphan_red4.svg-b6aa919f74c7c5f9e6a5a87210e2194e.ctex"
 metadata={
+"has_editor_variant": true,
 "vram_texture": false
 }
 
@@ -33,5 +34,5 @@ process/hdr_clamp_exposure=false
 process/size_limit=0
 detect_3d/compress_to=1
 svg/scale=1.0
-editor/scale_with_editor_scale=false
-editor/convert_colors_with_editor_theme=false
+editor/scale_with_editor_scale=true
+editor/convert_colors_with_editor_theme=true

--- a/addons/gdUnit4/src/ui/assets/orphan/orphan_red5.svg.import
+++ b/addons/gdUnit4/src/ui/assets/orphan/orphan_red5.svg.import
@@ -5,6 +5,7 @@ type="CompressedTexture2D"
 uid="uid://nj6xpoxpf6i5"
 path="res://.godot/imported/orphan_red5.svg-94eac4c39a2d4020f502eab72982b3f2.ctex"
 metadata={
+"has_editor_variant": true,
 "vram_texture": false
 }
 
@@ -33,5 +34,5 @@ process/hdr_clamp_exposure=false
 process/size_limit=0
 detect_3d/compress_to=1
 svg/scale=1.0
-editor/scale_with_editor_scale=false
-editor/convert_colors_with_editor_theme=false
+editor/scale_with_editor_scale=true
+editor/convert_colors_with_editor_theme=true

--- a/addons/gdUnit4/src/ui/assets/orphan/orphan_red6.svg.import
+++ b/addons/gdUnit4/src/ui/assets/orphan/orphan_red6.svg.import
@@ -5,6 +5,7 @@ type="CompressedTexture2D"
 uid="uid://bylpj2dbacbaw"
 path="res://.godot/imported/orphan_red6.svg-fb927f6dc4442199133d2e25e9d9d21a.ctex"
 metadata={
+"has_editor_variant": true,
 "vram_texture": false
 }
 
@@ -33,5 +34,5 @@ process/hdr_clamp_exposure=false
 process/size_limit=0
 detect_3d/compress_to=1
 svg/scale=1.0
-editor/scale_with_editor_scale=false
-editor/convert_colors_with_editor_theme=false
+editor/scale_with_editor_scale=true
+editor/convert_colors_with_editor_theme=true

--- a/addons/gdUnit4/src/ui/assets/orphan/orphan_red7.svg.import
+++ b/addons/gdUnit4/src/ui/assets/orphan/orphan_red7.svg.import
@@ -5,6 +5,7 @@ type="CompressedTexture2D"
 uid="uid://bpqfgn22gmpjm"
 path="res://.godot/imported/orphan_red7.svg-4b4ab8aec1bc8343d5df6b64a24f7c22.ctex"
 metadata={
+"has_editor_variant": true,
 "vram_texture": false
 }
 
@@ -33,5 +34,5 @@ process/hdr_clamp_exposure=false
 process/size_limit=0
 detect_3d/compress_to=1
 svg/scale=1.0
-editor/scale_with_editor_scale=false
-editor/convert_colors_with_editor_theme=false
+editor/scale_with_editor_scale=true
+editor/convert_colors_with_editor_theme=true

--- a/addons/gdUnit4/src/ui/assets/spinner/Progress1.svg.import
+++ b/addons/gdUnit4/src/ui/assets/spinner/Progress1.svg.import
@@ -5,6 +5,7 @@ type="CompressedTexture2D"
 uid="uid://ddxpytkht0m5p"
 path="res://.godot/imported/Progress1.svg-baca226eb5c6ca50a0b5f3af77fe615c.ctex"
 metadata={
+"has_editor_variant": true,
 "vram_texture": false
 }
 
@@ -33,5 +34,5 @@ process/hdr_clamp_exposure=false
 process/size_limit=0
 detect_3d/compress_to=1
 svg/scale=1.0
-editor/scale_with_editor_scale=false
-editor/convert_colors_with_editor_theme=false
+editor/scale_with_editor_scale=true
+editor/convert_colors_with_editor_theme=true

--- a/addons/gdUnit4/src/ui/assets/spinner/Progress2.svg.import
+++ b/addons/gdUnit4/src/ui/assets/spinner/Progress2.svg.import
@@ -5,6 +5,7 @@ type="CompressedTexture2D"
 uid="uid://dowca7ike2thl"
 path="res://.godot/imported/Progress2.svg-6a0cbcb42a8df535c533cf79599952d6.ctex"
 metadata={
+"has_editor_variant": true,
 "vram_texture": false
 }
 
@@ -33,5 +34,5 @@ process/hdr_clamp_exposure=false
 process/size_limit=0
 detect_3d/compress_to=1
 svg/scale=1.0
-editor/scale_with_editor_scale=false
-editor/convert_colors_with_editor_theme=false
+editor/scale_with_editor_scale=true
+editor/convert_colors_with_editor_theme=true

--- a/addons/gdUnit4/src/ui/assets/spinner/Progress3.svg.import
+++ b/addons/gdUnit4/src/ui/assets/spinner/Progress3.svg.import
@@ -5,6 +5,7 @@ type="CompressedTexture2D"
 uid="uid://cwh8md6qipmdw"
 path="res://.godot/imported/Progress3.svg-0b465f11e95f98f7b157a0bf0ded40c1.ctex"
 metadata={
+"has_editor_variant": true,
 "vram_texture": false
 }
 
@@ -33,5 +34,5 @@ process/hdr_clamp_exposure=false
 process/size_limit=0
 detect_3d/compress_to=1
 svg/scale=1.0
-editor/scale_with_editor_scale=false
-editor/convert_colors_with_editor_theme=false
+editor/scale_with_editor_scale=true
+editor/convert_colors_with_editor_theme=true

--- a/addons/gdUnit4/src/ui/assets/spinner/Progress4.svg.import
+++ b/addons/gdUnit4/src/ui/assets/spinner/Progress4.svg.import
@@ -5,6 +5,7 @@ type="CompressedTexture2D"
 uid="uid://dm0jpqdjetv2c"
 path="res://.godot/imported/Progress4.svg-09def7d3fee66ec2764c9bbd72c3a961.ctex"
 metadata={
+"has_editor_variant": true,
 "vram_texture": false
 }
 
@@ -33,5 +34,5 @@ process/hdr_clamp_exposure=false
 process/size_limit=0
 detect_3d/compress_to=1
 svg/scale=1.0
-editor/scale_with_editor_scale=false
-editor/convert_colors_with_editor_theme=false
+editor/scale_with_editor_scale=true
+editor/convert_colors_with_editor_theme=true

--- a/addons/gdUnit4/src/ui/assets/spinner/Progress5.svg.import
+++ b/addons/gdUnit4/src/ui/assets/spinner/Progress5.svg.import
@@ -5,6 +5,7 @@ type="CompressedTexture2D"
 uid="uid://bkj6kjyjyi7cd"
 path="res://.godot/imported/Progress5.svg-9874b4bd1c734fd859a28d95960c17c5.ctex"
 metadata={
+"has_editor_variant": true,
 "vram_texture": false
 }
 
@@ -33,5 +34,5 @@ process/hdr_clamp_exposure=false
 process/size_limit=0
 detect_3d/compress_to=1
 svg/scale=1.0
-editor/scale_with_editor_scale=false
-editor/convert_colors_with_editor_theme=false
+editor/scale_with_editor_scale=true
+editor/convert_colors_with_editor_theme=true

--- a/addons/gdUnit4/src/ui/assets/spinner/Progress6.svg.import
+++ b/addons/gdUnit4/src/ui/assets/spinner/Progress6.svg.import
@@ -5,6 +5,7 @@ type="CompressedTexture2D"
 uid="uid://bsljbs1aiyels"
 path="res://.godot/imported/Progress6.svg-0a3b2b954e3a285cee1f29222aac701b.ctex"
 metadata={
+"has_editor_variant": true,
 "vram_texture": false
 }
 
@@ -33,5 +34,5 @@ process/hdr_clamp_exposure=false
 process/size_limit=0
 detect_3d/compress_to=1
 svg/scale=1.0
-editor/scale_with_editor_scale=false
-editor/convert_colors_with_editor_theme=false
+editor/scale_with_editor_scale=true
+editor/convert_colors_with_editor_theme=true

--- a/addons/gdUnit4/src/ui/assets/spinner/Progress7.svg.import
+++ b/addons/gdUnit4/src/ui/assets/spinner/Progress7.svg.import
@@ -5,6 +5,7 @@ type="CompressedTexture2D"
 uid="uid://cct6crbhix7u8"
 path="res://.godot/imported/Progress7.svg-e824844cb9cfdf076f9196cf47098a7d.ctex"
 metadata={
+"has_editor_variant": true,
 "vram_texture": false
 }
 
@@ -33,5 +34,5 @@ process/hdr_clamp_exposure=false
 process/size_limit=0
 detect_3d/compress_to=1
 svg/scale=1.0
-editor/scale_with_editor_scale=false
-editor/convert_colors_with_editor_theme=false
+editor/scale_with_editor_scale=true
+editor/convert_colors_with_editor_theme=true

--- a/addons/gdUnit4/src/ui/assets/spinner/Progress8.svg.import
+++ b/addons/gdUnit4/src/ui/assets/spinner/Progress8.svg.import
@@ -5,6 +5,7 @@ type="CompressedTexture2D"
 uid="uid://dqc521iq12a7l"
 path="res://.godot/imported/Progress8.svg-b37d84176a257f378f0f5dff81bfc322.ctex"
 metadata={
+"has_editor_variant": true,
 "vram_texture": false
 }
 
@@ -33,5 +34,5 @@ process/hdr_clamp_exposure=false
 process/size_limit=0
 detect_3d/compress_to=1
 svg/scale=1.0
-editor/scale_with_editor_scale=false
-editor/convert_colors_with_editor_theme=false
+editor/scale_with_editor_scale=true
+editor/convert_colors_with_editor_theme=true

--- a/project.godot
+++ b/project.godot
@@ -24,11 +24,40 @@ file_logging/enable_file_logging=true
 gdscript/warnings/unused_signal=false
 gdscript/warnings/return_value_discarded=false
 
+[editor_plugins]
+
+enabled=PackedStringArray("res://addons/gdUnit4/plugin.cfg")
+
 [gdunit4]
 
 settings/common/update_notification_enabled=false
 report/assert/verbose_errors=false
 report/assert/verbose_warnings=false
+
+[importer_defaults]
+
+texture={
+"compress/channel_pack": 0,
+"compress/hdr_compression": 1,
+"compress/high_quality": false,
+"compress/lossy_quality": 0.7,
+"compress/mode": 0,
+"compress/normal_map": 0,
+"detect_3d/compress_to": 1,
+"editor/convert_colors_with_editor_theme": true,
+"editor/scale_with_editor_scale": true,
+"mipmaps/generate": false,
+"mipmaps/limit": -1,
+"process/fix_alpha_border": true,
+"process/hdr_as_srgb": false,
+"process/hdr_clamp_exposure": false,
+"process/normal_map_invert_y": false,
+"process/premult_alpha": false,
+"process/size_limit": 0,
+"roughness/mode": 0,
+"roughness/src_normal": "",
+"svg/scale": 1.0
+}
 
 [network]
 


### PR DESCRIPTION
# Why

On 4K monitors especially, the icons are too small and do not scale properly with the Godot editor.


# What

I updated the import settings to ensure icons now are displayed correctly. Individual test icons are still tiny but this is due to the height of the UI component by the looks of it.

**Before**

![before](https://github.com/MikeSchulze/gdUnit4/assets/822035/b4e8b4a8-5772-4177-b09a-e298c8ea3d39)

**After**

![after](https://github.com/MikeSchulze/gdUnit4/assets/822035/fa247e3e-b940-4e8d-939a-85f631e6ca6f)

