### PR TITLE
GD-301: Add Godot `4.2.1` to CI

### DIFF
--- a/.github/workflows/ci-dev.yml
+++ b/.github/workflows/ci-dev.yml
@@ -21,7 +21,7 @@ jobs:
       fail-fast: false
       max-parallel: 10
       matrix:
-        godot-version: ['4.0.1', '4.0.2', '4.0.3', '4.1', '4.1.1', '4.1.2', '4.1.3', '4.2']
+        godot-version: ['4.0.1', '4.0.2', '4.0.3', '4.1', '4.1.1', '4.1.2', '4.1.3', '4.2', '4.2.1']
 
     name: "CI on Godot 🐧 v${{ matrix.godot-version }}-stable"
     uses: ./.github/workflows/unit-tests.yml

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -4,7 +4,6 @@ run-name: ${{ github.head_ref || github.ref_name }}-ci-pr
 on:
   pull_request:
     paths-ignore:
-      - '**.yml'
       - '**.jpg'
       - '**.png'
       - '**.md'
@@ -22,11 +21,11 @@ jobs:
       fail-fast: false
       max-parallel: 10
       matrix:
-        godot-version: ['4.0.1', '4.0.2', '4.0.3', '4.1', '4.1.1', '4.1.2', '4.1.3', '4.2']
+        godot-version: ['4.0.1', '4.0.2', '4.0.3', '4.1', '4.1.1', '4.1.2', '4.1.3', '4.2', '4.2.1']
         godot-status: ['stable']
-#        include:
-#          - godot-version: '4.2'
-#            godot-status: 'beta4'
+        include:
+          - godot-version: '4.3'
+            godot-status: 'dev1'
 
 
     name: "CI on Godot 🐧 v${{ matrix.godot-version }}-${{ matrix.godot-status }}"

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -99,7 +99,8 @@ jobs:
 
   unit-test-mono:
     name: "Unit Tests Mono"
-    if: ${{ startsWith(inputs.godot-version, '4.1') || startsWith(inputs.godot-version, '4.2') }}
+    # We exclude Godot 4.0.x
+    if: ${{ !startsWith(inputs.godot-version, '4.0') }}
     runs-on: ${{ inputs.os }}
     timeout-minutes: 5
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 ---
 <h1 align="center">GdUnit4</h1>
-<p align="center">This version of GdUnit4 is based on Godot <strong>v4.2.stable.mono.official [46dc27791]</strong> (master branch)</p>
+<p align="center">This version of GdUnit4 is based on Godot <strong>v4.2.1.stable.official [b09f793f5]</strong> (master branch)</p>
 </h2>
 
 
@@ -20,6 +20,7 @@
   <img src="https://img.shields.io/badge/Godot-v4.1.2-%23478cbf?logo=godot-engine&logoColor=cyian&color=green">
   <img src="https://img.shields.io/badge/Godot-v4.1.3-%23478cbf?logo=godot-engine&logoColor=cyian&color=green">
   <img src="https://img.shields.io/badge/Godot-v4.2.0-%23478cbf?logo=godot-engine&logoColor=cyian&color=green">
+  <img src="https://img.shields.io/badge/Godot-v4.2.1-%23478cbf?logo=godot-engine&logoColor=cyian&color=green">
 </p>
 
 <p align="center"><a href="https://github.com/MikeSchulze/gdUnit4"><img src="https://github.com/MikeSchulze/gdUnit4/blob/master/assets/gdUnit4-animated.gif" width="100%"/></p><br/>


### PR DESCRIPTION
#  Why
We need to cover Godot 4.2.1 and upcoming Godot 4.3 on CI.

# What
- Add Godot 4.2.1 and 4.3-dev to CI-PR
- Add Godot 4.2.1 to CI-DEV


