### PR TITLE
GD-262: Add simple ci workflow example

### DIFF
--- a/.github/workflows/ci-pr-example.yml
+++ b/.github/workflows/ci-pr-example.yml
@@ -1,0 +1,105 @@
+name: ci-pr-example
+run-name: ${{ github.head_ref || github.ref_name }}-ci-pr-example
+
+on:
+  pull_request:
+    paths-ignore:
+      - '**.yml'
+      - '**.md'
+  workflow_dispatch:
+
+
+concurrency:
+  group: ci-pr-example${{ github.event.number }}
+  cancel-in-progress: true
+
+
+jobs:
+  unit-test:
+    strategy:
+      fail-fast: false
+      matrix:
+        godot-version: ['4.1.1'] # Insert here the Godot version you want to run your tests with
+
+    name: "CI Unit Test 🐧 v${{ matrix.godot-version }}"
+    runs-on: 'ubuntu-22.04'
+    timeout-minutes: 10 # The overall timeout
+
+    steps:
+      - name: "Checkout your Repository"
+        uses: actions/checkout@v3
+        with:
+          lfs: true
+
+      - name: "🐧Download and Install Godot ${{ matrix.godot-version }}"
+        continue-on-error: false
+        shell: bash
+        run: |
+          GODOT_HOME=$HOME/bin
+          GODOT_BIN=$GODOT_HOME/godot
+          mkdir -p $GODOT_HOME
+          chmod 770 $GODOT_HOME
+          GODOT_CONF_PATH=$HOME/.config/godot
+          if [ ! -d $GODOT_CONF_PATH ]; then
+            mkdir -p $GODOT_CONF_PATH
+            chmod 770 $GODOT_CONF_PATH
+          fi
+
+          GODOT_PACKAGE=Godot_v${{ matrix.godot-version }}-stable_linux.x86_64
+          wget https://github.com/godotengine/godot/releases/download/${{ matrix.godot-version }}-stable/$GODOT_PACKAGE.zip -P ${{ runner.temp }}
+          unzip ${{ runner.temp }}/$GODOT_PACKAGE.zip -d $GODOT_HOME
+          mv $GODOT_HOME/$GODOT_PACKAGE $GODOT_BIN
+          chmod u+x $GODOT_BIN
+          echo "GODOT_HOME=$GODOT_HOME" >> "$GITHUB_ENV"
+          echo "GODOT_BIN=$GODOT_BIN" >> "$GITHUB_ENV"
+
+      # We need to update the project before running tests, Godot has actually issues with loading the plugin
+      - name: "Update Project"
+        if: ${{ !cancelled() }}
+        timeout-minutes: 1
+        continue-on-error: true # we still ignore the timeout, the script is not quit and we run into a timeout
+        shell: bash
+        run: |
+          ${{ env.GODOT_BIN }} -e --path . -s res://addons/gdUnit4/bin/ProjectScanner.gd --headless --audio-driver Dummy
+
+      - name: "Run Unit Tests"
+        if: ${{ !cancelled() }}
+        timeout-minutes: 8 # set your expected test timeout
+        env:
+          GODOT_BIN: ${{ env.GODOT_BIN }}
+        shell: bash
+        run: |
+          chmod +x ./addons/gdUnit4/runtest.sh
+          xvfb-run --auto-servernum ./addons/gdUnit4/runtest.sh --add "res://test" --audio-driver Dummy --display-driver x11 --rendering-driver opengl3 --screen 0 --continue
+
+      - name: "Publish Test Report"
+        if: ${{ always() }}
+        uses: dorny/test-reporter@v1.6.0
+        with:
+          name: "test_report_${{ matrix.godot-version }}"
+          path: "reports/**/results.xml"
+          reporter: java-junit
+          fail-on-error: 'false'
+
+      - name: "Upload Unit Test Reports"
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v3
+        with:
+          name: "test_report_${{ matrix.godot-version }}"
+          path: |
+            reports/**
+            /var/lib/systemd/coredump/**
+            /var/log/syslog
+
+  finalize:
+    if: ${{ !cancelled() }}
+    runs-on: ubuntu-latest
+    name: Final Results
+    needs: [unit-test]
+    steps:
+      - run: exit 1
+        if: >-
+          ${{
+              contains(needs.*.result, 'failure')
+            || contains(needs.*.result, 'cancelled')
+          }}


### PR DESCRIPTION
# Why
Users want to get a fast introduce how to run GdUnit4 in a CI workflow.

# What
Provide a minimized example ci workflow to run tests on a PR.

