### PR TITLE
Update to new GdUnit4 CSharp API package

### DIFF
--- a/addons/gdUnit4/bin/GdUnitCmdTool.gd
+++ b/addons/gdUnit4/bin/GdUnitCmdTool.gd
@@ -289,8 +289,8 @@ class CLIRunner extends Node:
 		return total
 	
 	
-	func PublishEvent(data) -> void:
-		_on_gdunit_event(GdUnitEvent.new().deserialize(data.AsDictionary()))
+	func PublishEvent(data :Dictionary) -> void:
+		_on_gdunit_event(GdUnitEvent.new().deserialize(data))
 	
 	
 	func _on_gdunit_event(event :GdUnitEvent):
@@ -398,8 +398,6 @@ func _initialize():
 
 func _finalize():
 	prints("Finallize ..")
-	if is_instance_valid(_cli_runner):
-		_cli_runner.free()
 	prints("-Orphan nodes report-----------------------")
 	Window.print_orphan_nodes()
 	prints("Finallize .. done")

--- a/addons/gdUnit4/bin/ProjectScanner.gd
+++ b/addons/gdUnit4/bin/ProjectScanner.gd
@@ -11,11 +11,6 @@ func _initialize():
 	root.add_child(scanner)
 
 
-func _process(_delta):
-	if not is_instance_valid(scanner):
-		quit(0)
-
-
 func _finalize():
 	prints("__finalize")
 
@@ -58,7 +53,7 @@ class SourceScanner extends Node:
 			_console.prints_color("======================================", Color.CORNFLOWER_BLUE)
 			_console.new_line()
 			await get_tree().process_frame
-			queue_free()
+			get_tree().quit(0)
 	
 	
 	func scan_project() -> void:
@@ -90,4 +85,6 @@ class SourceScanner extends Node:
 			_console.progressBar(fs.get_scanning_progress() * 100 as int)
 		_console.progressBar(100)
 		_console.new_line()
+		await get_tree().process_frame
 		plugin.queue_free()
+		await get_tree().process_frame

--- a/addons/gdUnit4/src/core/GdUnitRunner.gd
+++ b/addons/gdUnit4/src/core/GdUnitRunner.gd
@@ -163,6 +163,6 @@ func _on_gdunit_event(event :GdUnitEvent):
 
 
 # Event bridge from C# GdUnit4.ITestEventListener.cs
-func PublishEvent(data) -> void:
-	var event := GdUnitEvent.new().deserialize(data.AsDictionary())
+func PublishEvent(data :Dictionary) -> void:
+	var event := GdUnitEvent.new().deserialize(data)
 	_client.rpc_send(RPCGdUnitEvent.of(event))

--- a/gdUnit4.csproj
+++ b/gdUnit4.csproj
@@ -10,6 +10,6 @@
   </PropertyGroup>
   <ItemGroup>
     <!--Required for GdUnit4-->
-    <PackageReference Include="GdUnit4MonoApi" Version="4.2.0-rc*" />
+    <PackageReference Include="gdUnit4.api" Version="4.2.0-rc*" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
# Why
The C# GdUnit4 API package is renamed to gdUnit4.api and the serialization of TestEvent has changed

# What
- Update the project to use NuGet package 'gdUnit4.api'
- Update `PublishEvent` handled incoming data as dictionary


