### PR TITLE
GD-296: Fix `signal_assert` to collect many signals at same time

### DIFF
--- a/addons/gdUnit4/src/asserts/GdUnitSignalAssertImpl.gd
+++ b/addons/gdUnit4/src/asserts/GdUnitSignalAssertImpl.gd
@@ -106,5 +106,5 @@ func _wail_until_signal(signal_name :String, expected_args :Array, expect_not_em
 		report_error(GdAssertMessages.error_wait_signal(signal_name, expected_args, LocalTime.elapsed(_timeout)))
 	timer.free()
 	if is_instance_valid(_emitter):
-		_signal_collector.reset_received_signals(_emitter)
+		_signal_collector.reset_received_signals(_emitter, signal_name, expected_args)
 	return self

--- a/addons/gdUnit4/src/core/GdUnitSignalCollector.gd
+++ b/addons/gdUnit4/src/core/GdUnitSignalCollector.gd
@@ -63,17 +63,18 @@ func _on_signal_emmited( arg0=NO_ARG, arg1=NO_ARG, arg2=NO_ARG, arg3=NO_ARG, arg
 	# extract the emitter and signal_name from the last two arguments (see line 61 where is added)
 	var signal_name :String = signal_args.pop_back()
 	var emitter :Object = signal_args.pop_back()
-	# prints("_on_signal_emmited:", emitter, signal_name, signal_args)
+	#prints("_on_signal_emmited:", emitter, signal_name, signal_args)
 	if is_signal_collecting(emitter, signal_name):
 		_collected_signals[emitter][signal_name].append(signal_args)
 
 
-func reset_received_signals(emitter :Object):
-	# _debug_signal_list("before claer");
+func reset_received_signals(emitter :Object, signal_name: String, signal_args :Array):
+	#_debug_signal_list("before claer");
 	if _collected_signals.has(emitter):
-		for signal_name in _collected_signals[emitter]:
-			_collected_signals[emitter][signal_name].clear()
-	# _debug_signal_list("after claer");
+		var signals_by_emitter = _collected_signals[emitter]
+		if signals_by_emitter.has(signal_name):
+			_collected_signals[emitter][signal_name].erase(signal_args)
+	#_debug_signal_list("after claer");
 
 
 func is_signal_collecting(emitter :Object, signal_name :String) -> bool:
@@ -85,7 +86,7 @@ func match(emitter :Object, signal_name :String, args :Array) -> bool:
 	if _collected_signals.is_empty() or not _collected_signals.has(emitter):
 		return false
 	for received_args in _collected_signals[emitter][signal_name]:
-		# prints("testing", signal_name, received_args, "vs", args)
+		#prints("testing", signal_name, received_args, "vs", args)
 		if GdObjects.equals(received_args, args):
 			return true
 	return false

--- a/addons/gdUnit4/test/asserts/GdUnitSignalAssertImplTest.gd
+++ b/addons/gdUnit4/test/asserts/GdUnitSignalAssertImplTest.gd
@@ -11,7 +11,7 @@ const GdUnitTools = preload("res://addons/gdUnit4/src/core/GdUnitTools.gd")
 
 class TestEmitter extends Node:
 	signal test_signal_counted(value)
-	signal test_signal()
+	signal test_signal(value :int)
 	signal test_signal_unused()
 	
 	var _trigger_count :int
@@ -25,7 +25,8 @@ class TestEmitter extends Node:
 			test_signal_counted.emit(_count)
 		
 		if _count == 20:
-			test_signal.emit()
+			test_signal.emit(10)
+			test_signal.emit(20)
 		_count += 1
 
 
@@ -66,7 +67,8 @@ func test_unknown_signal() -> void:
 
 func test_signal_is_emitted_without_args() -> void:
 	# wait until signal 'test_signal_counted' without args
-	await assert_signal(signal_emitter).is_emitted("test_signal")
+	await assert_signal(signal_emitter).is_emitted("test_signal", [10])
+	await assert_signal(signal_emitter).is_emitted("test_signal", [20])
 	# wait until signal 'test_signal_unused' where is never emitted
 	
 	if is_skip_fail_await():
@@ -207,3 +209,4 @@ func test_monitor_signals_on_resource_set() -> void:
 	# title change should emit "changed" signal
 	await assert_signal(emitter).is_emitted("changed")
 	assert_str(sut.title).is_equal("Some title")
+


### PR DESCRIPTION
# Why
The `signal_assert` was not able to collect many signals at the same time, each assert call resulted in a cleanup of the collected signals, so the next `assert_signal` failed

# What
Correct cleanup of collected signals, clean up only the signals used by the specific assert call


