### PR TITLE
Refer to the scripts using res:// URL.

### DIFF
--- a/addons/gdUnit4/runtest.cmd
+++ b/addons/gdUnit4/runtest.cmd
@@ -16,9 +16,9 @@ IF "%GODOT_TYPE%" == "mono" (
 	ECHO done %errorlevel%
 )
 
-%GODOT_BIN% -s -d .\addons\gdUnit4\bin\GdUnitCmdTool.gd %*
+%GODOT_BIN% -s -d res://addons/gdUnit4/bin/GdUnitCmdTool.gd %*
 SET exit_code=%errorlevel%
-%GODOT_BIN% --headless --quiet -s -d .\addons\gdUnit4\bin\GdUnitCopyLog.gd %*
+%GODOT_BIN% --headless --quiet -s -d res://addons/gdUnit4/bin/GdUnitCopyLog.gd %*
 
 ECHO %exit_code%
 

--- a/addons/gdUnit4/runtest.sh
+++ b/addons/gdUnit4/runtest.sh
@@ -6,10 +6,10 @@ if [ -z "$GODOT_BIN" ]; then
     exit 1
 fi
 
-$GODOT_BIN --path . -s -d ./addons/gdUnit4/bin/GdUnitCmdTool.gd $*
+$GODOT_BIN --path . -s -d res://addons/gdUnit4/bin/GdUnitCmdTool.gd $*
 exit_code=$?
 echo "Run tests ends with $exit_code"
 
-$GODOT_BIN --headless --path . --quiet -s -d ./addons/gdUnit4/bin/GdUnitCopyLog.gd $* > /dev/null
+$GODOT_BIN --headless --path . --quiet -s -d res://addons/gdUnit4/bin/GdUnitCopyLog.gd $* > /dev/null
 exit_code2=$?
 exit $exit_code


### PR DESCRIPTION
This ensures that settings of `Exclude Addons` for strict type checking on the project is honored.

Fixes #365

# Why
This fixes the issue with the Github actions failing because the project settings have strict type checking on but have `Exclude Addons` settings turned on.

# What
Change runtest.sh and runtest.cmd to use the res:// URL format so that the Exclude setting is properly applied.

I was able to test the Linux(runtest.sh) version here-  https://github.com/vikerman/GDUnitTest/actions/runs/8217131139
but not the Windows version (runtest.cmd).