### PR TITLE
GD-356: SceneRunner made more robust

### DIFF
--- a/addons/gdUnit4/src/GdUnitSceneRunner.gd
+++ b/addons/gdUnit4/src/GdUnitSceneRunner.gd
@@ -56,9 +56,16 @@ func simulate_mouse_move(pos :Vector2) -> GdUnitSceneRunner:
 
 
 ## Simulates a mouse move to the relative coordinates (offset).[br]
+## [color=yellow]You must use [b]await[/b] to wait until the simulated mouse movement is complete.[/color][br]
+## [br]
 ## [member relative] : The relative position, indicating the mouse position offset.[br]
 ## [member time] : The time to move the mouse by the relative position in seconds (default is 1 second).[br]
 ## [member trans_type] : Sets the type of transition used (default is TRANS_LINEAR).[br]
+## [codeblock]
+##    func test_move_mouse():
+##       var runner = scene_runner("res://scenes/simple_scene.tscn")
+##       await runner.simulate_mouse_move_relative(Vector2(100,100))
+## [/codeblock]
 @warning_ignore("unused_parameter")
 func simulate_mouse_move_relative(relative: Vector2, time: float = 1.0, trans_type: Tween.TransitionType = Tween.TRANS_LINEAR) -> GdUnitSceneRunner:
 	await Engine.get_main_loop().process_frame
@@ -66,9 +73,16 @@ func simulate_mouse_move_relative(relative: Vector2, time: float = 1.0, trans_ty
 
 
 ## Simulates a mouse move to the absolute coordinates.[br]
+## [color=yellow]You must use [b]await[/b] to wait until the simulated mouse movement is complete.[/color][br]
+## [br]
 ## [member position] : The final position of the mouse.[br]
 ## [member time] : The time to move the mouse to the final position in seconds (default is 1 second).[br]
 ## [member trans_type] : Sets the type of transition used (default is TRANS_LINEAR).[br]
+## [codeblock]
+##    func test_move_mouse():
+##       var runner = scene_runner("res://scenes/simple_scene.tscn")
+##       await runner.simulate_mouse_move_absolute(Vector2(100,100))
+## [/codeblock]
 @warning_ignore("unused_parameter")
 func simulate_mouse_move_absolute(position: Vector2, time: float = 1.0, trans_type: Tween.TransitionType = Tween.TRANS_LINEAR) -> GdUnitSceneRunner:
 	await Engine.get_main_loop().process_frame

--- a/addons/gdUnit4/test/core/resources/scenes/simple_scene.gd
+++ b/addons/gdUnit4/test/core/resources/scenes/simple_scene.gd
@@ -1,7 +1,15 @@
 extends Node2D
 
+class Player extends Node:
+	var position :Vector3 = Vector3.ZERO
+
+
+	func _init():
+		set_name("Player")
+
+	func is_on_floor() -> bool:
+		return true
+
 
 func _ready():
-	pass # Replace with function body.
-
-
+	add_child(Player.new(), true)

--- a/addons/gdUnit4/test/core/resources/scenes/simple_scene.tscn
+++ b/addons/gdUnit4/test/core/resources/scenes/simple_scene.tscn
@@ -1,11 +1,11 @@
-[gd_scene load_steps=3 format=2]
+[gd_scene load_steps=3 format=3 uid="uid://cn8ucy2rheu0f"]
 
-[ext_resource path="res://icon.png" type="Texture2D" id=1]
-[ext_resource path="res://addons/gdUnit4/test/core/resources/scenes/simple_scene.gd" type="Script" id=2]
+[ext_resource type="Texture2D" uid="uid://t80a6k3vyrrd" path="res://icon.png" id="1"]
+[ext_resource type="Script" path="res://addons/gdUnit4/test/core/resources/scenes/simple_scene.gd" id="2"]
 
 [node name="Node2D" type="Node2D"]
-script = ExtResource( 2 )
+script = ExtResource("2")
 
 [node name="Sprite2D" type="Sprite2D" parent="."]
-position = Vector2( 504, 252 )
-texture = ExtResource( 1 )
+position = Vector2(504, 252)
+texture = ExtResource("1")


### PR DESCRIPTION
# Why
A user runs into an error of scene is not valid during test execution by using `simulate_mouse_move_relative` without the `await`

# What
- Added test to reproduce the issue
- made the runner more robust for such exceptional cases
- improve the inline documentation to be more present in the fact to use `await`

