### PR TITLE
GD-286: Update project to Godot 4.2

### DIFF
--- a/addons/gdUnit4/src/core/GodotVersionFixures.gd
+++ b/addons/gdUnit4/src/core/GodotVersionFixures.gd
@@ -9,3 +9,13 @@ static func get_icon(control :Control, icon_name :String) -> Texture2D:
 	if Engine.get_version_info().hex >= 040200:
 		return control.get_theme_icon(icon_name, "EditorIcons")
 	return control.theme.get_icon(icon_name, "EditorIcons")
+
+
+@warning_ignore("shadowed_global_identifier")
+static func type_convert(value: Variant, type: int):
+	return convert(value, type)
+
+
+@warning_ignore("shadowed_global_identifier")
+static func convert(value: Variant, type: int) -> Variant:
+	return type_convert(value, type)

--- a/addons/gdUnit4/src/core/parse/GdFunctionArgument.gd
+++ b/addons/gdUnit4/src/core/parse/GdFunctionArgument.gd
@@ -20,7 +20,7 @@ func name() -> String:
 
 
 func default() -> Variant:
-	return type_convert(_default_value, _type)
+	return GodotVersionFixures.convert(_default_value, _type)
 
 
 func value_as_string() -> String:

--- a/addons/gdUnit4/src/core/parse/GdFunctionArgument.gd
+++ b/addons/gdUnit4/src/core/parse/GdFunctionArgument.gd
@@ -20,7 +20,7 @@ func name() -> String:
 
 
 func default() -> Variant:
-	return convert(_default_value, _type)
+	return type_convert(_default_value, _type)
 
 
 func value_as_string() -> String:


### PR DESCRIPTION
# Why
Fixing a syntax error when opening `GdUnit4` in Godot 4.2 stable, closes https://github.com/MikeSchulze/gdUnit4/issues/286


# What
<!-- Describe exactly what you have changed and what the effects are -->
Renames `convert()` to [`type_convert()`](https://docs.godotengine.org/en/stable/classes/class_@globalscope.html#class-globalscope-method-type-convert).
```diff
 func default() -> Variant:
-       return convert(_default_value, _type)
+       return type_convert(_default_value, _type)
```