### PR TITLE
GD-348: Change gdUnit3 to gdUnit4 in report templates, fix some spelling errors

### DIFF
--- a/addons/gdUnit4/src/network/GdUnitTcpServer.gd
+++ b/addons/gdUnit4/src/network/GdUnitTcpServer.gd
@@ -140,7 +140,7 @@ func disconnect_client(client_id :int) -> void:
 func _process(_delta):
 	if not _server.is_listening():
 		return
-	# check is new connection incomming
+	# check if connection is ready to be used
 	if _server.is_connection_available():
 		add_child(TcpConnection.new(_server))
 

--- a/addons/gdUnit4/src/report/template/folder_report.html
+++ b/addons/gdUnit4/src/report/template/folder_report.html
@@ -10,7 +10,7 @@
 
 <body>
 	<div class="header" id="header">
-		<h1><img src="../css/icon.png"><span class="color1">Gd</span><span class="color2">Unit</span><span class="color1">3</span> <span class="color3">Report</span></h1>
+		<h1><img src="../css/icon.png"><span class="color1">Gd</span><span class="color2">Unit</span><span class="color1">4</span> <span class="color3">Report</span></h1>
 	</div>
 
 	<div class="content">
@@ -52,8 +52,8 @@
 				</table>
 			</div>
 			<div class="grid-item history">
-			  <h1>History</h1>
-			  <p>Comming Next</p>
+				<h1>History</h1>
+				<p>Coming Next</p>
 			</div>
 		</div>
 

--- a/addons/gdUnit4/src/report/template/index.html
+++ b/addons/gdUnit4/src/report/template/index.html
@@ -9,7 +9,7 @@
 
 <body>
 	<div class="header">
-		<h1><img src="css/icon.png"><span class="color1">Gd</span><span class="color2">Unit</span><span class="color1">3</span> <span class="color3">Report</span></h1>
+		<h1><img src="css/icon.png"><span class="color1">Gd</span><span class="color2">Unit</span><span class="color1">4</span> <span class="color3">Report</span></h1>
 	</div>
 
 	<div class="content">
@@ -51,8 +51,8 @@
 				</table>
 			</div>
 			<div class="grid-item history">
-			  <h1>History</h1>
-			  <p>Comming Next</p>
+				<h1>History</h1>
+				<p>Coming Next</p>
 			</div>
 		</div>
 
@@ -113,7 +113,7 @@
 					</div>
 				</section>
 			</div>
-	  </div>
+		</div>
 	</div>
 
 	<footer>

--- a/addons/gdUnit4/src/report/template/suite_report.html
+++ b/addons/gdUnit4/src/report/template/suite_report.html
@@ -26,7 +26,7 @@
 <body>
 	<div class="header" id="header">
 		<h1><img src="../css/icon.png"><span class="color1">Gd</span><span class="color2">Unit</span><span
-				class="color1">3</span> <span class="color3">Report</span></h1>
+				class="color1">4</span> <span class="color3">Report</span></h1>
 	</div>
 
 	<div class="content">
@@ -65,7 +65,7 @@
 			</div>
 			<div class="grid-item history">
 				<h1>History</h1>
-				<p>Comming Next</p>
+				<p>Coming Next</p>
 			</div>
 		</div>
 


### PR DESCRIPTION
# Why
Some reports still reference gdUnit3 when rendered. There are also some spelling errors (e.g., "Comming" instead of "Coming".


# What
I updated the version in the templates and fixed some spelling errors I found