### PR TITLE
GD-303: Do not report script errors when if already tested by using `assert_error`

### DIFF
--- a/.github/workflows/ci-dev.yml
+++ b/.github/workflows/ci-dev.yml
@@ -21,7 +21,7 @@ jobs:
       fail-fast: false
       max-parallel: 10
       matrix:
-        godot-version: ['4.0.1', '4.0.2', '4.0.3', '4.1', '4.1.1', '4.1.2', '4.1.3', '4.2', '4.2.1']
+        godot-version: ['4.1', '4.1.1', '4.1.2', '4.1.3', '4.2', '4.2.1']
 
     name: "CI on Godot 🐧 v${{ matrix.godot-version }}-stable"
     uses: ./.github/workflows/unit-tests.yml

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -21,7 +21,7 @@ jobs:
       fail-fast: false
       max-parallel: 10
       matrix:
-        godot-version: ['4.0.1', '4.0.2', '4.0.3', '4.1', '4.1.1', '4.1.2', '4.1.3', '4.2', '4.2.1']
+        godot-version: ['4.1', '4.1.1', '4.1.2', '4.1.3', '4.2', '4.2.1']
         godot-status: ['stable']
         include:
           - godot-version: '4.3'

--- a/README.md
+++ b/README.md
@@ -10,11 +10,8 @@
 
 
 ---
-
+<h1 align="center">Supported Godot Versions</h2>
 <p align="center">
-  <img src="https://img.shields.io/badge/Godot-v4.0.1-%23478cbf?logo=godot-engine&logoColor=cyian&color=green">
-  <img src="https://img.shields.io/badge/Godot-v4.0.2-%23478cbf?logo=godot-engine&logoColor=cyian&color=green">
-  <img src="https://img.shields.io/badge/Godot-v4.0.3-%23478cbf?logo=godot-engine&logoColor=cyian&color=green">
   <img src="https://img.shields.io/badge/Godot-v4.1-%23478cbf?logo=godot-engine&logoColor=cyian&color=green">
   <img src="https://img.shields.io/badge/Godot-v4.1.1-%23478cbf?logo=godot-engine&logoColor=cyian&color=green">
   <img src="https://img.shields.io/badge/Godot-v4.1.2-%23478cbf?logo=godot-engine&logoColor=cyian&color=green">

--- a/addons/gdUnit4/bin/GdUnitCmdTool.gd
+++ b/addons/gdUnit4/bin/GdUnitCmdTool.gd
@@ -18,6 +18,7 @@ class CLIRunner extends Node:
 	const RETURN_SUCCESS  =   0
 	const RETURN_ERROR    = 100
 	const RETURN_ERROR_HEADLESS_NOT_SUPPORTED  = 103
+	const RETURN_ERROR_GODOT_VERSION_NOT_SUPPORTED  = 104
 	const RETURN_WARNING  = 101
 
 	var _state = READY
@@ -391,6 +392,10 @@ var _cli_runner :CLIRunner
 
 
 func _initialize():
+	if Engine.get_version_info().hex < 0x40100:
+		prints("GdUnit4 requires a minimum of Godot 4.1.x Version!")
+		quit(CLIRunner.RETURN_ERROR_GODOT_VERSION_NOT_SUPPORTED)
+		return
 	DisplayServer.window_set_mode(DisplayServer.WINDOW_MODE_MINIMIZED)
 	_cli_runner = CLIRunner.new()
 	root.add_child(_cli_runner)

--- a/addons/gdUnit4/plugin.gd
+++ b/addons/gdUnit4/plugin.gd
@@ -9,6 +9,9 @@ var _gd_console :Node
 
 
 func _enter_tree():
+	if Engine.get_version_info().hex < 0x40100:
+		prints("GdUnit4 plugin requires a minimum of Godot 4.1.x Version!")
+		return
 	Engine.set_meta("GdUnitEditorPlugin", self)
 	GdUnitSettings.setup()
 	# install the GdUnit inspector

--- a/addons/gdUnit4/src/asserts/GdUnitGodotErrorAssertImpl.gd
+++ b/addons/gdUnit4/src/asserts/GdUnitGodotErrorAssertImpl.gd
@@ -15,14 +15,15 @@ func _init(callable :Callable):
 
 func _execute() -> Array[ErrorLogEntry]:
 	# execute the given code and monitor for runtime errors
-	var monitor := GodotGdErrorMonitor.new(true)
-	monitor.start()
 	if _callable == null or not _callable.is_valid():
 		_report_error("Invalid Callable '%s'" % _callable)
 	else:
 		await _callable.call()
-	monitor.stop()
-	return await monitor.scan()
+	return await _error_monitor().scan(true)
+
+
+func _error_monitor() -> GodotGdErrorMonitor:
+	return GdUnitThreadManager.get_current_context().get_execution_context().error_monitor
 
 
 func _failure_message() -> String:
@@ -44,6 +45,8 @@ func _report_error(error_message :String, failure_line_number: int = -1) -> GdUn
 func _has_log_entry(log_entries :Array[ErrorLogEntry], type :ErrorLogEntry.TYPE, error :String) -> bool:
 	for entry in log_entries:
 		if entry._type == type and entry._message == error:
+			# Erase the log entry we already handled it by this assertion, otherwise it will report at twice
+			_error_monitor().erase_log_entry(entry)
 			return true
 	return false
 

--- a/addons/gdUnit4/src/core/_TestCase.gd
+++ b/addons/gdUnit4/src/core/_TestCase.gd
@@ -26,15 +26,6 @@ var _failed := false
 var _report :GdUnitReport = null
 
 
-var monitor : GodotGdErrorMonitor = null:
-	set (value):
-		monitor = value
-	get:
-		if monitor == null:
-			monitor = GodotGdErrorMonitor.new()
-		return monitor
-
-
 var timeout : int = DEFAULT_TIMEOUT:
 	set (value):
 		timeout = value
@@ -62,31 +53,19 @@ func execute(p_test_parameter := Array(), p_iteration := 0):
 	if _current_iteration == -1:
 		_set_failure_handler()
 		set_timeout()
-	monitor.start()
 	if not p_test_parameter.is_empty():
 		update_fuzzers(p_test_parameter, p_iteration)
 		_execute_test_case(name, p_test_parameter) 
 	else:
 		_execute_test_case(name, [])
 	await completed
-	monitor.stop()
-	for report_ in monitor.reports():
-		if report_.is_error():
-			_report = report_
-			_interupted = true
 
 
 func execute_paramaterized(p_test_parameter :Array):
 	_failure_received(false)
 	set_timeout()
-	monitor.start()
 	_execute_test_case(name, p_test_parameter)
 	await completed
-	monitor.stop()
-	for report_ in monitor.reports():
-		if report_.is_error():
-			_report = report_
-			_interupted = true
 
 
 var _is_disposed := false

--- a/addons/gdUnit4/src/core/execution/GdUnitExecutionContext.gd
+++ b/addons/gdUnit4/src/core/execution/GdUnitExecutionContext.gd
@@ -12,6 +12,15 @@ var _test_case_name: StringName
 var _name :String
 
 
+var error_monitor : GodotGdErrorMonitor = null:
+	set (value):
+		error_monitor = value
+	get:
+		if _parent_context != null:
+			return _parent_context.error_monitor
+		return error_monitor
+
+
 var test_suite : GdUnitTestSuite = null:
 	set (value):
 		test_suite = value
@@ -35,6 +44,7 @@ func _init(name :String, parent_context :GdUnitExecutionContext = null) -> void:
 	_orphan_monitor = GdUnitOrphanNodesMonitor.new(name)
 	_orphan_monitor.start()
 	_memory_observer = GdUnitMemoryObserver.new()
+	error_monitor = GodotGdErrorMonitor.new()
 	_report_collector = GdUnitTestReportCollector.new(get_instance_id())
 	if parent_context != null:
 		parent_context._sub_context.append(self)
@@ -82,6 +92,17 @@ static func of(pe :GdUnitExecutionContext) -> GdUnitExecutionContext:
 
 func test_failed() -> bool:
 	return has_failures() or has_errors()
+
+
+func error_monitor_start() -> void:
+	error_monitor.start()
+
+
+func error_monitor_stop() -> void:
+	await error_monitor.scan()
+	for error_report in error_monitor.to_reports():
+		if error_report.is_error():
+			_report_collector._reports.append(error_report)
 
 
 func orphan_monitor_start() -> void:

--- a/addons/gdUnit4/src/core/execution/stages/GdUnitTestCaseAfterStage.gd
+++ b/addons/gdUnit4/src/core/execution/stages/GdUnitTestCaseAfterStage.gd
@@ -14,14 +14,13 @@ func _init(call_stage := true):
 
 func _execute(context :GdUnitExecutionContext) -> void:
 	var test_suite := context.test_suite
-	
 	if _call_stage:
 		@warning_ignore("redundant_await")
 		await test_suite.after_test()
 	# unreference last used assert form the test to prevent memory leaks
 	GdUnitThreadManager.get_current_context().set_assert(null)
 	await context.gc()
-	
+	await context.error_monitor_stop()
 	if context.test_case.is_skipped():
 		fire_test_skipped(context)
 	else:

--- a/addons/gdUnit4/src/core/execution/stages/GdUnitTestCaseBeforeStage.gd
+++ b/addons/gdUnit4/src/core/execution/stages/GdUnitTestCaseBeforeStage.gd
@@ -22,6 +22,7 @@ func _execute(context :GdUnitExecutionContext) -> void:
 	if _call_stage:
 		@warning_ignore("redundant_await")
 		await test_suite.before_test()
+	context.error_monitor_start()
 
 
 func set_test_name(test_name :StringName):

--- a/addons/gdUnit4/src/monitor/GodotGdErrorMonitor.gd
+++ b/addons/gdUnit4/src/monitor/GodotGdErrorMonitor.gd
@@ -4,32 +4,30 @@ extends GdUnitMonitor
 var _godot_log_file :String
 var _eof :int
 var _report_enabled := false
-var _report_force : bool
+var _entries: Array[ErrorLogEntry] = []
 
 
-func _init(force := false):
+func _init():
 	super("GodotGdErrorMonitor")
-	_report_force = force
 	_godot_log_file = GdUnitSettings.get_log_path()
+	_report_enabled = _is_reporting_enabled()
 
 
 func start():
-	_report_enabled = _report_force or is_reporting_enabled()
-	if _report_enabled:
-		var file = FileAccess.open(_godot_log_file, FileAccess.READ)
-		if file:
-			file.seek_end(0)
-			_eof = file.get_length()
+	var file = FileAccess.open(_godot_log_file, FileAccess.READ)
+	if file:
+		file.seek_end(0)
+		_eof = file.get_length()
 
 
 func stop():
 	pass
 
 
-func reports() -> Array[GdUnitReport]:
+func to_reports() -> Array[GdUnitReport]:
 	var reports_ :Array[GdUnitReport] = []
 	if _report_enabled:
-		reports_.assign(_collect_log_entries().map(_to_report))
+		reports_.assign(_entries.map(_to_report))
 	return reports_
 
 
@@ -42,35 +40,44 @@ static func _to_report(errorLog :ErrorLogEntry) -> GdUnitReport:
 	return GdUnitReport.new().create(GdUnitReport.ABORT, errorLog._line, failure)
 
 
-func scan() -> Array[ErrorLogEntry]:
+func scan(force_collect_reports := false) -> Array[ErrorLogEntry]:
 	await Engine.get_main_loop().process_frame
-	return _collect_log_entries()
+	_entries.append_array(_collect_log_entries(force_collect_reports))
+	return _entries
 
 
-func _collect_log_entries() -> Array[ErrorLogEntry]:
+func erase_log_entry(entry :ErrorLogEntry) -> void:
+	_entries.erase(entry)
+
+
+func _collect_log_entries(force_collect_reports :bool) -> Array[ErrorLogEntry]:
 	var file = FileAccess.open(_godot_log_file, FileAccess.READ)
 	file.seek(_eof)
 	var records := PackedStringArray()
 	while not file.eof_reached():
 		records.append(file.get_line())
+	file.seek_end(0)
+	_eof = file.get_length()
 	var log_entries :Array[ErrorLogEntry]= []
+	var is_report_errors := force_collect_reports or _is_report_push_errors()
+	var is_report_script_errors := force_collect_reports or _is_report_script_errors()
 	for index in records.size():
-		if _report_force:
+		if force_collect_reports:
 			log_entries.append(ErrorLogEntry.extract_push_warning(records, index))
-		if _is_report_push_errors():
+		if is_report_errors:
 			log_entries.append(ErrorLogEntry.extract_push_error(records, index))
-		if _is_report_script_errors():
+		if is_report_script_errors:
 			log_entries.append(ErrorLogEntry.extract_error(records, index))
 	return log_entries.filter(func(value): return value != null )
 
 
-func is_reporting_enabled() -> bool:
+func _is_reporting_enabled() -> bool:
 	return _is_report_script_errors() or _is_report_push_errors()
 
 
 func _is_report_push_errors() -> bool:
-	return _report_force or GdUnitSettings.is_report_push_errors()
+	return GdUnitSettings.is_report_push_errors()
 
 
 func _is_report_script_errors() -> bool:
-	return _report_force or GdUnitSettings.is_report_script_errors()
+	return GdUnitSettings.is_report_script_errors()

--- a/addons/gdUnit4/test/asserts/GdUnitGodotErrorAssertImplTest.gd
+++ b/addons/gdUnit4/test/asserts/GdUnitGodotErrorAssertImplTest.gd
@@ -63,6 +63,11 @@ func after():
 	ProjectSettings.set_setting(GdUnitSettings.REPORT_SCRIPT_ERRORS, _save_is_report_script_errors)
 
 
+func after_test():
+	# Cleanup report artifacts
+	GdUnitThreadManager.get_current_context().get_execution_context().error_monitor._entries.clear()
+
+
 func test_invalid_callable() -> void:
 	assert_failure(func(): assert_error(Callable()).is_success())\
 		.is_failed()\

--- a/addons/gdUnit4/test/asserts/GdUnitGodotErrorWithAssertTest.gd
+++ b/addons/gdUnit4/test/asserts/GdUnitGodotErrorWithAssertTest.gd
@@ -1,0 +1,40 @@
+extends GdUnitTestSuite
+
+
+var _catched_events :Array[GdUnitEvent] = []
+
+
+func test_assert_method_with_enabled_global_error_report() -> void:
+	ProjectSettings.set_setting(GdUnitSettings.REPORT_SCRIPT_ERRORS, true)
+	await assert_error(do_a_fail).is_runtime_error('Assertion failed: test')
+
+
+func test_assert_method_with_disabled_global_error_report() -> void:
+	ProjectSettings.set_setting(GdUnitSettings.REPORT_SCRIPT_ERRORS, false)
+	await assert_error(do_a_fail).is_runtime_error('Assertion failed: test')
+
+
+@warning_ignore("assert_always_false")
+func do_a_fail():
+	if OS.is_debug_build():
+		# On debug level we need to simulate the assert log entry, otherwise we stuck on a breakpoint
+		prints("""
+		USER SCRIPT ERROR: Assertion failed: test
+		   at: do_a_fail (res://addons/gdUnit4/test/asserts/GdUnitErrorAssertTest.gd:20)""")
+	else:
+		assert(3 == 1, 'test')
+
+
+func catch_test_events(event :GdUnitEvent) -> void:
+	_catched_events.append(event)
+
+
+func before() -> void:
+	GdUnitSignals.instance().gdunit_event.connect(catch_test_events)
+
+
+func after() -> void:
+	# We expect no errors or failures, as we caught already the assert error by using the assert `assert_error` on the test case
+	assert_array(_catched_events).extractv(extr("error_count"), extr("failed_count"))\
+		.contains_exactly([tuple(0, 0), tuple(0,0), tuple(0,0), tuple(0,0)])
+	GdUnitSignals.instance().gdunit_event.disconnect(catch_test_events)

--- a/addons/gdUnit4/test/monitor/GodotGdErrorMonitorTest.gd
+++ b/addons/gdUnit4/test/monitor/GodotGdErrorMonitorTest.gd
@@ -43,14 +43,14 @@ func write_log(content :String) -> String:
 
 
 func test_scan_for_push_errors() -> void:
-	var log_file := write_log(error_report)
 	var monitor := mock(GodotGdErrorMonitor, CALL_REAL_FUNC) as GodotGdErrorMonitor
-	monitor._godot_log_file = log_file
+	monitor._godot_log_file = write_log(error_report)
 	monitor._report_enabled = true
 	
 	# with disabled push_error reporting
 	do_return(false).on(monitor)._is_report_push_errors()
-	assert_array(monitor.reports()).is_empty()
+	await monitor.scan()
+	assert_array(monitor.to_reports()).is_empty()
 	
 	# with enabled push_error reporting
 	do_return(true).on(monitor)._is_report_push_errors()
@@ -59,7 +59,9 @@ func test_scan_for_push_errors() -> void:
 		"this is an error",
 		"at: push_error (core/variant/variant_utility.cpp:880)")
 	var expected_report := GodotGdErrorMonitor._to_report(entry)
-	assert_array(monitor.reports()).contains_exactly([expected_report])
+	monitor._eof = 0
+	await monitor.scan()
+	assert_array(monitor.to_reports()).contains_exactly([expected_report])
 
 
 func test_scan_for_script_errors() -> void:
@@ -70,7 +72,8 @@ func test_scan_for_script_errors() -> void:
 	
 	# with disabled push_error reporting
 	do_return(false).on(monitor)._is_report_script_errors()
-	assert_array(monitor.reports()).is_empty()
+	await monitor.scan()
+	assert_array(monitor.to_reports()).is_empty()
 	
 	# with enabled push_error reporting
 	do_return(true).on(monitor)._is_report_script_errors()
@@ -79,7 +82,9 @@ func test_scan_for_script_errors() -> void:
 		"Trying to call a function on a previously freed instance.",
 		"at: GdUnitScriptTypeTest.test_xx (res://addons/gdUnit4/test/GdUnitScriptTypeTest.gd:22)")
 	var expected_report := GodotGdErrorMonitor._to_report(entry)
-	assert_array(monitor.reports()).contains_exactly([expected_report])
+	monitor._eof = 0
+	await monitor.scan()
+	assert_array(monitor.to_reports()).contains_exactly([expected_report])
 
 
 func test_custom_log_path() -> void:
@@ -97,18 +102,21 @@ func test_custom_log_path() -> void:
 
 
 func test_integration_test() -> void:
-	var monitor := GodotGdErrorMonitor.new(true)
+	var monitor := GodotGdErrorMonitor.new()
+	monitor._report_enabled = true
 	# no errors reported
 	monitor.start()
 	monitor.stop()
-	assert_array(monitor.reports()).is_empty()
+	await monitor.scan(true)
+	assert_array(monitor.to_reports()).is_empty()
 	
 	# push error
 	monitor.start()
 	push_error("Test GodotGdErrorMonitor 'push_error' reporting")
 	push_warning("Test GodotGdErrorMonitor 'push_warning' reporting")
 	monitor.stop()
-	var reports := monitor.reports()
+	await monitor.scan(true)
+	var reports := monitor.to_reports()
 	assert_array(reports).has_size(2)
 	if not reports.is_empty():
 		assert_str(reports[0].message()).contains("Test GodotGdErrorMonitor 'push_error' reporting")

--- a/addons/gdUnit4/test/spy/GdUnitSpyTest.gd
+++ b/addons/gdUnit4/test/spy/GdUnitSpyTest.gd
@@ -168,16 +168,17 @@ func test_spy_on_inner_class():
 
 func test_spy_on_singleton():
 	# setup monitor to collect expected push_error notifications
-	var monitor := GodotGdErrorMonitor.new(true)
+	var monitor := GodotGdErrorMonitor.new()
 	monitor.start()
 	# We not allow to spy on a singleton
 	var spy_node = spy(Input)
 	await await_idle_frame()
 	monitor.stop()
 	assert_object(spy_node).is_null()
-	assert_array(monitor.reports()).has_size(1)
+	await monitor.scan(true)
+	assert_array(monitor.to_reports()).has_size(1)
 	if not is_failure():
-		assert_str(monitor.reports()[0].message()).contains("Spy on a Singleton is not allowed! 'Input'")
+		assert_str(monitor.to_reports()[0].message()).contains("Spy on a Singleton is not allowed! 'Input'")
 
 
 func test_example_verify():
@@ -220,7 +221,7 @@ func test_verify_fail():
 			.dedent().trim_prefix("\n")
 	assert_failure(func(): verify(spy_node, 1).set_process(true)) \
 		.is_failed() \
-		.has_line(221) \
+		.has_line(222) \
 		.has_message(expected_error)
 
 
@@ -247,7 +248,7 @@ func test_verify_func_interaction_wiht_PackedStringArray_fail():
 			.dedent().trim_prefix("\n")
 	assert_failure(func(): verify(spy_instance, 1).set_values([])) \
 		.is_failed() \
-		.has_line(248) \
+		.has_line(249) \
 		.has_message(expected_error)
 	
 	reset(spy_instance)
@@ -265,7 +266,7 @@ func test_verify_func_interaction_wiht_PackedStringArray_fail():
 			.dedent().trim_prefix("\n")
 	assert_failure(func(): verify(spy_instance, 1).set_values([])) \
 		.is_failed() \
-		.has_line(266) \
+		.has_line(267) \
 		.has_message(expected_error)
 
 
@@ -313,7 +314,7 @@ func test_verify_no_interactions_fails():
 	# it should fail because we have interactions
 	assert_failure(func(): verify_no_interactions(spy_node)) \
 		.is_failed() \
-		.has_line(314) \
+		.has_line(315) \
 		.has_message(expected_error)
 
 
@@ -368,7 +369,7 @@ func test_verify_no_more_interactions_but_has():
 			.dedent().trim_prefix("\n")
 	assert_failure(func(): verify_no_more_interactions(spy_node)) \
 		.is_failed() \
-		.has_line(369) \
+		.has_line(370) \
 		.has_message(expected_error)
 
 


### PR DESCRIPTION
# Why
If a test case loads/executes a script and contains script errors, and it was tested with `assert_error`, it was still reported as an error.

# What
- Revision of `GodotGdErrorMonitor`
- create the monitor in the execution context to get full control over the test execution time
- filter out tested errors when `assert_error` is used
- set minimum required Godot version to 4.1.x
