### PR TITLE
GD-255: Fix `runtest.cmd` to run `GdUnitCopyLog` in headless mode

### DIFF
--- a/addons/gdUnit4/runtest.cmd
+++ b/addons/gdUnit4/runtest.cmd
@@ -18,7 +18,7 @@ IF "%GODOT_TYPE%" == "mono" (
 
 %GODOT_BIN% -s -d .\addons\gdUnit4\bin\GdUnitCmdTool.gd %*
 SET exit_code=%errorlevel%
-%GODOT_BIN% --no-window --quiet -s -d .\addons\gdUnit4\bin\GdUnitCopyLog.gd %*
+%GODOT_BIN% --headless --quiet -s -d .\addons\gdUnit4\bin\GdUnitCopyLog.gd %*
 
 ECHO %exit_code%
 


### PR DESCRIPTION
# Why
The 'runtest.cmd' scripts still contains the '--no-window' argument where is changed with Godot4 to `--headless`

# What
Use `--headless` argument to execute `GdUnitCopyLog` in headless mode