### PR TITLE
GD-363: Follow-up to fix errors on parameterized test naming resolving

### DIFF
--- a/addons/gdUnit4/src/core/_TestCase.gd
+++ b/addons/gdUnit4/src/core/_TestCase.gd
@@ -235,13 +235,15 @@ func test_case_names() -> PackedStringArray:
 		return _extract_test_names_from_expression()
 	# parse the parameters and build the test names
 	var regex := RegEx.new()
-	var s = "(?m)\\[.{1}(\\s*|((?:.|\n)*?)\\s*)\\]"
+	var s = "(?m)\\[(\\s*|((?:.|\n)*?)\\s*)\\]"
 	regex.compile(s)
+	# remove start of array before parsing
 	var matches = regex.search_all(test_parameter_expresion)
 	if matches.size() == 0:
 		push_error("Internal Error: Can't parse the parameterized test arguments!")
 	for index in matches.size():
 		var parameter = matches[index].get_string(0)
+		parameter = parameter.replace("[\n", "").replace("\n", "").replace("\t", "")
 		_test_case_names.append(_build_test_case_name(parameter, index))
 	return _test_case_names
 
@@ -254,7 +256,13 @@ func _extract_test_names_from_expression() -> PackedStringArray:
 
 
 func _build_test_case_name(test_parameter :String, parameter_index :int) -> String:
-	return "%s:%d %s" % [get_name(), parameter_index, test_parameter.replace('"', "'").replace("&'", "'")]
+	prints("'%s'" % test_parameter)
+	if not test_parameter.begins_with("["):
+		test_parameter = "[" + test_parameter
+	var test_name = "%s:%d %s" % [get_name(), parameter_index, test_parameter.replace('"', "'").replace("&'", "'")]
+	if test_name.length() > 96:
+		return test_name.substr(0, 96) + " ..."
+	return test_name
 
 
 func _to_string():

--- a/addons/gdUnit4/src/core/execution/stages/parameterized/GdUnitTestCaseParameterizedTestStage.gd
+++ b/addons/gdUnit4/src/core/execution/stages/parameterized/GdUnitTestCaseParameterizedTestStage.gd
@@ -21,7 +21,7 @@ func _execute(context :GdUnitExecutionContext) -> void:
 	if not error.is_empty():
 		test_case.skip(true, error)
 		return
-	var test_names := test_case.test_case_names();
+	var test_names := test_case.test_case_names()
 	for test_case_index in parameters.size():
 		# is test_parameter_index is set, we run this parameterized test only
 		if test_parameter_index != -1 and test_parameter_index != test_case_index:

--- a/addons/gdUnit4/test/core/ParameterizedTestCaseTest.gd
+++ b/addons/gdUnit4/test/core/ParameterizedTestCaseTest.gd
@@ -44,6 +44,11 @@ var _expected_tests = {
 		["test_a"],
 		["test_b"],
 		["test_c"]
+	],
+	"test_with_dynamic_paramater_resolving2" : [
+		["test_a"],
+		["test_b"],
+		["test_c"]
 	]
 }
 
@@ -229,3 +234,28 @@ func test_with_dynamic_paramater_resolving(name: String, value, expected, test_p
 ]) -> void:
 	assert_that(value).is_not_null().is_instanceof(expected)
 	collect_test_call("test_with_dynamic_paramater_resolving", [name])
+
+
+@warning_ignore("unused_parameter")
+func test_with_dynamic_paramater_resolving2(
+	name: String,
+	type,
+	log_level,
+	expected_logs,
+	test_parameters = [
+		["test_a", null, "LOG", {}],
+		[
+			"test_b",
+			Node2D,
+			null,
+			{Node2D: "ERROR"}
+		],
+		[
+			"test_c",
+			Node2D,
+			"LOG",
+			{Node2D: "LOG"}
+		]
+	]
+):
+	collect_test_call("test_with_dynamic_paramater_resolving2", [name])


### PR DESCRIPTION
# Why
With https://github.com/MikeSchulze/gdUnit4/issues/359 i introduced a bug and the test resolving was broken.

# What
fixed the test name resolving to handle multiline test arguments
