### PR TITLE
GD-370: Mock a class with functions return type enum results in an error Parser Error: Cannot return a value of type "null"

### DIFF
--- a/addons/gdUnit4/src/core/GdFunctionDoubler.gd
+++ b/addons/gdUnit4/src/core/GdFunctionDoubler.gd
@@ -40,6 +40,8 @@ const DEFAULT_TYPED_RETURN_VALUES := {
 	TYPE_PACKED_VECTOR2_ARRAY: "PackedVector2Array()",
 	TYPE_PACKED_VECTOR3_ARRAY: "PackedVector3Array()",
 	TYPE_PACKED_COLOR_ARRAY: "PackedColorArray()",
+	GdObjects.TYPE_VARIANT: "null",
+	GdObjects.TYPE_ENUM: "0"
 }
 
 # @GlobalScript enums
@@ -73,20 +75,20 @@ static func default_return_value(func_descriptor :GdFunctionDescriptor) -> Strin
 		var enum_path := func_descriptor._return_class.split(".")
 		if enum_path.size() == 2:
 			var keys := ClassDB.class_get_enum_constants(enum_path[0], enum_path[1])
-			return "%s.%s" % [enum_path[0], keys[0]]
+			if not keys.is_empty():
+				return "%s.%s" % [enum_path[0], keys[0]]
 		# we need fallback for @GlobalScript enums,
 		return DEFAULT_ENUM_RETURN_VALUES.get(func_descriptor._return_class, "0")
-	return DEFAULT_TYPED_RETURN_VALUES.get(return_type, "null")
+	return DEFAULT_TYPED_RETURN_VALUES.get(return_type, "invalid")
 
 
 func _init(push_errors :bool = false):
 	_push_errors = "true" if push_errors else "false"
-	if DEFAULT_TYPED_RETURN_VALUES.size() != TYPE_MAX:
-		push_error("missing default definitions! Expexting %d bud is %d" % [DEFAULT_TYPED_RETURN_VALUES.size(), TYPE_MAX])
-		for type_key in range(0, DEFAULT_TYPED_RETURN_VALUES.size()):
-			if not DEFAULT_TYPED_RETURN_VALUES.has(type_key):
-				prints("missing default definition for type", type_key)
-				assert(DEFAULT_TYPED_RETURN_VALUES.has(type_key), "Missing Type default definition!")
+	for type_key in TYPE_MAX:
+		if not DEFAULT_TYPED_RETURN_VALUES.has(type_key):
+			push_error("missing default definitions! Expexting %d bud is %d" % [DEFAULT_TYPED_RETURN_VALUES.size(), TYPE_MAX])
+			prints("missing default definition for type", type_key)
+			assert(DEFAULT_TYPED_RETURN_VALUES.has(type_key), "Missing Type default definition!")
 
 
 @warning_ignore("unused_parameter")

--- a/addons/gdUnit4/test/mocker/CustomEnums.gd
+++ b/addons/gdUnit4/test/mocker/CustomEnums.gd
@@ -1,0 +1,8 @@
+class_name CustomEnums
+extends RefCounted
+
+
+enum TEST_ENUM {
+	FOO = 11,
+	BAR = 22
+}

--- a/addons/gdUnit4/test/mocker/GdUnitMockerTest.gd
+++ b/addons/gdUnit4/test/mocker/GdUnitMockerTest.gd
@@ -415,6 +415,69 @@ func test_mock_custom_class_func_bar_real_func():
 	verify(m, 1).bar(10, 20, "other")
 
 
+func test_mock_custom_class_func_return_type_enum():
+	var m = mock(ClassWithEnumReturnTypes)
+	assert_that(m).is_not_null()
+	verify(m, 0).get_enum()
+	
+	# verify enum return default 0
+	assert_that(m.get_enum()).is_equal(0)
+	do_return(ClassWithEnumReturnTypes.TEST_ENUM.BAR).on(m).get_enum()
+	assert_that(m.get_enum()).is_equal(ClassWithEnumReturnTypes.TEST_ENUM.BAR)
+	verify(m, 2).get_enum()
+	
+	# with call real functions
+	var m2 = mock(ClassWithEnumReturnTypes, CALL_REAL_FUNC)
+	assert_that(m2).is_not_null()
+	
+	# verify enum return type
+	assert_that(m2.get_enum()).is_equal(ClassWithEnumReturnTypes.TEST_ENUM.FOO)
+	do_return(ClassWithEnumReturnTypes.TEST_ENUM.BAR).on(m2).get_enum()
+	assert_that(m2.get_enum()).is_equal(ClassWithEnumReturnTypes.TEST_ENUM.BAR)
+
+
+func test_mock_custom_class_func_return_type_internal_class_enum():
+	var m = mock(ClassWithEnumReturnTypes)
+	assert_that(m).is_not_null()
+	verify(m, 0).get_inner_class_enum()
+	
+	# verify enum return default 0
+	assert_that(m.get_inner_class_enum()).is_equal(0)
+	do_return(ClassWithEnumReturnTypes.InnerClass.TEST_ENUM.BAR).on(m).get_inner_class_enum()
+	assert_that(m.get_inner_class_enum()).is_equal(ClassWithEnumReturnTypes.InnerClass.TEST_ENUM.BAR)
+	verify(m, 2).get_inner_class_enum()
+	
+	# with call real functions
+	var m2= mock(ClassWithEnumReturnTypes, CALL_REAL_FUNC)
+	assert_that(m2).is_not_null()
+	
+	# verify enum return type
+	assert_that(m2.get_inner_class_enum()).is_equal(ClassWithEnumReturnTypes.InnerClass.TEST_ENUM.FOO)
+	do_return(ClassWithEnumReturnTypes.InnerClass.TEST_ENUM.BAR).on(m2).get_inner_class_enum()
+	assert_that(m2.get_inner_class_enum()).is_equal(ClassWithEnumReturnTypes.InnerClass.TEST_ENUM.BAR)
+
+
+func test_mock_custom_class_func_return_type_external_class_enum():
+	var m = mock(ClassWithEnumReturnTypes)
+	assert_that(m).is_not_null()
+	verify(m, 0).get_external_class_enum()
+	
+	# verify enum return default 0
+	assert_that(m.get_external_class_enum()).is_equal(0)
+	do_return(CustomEnums.TEST_ENUM.BAR).on(m).get_external_class_enum()
+	assert_that(m.get_external_class_enum()).is_equal(CustomEnums.TEST_ENUM.BAR)
+	verify(m, 2).get_external_class_enum()
+	
+	# with call real functions
+	var m2 = mock(ClassWithEnumReturnTypes, CALL_REAL_FUNC)
+	assert_that(m2).is_not_null()
+	
+	# verify enum return type
+	assert_that(m2.get_external_class_enum()).is_equal(CustomEnums.TEST_ENUM.FOO)
+	do_return(CustomEnums.TEST_ENUM.BAR).on(m2).get_external_class_enum()
+	assert_that(m2.get_external_class_enum()).is_equal(CustomEnums.TEST_ENUM.BAR)
+
+
 func test_mock_custom_class_extends_Node():
 	var m = mock(CustomNodeTestClass)
 	assert_that(m).is_not_null()

--- a/addons/gdUnit4/test/mocker/resources/ClassWithEnumReturnTypes.gd
+++ b/addons/gdUnit4/test/mocker/resources/ClassWithEnumReturnTypes.gd
@@ -1,0 +1,26 @@
+class_name ClassWithEnumReturnTypes
+extends Resource
+
+
+class InnerClass:
+	enum TEST_ENUM { FOO = 111, BAR = 222 }
+
+enum TEST_ENUM { FOO = 1, BAR = 2 }
+
+const NOT_AN_ENUM := 1
+
+const X := { FOO=1, BAR=2 }
+
+
+func get_enum() -> TEST_ENUM:
+	return TEST_ENUM.FOO
+
+
+# function signature with an external enum reference
+func get_external_class_enum() -> CustomEnums.TEST_ENUM:
+	return CustomEnums.TEST_ENUM.FOO
+
+
+# function signature with an inner class enum reference
+func get_inner_class_enum() -> InnerClass.TEST_ENUM:
+	return InnerClass.TEST_ENUM.FOO


### PR DESCRIPTION

# Why
The mock was build invalid for classes containing functions with enum return types. It results into a runtime error.

# What
- Fix script parser to handle enum return types.
- Add test coverage for all variants of enums (class enum, internal class enums, external class enums)

