### PR TITLE
GD-307: Allow argument matchers on `assert_signal` arguments

### DIFF
--- a/addons/gdUnit4/src/GdUnitTestSuite.gd
+++ b/addons/gdUnit4/src/GdUnitTestSuite.gd
@@ -367,14 +367,14 @@ func any_basis() -> GdUnitArgumentMatcher:
 	return __gdunit_argument_matchers().by_type(TYPE_BASIS)
 
 
-## Argument matcher to match any Transform3D value
-func any_transform() -> GdUnitArgumentMatcher:
-	return __gdunit_argument_matchers().by_type(TYPE_TRANSFORM3D)
-
-
 ## Argument matcher to match any Transform2D value
 func any_transform_2d() -> GdUnitArgumentMatcher:
 	return __gdunit_argument_matchers().by_type(TYPE_TRANSFORM2D)
+
+
+## Argument matcher to match any Transform3D value
+func any_transform_3d() -> GdUnitArgumentMatcher:
+	return __gdunit_argument_matchers().by_type(TYPE_TRANSFORM3D)
 
 
 ## Argument matcher to match any NodePath value
@@ -403,37 +403,47 @@ func any_array() -> GdUnitArgumentMatcher:
 
 
 ## Argument matcher to match any PackedByteArray value
-func any_pool_byte_array() -> GdUnitArgumentMatcher:
+func any_packed_byte_array() -> GdUnitArgumentMatcher:
 	return __gdunit_argument_matchers().by_type(TYPE_PACKED_BYTE_ARRAY)
 
 
 ## Argument matcher to match any PackedInt32Array value
-func any_pool_int_array() -> GdUnitArgumentMatcher:
+func any_packed_int32_array() -> GdUnitArgumentMatcher:
 	return __gdunit_argument_matchers().by_type(TYPE_PACKED_INT32_ARRAY)
 
 
+## Argument matcher to match any PackedInt64Array value
+func any_packed_int64_array() -> GdUnitArgumentMatcher:
+	return __gdunit_argument_matchers().by_type(TYPE_PACKED_INT64_ARRAY)
+
+
 ## Argument matcher to match any PackedFloat32Array value
-func any_pool_float_array() -> GdUnitArgumentMatcher:
+func any_packed_float32_array() -> GdUnitArgumentMatcher:
 	return __gdunit_argument_matchers().by_type(TYPE_PACKED_FLOAT32_ARRAY)
 
 
+## Argument matcher to match any PackedFloat64Array value
+func any_packed_float64_array() -> GdUnitArgumentMatcher:
+	return __gdunit_argument_matchers().by_type(TYPE_PACKED_FLOAT64_ARRAY)
+
+
 ## Argument matcher to match any PackedStringArray value
-func any_pool_string_array() -> GdUnitArgumentMatcher:
+func any_packed_string_array() -> GdUnitArgumentMatcher:
 	return __gdunit_argument_matchers().by_type(TYPE_PACKED_STRING_ARRAY)
 
 
 ## Argument matcher to match any PackedVector2Array value
-func any_pool_vector2_array() -> GdUnitArgumentMatcher:
+func any_packed_vector2_array() -> GdUnitArgumentMatcher:
 	return __gdunit_argument_matchers().by_type(TYPE_PACKED_VECTOR2_ARRAY)
 
 
 ## Argument matcher to match any PackedVector3Array value
-func any_pool_vector3_array() -> GdUnitArgumentMatcher:
+func any_packed_vector3_array() -> GdUnitArgumentMatcher:
 	return __gdunit_argument_matchers().by_type(TYPE_PACKED_VECTOR3_ARRAY)
 
 
 ## Argument matcher to match any PackedColorArray value
-func any_pool_color_array() -> GdUnitArgumentMatcher:
+func any_packed_color_array() -> GdUnitArgumentMatcher:
 	return __gdunit_argument_matchers().by_type(TYPE_PACKED_COLOR_ARRAY)
 
 

--- a/addons/gdUnit4/src/core/GdObjects.gd
+++ b/addons/gdUnit4/src/core/GdObjects.gd
@@ -198,6 +198,12 @@ static func _equals(obj_a :Variant, obj_b :Variant, case_sensitive :bool, compar
 		push_error("GdUnit equals has max stack deep reached!")
 		return false
 	
+	# use argument matcher if requested
+	if is_instance_valid(obj_a) and obj_a is GdUnitArgumentMatcher:
+		return (obj_a as GdUnitArgumentMatcher).is_match(obj_b)
+	if is_instance_valid(obj_b) and obj_b is GdUnitArgumentMatcher:
+		return (obj_b as GdUnitArgumentMatcher).is_match(obj_a)
+	
 	stack_depth += 1
 	# fast fail is different types
 	if not _is_type_equivalent(type_a, type_b):

--- a/addons/gdUnit4/src/matchers/AnyArgumentMatcher.gd
+++ b/addons/gdUnit4/src/matchers/AnyArgumentMatcher.gd
@@ -5,3 +5,7 @@ extends GdUnitArgumentMatcher
 @warning_ignore("unused_parameter")
 func is_match(value) -> bool:
 	return true
+
+
+func _to_string() -> String:
+	return "any()"

--- a/addons/gdUnit4/src/matchers/AnyBuildInTypeArgumentMatcher.gd
+++ b/addons/gdUnit4/src/matchers/AnyBuildInTypeArgumentMatcher.gd
@@ -3,8 +3,48 @@ extends GdUnitArgumentMatcher
 
 var _type : PackedInt32Array = []
 
+
 func _init(type :PackedInt32Array):
 	_type = type
 
+
 func is_match(value) -> bool:
 	return _type.has(typeof(value))
+
+
+func _to_string() -> String:
+	match _type[0]:
+		TYPE_BOOL: return "any_bool()"
+		TYPE_STRING, TYPE_STRING_NAME: return "any_string()"
+		TYPE_INT: return "any_int()"
+		TYPE_FLOAT: return "any_float()"
+		TYPE_COLOR: return "any_color()"
+		TYPE_VECTOR2: return "any_vector2()" if _type.size() == 1 else "any_vector()"
+		TYPE_VECTOR2I: return "any_vector2i()"
+		TYPE_VECTOR3: return "any_vector3()"
+		TYPE_VECTOR3I: return "any_vector3i()"
+		TYPE_VECTOR4: return "any_vector4()"
+		TYPE_VECTOR4I: return "any_vector4i()"
+		TYPE_RECT2: return "any_rect2()"
+		TYPE_RECT2I: return "any_rect2i()"
+		TYPE_PLANE: return "any_plane()"
+		TYPE_QUATERNION: return "any_quat()"
+		TYPE_AABB: return "any_aabb()"
+		TYPE_BASIS: return "any_basis()"
+		TYPE_TRANSFORM2D: return "any_transform_2d()"
+		TYPE_TRANSFORM3D: return "any_transform_3d()"
+		TYPE_NODE_PATH: return "any_node_path()"
+		TYPE_RID: return "any_rid()"
+		TYPE_OBJECT: return "any_object()"
+		TYPE_DICTIONARY: return "any_dictionary()"
+		TYPE_ARRAY: return "any_array()"
+		TYPE_PACKED_BYTE_ARRAY: return "any_packed_byte_array()"
+		TYPE_PACKED_INT32_ARRAY: return "any_packed_int32_array()"
+		TYPE_PACKED_INT64_ARRAY: return "any_packed_int64_array()"
+		TYPE_PACKED_FLOAT32_ARRAY: return "any_packed_float32_array()"
+		TYPE_PACKED_FLOAT64_ARRAY: return "any_packed_float64_array()"
+		TYPE_PACKED_STRING_ARRAY: return "any_packed_string_array()"
+		TYPE_PACKED_VECTOR2_ARRAY: return "any_packed_vector2_array()"
+		TYPE_PACKED_VECTOR3_ARRAY: return "any_packed_vector3_array()"
+		TYPE_PACKED_COLOR_ARRAY: return "any_packed_color_array()"
+		_: return "any()"

--- a/addons/gdUnit4/src/matchers/AnyClazzArgumentMatcher.gd
+++ b/addons/gdUnit4/src/matchers/AnyClazzArgumentMatcher.gd
@@ -12,3 +12,17 @@ func is_match(value :Variant) -> bool:
 	if is_instance_valid(value) and GdObjects.is_script(_clazz):
 		return value.get_script() == _clazz
 	return is_instance_of(value, _clazz)
+
+
+func _to_string() -> String:
+	if (_clazz as Object).is_class("GDScriptNativeClass"):
+		var instance :Object = _clazz.new()
+		var clazz_name := instance.get_class()
+		if not instance is RefCounted:
+			instance.free()
+		return "any_class(<"+clazz_name+">)";
+	if _clazz is GDScript:
+		var result := GdObjects.extract_class_name(_clazz)
+		if result.is_success():
+			return "any_class(<"+ result.value() + ">)"
+	return "any_class()"

--- a/addons/gdUnit4/test/matchers/AnyArgumentMatcherTest.gd
+++ b/addons/gdUnit4/test/matchers/AnyArgumentMatcherTest.gd
@@ -5,6 +5,7 @@ extends GdUnitTestSuite
 # TestSuite generated from
 const __source = 'res://addons/gdUnit4/src/matchers/AnyArgumentMatcher.gd'
 
+
 func test_is_match():
 	var matcher := AnyArgumentMatcher.new()
 	
@@ -19,5 +20,10 @@ func test_is_match():
 	assert_bool(matcher.is_match(RefCounted.new())).is_true()
 	assert_bool(matcher.is_match(auto_free(Node.new()))).is_true()
 
+
 func test_any():
 	assert_object(any()).is_instanceof(AnyArgumentMatcher)
+
+
+func test_to_string() -> void:
+	assert_str(str(any())).is_equal("any()")

--- a/addons/gdUnit4/test/matchers/AnyBuildInTypeArgumentMatcherTest.gd
+++ b/addons/gdUnit4/test/matchers/AnyBuildInTypeArgumentMatcherTest.gd
@@ -18,6 +18,7 @@ func test_is_match_bool() -> void:
 	assert_bool(matcher.is_match(0.2)).is_false()
 	assert_bool(matcher.is_match(auto_free(Node.new()))).is_false()
 
+
 func test_is_match_int() -> void:
 	assert_object(any_int()).is_instanceof(AnyBuildInTypeArgumentMatcher)
 	
@@ -29,6 +30,7 @@ func test_is_match_int() -> void:
 	assert_bool(matcher.is_match([])).is_false()
 	assert_bool(matcher.is_match(0.2)).is_false()
 	assert_bool(matcher.is_match(auto_free(Node.new()))).is_false()
+
 
 func test_is_match_float() -> void:
 	assert_object(any_float()).is_instanceof(AnyBuildInTypeArgumentMatcher)
@@ -42,6 +44,7 @@ func test_is_match_float() -> void:
 	assert_bool(matcher.is_match(1000)).is_false()
 	assert_bool(matcher.is_match(auto_free(Node.new()))).is_false()
 
+
 func test_is_match_string() -> void:
 	assert_object(any_string()).is_instanceof(AnyBuildInTypeArgumentMatcher)
 	
@@ -54,6 +57,7 @@ func test_is_match_string() -> void:
 	assert_bool(matcher.is_match([])).is_false()
 	assert_bool(matcher.is_match(0.2)).is_false()
 	assert_bool(matcher.is_match(auto_free(Node.new()))).is_false()
+
 
 func test_is_match_color() -> void:
 	assert_object(any_color()).is_instanceof(AnyBuildInTypeArgumentMatcher)
@@ -91,7 +95,6 @@ func test_is_match_vector2() -> void:
 	
 	var matcher := any_vector2()
 	assert_bool(matcher.is_match(Vector2.ONE)).is_true()
-	
 	assert_bool(matcher.is_match("")).is_false()
 	assert_bool(matcher.is_match("abc")).is_false()
 	assert_bool(matcher.is_match(0)).is_false()
@@ -109,7 +112,6 @@ func test_is_match_vector2i() -> void:
 	
 	var matcher := any_vector2i()
 	assert_bool(matcher.is_match(Vector2i.ONE)).is_true()
-	
 	assert_bool(matcher.is_match("")).is_false()
 	assert_bool(matcher.is_match("abc")).is_false()
 	assert_bool(matcher.is_match(0)).is_false()
@@ -127,7 +129,6 @@ func test_is_match_vector3() -> void:
 	
 	var matcher := any_vector3()
 	assert_bool(matcher.is_match(Vector3.ONE)).is_true()
-
 	assert_bool(matcher.is_match("")).is_false()
 	assert_bool(matcher.is_match("abc")).is_false()
 	assert_bool(matcher.is_match(0)).is_false()
@@ -145,7 +146,6 @@ func test_is_match_vector3i() -> void:
 	
 	var matcher := any_vector3i()
 	assert_bool(matcher.is_match(Vector3i.ONE)).is_true()
-
 	assert_bool(matcher.is_match("")).is_false()
 	assert_bool(matcher.is_match("abc")).is_false()
 	assert_bool(matcher.is_match(0)).is_false()
@@ -163,7 +163,6 @@ func test_is_match_vector4() -> void:
 	
 	var matcher := any_vector4()
 	assert_bool(matcher.is_match(Vector4.ONE)).is_true()
-
 	assert_bool(matcher.is_match("")).is_false()
 	assert_bool(matcher.is_match("abc")).is_false()
 	assert_bool(matcher.is_match(0)).is_false()
@@ -181,7 +180,6 @@ func test_is_match_vector4i() -> void:
 	
 	var matcher := any_vector4i()
 	assert_bool(matcher.is_match(Vector4i.ONE)).is_true()
-
 	assert_bool(matcher.is_match("")).is_false()
 	assert_bool(matcher.is_match("abc")).is_false()
 	assert_bool(matcher.is_match(0)).is_false()
@@ -192,3 +190,39 @@ func test_is_match_vector4i() -> void:
 	assert_bool(matcher.is_match(Vector3.ONE)).is_false()
 	assert_bool(matcher.is_match(Vector3i.ONE)).is_false()
 	assert_bool(matcher.is_match(Vector4.ONE)).is_false()
+
+
+func test_to_string() -> void:
+	assert_str(str(any_bool())).is_equal("any_bool()")
+	assert_str(str(any_int())).is_equal("any_int()")
+	assert_str(str(any_float())).is_equal("any_float()")
+	assert_str(str(any_string())).is_equal("any_string()")
+	assert_str(str(any_color())).is_equal("any_color()")
+	assert_str(str(any_vector())).is_equal("any_vector()")
+	assert_str(str(any_vector2())).is_equal("any_vector2()")
+	assert_str(str(any_vector2i())).is_equal("any_vector2i()")
+	assert_str(str(any_vector3())).is_equal("any_vector3()")
+	assert_str(str(any_vector3i())).is_equal("any_vector3i()")
+	assert_str(str(any_vector4())).is_equal("any_vector4()")
+	assert_str(str(any_vector4i())).is_equal("any_vector4i()")
+	assert_str(str(any_rect2())).is_equal("any_rect2()")
+	assert_str(str(any_plane())).is_equal("any_plane()")
+	assert_str(str(any_quat())).is_equal("any_quat()")
+	assert_str(str(any_quat())).is_equal("any_quat()")
+	assert_str(str(any_basis())).is_equal("any_basis()")
+	assert_str(str(any_transform_2d())).is_equal("any_transform_2d()")
+	assert_str(str(any_transform_3d())).is_equal("any_transform_3d()")
+	assert_str(str(any_node_path())).is_equal("any_node_path()")
+	assert_str(str(any_rid())).is_equal("any_rid()")
+	assert_str(str(any_object())).is_equal("any_object()")
+	assert_str(str(any_dictionary())).is_equal("any_dictionary()")
+	assert_str(str(any_array())).is_equal("any_array()")
+	assert_str(str(any_packed_byte_array())).is_equal("any_packed_byte_array()")
+	assert_str(str(any_packed_int32_array())).is_equal("any_packed_int32_array()")
+	assert_str(str(any_packed_int64_array())).is_equal("any_packed_int64_array()")
+	assert_str(str(any_packed_float32_array())).is_equal("any_packed_float32_array()")
+	assert_str(str(any_packed_float64_array())).is_equal("any_packed_float64_array()")
+	assert_str(str(any_packed_string_array())).is_equal("any_packed_string_array()")
+	assert_str(str(any_packed_vector2_array())).is_equal("any_packed_vector2_array()")
+	assert_str(str(any_packed_vector3_array())).is_equal("any_packed_vector3_array()")
+	assert_str(str(any_packed_color_array())).is_equal("any_packed_color_array()")

--- a/addons/gdUnit4/test/matchers/AnyClazzArgumentMatcherTest.gd
+++ b/addons/gdUnit4/test/matchers/AnyClazzArgumentMatcherTest.gd
@@ -5,6 +5,7 @@ extends GdUnitTestSuite
 # TestSuite generated from
 const __source = 'res://addons/gdUnit4/src/matchers/AnyClazzArgumentMatcher.gd'
 
+
 func test_is_match_reference():
 	var matcher := AnyClazzArgumentMatcher.new(RefCounted)
 	
@@ -15,6 +16,7 @@ func test_is_match_reference():
 	assert_bool(matcher.is_match(0)).is_false()
 	assert_bool(matcher.is_match(false)).is_false()
 	assert_bool(matcher.is_match(true)).is_false()
+
 
 func test_is_match_node():
 	var matcher := AnyClazzArgumentMatcher.new(Node)
@@ -29,5 +31,13 @@ func test_is_match_node():
 	assert_bool(matcher.is_match(false)).is_false()
 	assert_bool(matcher.is_match(true)).is_false()
 
+
 func test_any_class():
 	assert_object(any_class(Node)).is_instanceof(AnyClazzArgumentMatcher)
+
+
+func test_to_string() -> void:
+	assert_str(str(any_class(Node))).is_equal("any_class(<Node>)")
+	assert_str(str(any_class(Object))).is_equal("any_class(<Object>)")
+	assert_str(str(any_class(RefCounted))).is_equal("any_class(<RefCounted>)")
+	assert_str(str(any_class(GdObjects))).is_equal("any_class(<GdObjects>)")

--- a/addons/gdUnit4/test/matchers/ChainedArgumentMatcherTest.gd
+++ b/addons/gdUnit4/test/matchers/ChainedArgumentMatcherTest.gd
@@ -14,6 +14,7 @@ func test_is_match_one_arg():
 	assert_bool(matcher.is_match(["foo"])).is_true()
 	assert_bool(matcher.is_match(["bar"])).is_false()
 
+
 func test_is_match_two_arg():
 	var matchers = [
 		EqualsArgumentMatcher.new("foo"),
@@ -24,6 +25,7 @@ func test_is_match_two_arg():
 	assert_bool(matcher.is_match(["foo", "value1"])).is_true()
 	assert_bool(matcher.is_match(["foo", "value2"])).is_false()
 	assert_bool(matcher.is_match(["bar", "value1"])).is_false()
+
 
 func test_is_match_different_arg_and_matcher():
 	var matchers = [

--- a/addons/gdUnit4/test/matchers/CustomArgumentMatcherTest.gd
+++ b/addons/gdUnit4/test/matchers/CustomArgumentMatcherTest.gd
@@ -1,5 +1,6 @@
 extends GdUnitTestSuite
 
+
 class CustomArgumentMatcher extends GdUnitArgumentMatcher:
 	var _peek :int
 	
@@ -8,6 +9,7 @@ class CustomArgumentMatcher extends GdUnitArgumentMatcher:
 
 	func is_match(value) -> bool:
 		return value > _peek
+
 
 func test_custom_matcher():
 	var mocked_test_class : CustomArgumentMatcherTestClass = mock(CustomArgumentMatcherTestClass)

--- a/addons/gdUnit4/test/matchers/GdUnitArgumentMatchersTest.gd
+++ b/addons/gdUnit4/test/matchers/GdUnitArgumentMatchersTest.gd
@@ -5,6 +5,7 @@ extends GdUnitTestSuite
 # TestSuite generated from
 const __source = 'res://addons/gdUnit4/src/matchers/GdUnitArgumentMatchers.gd'
 
+
 func test_arguments_to_chained_matcher():
 	var matcher := GdUnitArgumentMatchers.to_matcher(["foo", false, 1])
 	


### PR DESCRIPTION
# Why
Sometimes we want to test for an emitted signal, but are not interested in the signal arguments and therefore want to use an argument matcher.

# What
- extends the `equals` implementation to deal with argument matchers in general.

