### PR TITLE
GD-334: Provide a public GitHub action to run GdUnit4

### DIFF
--- a/.github/actions/godot-install/action.yml
+++ b/.github/actions/godot-install/action.yml
@@ -10,7 +10,7 @@ inputs:
     description: "The Godot engine status version"
     type: string
     required: true
-  godot-mono:
+  godot-net:
     required: false
     type: boolean
     default: false
@@ -29,14 +29,14 @@ runs:
     - name: "Set Cache Name"
       shell: bash
       run: |
-        if ${{inputs.godot-mono == 'true'}}; then
+        if ${{inputs.godot-net == 'true'}}; then
             echo "CACHE_NAME=${{ runner.OS }}-Godot_v${{ inputs.godot-version }}-${{ inputs.godot-status-version }}_mono" >> "$GITHUB_ENV"
         else
             echo "CACHE_NAME=${{ runner.OS }}-Godot_v${{ inputs.godot-version }}-${{ inputs.godot-status-version }}" >> "$GITHUB_ENV"
         fi
 
     - name: "Build Cache"
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: godot-cache-binary
       with:
         path: ${{ inputs.godot-cache-path }}
@@ -58,7 +58,7 @@ runs:
 
         DOWNLOAD_URL=https://github.com/godotengine/godot-builds/releases/download/${{ inputs.godot-version }}-${{ inputs.godot-status-version }}
         GODOT_BIN=Godot_v${{ inputs.godot-version }}-${{ inputs.godot-status-version }}_${{ inputs.godot-bin-name }}
-        if ${{inputs.godot-mono == 'true'}}; then
+        if ${{inputs.godot-net == 'true'}}; then
           GODOT_BIN=Godot_v${{ inputs.godot-version }}-${{ inputs.godot-status-version }}_mono_${{ inputs.godot-bin-name }}
         fi
 
@@ -70,7 +70,7 @@ runs:
         if ${{runner.OS == 'Linux'}}; then
           echo "Run linux part"
 
-          if ${{inputs.godot-mono == 'true'}}; then
+          if ${{inputs.godot-net == 'true'}}; then
             mv ${{ inputs.godot-cache-path }}/$GODOT_BIN/* ${{ inputs.godot-cache-path }}
             rmdir ${{ inputs.godot-cache-path }}/$GODOT_BIN/
           fi

--- a/.github/actions/publish-test-report/action.yml
+++ b/.github/actions/publish-test-report/action.yml
@@ -1,9 +1,9 @@
 name: publish-test-report
-description: "Publishes the GdUnit test results"
+description: 'Publishes the GdUnit test results'
 
 inputs:
   report-name:
-    description: "Name of the check run which will be created."
+    description: 'Name of the check run which will be created.'
     required: true
 
 runs:

--- a/.github/actions/publish-test-report/action.yml
+++ b/.github/actions/publish-test-report/action.yml
@@ -16,9 +16,9 @@ runs:
         git config --global --add safe.directory '*'
 
     - name: 'Publish Test Results'
-      uses: dorny/test-reporter@v1.6.0
+      uses: dorny/test-reporter@v1.7.0
       with:
-        name: test_report_${{ inputs.report-name }}
+        name: ${{ inputs.report-name }}
         path: 'reports/**/results.xml'
         reporter: java-junit
         fail-on-error: 'false'

--- a/.github/actions/unit-test/action.yml
+++ b/.github/actions/unit-test/action.yml
@@ -1,9 +1,12 @@
 name: unit-test
-description: "Runs the unit tests on GdUnit4 API"
+description: 'Runs the unit tests on GdUnit4 API'
 
 inputs:
+  version:
+    description: 'The GdUnit4 version'
+    required: true
   test-includes:
-    description: "The path to include tests to be run"
+    description: 'The path to include tests to be run'
     required: true
   godot-bin:
     required: true
@@ -12,10 +15,10 @@ runs:
   using: composite
 
   steps:
-    - name: "Unit Test Linux"
+    - name: 'Unit Test Linux'
       if: ${{ runner.OS == 'Linux' }}
       env:
-        GODOT_BIN: "/home/runner/godot-linux/godot"
+        GODOT_BIN: '/home/runner/godot-linux/godot'
       shell: bash
       run: |
         chmod +x ./addons/gdUnit4/runtest.sh
@@ -23,19 +26,19 @@ runs:
 
 
 # not tested yet
-    - name: "Unit Test Windows cmd"
+    - name: 'Unit Test Windows cmd'
       if: ${{ runner.OS == 'Windows' }}
       env:
-        GODOT_BIN: "C:\\Users\\runneradmin/godot-win/godot.exe"
+        GODOT_BIN: 'C:\\Users\\runneradmin/godot-win/godot.exe'
       shell: cmd
       run: |
-        echo "%HOMEPATH%"
+        echo '%HOMEPATH%'
         set unix_path=${{ inputs.godot-bin }}
         set win_path=%unix_path:~1%
         set win_path=%HOMEPATH%%unix_path:~1%
         set win_path=%win_path:/=\%
-        echo "%win_path%"
-        echo "%GODOT_BIN%"
+        echo '%win_path%'
+        echo '%GODOT_BIN%'
 
         %GODOT_BIN% -s -d .\addons\gdUnit4\bin\GdUnitCmdTool.gd
 

--- a/.github/actions/upload-test-report/action.yml
+++ b/.github/actions/upload-test-report/action.yml
@@ -1,17 +1,18 @@
-name: upload-test-report
-description: "Uploads the GdUnit test reports"
+name: 'upload test report'
+description: 'Uploads the GdUnit test reports'
 
 inputs:
   report-name:
-    description: "Name of the report to be upload."
+    description: 'Name of the report to be upload.'
     required: true
 
 runs:
   using: composite
   steps:
-    - name: Collect Test Artifacts
-      uses: actions/upload-artifact@v3
+    - name: 'Collect Test Artifacts'
+      uses: actions/upload-artifact@v4
       with:
+        retention-days: 10
         name: test_report_${{ inputs.report-name }}
         path: |
           reports/**

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,13 @@
 
 version: 2
 updates:
-  - package-ecosystem: "npm" # See documentation for possible values
-    directory: "/addons/gdUnit4/" # Location of package manifests
+  - package-ecosystem: npm
+    directory: '/addons/gdUnit4/'
     schedule:
-      interval: "daily"
+      interval: daily
+
+  - package-ecosystem: github-actions
+    directory: '/'
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 5

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -24,23 +24,44 @@ jobs:
 
 
   unit-tests:
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       max-parallel: 10
       matrix:
         godot-version: ['4.1', '4.1.1', '4.1.2', '4.1.3', '4.2', '4.2.1']
         godot-status: ['stable']
+        godot-net: ['.Net', '']
         include:
           - godot-version: '4.3'
             godot-status: 'dev2'
 
+    steps:
+      - name: "Checkout GdUnit4"
+        uses: actions/checkout@v4
+        with:
+          lfs: true
+          
+      - name: CI on 🐧 Godot_v${{ matrix.godot-version }}-${{ matrix.godot-status }}
+        if: ${{ matrix.godot-net == '' }}
+        uses: ./
+        with:
+          godot-version: ${{ matrix.godot-version }}
+          godot-status: ${{ matrix.godot-status }}
+          godot-net: false
+          paths: "res://addons/gdUnit4/test/"
+          report-name: test-report_${{ matrix.godot-version }}-${{ matrix.godot-status }}
 
-    name: "CI on Godot 🐧 v${{ matrix.godot-version }}-${{ matrix.godot-status }}"
-    needs: [gdlint]
-    uses: ./.github/workflows/unit-tests.yml
-    with:
-      godot-version: ${{ matrix.godot-version }}
-      godot-status: ${{ matrix.godot-status }}
+      - name: CI on 🐧 Godot_v${{ matrix.godot-version }}-${{ matrix.godot-status }}-net
+        if: ${{ matrix.godot-net == '.Net' }}
+        uses: ./
+        with:
+          godot-version: ${{ matrix.godot-version }}
+          godot-status: ${{ matrix.godot-status }}
+          godot-net: true
+          paths: "res://addons/gdUnit4/test/mono"
+          report-name: test-report_${{ matrix.godot-version }}-${{ matrix.godot-status }}-net
+
 
   finalize:
     if: ${{ !cancelled() }}

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -19,7 +19,7 @@ jobs:
 
   gdlint:
     if: ${{ !cancelled() }}
-    name: "🔧 GDLint"
+    name: '🔧 GDLint'
     uses: ./.github/workflows/gdlint.yml
 
 
@@ -37,36 +37,38 @@ jobs:
             godot-status: 'dev2'
 
     steps:
-      - name: "Checkout GdUnit4"
+      - name: 'Checkout GdUnit4'
         uses: actions/checkout@v4
         with:
           lfs: true
-          
-      - name: CI on 🐧 Godot_v${{ matrix.godot-version }}-${{ matrix.godot-status }}
+
+      - name: 'CI on 🐧 Godot_v${{ matrix.godot-version }}-${{ matrix.godot-status }}'
         if: ${{ matrix.godot-net == '' }}
         uses: ./
         with:
           godot-version: ${{ matrix.godot-version }}
           godot-status: ${{ matrix.godot-status }}
           godot-net: false
-          paths: "res://addons/gdUnit4/test/"
+          gdunit-version: latest
+          gdunit-tests: 'res://addons/gdUnit4/test/'
           report-name: test-report_${{ matrix.godot-version }}-${{ matrix.godot-status }}
 
-      - name: CI on 🐧 Godot_v${{ matrix.godot-version }}-${{ matrix.godot-status }}-net
+      - name: 'CI on 🐧 Godot_v${{ matrix.godot-version }}-${{ matrix.godot-status }}-net'
         if: ${{ matrix.godot-net == '.Net' }}
         uses: ./
         with:
           godot-version: ${{ matrix.godot-version }}
           godot-status: ${{ matrix.godot-status }}
           godot-net: true
-          paths: "res://addons/gdUnit4/test/mono"
+          gdunit-version: latest
+          gdunit-tests: 'res://addons/gdUnit4/test/mono'
           report-name: test-report_${{ matrix.godot-version }}-${{ matrix.godot-status }}-net
 
 
   finalize:
     if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
-    name: Final Results
+    name: 'Final Results'
     needs: [gdlint, unit-tests]
     steps:
       - run: exit 1

--- a/.github/workflows/gdlint.yml
+++ b/.github/workflows/gdlint.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       - name: Checkout GdUnit Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           lfs: true
 

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -14,6 +14,17 @@ on:
       godot-status:
         required: true
         type: string
+      godot-mono:
+          required: false
+          type: bool
+          default: false
+      paths:
+        required: true
+        type: list
+      report-name:
+        required: false
+        type: string
+        default: 'test-report.xml'
 
   workflow_dispatch:
     inputs:
@@ -27,6 +38,18 @@ on:
       godot-status:
         required: true
         type: string
+      godot-mono:
+          required: false
+          type: bool
+          default: false
+      paths:
+        required: true
+        type: list
+      report-name:
+        required: false
+        type: string
+        default: 'test-report.xml'
+
 
 concurrency:
   group: unit-tests-${{ github.head_ref || github.ref_name }}-${{ inputs.godot-version }}
@@ -70,7 +93,7 @@ jobs:
         uses: ./.github/actions/unit-test
         with:
           godot-bin: '~/godot-linux/godot'
-          test-includes: "res://addons/gdUnit4/test/"
+          test-includes: ${{ inputs.paths }}
 
       - name: "Run Unit Test Examples"
         if: ${{ !cancelled() }}

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,6 @@
-name: 'GdUnit4 CI'
+name: 'GdUnit4 - Test Runner'
 description: 'This GitHub action provides the GdUnit4 test runner'
+author: Mike Schulze <mikeschulze.lpz@kabelmail.de>
 
 inputs:
   godot-version:
@@ -12,19 +13,30 @@ inputs:
     required: false
     type: bool
     default: false
-  paths:
+  gdunit-version:
+    required: false
+    type: string
+    default: latest
+  gdunit-tests:
     required: true
-    type: list
+    type: string
   report-name:
     required: false
     type: string
     default: 'test-report.xml'
 
-runs:
-  using: "composite"
+outputs:
+  artifactsPath:
+    description: 'Path where the test artifacts are stored.'
 
+branding:
+  icon: 'refresh-cw'
+  color: 'purple'
+
+runs:
+  using: 'composite'
   steps:
-    - name: "Update Ubuntu"
+    - name: 'Update Ubuntu'
       if: ${{ !cancelled() }}
       shell: bash
       run: |
@@ -33,7 +45,7 @@ runs:
         sudo apt update
         sudo apt -y install systemd-coredump
 
-    - name: "Install Godot ${{ inputs.godot-version }}"
+    - name: 'Install Godot ${{ inputs.godot-version }}'
       uses: ./.github/actions/godot-install
       with:
         godot-version: ${{ inputs.godot-version }}
@@ -42,13 +54,13 @@ runs:
         godot-bin-name: 'linux.x86_64'
         godot-cache-path: '~/godot-linux'
 
-    - name: "Setup .NET"
+    - name: 'Setup .NET'
       if:  ${{ inputs.godot-net }}
       uses: actions/setup-dotnet@v4
       with:
         dotnet-version: 7.0.x
 
-    - name: "Update Project"
+    - name: 'Update Project'
       if: ${{ !cancelled() }}
       shell: bash
       run: |
@@ -58,22 +70,28 @@ runs:
         fi
         xvfb-run --auto-servernum ~/godot-linux/godot -e --path . -s res://addons/gdUnit4/bin/ProjectScanner.gd --headless --audio-driver Dummy 2> /dev/null
 
-    - name: "Run Unit Tests"
+    - name: 'Run Unit Tests'
       if: ${{ !cancelled() }}
       uses: ./.github/actions/unit-test
       with:
         godot-bin: '~/godot-linux/godot'
-        test-includes: ${{ inputs.paths }}
+        version: ${{ inputs.gdunit-version }}
+        test-includes: ${{ inputs.gdunit-tests }}
 
-
-    - name: "Coredump Check"
+    - name: 'Coredump Check'
       if: ${{ !cancelled() && inputs.godot-net }}
       uses: ./.github/actions/check-coredump
       with:
-        artifact-name: "TestRunner-${{ inputs.os }}-${{ inputs.godot-version }}-mono"
+        artifact-name: 'TestRunner-${{ inputs.os }}-${{ inputs.godot-version }}-mono'
 
-    - name: "Publish Unit Test Reports"
+    - name: 'Publish Unit Test Reports'
       if: ${{ !cancelled() }}
       uses: ./.github/actions/publish-test-report
+      with:
+        report-name: ${{ inputs.report-name }}
+
+    - name: 'Upload Unit Test Reports'
+      if: ${{ !cancelled() }}
+      uses: ./.github/actions/upload-test-report
       with:
         report-name: ${{ inputs.report-name }}

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,79 @@
+name: 'GdUnit4 CI'
+description: 'This GitHub action provides the GdUnit4 test runner'
+
+inputs:
+  godot-version:
+    required: true
+    type: string
+  godot-status:
+    required: true
+    type: string
+  godot-net:
+    required: false
+    type: bool
+    default: false
+  paths:
+    required: true
+    type: list
+  report-name:
+    required: false
+    type: string
+    default: 'test-report.xml'
+
+runs:
+  using: "composite"
+
+  steps:
+    - name: "Update Ubuntu"
+      if: ${{ !cancelled() }}
+      shell: bash
+      run: |
+        sudo apt-get update
+        sudo apt-get -y install systemd-coredump
+        sudo apt update
+        sudo apt -y install systemd-coredump
+
+    - name: "Install Godot ${{ inputs.godot-version }}"
+      uses: ./.github/actions/godot-install
+      with:
+        godot-version: ${{ inputs.godot-version }}
+        godot-net: ${{ inputs.godot-net }}
+        godot-status-version: ${{ inputs.godot-status }}
+        godot-bin-name: 'linux.x86_64'
+        godot-cache-path: '~/godot-linux'
+
+    - name: "Setup .NET"
+      if:  ${{ inputs.godot-net }}
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: 7.0.x
+
+    - name: "Update Project"
+      if: ${{ !cancelled() }}
+      shell: bash
+      run: |
+        if ${{ inputs.godot-net }}; then
+          dotnet restore
+          dotnet build
+        fi
+        xvfb-run --auto-servernum ~/godot-linux/godot -e --path . -s res://addons/gdUnit4/bin/ProjectScanner.gd --headless --audio-driver Dummy 2> /dev/null
+
+    - name: "Run Unit Tests"
+      if: ${{ !cancelled() }}
+      uses: ./.github/actions/unit-test
+      with:
+        godot-bin: '~/godot-linux/godot'
+        test-includes: ${{ inputs.paths }}
+
+
+    - name: "Coredump Check"
+      if: ${{ !cancelled() && inputs.godot-net }}
+      uses: ./.github/actions/check-coredump
+      with:
+        artifact-name: "TestRunner-${{ inputs.os }}-${{ inputs.godot-version }}-mono"
+
+    - name: "Publish Unit Test Reports"
+      if: ${{ !cancelled() }}
+      uses: ./.github/actions/publish-test-report
+      with:
+        report-name: ${{ inputs.report-name }}

--- a/addons/gdUnit4/src/monitor/GodotGdErrorMonitor.gd
+++ b/addons/gdUnit4/src/monitor/GodotGdErrorMonitor.gd
@@ -42,6 +42,7 @@ static func _to_report(errorLog :ErrorLogEntry) -> GdUnitReport:
 
 func scan(force_collect_reports := false) -> Array[ErrorLogEntry]:
 	await Engine.get_main_loop().process_frame
+	await Engine.get_main_loop().physics_frame
 	_entries.append_array(_collect_log_entries(force_collect_reports))
 	return _entries
 

--- a/addons/gdUnit4/test/spy/GdUnitSpyTest.gd
+++ b/addons/gdUnit4/test/spy/GdUnitSpyTest.gd
@@ -167,18 +167,10 @@ func test_spy_on_inner_class():
 
 
 func test_spy_on_singleton():
-	# setup monitor to collect expected push_error notifications
-	var monitor := GodotGdErrorMonitor.new()
-	monitor.start()
-	# We not allow to spy on a singleton
-	var spy_node = spy(Input)
-	await await_idle_frame()
-	monitor.stop()
-	assert_object(spy_node).is_null()
-	await monitor.scan(true)
-	assert_array(monitor.to_reports()).has_size(1)
-	if not is_failure():
-		assert_str(monitor.to_reports()[0].message()).contains("Spy on a Singleton is not allowed! 'Input'")
+	await assert_error(func () -> void: 
+							var spy_node_ = spy(Input)
+							assert_object(spy_node_).is_null()
+							await await_idle_frame()).is_push_error("Spy on a Singleton is not allowed! 'Input'")
 
 
 func test_example_verify():
@@ -221,7 +213,7 @@ func test_verify_fail():
 			.dedent().trim_prefix("\n")
 	assert_failure(func(): verify(spy_node, 1).set_process(true)) \
 		.is_failed() \
-		.has_line(222) \
+		.has_line(214) \
 		.has_message(expected_error)
 
 
@@ -248,7 +240,7 @@ func test_verify_func_interaction_wiht_PackedStringArray_fail():
 			.dedent().trim_prefix("\n")
 	assert_failure(func(): verify(spy_instance, 1).set_values([])) \
 		.is_failed() \
-		.has_line(249) \
+		.has_line(241) \
 		.has_message(expected_error)
 	
 	reset(spy_instance)
@@ -266,7 +258,7 @@ func test_verify_func_interaction_wiht_PackedStringArray_fail():
 			.dedent().trim_prefix("\n")
 	assert_failure(func(): verify(spy_instance, 1).set_values([])) \
 		.is_failed() \
-		.has_line(267) \
+		.has_line(259) \
 		.has_message(expected_error)
 
 
@@ -314,7 +306,7 @@ func test_verify_no_interactions_fails():
 	# it should fail because we have interactions
 	assert_failure(func(): verify_no_interactions(spy_node)) \
 		.is_failed() \
-		.has_line(315) \
+		.has_line(307) \
 		.has_message(expected_error)
 
 
@@ -369,7 +361,7 @@ func test_verify_no_more_interactions_but_has():
 			.dedent().trim_prefix("\n")
 	assert_failure(func(): verify_no_more_interactions(spy_node)) \
 		.is_failed() \
-		.has_line(370) \
+		.has_line(362) \
 		.has_message(expected_error)
 
 


### PR DESCRIPTION
# Why
Instead of having to manually build the setup to run tests, it would be nice to use a pre-built GitHub action.

# What
added public GitHub action to enable run GdUnit4 test in a CI workflow

