### PR TITLE
Cleanup script erros

### DIFF
--- a/addons/gdUnit4/src/core/execution/GdUnitMemoryObserver.gd
+++ b/addons/gdUnit4/src/core/execution/GdUnitMemoryObserver.gd
@@ -43,7 +43,7 @@ func register_auto_free(obj) -> Variant:
 
 # to disable instance guard when run into issues.
 static func _is_instance_guard_enabled() -> bool:
-	return true
+	return false
 
 
 static func debug_observe(name :String, obj :Object, indent :int = 0) -> void:

--- a/addons/gdUnit4/src/core/execution/stages/GdUnitTestSuiteExecutionStage.gd
+++ b/addons/gdUnit4/src/core/execution/stages/GdUnitTestSuiteExecutionStage.gd
@@ -56,7 +56,7 @@ func clone_test_suite(test_suite :GdUnitTestSuite) -> GdUnitTestSuite:
 		test_suite.remove_child(child)
 		_test_suite.add_child(child)
 	parent.add_child(_test_suite)
-	await GdUnitMemoryObserver.guard_instance(_test_suite.__awaiter)
+	GdUnitMemoryObserver.guard_instance(_test_suite.__awaiter)
 	# finally free current test suite instance
 	test_suite.free()
 	await Engine.get_main_loop().process_frame

--- a/addons/gdUnit4/src/core/execution/stages/fuzzed/GdUnitTestCaseFuzzedExecutionStage.gd
+++ b/addons/gdUnit4/src/core/execution/stages/fuzzed/GdUnitTestCaseFuzzedExecutionStage.gd
@@ -9,7 +9,8 @@ var _stage_test :IGdUnitExecutionStage = GdUnitTestCaseFuzzedTestStage.new()
 
 func _execute(context :GdUnitExecutionContext) -> void:
 	await _stage_before.execute(context)
-	await _stage_test.execute(GdUnitExecutionContext.of(context))
+	if not context.test_case.is_skipped():
+		await _stage_test.execute(GdUnitExecutionContext.of(context))
 	await _stage_after.execute(context)
 
 

--- a/addons/gdUnit4/src/core/execution/stages/parameterized/GdUnitTestCaseParameterizedExecutionStage.gd
+++ b/addons/gdUnit4/src/core/execution/stages/parameterized/GdUnitTestCaseParameterizedExecutionStage.gd
@@ -10,7 +10,8 @@ var _stage_test :IGdUnitExecutionStage = GdUnitTestCaseParamaterizedTestStage.ne
 
 func _execute(context :GdUnitExecutionContext) -> void:
 	await _stage_before.execute(context)
-	await _stage_test.execute(GdUnitExecutionContext.of(context))
+	if not context.test_case.is_skipped():
+		await _stage_test.execute(GdUnitExecutionContext.of(context))
 	await _stage_after.execute(context)
 
 

--- a/addons/gdUnit4/src/core/execution/stages/single/GdUnitTestCaseSingleExecutionStage.gd
+++ b/addons/gdUnit4/src/core/execution/stages/single/GdUnitTestCaseSingleExecutionStage.gd
@@ -10,7 +10,8 @@ var _stage_test :IGdUnitExecutionStage = GdUnitTestCaseSingleTestStage.new()
 
 func _execute(context :GdUnitExecutionContext) -> void:
 	await _stage_before.execute(context)
-	await _stage_test.execute(GdUnitExecutionContext.of(context))
+	if not context.test_case.is_skipped():
+		await _stage_test.execute(GdUnitExecutionContext.of(context))
 	await _stage_after.execute(context)
 
 

--- a/addons/gdUnit4/src/core/parse/GdDefaultValueDecoder.gd
+++ b/addons/gdUnit4/src/core/parse/GdDefaultValueDecoder.gd
@@ -243,6 +243,8 @@ static func decode(value :Variant) -> String:
 
 
 static func decode_typed(type :int, value :Variant) -> String:
+	if value == null:
+		return "null"
 	var decoder :Callable = instance("GdUnitDefaultValueDecoders", func(): return GdDefaultValueDecoder.new()).get_decoder(type)
 	if decoder == null:
 		push_error("No value decoder registered for type '%d'! Please open a Bug issue at 'https://github.com/MikeSchulze/gdUnit4/issues/new/choose'." % type)

--- a/addons/gdUnit4/src/core/parse/GdFunctionArgument.gd
+++ b/addons/gdUnit4/src/core/parse/GdFunctionArgument.gd
@@ -5,7 +5,7 @@ var _name: String
 var _type: int
 var _default_value :Variant
 
-const UNDEFINED = "<-NO_ARG->"
+const UNDEFINED :Variant = "<-NO_ARG->"
 const ARG_PARAMETERIZED_TEST := "test_parameters"
 
 
@@ -20,7 +20,7 @@ func name() -> String:
 
 
 func default() -> Variant:
-	return convert(_default_value, _type)
+	return _default_value
 
 
 func value_as_string() -> String:
@@ -34,7 +34,7 @@ func type() -> int:
 
 
 func has_default() -> bool:
-	return _default_value != UNDEFINED
+	return not is_same(_default_value, UNDEFINED)
 
 
 func is_parameter_set() -> bool:

--- a/addons/gdUnit4/src/core/parse/GdFunctionArgument.gd
+++ b/addons/gdUnit4/src/core/parse/GdFunctionArgument.gd
@@ -20,7 +20,7 @@ func name() -> String:
 
 
 func default() -> Variant:
-	return _default_value
+	return convert(_default_value, _type)
 
 
 func value_as_string() -> String:

--- a/addons/gdUnit4/src/core/parse/GdFunctionDescriptor.gd
+++ b/addons/gdUnit4/src/core/parse/GdFunctionDescriptor.gd
@@ -204,9 +204,10 @@ static func _extract_args(descriptor :Dictionary) -> Array[GdFunctionArgument]:
 		var arg :Dictionary = arguments.pop_back()
 		var arg_name := _argument_name(arg)
 		var arg_type := _argument_type(arg)
-		var arg_default := GdFunctionArgument.UNDEFINED
+		var arg_default :Variant = GdFunctionArgument.UNDEFINED
 		if not defaults.is_empty():
-			arg_default = _argument_default_value(arg, arg_type, defaults.pop_back())
+			var default_value = defaults.pop_back()
+			arg_default = GdDefaultValueDecoder.decode_typed(arg_type, default_value)
 		args_.push_front(GdFunctionArgument.new(arg_name, arg_type, arg_default))
 	return args_
 
@@ -247,9 +248,3 @@ static func _argument_type_as_string(arg :Dictionary) -> String:
 			return ""
 		_:
 			return GdObjects.type_as_string(type)
-
-
-static func _argument_default_value(arg :Dictionary, arg_type :int, default_value) -> String:
-	if default_value == null:
-		return "null"
-	return GdDefaultValueDecoder.decode_typed(arg_type, default_value)

--- a/addons/gdUnit4/src/extractors/GdUnitFuncValueExtractor.gd
+++ b/addons/gdUnit4/src/extractors/GdUnitFuncValueExtractor.gd
@@ -52,14 +52,18 @@ func _call_func(value, func_name :String):
 	if GdArrayTools.is_array_type(value) and func_name == "empty":
 		return value.is_empty()
 	
-	if not (value is Object):
-		if GdUnitSettings.is_verbose_assert_warnings():
-			push_warning("Extracting value from element '%s' by func '%s' failed! Converting to \"n.a.\"" % [value, func_name])
-		return "n.a."
-	var extract := Callable(value, func_name)
-	if extract.is_valid():
-		return value.call(func_name) if args().is_empty() else value.callv(func_name, args())
-	else:
-		if GdUnitSettings.is_verbose_assert_warnings():
-			push_warning("Extracting value from element '%s' by func '%s' failed! Converting to \"n.a.\"" % [value, func_name])
-		return "n.a."
+	if is_instance_valid(value):
+		# extract from function
+		if value.has_method(func_name):
+			var extract := Callable(value, func_name)
+			if extract.is_valid():
+				return value.call(func_name) if args().is_empty() else value.callv(func_name, args())
+		else:
+			# if no function exists than try to extract form parmeters
+			var parameter = value.get(func_name)
+			if parameter != null:
+				return parameter
+	# nothing found than return 'n.a.'
+	if GdUnitSettings.is_verbose_assert_warnings():
+		push_warning("Extracting value from element '%s' by func '%s' failed! Converting to \"n.a.\"" % [value, func_name])
+	return "n.a."

--- a/addons/gdUnit4/src/report/GdUnitByPathReport.gd
+++ b/addons/gdUnit4/src/report/GdUnitByPathReport.gd
@@ -2,14 +2,14 @@ class_name GdUnitByPathReport
 extends GdUnitReportSummary
 
 
-func _init(path :String, reports :Array[GdUnitReportSummary]):
-	_resource_path = path
-	_reports = reports
+func _init(path_ :String, reports_ :Array[GdUnitReportSummary]):
+	_resource_path = path_
+	_reports = reports_
 
 
-static func sort_reports_by_path(reports :Array[GdUnitReportSummary]) -> Dictionary:
+static func sort_reports_by_path(reports_ :Array[GdUnitReportSummary]) -> Dictionary:
 	var by_path := Dictionary()
-	for report in reports:
+	for report in reports_:
 		var suite_path :String = report.path()
 		var suite_report :Array[GdUnitReportSummary] = by_path.get(suite_path, [] as Array[GdUnitReportSummary])
 		suite_report.append(report)
@@ -38,10 +38,10 @@ func write(report_dir :String) -> String:
 	return output_path
 
 
-static func apply_testsuite_reports(report_dir :String, template :String, reports :Array[GdUnitReportSummary]) -> String:
+func apply_testsuite_reports(report_dir :String, template :String, reports_ :Array[GdUnitReportSummary]) -> String:
 	var table_records := PackedStringArray()
 	
-	for report in reports:
+	for report in reports_:
 		var report_link = report.output_path(report_dir).replace(report_dir, "..")
 		table_records.append(report.create_record(report_link))
 	return template.replace(GdUnitHtmlPatterns.TABLE_BY_TESTSUITES, "\n".join(table_records))

--- a/addons/gdUnit4/src/report/GdUnitHtmlReport.gd
+++ b/addons/gdUnit4/src/report/GdUnitHtmlReport.gd
@@ -7,9 +7,9 @@ var _report_path :String
 var _iteration :int
 
 
-func _init(path :String):
-	_iteration = GdUnitTools.find_last_path_index(path, REPORT_DIR_PREFIX) + 1
-	_report_path = "%s/%s%d" % [path, REPORT_DIR_PREFIX, _iteration]
+func _init(path_ :String):
+	_iteration = GdUnitTools.find_last_path_index(path_, REPORT_DIR_PREFIX) + 1
+	_report_path = "%s/%s%d" % [path_, REPORT_DIR_PREFIX, _iteration]
 	DirAccess.make_dir_recursive_absolute(_report_path)
 
 
@@ -17,37 +17,37 @@ func add_testsuite_report(suite_report :GdUnitTestSuiteReport):
 	_reports.append(suite_report)
 
 
-func add_testcase_report(resource_path :String, suite_report :GdUnitTestCaseReport) -> void:
+func add_testcase_report(resource_path_ :String, suite_report :GdUnitTestCaseReport) -> void:
 	for report in _reports:
-		if report.resource_path() == resource_path:
+		if report.resource_path() == resource_path_:
 			report.add_report(suite_report)
 
 
 func update_test_suite_report(
-	resource_path :String,
-	duration :int,
-	is_error :bool,
-	is_failed: bool,
-	is_warning :bool,
-	is_skipped :bool,
-	skipped_count :int,
-	failed_count :int,
-	orphan_count :int,
-	reports :Array = []) -> void:
+	resource_path_ :String,
+	duration_ :int,
+	_is_error :bool,
+	is_failed_: bool,
+	_is_warning :bool,
+	is_skipped_ :bool,
+	skipped_count_ :int,
+	failed_count_ :int,
+	orphan_count_ :int,
+	reports_ :Array = []) -> void:
 	
 	for report in _reports:
-		if report.resource_path() == resource_path:
-			report.set_duration(duration)
-			report.set_failed(is_failed, failed_count)
-			report.set_orphans(orphan_count)
-			report.set_reports(reports)
-	if is_skipped:
-		_skipped_count = skipped_count
+		if report.resource_path() == resource_path_:
+			report.set_duration(duration_)
+			report.set_failed(is_failed_, failed_count_)
+			report.set_orphans(orphan_count_)
+			report.set_reports(reports_)
+	if is_skipped_:
+		_skipped_count = skipped_count_
 
 
-func update_testcase_report(resource_path :String, test_report :GdUnitTestCaseReport):
+func update_testcase_report(resource_path_ :String, test_report :GdUnitTestCaseReport):
 	for report in _reports:
-		if report.resource_path() == resource_path:
+		if report.resource_path() == resource_path_:
 			report.update(test_report)
 
 
@@ -67,21 +67,21 @@ func delete_history(max_reports :int) -> int:
 	return GdUnitTools.delete_path_index_lower_equals_than(_report_path.get_base_dir(), REPORT_DIR_PREFIX, _iteration-max_reports)
 
 
-static func apply_path_reports(report_dir :String, template :String, reports :Array) -> String:
-	var path_report_mapping := GdUnitByPathReport.sort_reports_by_path(reports)
+func apply_path_reports(report_dir :String, template :String, reports_ :Array) -> String:
+	var path_report_mapping := GdUnitByPathReport.sort_reports_by_path(reports_)
 	var table_records := PackedStringArray()
 	var paths := path_report_mapping.keys()
 	paths.sort()
-	for path in paths:
-		var report := GdUnitByPathReport.new(path, path_report_mapping.get(path))
+	for path_ in paths:
+		var report := GdUnitByPathReport.new(path_, path_report_mapping.get(path_))
 		var report_link :String = report.write(report_dir).replace(report_dir, ".")
 		table_records.append(report.create_record(report_link))
 	return template.replace(GdUnitHtmlPatterns.TABLE_BY_PATHS, "\n".join(table_records))
 
 
-static func apply_testsuite_reports(report_dir :String, template :String, reports :Array) -> String:
+func apply_testsuite_reports(report_dir :String, template :String, reports_ :Array) -> String:
 	var table_records := PackedStringArray()
-	for report in reports:
+	for report in reports_:
 		var report_link :String = report.write(report_dir).replace(report_dir, ".")
 		table_records.append(report.create_record(report_link))
 	return template.replace(GdUnitHtmlPatterns.TABLE_BY_TESTSUITES, "\n".join(table_records))

--- a/addons/gdUnit4/src/report/GdUnitTestCaseReport.gd
+++ b/addons/gdUnit4/src/report/GdUnitTestCaseReport.gd
@@ -9,7 +9,7 @@ func _init(
 		p_suite_name :String,
 		test_name :String,
 		is_error := false,
-		is_failed := false,
+		_is_failed := false,
 		failed_count :int = 0,
 		orphan_count_ :int = 0,
 		is_skipped := false,

--- a/addons/gdUnit4/test/asserts/GdUnitArrayAssertImplTest.gd
+++ b/addons/gdUnit4/test/asserts/GdUnitArrayAssertImplTest.gd
@@ -4,6 +4,17 @@ extends GdUnitTestSuite
 # TestSuite generated from
 const __source = 'res://addons/gdUnit4/src/asserts/GdUnitArrayAssertImpl.gd'
 
+var _saved_report_assert_warnings
+
+
+func before():
+	_saved_report_assert_warnings = ProjectSettings.get_setting(GdUnitSettings.REPORT_ASSERT_WARNINGS)
+	ProjectSettings.set_setting(GdUnitSettings.REPORT_ASSERT_WARNINGS, false)
+
+
+func after():
+	ProjectSettings.set_setting(GdUnitSettings.REPORT_ASSERT_WARNINGS, _saved_report_assert_warnings)
+
 
 func test_is_null() -> void:
 	assert_array(null).is_null()

--- a/addons/gdUnit4/test/core/parse/GdDefaultValueDecoderTest.gd
+++ b/addons/gdUnit4/test/core/parse/GdDefaultValueDecoderTest.gd
@@ -21,6 +21,7 @@ func after():
 			.is_not_null()
 
 
+@warning_ignore("unused_parameter")
 func test_decode_Primitives(variant_type :int, value, expected :String, test_parameters := [
 	[TYPE_NIL, null, "null"],
 	[TYPE_BOOL, true, "true"],
@@ -42,6 +43,7 @@ func test_decode_Primitives(variant_type :int, value, expected :String, test_par
 	_tested_types[variant_type] = 1
 
 
+@warning_ignore("unused_parameter")
 func test_decode_Vectors(variant_type :int, value, expected :String, test_parameters := [
 	[TYPE_VECTOR2, Vector2(), "Vector2()"],
 	[TYPE_VECTOR2, Vector2(1,2), "Vector2(1, 2)"],
@@ -61,6 +63,7 @@ func test_decode_Vectors(variant_type :int, value, expected :String, test_parame
 	_tested_types[variant_type] = 1
 
 
+@warning_ignore("unused_parameter")
 func test_decode_Rect2(variant_type :int, value, expected :String, test_parameters := [
 	[TYPE_RECT2, Rect2(), "Rect2()"],
 	[TYPE_RECT2, Rect2(1,2, 10,20), "Rect2(Vector2(1, 2), Vector2(10, 20))"],
@@ -72,6 +75,7 @@ func test_decode_Rect2(variant_type :int, value, expected :String, test_paramete
 	_tested_types[variant_type] = 1
 
 
+@warning_ignore("unused_parameter")
 func test_decode_Transforms(variant_type :int, value, expected :String, test_parameters := [
 	[TYPE_TRANSFORM2D, Transform2D(),
 		"Transform2D()"],
@@ -96,6 +100,7 @@ func test_decode_Transforms(variant_type :int, value, expected :String, test_par
 	_tested_types[variant_type] = 1
 
 
+@warning_ignore("unused_parameter")
 func test_decode_Plane(variant_type :int, value, expected :String, test_parameters := [
 	[TYPE_PLANE, Plane(), "Plane()"],
 	[TYPE_PLANE, Plane(1,2,3,4), "Plane(1, 2, 3, 4)"],
@@ -105,6 +110,7 @@ func test_decode_Plane(variant_type :int, value, expected :String, test_paramete
 	_tested_types[variant_type] = 1
 
 
+@warning_ignore("unused_parameter")
 func test_decode_Quaternion(variant_type :int, value, expected :String, test_parameters := [
 	[TYPE_QUATERNION, Quaternion(), "Quaternion()"],
 	[TYPE_QUATERNION, Quaternion(1,2,3,4), "Quaternion(1, 2, 3, 4)"],
@@ -113,6 +119,7 @@ func test_decode_Quaternion(variant_type :int, value, expected :String, test_par
 	_tested_types[variant_type] = 1
 
 
+@warning_ignore("unused_parameter")
 func test_decode_AABB(variant_type :int, value, expected :String, test_parameters := [
 	[TYPE_AABB, AABB(), "AABB()"],
 	[TYPE_AABB, AABB(Vector3.ONE, Vector3(10,20,30)), "AABB(Vector3(1, 1, 1), Vector3(10, 20, 30))"],
@@ -121,6 +128,7 @@ func test_decode_AABB(variant_type :int, value, expected :String, test_parameter
 	_tested_types[variant_type] = 1
 
 
+@warning_ignore("unused_parameter")
 func test_decode_Basis(variant_type :int, value, expected :String, test_parameters := [
 	[TYPE_BASIS, Basis(), "Basis()"],
 	[TYPE_BASIS, Basis(Vector3(0.1,0.2,0.3).normalized(), .1),
@@ -132,6 +140,7 @@ func test_decode_Basis(variant_type :int, value, expected :String, test_paramete
 	_tested_types[variant_type] = 1
 
 
+@warning_ignore("unused_parameter")
 func test_decode_Color(variant_type :int, value, expected :String, test_parameters := [
 	[TYPE_COLOR, Color(), "Color()"],
 	[TYPE_COLOR, Color.RED, "Color(1, 0, 0, 1)"],
@@ -141,6 +150,7 @@ func test_decode_Color(variant_type :int, value, expected :String, test_paramete
 	_tested_types[variant_type] = 1
 
 
+@warning_ignore("unused_parameter")
 func test_decode_NodePath(variant_type :int, value, expected :String, test_parameters := [
 	[TYPE_NODE_PATH, NodePath(), 'NodePath()'],
 	[TYPE_NODE_PATH, NodePath("/foo/bar"), 'NodePath("/foo/bar")'],
@@ -149,6 +159,7 @@ func test_decode_NodePath(variant_type :int, value, expected :String, test_param
 	_tested_types[variant_type] = 1
 
 
+@warning_ignore("unused_parameter")
 func test_decode_RID(variant_type :int, value, expected :String, test_parameters := [
 	[TYPE_RID, RID(), 'RID()'],
 	]) -> void:
@@ -156,6 +167,7 @@ func test_decode_RID(variant_type :int, value, expected :String, test_parameters
 	_tested_types[variant_type] = 1
 
 
+@warning_ignore("unused_parameter")
 func _test_decode_Object(variant_type :int, value, expected :String, test_parameters := [
 	[TYPE_OBJECT, Node.new(), 'Node.new()'],
 	]) -> void:
@@ -163,6 +175,7 @@ func _test_decode_Object(variant_type :int, value, expected :String, test_parame
 	_tested_types[variant_type] = 1
 
 
+@warning_ignore("unused_parameter")
 func test_decode_Callable(variant_type :int, value, expected :String, test_parameters := [
 	[TYPE_CALLABLE, Callable(), 'Callable()'],
 	]) -> void:
@@ -170,6 +183,7 @@ func test_decode_Callable(variant_type :int, value, expected :String, test_param
 	_tested_types[variant_type] = 1
 
 
+@warning_ignore("unused_parameter")
 func test_decode_Signal(variant_type :int, value, expected :String, test_parameters := [
 	[TYPE_SIGNAL, Signal(), 'Signal()'],
 	]) -> void:
@@ -177,6 +191,7 @@ func test_decode_Signal(variant_type :int, value, expected :String, test_paramet
 	_tested_types[variant_type] = 1
 
 
+@warning_ignore("unused_parameter")
 func test_decode_Dictionary(variant_type :int, value, expected :String, test_parameters := [
 	[TYPE_DICTIONARY, {}, '{}'],
 	[TYPE_DICTIONARY, Dictionary(), '{}'],
@@ -187,6 +202,7 @@ func test_decode_Dictionary(variant_type :int, value, expected :String, test_par
 	_tested_types[variant_type] = 1
 
 
+@warning_ignore("unused_parameter")
 func test_decode_Array(variant_type :int, value, expected :String, test_parameters := [
 	[TYPE_ARRAY, [], '[]'],
 	[TYPE_ARRAY, Array(), '[]'],
@@ -196,6 +212,7 @@ func test_decode_Array(variant_type :int, value, expected :String, test_paramete
 	_tested_types[variant_type] = 1
 
 
+@warning_ignore("unused_parameter")
 func test_decode_typedArrays(variant_type :int, value, expected :String, test_parameters := [
 	[TYPE_PACKED_BYTE_ARRAY, PackedByteArray(),
 		'PackedByteArray()'],


### PR DESCRIPTION
# Why
GdUnit4 contains some script errors such as:
- redundant awaits
- shadowing an already-declared function at line xxx


# What
- Fix error messages to rid the log of script errors generated by the GdUnit4 framework
- Fix bug in the new executor, do not execute skipped test cases
- Disable the leaked instance gurad for now, it let the engine randomly crash at exit and needs an deeper investigate to fix 
