### PR TITLE
GD-269: Lazy loading of gdunit assets affects test case execution time.

### DIFF
--- a/addons/gdUnit4/src/GdUnitTestSuite.gd
+++ b/addons/gdUnit4/src/GdUnitTestSuite.gd
@@ -28,7 +28,7 @@ var __skip_reason :String = "Unknow."
 # We go this hard way to increase the loading performance to avoid reparsing all the used scripts
 # for more detailed info -> https://github.com/godotengine/godot/issues/67400
 func __lazy_load(script_path :String) -> GDScript:
-	return ResourceLoader.load(script_path, "GDScript", ResourceLoader.CACHE_MODE_REUSE)
+	return GdUnitAssertions.__lazy_load(script_path)
 
 
 func __gdunit_assert() -> GDScript:

--- a/addons/gdUnit4/src/asserts/GdUnitAssertions.gd
+++ b/addons/gdUnit4/src/asserts/GdUnitAssertions.gd
@@ -1,0 +1,30 @@
+# Preloads all GdUnit assertions
+class_name GdUnitAssertions
+extends RefCounted
+
+
+func _init():
+	# preload all gdunit assertions to speedup testsuite loading time
+	GdUnitAssertions.__lazy_load("res://addons/gdUnit4/src/asserts/GdUnitAssertImpl.gd")
+	GdUnitAssertions.__lazy_load("res://addons/gdUnit4/src/asserts/GdUnitBoolAssertImpl.gd")
+	GdUnitAssertions.__lazy_load("res://addons/gdUnit4/src/asserts/GdUnitStringAssertImpl.gd")
+	GdUnitAssertions.__lazy_load("res://addons/gdUnit4/src/asserts/GdUnitIntAssertImpl.gd")
+	GdUnitAssertions.__lazy_load("res://addons/gdUnit4/src/asserts/GdUnitFloatAssertImpl.gd")
+	GdUnitAssertions.__lazy_load("res://addons/gdUnit4/src/asserts/GdUnitVectorAssertImpl.gd")
+	GdUnitAssertions.__lazy_load("res://addons/gdUnit4/src/asserts/GdUnitArrayAssertImpl.gd")
+	GdUnitAssertions.__lazy_load("res://addons/gdUnit4/src/asserts/GdUnitDictionaryAssertImpl.gd")
+	GdUnitAssertions.__lazy_load("res://addons/gdUnit4/src/asserts/GdUnitFileAssertImpl.gd")
+	GdUnitAssertions.__lazy_load("res://addons/gdUnit4/src/asserts/GdUnitObjectAssertImpl.gd")
+	GdUnitAssertions.__lazy_load("res://addons/gdUnit4/src/asserts/GdUnitResultAssertImpl.gd")
+	GdUnitAssertions.__lazy_load("res://addons/gdUnit4/src/asserts/GdUnitFuncAssertImpl.gd")
+	GdUnitAssertions.__lazy_load("res://addons/gdUnit4/src/asserts/GdUnitSignalAssertImpl.gd")
+	GdUnitAssertions.__lazy_load("res://addons/gdUnit4/src/asserts/GdUnitFailureAssertImpl.gd")
+	GdUnitAssertions.__lazy_load("res://addons/gdUnit4/src/asserts/GdUnitGodotErrorAssertImpl.gd")
+
+
+### We now load all used asserts and tool scripts into the cache according to the principle of "lazy loading"
+### in order to noticeably reduce the loading time of the test suite.
+# We go this hard way to increase the loading performance to avoid reparsing all the used scripts
+# for more detailed info -> https://github.com/godotengine/godot/issues/67400
+static func __lazy_load(script_path :String) -> GDScript:
+	return ResourceLoader.load(script_path, "GDScript", ResourceLoader.CACHE_MODE_REUSE)

--- a/addons/gdUnit4/src/core/GdUnitExecutor.gd
+++ b/addons/gdUnit4/src/core/GdUnitExecutor.gd
@@ -15,6 +15,9 @@ const STAGE_TEST_CASE_AFTER = GdUnitReportCollector.STAGE_TEST_CASE_AFTER
 var _testsuite_timer :LocalTime
 var _testcase_timer :LocalTime
 
+# preload all asserts here
+@warning_ignore("unused_private_class_variable")
+var _assertions := GdUnitAssertions.new()
 var _memory_pool := GdUnitMemoryPool.new()
 var _report_errors_enabled :bool
 var _report_collector := GdUnitReportCollector.new()


### PR DESCRIPTION
# Why
The asserts was first loaded (lazy) when a test is executed, this distorts the test execution time

# What
Preload all gdunit assets that are initially loaded when the executor is created. Each next lazy load will then take the script out of the cache.


* before fix
![image](https://github.com/MikeSchulze/gdUnit4/assets/347037/e78a8fea-f1b4-4436-b1e9-6d1f9ecf077b)
* after fix
![image](https://github.com/MikeSchulze/gdUnit4/assets/347037/7537dc9f-0d3f-4b95-90e9-2b03ad0f515b)
