### PR TITLE
GD-323: Fix `simulate_mouse_move_relative` to use a time parameter instead of speed as pixels peer seconds

### DIFF
--- a/addons/gdUnit4/src/GdUnitSceneRunner.gd
+++ b/addons/gdUnit4/src/GdUnitSceneRunner.gd
@@ -56,10 +56,21 @@ func simulate_mouse_move(pos :Vector2) -> GdUnitSceneRunner:
 
 
 ## Simulates a mouse move to the relative coordinates (offset).[br]
-## [member relative] : The relative position, e.g. the mouse position offset[br]
-## [member speed] : The mouse speed in pixels per second.[br]
+## [member relative] : The relative position, indicating the mouse position offset.[br]
+## [member time] : The time to move the mouse by the relative position in seconds (default is 1 second).[br]
+## [member trans_type] : Sets the type of transition used (default is TRANS_LINEAR).[br]
 @warning_ignore("unused_parameter")
-func simulate_mouse_move_relative(relative :Vector2, speed :Vector2 = Vector2.ONE) -> GdUnitSceneRunner:
+func simulate_mouse_move_relative(relative: Vector2, time: float = 1.0, trans_type: Tween.TransitionType = Tween.TRANS_LINEAR) -> GdUnitSceneRunner:
+	await Engine.get_main_loop().process_frame
+	return self
+
+
+## Simulates a mouse move to the absolute coordinates.[br]
+## [member position] : The final position of the mouse.[br]
+## [member time] : The time to move the mouse to the final position in seconds (default is 1 second).[br]
+## [member trans_type] : Sets the type of transition used (default is TRANS_LINEAR).[br]
+@warning_ignore("unused_parameter")
+func simulate_mouse_move_absolute(position: Vector2, time: float = 1.0, trans_type: Tween.TransitionType = Tween.TRANS_LINEAR) -> GdUnitSceneRunner:
 	await Engine.get_main_loop().process_frame
 	return self
 

--- a/addons/gdUnit4/src/core/GdUnitTools.gd
+++ b/addons/gdUnit4/src/core/GdUnitTools.gd
@@ -41,6 +41,7 @@ static func free_instance(instance :Variant, is_stdout_verbose :=false) -> bool:
 	if instance is RefCounted:
 		instance.notification(Object.NOTIFICATION_PREDELETE)
 		await Engine.get_main_loop().process_frame
+		await Engine.get_main_loop().physics_frame
 		return true
 	else:
 		# is instance already freed?

--- a/addons/gdUnit4/test/core/GdUnitSceneRunnerInputEventTest.gd
+++ b/addons/gdUnit4/test/core/GdUnitSceneRunnerInputEventTest.gd
@@ -270,11 +270,33 @@ func test_simulate_mouse_move_relative():
 	#OS.window_minimized = false
 	_runner.set_mouse_pos(Vector2(10, 10))
 	await await_idle_frame()
-	#assert_that(_runner.get_mouse_position()).is_equal(Vector2(10, 10))
+	assert_that(_runner.get_mouse_position()).is_equal(Vector2(10, 10))
 	
-	await _runner.simulate_mouse_move_relative(Vector2(900, 400), Vector2(.2, 1))
+	# move the mouse in time of 1 second
+	# the final position is current + relative = Vector2(10, 10) + (Vector2(900, 400)
+	await _runner.simulate_mouse_move_relative(Vector2(900, 400), 1)
+	assert_vector(_runner.get_mouse_position()).is_equal_approx(Vector2(910, 410), Vector2.ONE)
+	
+	# move the mouse back in time of 0.1 second
+	# Use the negative value of the previously moved action to move it back to the starting position
+	await _runner.simulate_mouse_move_relative(Vector2(-900, -400), 0.1)
+	assert_vector(_runner.get_mouse_position()).is_equal_approx(Vector2(10, 10), Vector2.ONE)
+
+
+func test_simulate_mouse_move_absolute():
+	#OS.window_minimized = false
+	_runner.set_mouse_pos(Vector2(10, 10))
 	await await_idle_frame()
-	assert_that(_runner.get_mouse_position()).is_equal(Vector2(910, 410))
+	assert_that(_runner.get_mouse_position()).is_equal(Vector2(10, 10))
+	
+	# move the mouse in time of 1 second
+	await _runner.simulate_mouse_move_absolute(Vector2(900, 400), 1)
+	assert_vector(_runner.get_mouse_position()).is_equal_approx(Vector2(900, 400), Vector2.ONE)
+	
+	# move the mouse back in time of 0.1 second
+	await _runner.simulate_mouse_move_absolute(Vector2(10, 10), 0.1)
+	assert_vector(_runner.get_mouse_position()).is_equal_approx(Vector2(10, 10), Vector2.ONE)
+
 
 func test_simulate_mouse_button_press_left():
 	# simulate mouse button press and hold


### PR DESCRIPTION

# Why
The simulate function `simulate_mouse_move_relative` was confusing the tester and has not work as described. It would be simpler to define a time to move instead of a speed with pixels/second.

# What
* rework the  `simulate_mouse_move_relative` to using a time parameter.
* added `simulate_mouse_move_absolute` to move the mouse to an absolute position

```
## Simulates a mouse move to the relative coordinates (offset).[br]
## [member relative] : The relative position, indicating the mouse position offset.[br]
## [member time] : The time to move the mouse by the relative position in seconds (default is 1 second).[br]
## [member trans_type] : Sets the type of transition used (default is TRANS_LINEAR).[br]
func simulate_mouse_move_relative(relative: Vector2, time: float = 1.0, trans_type: Tween.TransitionType = Tween.TRANS_LINEAR) -> GdUnitSceneRunner:


## Simulates a mouse move to the absolute coordinates.[br]
## [member position] : The final position of the mouse.[br]
## [member time] : The time to move the mouse to the final position in seconds (default is 1 second).[br]
## [member trans_type] : Sets the type of transition used (default is TRANS_LINEAR).[br]
func simulate_mouse_move_absolute(position: Vector2, time: float = 1.0, trans_type: Tween.TransitionType = Tween.TRANS_LINEAR) -> GdUnitSceneRunner:
```