### PR TITLE
GD-312: `Mock` and `Spy` should generate type save doubles

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -25,7 +25,7 @@ jobs:
         godot-status: ['stable']
         include:
           - godot-version: '4.3'
-            godot-status: 'dev1'
+            godot-status: 'dev2'
 
 
     name: "CI on Godot 🐧 v${{ matrix.godot-version }}-${{ matrix.godot-status }}"

--- a/addons/gdUnit4/src/asserts/GdUnitAssertImpl.gd
+++ b/addons/gdUnit4/src/asserts/GdUnitAssertImpl.gd
@@ -6,7 +6,7 @@ var _current_error_message :String = ""
 var _custom_failure_message :String = ""
 
 
-func _init(current :Variant):
+func _init(current :Variant) -> void:
 	_current = current
 	# save the actual assert instance on the current thread context
 	GdUnitThreadManager.get_current_context().set_assert(self)

--- a/addons/gdUnit4/src/core/GdFunctionDoubler.gd
+++ b/addons/gdUnit4/src/core/GdFunctionDoubler.gd
@@ -110,10 +110,11 @@ func double(func_descriptor :GdFunctionDescriptor) -> PackedStringArray:
 	# save original constructor arguments
 	if func_name == "_init":
 		var constructor_args := ",".join(GdFunctionDoubler.extract_constructor_args(args))
-		var constructor := "func _init(%s):\n	super(%s)\n	pass\n" % [constructor_args, ", ".join(arg_names)]
+		var constructor := "func _init(%s) -> void:\n	super(%s)\n	pass\n" % [constructor_args, ", ".join(arg_names)]
 		return constructor.split("\n")
 	
 	var double_src := ""
+	double_src += '@warning_ignore("untyped_declaration")\n' if Engine.get_version_info().hex >= 0x40200 else '\n'
 	if func_descriptor.is_engine():
 		double_src += '@warning_ignore("native_method_override")\n'
 	double_src += '@warning_ignore("shadowed_variable")\n'
@@ -148,7 +149,10 @@ static func extract_constructor_args(args :Array) -> PackedStringArray:
 		var a := arg as GdFunctionArgument
 		var arg_name := a._name
 		var default_value = get_default(a)
-		constructor_args.append(arg_name + "=" + default_value)
+		if default_value == "null":
+			constructor_args.append(arg_name + ":Variant=" + default_value)
+		else:
+			constructor_args.append(arg_name + ":=" + default_value)
 	return constructor_args
 
 

--- a/addons/gdUnit4/src/core/GdObjects.gd
+++ b/addons/gdUnit4/src/core/GdObjects.gd
@@ -178,7 +178,7 @@ static func obj2dict(obj :Object, hashed_objects := Dictionary()) -> Dictionary:
 	return {"%s" % clazz_name : dict}
 
 
-static func equals(obj_a, obj_b, case_sensitive :bool = false, compare_mode :COMPARE_MODE = COMPARE_MODE.PARAMETER_DEEP_TEST) -> bool:
+static func equals(obj_a :Variant, obj_b :Variant, case_sensitive :bool = false, compare_mode :COMPARE_MODE = COMPARE_MODE.PARAMETER_DEEP_TEST) -> bool:
 	return _equals(obj_a, obj_b, case_sensitive, compare_mode, [], 0)
 
 
@@ -190,7 +190,7 @@ static func equals_sorted(obj_a :Array, obj_b :Array, case_sensitive :bool = fal
 	return equals(a, b, case_sensitive, compare_mode)
 
 
-static func _equals(obj_a, obj_b, case_sensitive :bool, compare_mode :COMPARE_MODE, deep_stack, stack_depth :int ) -> bool:
+static func _equals(obj_a :Variant, obj_b :Variant, case_sensitive :bool, compare_mode :COMPARE_MODE, deep_stack :Array, stack_depth :int ) -> bool:
 	var type_a := typeof(obj_a)
 	var type_b := typeof(obj_b)
 	if stack_depth > 32:
@@ -305,7 +305,7 @@ static func type_as_string(type :int) -> String:
 	return TYPE_AS_STRING_MAPPINGS.get(type, "Variant")
 
 
-static func typeof_as_string(value) -> String:
+static func typeof_as_string(value :Variant) -> String:
 	return TYPE_AS_STRING_MAPPINGS.get(typeof(value), "Unknown type")
 
 
@@ -314,15 +314,15 @@ static func all_types() -> PackedInt32Array:
 
 
 static func string_as_typeof(type_name :String) -> int:
-	var type = TYPE_AS_STRING_MAPPINGS.find_key(type_name)
+	var type :Variant = TYPE_AS_STRING_MAPPINGS.find_key(type_name)
 	return type if type != null else TYPE_VARIANT
 
 
-static func is_primitive_type(value) -> bool:
+static func is_primitive_type(value :Variant) -> bool:
 	return typeof(value) in [TYPE_BOOL, TYPE_STRING, TYPE_STRING_NAME, TYPE_INT, TYPE_FLOAT]
 
 
-static func _is_type_equivalent(type_a, type_b) -> bool:
+static func _is_type_equivalent(type_a :int, type_b :int) -> bool:
 	# don't test for TYPE_STRING_NAME equivalenz
 	if type_a == TYPE_STRING_NAME or type_b == TYPE_STRING_NAME:
 		return true
@@ -353,8 +353,7 @@ static func is_type(value :Variant) -> bool:
 	return false
 
 
-@warning_ignore("shadowed_global_identifier")
-static func _is_same(left, right) -> bool:
+static func _is_same(left :Variant, right :Variant) -> bool:
 	var left_type := -1 if left == null else typeof(left)
 	var right_type := -1 if right == null else typeof(right)
 
@@ -366,11 +365,11 @@ static func _is_same(left, right) -> bool:
 	return equals(left, right)
 
 
-static func is_object(value) -> bool:
+static func is_object(value :Variant) -> bool:
 	return typeof(value) == TYPE_OBJECT
 
 
-static func is_script(value) -> bool:
+static func is_script(value :Variant) -> bool:
 	return is_object(value) and value is Script
 
 
@@ -378,15 +377,15 @@ static func is_test_suite(script :Script) -> bool:
 	return is_gd_testsuite(script) or GdUnit4MonoApiLoader.is_test_suite(script.resource_path)
 
 
-static func is_native_class(value) -> bool:
+static func is_native_class(value :Variant) -> bool:
 	return is_object(value) and is_engine_type(value)
 
 
-static func is_scene(value) -> bool:
+static func is_scene(value :Variant) -> bool:
 	return is_object(value) and value is PackedScene
 
 
-static func is_scene_resource_path(value) -> bool:
+static func is_scene_resource_path(value :Variant) -> bool:
 	return value is String and value.ends_with(".tscn")
 
 
@@ -432,7 +431,7 @@ static func is_instance(value :Variant) -> bool:
 
 
 # only object form type Node and attached filename
-static func is_instance_scene(instance) -> bool:
+static func is_instance_scene(instance :Variant) -> bool:
 	if instance is Node:
 		var node := instance as Node
 		return node.get_scene_file_path() != null and not node.get_scene_file_path().is_empty()
@@ -445,7 +444,7 @@ static func can_be_instantiate(obj :Variant) -> bool:
 	return obj.has_method("new")
 
 
-static func create_instance(clazz) -> GdUnitResult:
+static func create_instance(clazz :Variant) -> GdUnitResult:
 	match typeof(clazz):
 		TYPE_OBJECT:
 			# test is given clazz already an instance
@@ -463,7 +462,7 @@ static func create_instance(clazz) -> GdUnitResult:
 				var clazz_path :String = extract_class_path(clazz)[0]
 				if not FileAccess.file_exists(clazz_path):
 					return GdUnitResult.error("Class '%s' not found." % clazz)
-				var script = load(clazz_path)
+				var script := load(clazz_path)
 				if script != null:
 					return GdUnitResult.success(script.new())
 				else:
@@ -471,7 +470,7 @@ static func create_instance(clazz) -> GdUnitResult:
 	return GdUnitResult.error("Can't create instance for class '%s'." % clazz)
 
 
-static func extract_class_path(clazz) -> PackedStringArray:
+static func extract_class_path(clazz :Variant) -> PackedStringArray:
 	var clazz_path := PackedStringArray()
 	if clazz is String:
 		clazz_path.append(clazz)
@@ -513,7 +512,7 @@ static func extract_class_name_from_class_path(clazz_path :PackedStringArray) ->
 	return  clazz_name
 
 
-static func extract_class_name(clazz) -> GdUnitResult:
+static func extract_class_name(clazz :Variant) -> GdUnitResult:
 	if clazz == null:
 		return GdUnitResult.error("Can't extract class name form a null value.")
 	
@@ -529,7 +528,7 @@ static func extract_class_name(clazz) -> GdUnitResult:
 		if ClassDB.class_exists(clazz):
 			return GdUnitResult.success(clazz)
 		var source_sript :Script = load(clazz)
-		var clazz_name = load("res://addons/gdUnit4/src/core/parse/GdScriptParser.gd").new().get_class_name(source_sript)
+		var clazz_name :String = load("res://addons/gdUnit4/src/core/parse/GdScriptParser.gd").new().get_class_name(source_sript)
 		return GdUnitResult.success(to_pascal_case(clazz_name))
 	
 	if is_primitive_type(clazz):
@@ -537,12 +536,12 @@ static func extract_class_name(clazz) -> GdUnitResult:
 	
 	if is_script(clazz):
 		if clazz.resource_path.is_empty():
-			var class_path = extract_class_name_from_class_path(extract_class_path(clazz))
+			var class_path := extract_class_name_from_class_path(extract_class_path(clazz))
 			return GdUnitResult.success(class_path);
 		return extract_class_name(clazz.resource_path)
 	
 	# need to create an instance for a class typ the extract the class name
-	var instance = clazz.new()
+	var instance :Variant = clazz.new()
 	if instance == null:
 		return GdUnitResult.error("Can't create a instance for class '%s'" % clazz)
 	var result := extract_class_name(instance)
@@ -589,7 +588,7 @@ static func extract_class_functions(clazz_name :String, script_path :PackedStrin
 # scans all registert script classes for given <clazz_name>
 # if the class is public in the global space than return true otherwise false
 # public class means the script class is defined by 'class_name <name>'
-static func is_public_script_class(clazz_name) -> bool:
+static func is_public_script_class(clazz_name :String) -> bool:
 	var script_classes:Array[Dictionary] = ProjectSettings.get_global_class_list()
 	for class_info in script_classes:
 		if class_info.has("class"):

--- a/addons/gdUnit4/src/core/GdUnitObjectInteractionsTemplate.gd
+++ b/addons/gdUnit4/src/core/GdUnitObjectInteractionsTemplate.gd
@@ -5,9 +5,10 @@ var __saved_interactions := Dictionary()
 var __verified_interactions := Array()
 
 
-func __save_function_interaction(args :Array) -> void:
+func __save_function_interaction(args :Array[Variant]) -> void:
 	var matcher := GdUnitArgumentMatchers.to_matcher(args, true)
-	for key in __saved_interactions.keys():
+	for index in __saved_interactions.keys().size():
+		var key :Variant = __saved_interactions.keys()[index]
 		if matcher.is_match(key):
 			__saved_interactions[key] += 1
 			return
@@ -23,11 +24,12 @@ func __do_verify_interactions(times :int = 1) -> Object:
 	return self
 
 
-func __verify_interactions(args :Array):
+func __verify_interactions(args :Array[Variant]) -> void:
 	var summary := Dictionary()
 	var total_interactions := 0
 	var matcher := GdUnitArgumentMatchers.to_matcher(args, true)
-	for key in __saved_interactions.keys():
+	for index in __saved_interactions.keys().size():
+		var key :Variant = __saved_interactions.keys()[index]
 		if matcher.is_match(key):
 			var interactions :int = __saved_interactions.get(key, 0)
 			total_interactions += interactions
@@ -37,11 +39,11 @@ func __verify_interactions(args :Array):
 	
 	var gd_assert := GdUnitAssertImpl.new("")
 	if total_interactions != __expected_interactions:
-		var expected_summary = {args : __expected_interactions}
+		var expected_summary := {args : __expected_interactions}
 		var error_message :String
 		# if no interactions macht collect not verified interactions for failure report
 		if summary.is_empty():
-			var current_summary = __verify_no_more_interactions()
+			var current_summary := __verify_no_more_interactions()
 			error_message = GdAssertMessages.error_validate_interactions(current_summary, expected_summary)
 		else:
 			error_message = GdAssertMessages.error_validate_interactions(summary, expected_summary)
@@ -54,21 +56,23 @@ func __verify_interactions(args :Array):
 func __verify_no_interactions() -> Dictionary:
 	var summary := Dictionary()
 	if not __saved_interactions.is_empty():
-		for func_call in __saved_interactions.keys():
+		for index in __saved_interactions.keys().size():
+			var func_call :Variant = __saved_interactions.keys()[index]
 			summary[func_call] = __saved_interactions[func_call]
 	return summary
 
 
 func __verify_no_more_interactions() -> Dictionary:
 	var summary := Dictionary()
-	var called_functions :Array = __saved_interactions.keys()
+	var called_functions :Array[Variant] = __saved_interactions.keys()
 	if called_functions != __verified_interactions:
 		# collect the not verified functions
 		var called_but_not_verified := called_functions.duplicate()
-		for verified_function in __verified_interactions:
-			called_but_not_verified.erase(verified_function)
+		for index in __verified_interactions.size():
+			called_but_not_verified.erase(__verified_interactions[index])
 		
-		for not_verified in called_but_not_verified:
+		for index in called_but_not_verified.size():
+			var not_verified :Variant = called_but_not_verified[index]
 			summary[not_verified] = __saved_interactions[not_verified]
 	return summary
 
@@ -77,9 +81,10 @@ func __reset_interactions() -> void:
 	__saved_interactions.clear()
 
 
-func __filter_vargs(arg_values :Array) -> Array:
-	var filtered := Array()
-	for arg in arg_values:
+func __filter_vargs(arg_values :Array[Variant]) -> Array[Variant]:
+	var filtered :Array[Variant] = []
+	for index in arg_values.size():
+		var arg :Variant = arg_values[index]
 		if typeof(arg) == TYPE_STRING and arg == GdObjects.TYPE_VARARG_PLACEHOLDER_VALUE:
 			continue
 		filtered.append(arg)

--- a/addons/gdUnit4/src/matchers/AnyClazzArgumentMatcher.gd
+++ b/addons/gdUnit4/src/matchers/AnyClazzArgumentMatcher.gd
@@ -3,7 +3,7 @@ extends GdUnitArgumentMatcher
 	
 var _clazz :Object
 
-func _init(clazz :Object):
+func _init(clazz :Object) -> void:
 	_clazz = clazz
 
 func is_match(value :Variant) -> bool:

--- a/addons/gdUnit4/src/matchers/ChainedArgumentMatcher.gd
+++ b/addons/gdUnit4/src/matchers/ChainedArgumentMatcher.gd
@@ -3,15 +3,18 @@ extends GdUnitArgumentMatcher
 
 var _matchers :Array
 
+
 func _init(matchers :Array):
 	_matchers = matchers
 
-func is_match(arguments :Array) -> bool:
-	if arguments.size() != _matchers.size():
+
+func is_match(arguments :Variant) -> bool:
+	var arg_array := arguments as Array
+	if arg_array.size() != _matchers.size():
 		return false
 	
-	for index in arguments.size():
-		var arg = arguments[index]
+	for index in arg_array.size():
+		var arg :Variant = arg_array[index]
 		var matcher = _matchers[index] as GdUnitArgumentMatcher
 		
 		if not matcher.is_match(arg):

--- a/addons/gdUnit4/src/matchers/GdUnitArgumentMatcher.gd
+++ b/addons/gdUnit4/src/matchers/GdUnitArgumentMatcher.gd
@@ -4,5 +4,5 @@ extends RefCounted
 
 
 @warning_ignore("unused_parameter")
-func is_match(value) -> bool:
+func is_match(value :Variant) -> bool:
 	return true

--- a/addons/gdUnit4/src/matchers/GdUnitArgumentMatchers.gd
+++ b/addons/gdUnit4/src/matchers/GdUnitArgumentMatchers.gd
@@ -4,8 +4,8 @@ extends RefCounted
 const TYPE_ANY = TYPE_MAX + 100
 
 
-static func to_matcher(arguments :Array, auto_deep_check_mode := false) -> ChainedArgumentMatcher:
-	var matchers := Array()
+static func to_matcher(arguments :Array[Variant], auto_deep_check_mode := false) -> ChainedArgumentMatcher:
+	var matchers :Array[Variant] = []
 	for arg in arguments:
 		# argument is already a matcher
 		if arg is GdUnitArgumentMatcher:
@@ -28,5 +28,5 @@ static func by_types(types :PackedInt32Array) -> GdUnitArgumentMatcher:
 	return AnyBuildInTypeArgumentMatcher.new(types)
 
 
-static func any_class(clazz) -> GdUnitArgumentMatcher:
+static func any_class(clazz :Object) -> GdUnitArgumentMatcher:
 	return AnyClazzArgumentMatcher.new(clazz)

--- a/addons/gdUnit4/src/mocking/GdUnitMockImpl.gd
+++ b/addons/gdUnit4/src/mocking/GdUnitMockImpl.gd
@@ -7,7 +7,7 @@ const __SOURCE_CLASS = "${source_class}"
 
 var __working_mode := GdUnitMock.RETURN_DEFAULTS
 var __excluded_methods :PackedStringArray = []
-var __do_return_value = null
+var __do_return_value :Variant = null
 var __prepare_return_value := false
 
 #{ <func_name> = {
@@ -17,11 +17,11 @@ var __prepare_return_value := false
 var __mocked_return_values := Dictionary()
 
 
-static func __instance():
+static func __instance() -> Object:
 	return Engine.get_meta(__INSTANCE_ID)
 
 
-func _notification(what):
+func _notification(what :int) -> void:
 	if what == NOTIFICATION_PREDELETE:
 		if Engine.has_meta(__INSTANCE_ID):
 			Engine.remove_meta(__INSTANCE_ID)
@@ -31,12 +31,12 @@ func __instance_id() -> String:
 	return __INSTANCE_ID
 
 
-func __set_singleton():
+func __set_singleton() -> void:
 	# store self need to mock static functions
 	Engine.set_meta(__INSTANCE_ID, self)
 
 
-func __release_double():
+func __release_double() -> void:
 	# we need to release the self reference manually to prevent orphan nodes
 	Engine.remove_meta(__INSTANCE_ID)
 
@@ -46,7 +46,8 @@ func __is_prepare_return_value() -> bool:
 
 
 func __sort_by_argument_matcher(left_args :Array, _right_args :Array) -> bool:
-	for larg in left_args:
+	for index in left_args.size():
+		var larg :Variant = left_args[index]
 		if larg is GdUnitArgumentMatcher:
 			return false
 	return true
@@ -60,12 +61,13 @@ func __sort_dictionary(unsorted_args :Dictionary) -> Dictionary:
 	var sorted_args := unsorted_args.keys()
 	sorted_args.sort_custom(__sort_by_argument_matcher)
 	var sorted_result := {}
-	for key in sorted_args:
+	for index in sorted_args.size():
+		var key :Variant = sorted_args[index]
 		sorted_result[key] = unsorted_args[key]
 	return sorted_result
 
 
-func __save_function_return_value(args :Array):
+func __save_function_return_value(args :Array) -> void:
 	var func_name :String = args[0]
 	var func_args :Array = args.slice(1)
 	var mocked_return_value_by_args :Dictionary = __mocked_return_values.get(func_name, {})
@@ -77,13 +79,14 @@ func __save_function_return_value(args :Array):
 
 func __is_mocked_args_match(func_args :Array, mocked_args :Array) -> bool:
 	var is_matching := false
-	for args in mocked_args:
+	for index in mocked_args.size():
+		var args :Variant = mocked_args[index]
 		if func_args.size() != args.size():
 			continue
 		is_matching = true
 		for arg_index in func_args.size():
-			var func_arg = func_args[arg_index]
-			var mock_arg = args[arg_index]
+			var func_arg :Variant = func_args[arg_index]
+			var mock_arg :Variant = args[arg_index]
 			if mock_arg is GdUnitArgumentMatcher:
 				is_matching = is_matching and mock_arg.is_match(func_arg)
 			else:
@@ -101,7 +104,8 @@ func __get_mocked_return_value_or_default(args :Array, default_return_value :Var
 		return default_return_value
 	var func_args :Array = args.slice(1)
 	var mocked_args :Array = __mocked_return_values.get(func_name).keys()
-	for margs in mocked_args:
+	for index in mocked_args.size():
+		var margs :Variant = mocked_args[index]
 		if __is_mocked_args_match(func_args, [margs]):
 			return __mocked_return_values[func_name][margs]
 	return default_return_value
@@ -111,7 +115,7 @@ func __set_script(script :GDScript) -> void:
 	super.set_script(script)
 
 
-func __set_mode(working_mode :String):
+func __set_mode(working_mode :String) -> Object:
 	__working_mode = working_mode
 	return self
 
@@ -130,7 +134,7 @@ func __exclude_method_call(exluded_methods :PackedStringArray) -> void:
 	__excluded_methods.append_array(exluded_methods)
 
 
-func __do_return(return_value):
+func __do_return(return_value :Variant) -> Object:
 	__do_return_value = return_value
 	__prepare_return_value = true
 	return self

--- a/addons/gdUnit4/src/spy/GdUnitSpyBuilder.gd
+++ b/addons/gdUnit4/src/spy/GdUnitSpyBuilder.gd
@@ -5,7 +5,7 @@ const GdUnitTools := preload("res://addons/gdUnit4/src/core/GdUnitTools.gd")
 const SPY_TEMPLATE :GDScript = preload("res://addons/gdUnit4/src/spy/GdUnitSpyImpl.gd")
 
 
-static func build(to_spy, debug_write = false) -> Object:
+static func build(to_spy, debug_write := false) -> Object:
 	if GdObjects.is_singleton(to_spy):
 		push_error("Spy on a Singleton is not allowed! '%s'" % to_spy.get_class())
 		return null

--- a/addons/gdUnit4/src/spy/GdUnitSpyImpl.gd
+++ b/addons/gdUnit4/src/spy/GdUnitSpyImpl.gd
@@ -2,7 +2,7 @@
 const __INSTANCE_ID = "${instance_id}"
 const __SOURCE_CLASS = "${source_class}"
 
-var __instance_delegator
+var __instance_delegator :Object
 var __excluded_methods :PackedStringArray = []
 
 
@@ -10,7 +10,7 @@ static func __instance() -> Variant:
 	return Engine.get_meta(__INSTANCE_ID)
 
 
-func _notification(what):
+func _notification(what :int) -> void:
 	if what == NOTIFICATION_PREDELETE:
 		if Engine.has_meta(__INSTANCE_ID):
 			Engine.remove_meta(__INSTANCE_ID)
@@ -20,13 +20,13 @@ func __instance_id() -> String:
 	return __INSTANCE_ID
 
 
-func __set_singleton(delegator):
+func __set_singleton(delegator :Object) -> void:
 	# store self need to mock static functions
 	Engine.set_meta(__INSTANCE_ID, self)
 	__instance_delegator = delegator
 
 
-func __release_double():
+func __release_double() -> void:
 	# we need to release the self reference manually to prevent orphan nodes
 	Engine.remove_meta(__INSTANCE_ID)
 	__instance_delegator = null
@@ -40,5 +40,5 @@ func __exclude_method_call(exluded_methods :PackedStringArray) -> void:
 	__excluded_methods.append_array(exluded_methods)
 
 
-func __call_func(func_name :String, arguments :Array):
+func __call_func(func_name :String, arguments :Array) -> Variant:
 	return __instance_delegator.callv(func_name, arguments)

--- a/addons/gdUnit4/test/mocker/GdUnitMockBuilderTest.gd
+++ b/addons/gdUnit4/test/mocker/GdUnitMockBuilderTest.gd
@@ -20,6 +20,7 @@ func test_double_return_typed_function_without_arg() -> void:
 	# String get_class() const
 	var fd := get_function_description("Object", "get_class")
 	var expected := [
+		'@warning_ignore("untyped_declaration")' if Engine.get_version_info().hex >= 0x40200 else '',
 		'@warning_ignore("native_method_override")',
 		'@warning_ignore("shadowed_variable")',
 		'func get_class() -> String:',
@@ -47,6 +48,7 @@ func test_double_return_typed_function_with_args() -> void:
 	# bool is_connected(signal: String, callable_: Callable)) const
 	var fd := get_function_description("Object", "is_connected")
 	var expected := [
+		'@warning_ignore("untyped_declaration")' if Engine.get_version_info().hex >= 0x40200 else '',
 		'@warning_ignore("native_method_override")',
 		'@warning_ignore("shadowed_variable")',
 		'func is_connected(signal_, callable_) -> bool:',
@@ -75,6 +77,7 @@ func test_double_return_untyped_function_with_args() -> void:
 	# void disconnect(signal: StringName, callable: Callable)
 	var fd := get_function_description("Object", "disconnect")
 	var expected := [
+		'@warning_ignore("untyped_declaration")' if Engine.get_version_info().hex >= 0x40200 else '',
 		'@warning_ignore("native_method_override")',
 		'@warning_ignore("shadowed_variable")',
 		'func disconnect(signal_, callable_) -> void:',
@@ -102,6 +105,7 @@ func test_double_int_function_with_varargs() -> void:
 	# Error emit_signal(signal: StringName, ...) vararg
 	var fd := get_function_description("Object", "emit_signal")
 	var expected := [
+		'@warning_ignore("untyped_declaration")' if Engine.get_version_info().hex >= 0x40200 else '',
 		'@warning_ignore("native_method_override")',
 		'@warning_ignore("shadowed_variable")',
 		'func emit_signal(signal_, vararg0_="__null__", vararg1_="__null__", vararg2_="__null__", vararg3_="__null__", vararg4_="__null__", vararg5_="__null__", vararg6_="__null__", vararg7_="__null__", vararg8_="__null__", vararg9_="__null__") -> Error:',
@@ -146,6 +150,7 @@ func test_double_untyped_function_with_varargs() -> void:
 		[GdFunctionArgument.new("signal_", TYPE_SIGNAL)],
 		GdFunctionDescriptor._build_varargs(true))
 	var expected := [
+		'@warning_ignore("untyped_declaration")' if Engine.get_version_info().hex >= 0x40200 else '',
 		'@warning_ignore("shadowed_variable")',
 		'func emit_custom(signal_, vararg0_="__null__", vararg1_="__null__", vararg2_="__null__", vararg3_="__null__", vararg4_="__null__", vararg5_="__null__", vararg6_="__null__", vararg7_="__null__", vararg8_="__null__", vararg9_="__null__") -> void:',
 		'	var varargs :Array = __filter_vargs([vararg0_, vararg1_, vararg2_, vararg3_, vararg4_, vararg5_, vararg6_, vararg7_, vararg8_, vararg9_])',
@@ -187,6 +192,7 @@ func test_double_virtual_script_function_without_arg() -> void:
 	# void _ready() virtual
 	var fd := get_function_description("Node", "_ready")
 	var expected := [
+		'@warning_ignore("untyped_declaration")' if Engine.get_version_info().hex >= 0x40200 else '',
 		'@warning_ignore("native_method_override")',
 		'@warning_ignore("shadowed_variable")',
 		'func _ready() -> void:',
@@ -215,6 +221,7 @@ func test_double_virtual_script_function_with_arg() -> void:
 	# void _input(event: InputEvent) virtual
 	var fd := get_function_description("Node", "_input")
 	var expected := [
+		'@warning_ignore("untyped_declaration")' if Engine.get_version_info().hex >= 0x40200 else '',
 		'@warning_ignore("native_method_override")',
 		'@warning_ignore("shadowed_variable")',
 		'func _input(event_) -> void:',

--- a/addons/gdUnit4/test/spy/GdUnitSpyBuilderTest.gd
+++ b/addons/gdUnit4/test/spy/GdUnitSpyBuilderTest.gd
@@ -19,7 +19,7 @@ func test_double__init() -> void:
 	# void _init() virtual
 	var fd := get_function_description("Object", "_init")
 	var expected := [
-		'func _init():',
+		'func _init() -> void:',
 		'	super()',
 		'	pass',
 		'']
@@ -31,6 +31,7 @@ func test_double_return_typed_function_without_arg() -> void:
 	# String get_class() const
 	var fd := get_function_description("Object", "get_class")
 	var expected := [
+		'@warning_ignore("untyped_declaration")' if Engine.get_version_info().hex >= 0x40200 else '',
 		'@warning_ignore("native_method_override")',
 		'@warning_ignore("shadowed_variable")',
 		'func get_class() -> String:',
@@ -55,6 +56,7 @@ func test_double_return_typed_function_with_args() -> void:
 	# bool is_connected(signal: String,Callable(target: Object,method: String)) const
 	var fd := get_function_description("Object", "is_connected")
 	var expected := [
+		'@warning_ignore("untyped_declaration")' if Engine.get_version_info().hex >= 0x40200 else '',
 		'@warning_ignore("native_method_override")',
 		'@warning_ignore("shadowed_variable")',
 		'func is_connected(signal_, callable_) -> bool:',
@@ -79,6 +81,7 @@ func test_double_return_void_function_with_args() -> void:
 	# void disconnect(signal: StringName, callable: Callable)
 	var fd := get_function_description("Object", "disconnect")
 	var expected := [
+		'@warning_ignore("untyped_declaration")' if Engine.get_version_info().hex >= 0x40200 else '',
 		'@warning_ignore("native_method_override")',
 		'@warning_ignore("shadowed_variable")',
 		'func disconnect(signal_, callable_) -> void:',
@@ -102,6 +105,7 @@ func test_double_return_void_function_without_args() -> void:
 	# void free()
 	var fd := get_function_description("Object", "free")
 	var expected := [
+		'@warning_ignore("untyped_declaration")' if Engine.get_version_info().hex >= 0x40200 else '',
 		'@warning_ignore("native_method_override")',
 		'@warning_ignore("shadowed_variable")',
 		'func free() -> void:',
@@ -125,6 +129,7 @@ func test_double_return_typed_function_with_args_and_varargs() -> void:
 	# Error emit_signal(signal: StringName, ...) vararg
 	var fd := get_function_description("Object", "emit_signal")
 	var expected := [
+		'@warning_ignore("untyped_declaration")' if Engine.get_version_info().hex >= 0x40200 else '',
 		'@warning_ignore("native_method_override")',
 		'@warning_ignore("shadowed_variable")',
 		'func emit_signal(signal_, vararg0_="__null__", vararg1_="__null__", vararg2_="__null__", vararg3_="__null__", vararg4_="__null__", vararg5_="__null__", vararg6_="__null__", vararg7_="__null__", vararg8_="__null__", vararg9_="__null__") -> Error:',
@@ -148,6 +153,7 @@ func test_double_return_void_function_only_varargs() -> void:
 	# void bar(s...) vararg
 	var fd := GdFunctionDescriptor.new( "bar", 23, false, false, false, TYPE_NIL, "void", [], GdFunctionDescriptor._build_varargs(true))
 	var expected := [
+		'@warning_ignore("untyped_declaration")' if Engine.get_version_info().hex >= 0x40200 else '',
 		'@warning_ignore("shadowed_variable")',
 		'func bar(vararg0_="__null__", vararg1_="__null__", vararg2_="__null__", vararg3_="__null__", vararg4_="__null__", vararg5_="__null__", vararg6_="__null__", vararg7_="__null__", vararg8_="__null__", vararg9_="__null__") -> void:',
 		'	var varargs :Array = __filter_vargs([vararg0_, vararg1_, vararg2_, vararg3_, vararg4_, vararg5_, vararg6_, vararg7_, vararg8_, vararg9_])',
@@ -170,6 +176,7 @@ func test_double_return_typed_function_only_varargs() -> void:
 	# String bar(s...) vararg
 	var fd := GdFunctionDescriptor.new( "bar", 23, false, false, false, TYPE_STRING, "String", [], GdFunctionDescriptor._build_varargs(true))
 	var expected := [
+		'@warning_ignore("untyped_declaration")' if Engine.get_version_info().hex >= 0x40200 else '',
 		'@warning_ignore("shadowed_variable")',
 		'func bar(vararg0_="__null__", vararg1_="__null__", vararg2_="__null__", vararg3_="__null__", vararg4_="__null__", vararg5_="__null__", vararg6_="__null__", vararg7_="__null__", vararg8_="__null__", vararg9_="__null__") -> String:',
 		'	var varargs :Array = __filter_vargs([vararg0_, vararg1_, vararg2_, vararg3_, vararg4_, vararg5_, vararg6_, vararg7_, vararg8_, vararg9_])',
@@ -192,6 +199,7 @@ func test_double_static_return_void_function_without_args() -> void:
 	# void foo()
 	var fd := GdFunctionDescriptor.new( "foo", 23, false, true, false, TYPE_NIL, "", [])
 	var expected := [
+		'@warning_ignore("untyped_declaration")' if Engine.get_version_info().hex >= 0x40200 else '',
 		'@warning_ignore("shadowed_variable")',
 		'static func foo() -> void:',
 		'	var args :Array = ["foo", ]',
@@ -216,6 +224,7 @@ func test_double_static_return_void_function_with_args() -> void:
 		GdFunctionArgument.new("arg2", TYPE_STRING, '"default"')
 	])
 	var expected := [
+		'@warning_ignore("untyped_declaration")' if Engine.get_version_info().hex >= 0x40200 else '',
 		'@warning_ignore("shadowed_variable")',
 		'static func foo(arg1, arg2="default") -> void:',
 		'	var args :Array = ["foo", arg1, arg2]',
@@ -241,6 +250,7 @@ func test_double_static_script_function_with_args_return_bool() -> void:
 		GdFunctionArgument.new("arg2", TYPE_STRING, '"default"')
 	])
 	var expected := [
+		'@warning_ignore("untyped_declaration")' if Engine.get_version_info().hex >= 0x40200 else '',
 		'@warning_ignore("shadowed_variable")',
 		'static func foo(arg1, arg2="default") -> bool:',
 		'	var args :Array = ["foo", arg1, arg2]',
@@ -264,6 +274,7 @@ func test_double_virtual_return_void_function_with_arg() -> void:
 	# void _input(event: InputEvent) virtual
 	var fd := get_function_description("Node", "_input")
 	var expected := [
+		'@warning_ignore("untyped_declaration")' if Engine.get_version_info().hex >= 0x40200 else '',
 		'@warning_ignore("native_method_override")',
 		'@warning_ignore("shadowed_variable")',
 		'func _input(event_) -> void:',
@@ -287,6 +298,7 @@ func test_double_virtual_return_void_function_without_arg() -> void:
 	# void _ready() virtual
 	var fd := get_function_description("Node", "_ready")
 	var expected := [
+		'@warning_ignore("untyped_declaration")' if Engine.get_version_info().hex >= 0x40200 else '',
 		'@warning_ignore("native_method_override")',
 		'@warning_ignore("shadowed_variable")',
 		'func _ready() -> void:',


### PR DESCRIPTION
# Why
The mocking and spy fails if the project settings are set to `debug/gdscript/warnings/untyped_declaration=Error`.

# What
- Fixed missing/invalid type errors in mock and spy template and object interaction template
- set `@warning_ignore("untyped_declaration")` to doubled functions as it fails with Godot 4.2.x


