### PR TITLE
GD-292: Add test coverage to simulate input event as actions

### DIFF
--- a/addons/gdUnit4/test/core/GdUnitSceneRunnerTest.gd
+++ b/addons/gdUnit4/test/core/GdUnitSceneRunnerTest.gd
@@ -312,8 +312,10 @@ func test_runner_by_scene_instance() -> void:
 	runner._notification(NOTIFICATION_PREDELETE)
 	# give engine time to free the resources
 	await await_idle_frame()
-	# verify runner and scene is freed
-	assert_bool(is_instance_valid(scene)).is_false()
+	# scene runner using external scene do not free the scene at exit
+	assert_bool(is_instance_valid(scene)).is_true()
+	# needs to be manually freed
+	scene.free()
 
 
 func test_mouse_drag_and_drop() -> void:

--- a/addons/gdUnit4/test/core/parse/GdFunctionDescriptorTest.gd
+++ b/addons/gdUnit4/test/core/parse/GdFunctionDescriptorTest.gd
@@ -116,6 +116,10 @@ func test_extract_from_descriptor_is_virtual_func_full_check():
 		"_unhandled_input",
 		"_unhandled_key_input"
 	]
+	# since Godot 4.2 there are more virtual functions
+	if Engine.get_version_info().hex >= 0x40200:
+		expected_virtual_functions.append("_validate_property")
+		
 	var _count := 0
 	for method_descriptor in methods:
 		var fd := GdFunctionDescriptor.extract_from(method_descriptor)

--- a/addons/gdUnit4/test/core/resources/scenes/input_actions/InputEventTestScene.gd
+++ b/addons/gdUnit4/test/core/resources/scenes/input_actions/InputEventTestScene.gd
@@ -1,0 +1,15 @@
+extends Control
+
+var _player_jump_action_released := false
+
+# enable for manual testing
+func __init():
+	var event := InputEventKey.new()
+	event.keycode = KEY_SPACE
+	InputMap.add_action("player_jump")
+	InputMap.action_add_event("player_jump", event)
+
+
+func _input(event):
+	_player_jump_action_released = Input.is_action_just_released("player_jump", true)
+	#prints("_input2:player_jump", Input.is_action_just_released("player_jump"), Input.is_action_just_released("player_jump", true))

--- a/addons/gdUnit4/test/core/resources/scenes/input_actions/InputEventTestScene.tscn
+++ b/addons/gdUnit4/test/core/resources/scenes/input_actions/InputEventTestScene.tscn
@@ -1,0 +1,12 @@
+[gd_scene load_steps=2 format=3 uid="uid://cvklb72mxqh1h"]
+
+[ext_resource type="Script" path="res://addons/gdUnit4/test/core/resources/scenes/input_actions/InputEventTestScene.gd" id="1_wslmn"]
+
+[node name="InputEventTestScene" type="Control"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+script = ExtResource("1_wslmn")


### PR DESCRIPTION
# Why
A user reported input actions not work.


# What
- Add test coverage to verify it works as expected
- fix small scene memory free bug.


