### PR TITLE
GD-374: Improve mocking of fuctions with return type enum

### DIFF
--- a/addons/gdUnit4/src/core/GdUnitObjectInteractions.gd
+++ b/addons/gdUnit4/src/core/GdUnitObjectInteractions.gd
@@ -2,41 +2,41 @@ class_name GdUnitObjectInteractions
 extends RefCounted
 
 
-static func verify(obj :Object, times):
-	if not _is_mock_or_spy(obj, "__verify"):
-		return obj
-	return obj.__do_verify_interactions(times)
+static func verify(interaction_object :Object, interactions_times):
+	if not _is_mock_or_spy(interaction_object, "__verify"):
+		return interaction_object
+	return interaction_object.__do_verify_interactions(interactions_times)
 
 
-static func verify_no_interactions(obj :Object) -> GdUnitAssert:
-	var gd_assert = ResourceLoader.load("res://addons/gdUnit4/src/asserts/GdUnitAssertImpl.gd", "GDScript", ResourceLoader.CACHE_MODE_REUSE).new("")
-	if not _is_mock_or_spy(obj, "__verify"):
-		return gd_assert.report_success()
-	var summary :Dictionary = obj.__verify_no_interactions()
-	if summary.is_empty():
-		return gd_assert.report_success()
-	return gd_assert.report_error(GdAssertMessages.error_no_more_interactions(summary))
+static func verify_no_interactions(interaction_object :Object) -> GdUnitAssert:
+	var __gd_assert = ResourceLoader.load("res://addons/gdUnit4/src/asserts/GdUnitAssertImpl.gd", "GDScript", ResourceLoader.CACHE_MODE_REUSE).new("")
+	if not _is_mock_or_spy(interaction_object, "__verify"):
+		return __gd_assert.report_success()
+	var __summary :Dictionary = interaction_object.__verify_no_interactions()
+	if __summary.is_empty():
+		return __gd_assert.report_success()
+	return __gd_assert.report_error(GdAssertMessages.error_no_more_interactions(__summary))
 
 
-static func verify_no_more_interactions(obj :Object) -> GdUnitAssert:
-	var gd_assert = ResourceLoader.load("res://addons/gdUnit4/src/asserts/GdUnitAssertImpl.gd", "GDScript", ResourceLoader.CACHE_MODE_REUSE).new("")
-	if not _is_mock_or_spy(obj, "__verify_no_more_interactions"):
-		return gd_assert
-	var summary :Dictionary = obj.__verify_no_more_interactions()
-	if summary.is_empty():
-		return gd_assert
-	return gd_assert.report_error(GdAssertMessages.error_no_more_interactions(summary))
+static func verify_no_more_interactions(interaction_object :Object) -> GdUnitAssert:
+	var __gd_assert = ResourceLoader.load("res://addons/gdUnit4/src/asserts/GdUnitAssertImpl.gd", "GDScript", ResourceLoader.CACHE_MODE_REUSE).new("")
+	if not _is_mock_or_spy(interaction_object, "__verify_no_more_interactions"):
+		return __gd_assert
+	var __summary :Dictionary = interaction_object.__verify_no_more_interactions()
+	if __summary.is_empty():
+		return __gd_assert
+	return __gd_assert.report_error(GdAssertMessages.error_no_more_interactions(__summary))
 
 
-static func reset(obj :Object) -> Object:
-	if not _is_mock_or_spy( obj, "__reset"):
-		return obj
-	obj.__reset_interactions()
-	return obj
+static func reset(interaction_object :Object) -> Object:
+	if not _is_mock_or_spy(interaction_object, "__reset"):
+		return interaction_object
+	interaction_object.__reset_interactions()
+	return interaction_object
 
 
-static func _is_mock_or_spy(obj :Object, func_sig :String) -> bool:
-	if obj is GDScript and not obj.get_script().has_script_method(func_sig):
+static func _is_mock_or_spy(interaction_object :Object, mock_function_signature :String) -> bool:
+	if interaction_object is GDScript and not interaction_object.get_script().has_script_method(mock_function_signature):
 		push_error("Error: You try to use a non mock or spy!")
 		return false
 	return true

--- a/addons/gdUnit4/src/core/GdUnitObjectInteractionsTemplate.gd
+++ b/addons/gdUnit4/src/core/GdUnitObjectInteractionsTemplate.gd
@@ -5,76 +5,76 @@ var __saved_interactions := Dictionary()
 var __verified_interactions := Array()
 
 
-func __save_function_interaction(args :Array[Variant]) -> void:
-	var matcher := GdUnitArgumentMatchers.to_matcher(args, true)
-	for index in __saved_interactions.keys().size():
-		var key :Variant = __saved_interactions.keys()[index]
-		if matcher.is_match(key):
-			__saved_interactions[key] += 1
+func __save_function_interaction(function_args :Array[Variant]) -> void:
+	var __matcher := GdUnitArgumentMatchers.to_matcher(function_args, true)
+	for __index in __saved_interactions.keys().size():
+		var __key :Variant = __saved_interactions.keys()[__index]
+		if __matcher.is_match(__key):
+			__saved_interactions[__key] += 1
 			return
-	__saved_interactions[args] = 1
+	__saved_interactions[function_args] = 1
 
 
 func __is_verify_interactions() -> bool:
 	return __expected_interactions != -1
 
 
-func __do_verify_interactions(times :int = 1) -> Object:
-	__expected_interactions = times
+func __do_verify_interactions(interactions_times :int = 1) -> Object:
+	__expected_interactions = interactions_times
 	return self
 
 
-func __verify_interactions(args :Array[Variant]) -> void:
-	var summary := Dictionary()
-	var total_interactions := 0
-	var matcher := GdUnitArgumentMatchers.to_matcher(args, true)
-	for index in __saved_interactions.keys().size():
-		var key :Variant = __saved_interactions.keys()[index]
-		if matcher.is_match(key):
-			var interactions :int = __saved_interactions.get(key, 0)
-			total_interactions += interactions
-			summary[key] = interactions
+func __verify_interactions(function_args :Array[Variant]) -> void:
+	var __summary := Dictionary()
+	var __total_interactions := 0
+	var __matcher := GdUnitArgumentMatchers.to_matcher(function_args, true)
+	for __index in __saved_interactions.keys().size():
+		var __key :Variant = __saved_interactions.keys()[__index]
+		if __matcher.is_match(__key):
+			var __interactions :int = __saved_interactions.get(__key, 0)
+			__total_interactions += __interactions
+			__summary[__key] = __interactions
 			# add as verified
-			__verified_interactions.append(key)
+			__verified_interactions.append(__key)
 
-	var gd_assert := GdUnitAssertImpl.new("")
-	if total_interactions != __expected_interactions:
-		var expected_summary := {args : __expected_interactions}
-		var error_message :String
-		# if no interactions macht collect not verified interactions for failure report
-		if summary.is_empty():
-			var current_summary := __verify_no_more_interactions()
-			error_message = GdAssertMessages.error_validate_interactions(current_summary, expected_summary)
+	var __gd_assert := GdUnitAssertImpl.new("")
+	if __total_interactions != __expected_interactions:
+		var __expected_summary := {function_args : __expected_interactions}
+		var __error_message :String
+		# if no __interactions macht collect not verified __interactions for failure report
+		if __summary.is_empty():
+			var __current_summary := __verify_no_more_interactions()
+			__error_message = GdAssertMessages.error_validate_interactions(__current_summary, __expected_summary)
 		else:
-			error_message = GdAssertMessages.error_validate_interactions(summary, expected_summary)
-		gd_assert.report_error(error_message)
+			__error_message = GdAssertMessages.error_validate_interactions(__summary, __expected_summary)
+		__gd_assert.report_error(__error_message)
 	else:
-		gd_assert.report_success()
+		__gd_assert.report_success()
 	__expected_interactions = -1
 
 
 func __verify_no_interactions() -> Dictionary:
-	var summary := Dictionary()
+	var __summary := Dictionary()
 	if not __saved_interactions.is_empty():
-		for index in __saved_interactions.keys().size():
-			var func_call :Variant = __saved_interactions.keys()[index]
-			summary[func_call] = __saved_interactions[func_call]
-	return summary
+		for __index in __saved_interactions.keys().size():
+			var func_call :Variant = __saved_interactions.keys()[__index]
+			__summary[func_call] = __saved_interactions[func_call]
+	return __summary
 
 
 func __verify_no_more_interactions() -> Dictionary:
-	var summary := Dictionary()
+	var __summary := Dictionary()
 	var called_functions :Array[Variant] = __saved_interactions.keys()
 	if called_functions != __verified_interactions:
 		# collect the not verified functions
 		var called_but_not_verified := called_functions.duplicate()
-		for index in __verified_interactions.size():
-			called_but_not_verified.erase(__verified_interactions[index])
+		for __index in __verified_interactions.size():
+			called_but_not_verified.erase(__verified_interactions[__index])
 
-		for index in called_but_not_verified.size():
-			var not_verified :Variant = called_but_not_verified[index]
-			summary[not_verified] = __saved_interactions[not_verified]
-	return summary
+		for __index in called_but_not_verified.size():
+			var not_verified :Variant = called_but_not_verified[__index]
+			__summary[not_verified] = __saved_interactions[not_verified]
+	return __summary
 
 
 func __reset_interactions() -> void:
@@ -83,8 +83,8 @@ func __reset_interactions() -> void:
 
 func __filter_vargs(arg_values :Array[Variant]) -> Array[Variant]:
 	var filtered :Array[Variant] = []
-	for index in arg_values.size():
-		var arg :Variant = arg_values[index]
+	for __index in arg_values.size():
+		var arg :Variant = arg_values[__index]
 		if typeof(arg) == TYPE_STRING and arg == GdObjects.TYPE_VARARG_PLACEHOLDER_VALUE:
 			continue
 		filtered.append(arg)

--- a/addons/gdUnit4/src/core/parse/GdScriptParser.gd
+++ b/addons/gdUnit4/src/core/parse/GdScriptParser.gd
@@ -792,6 +792,8 @@ func _patch_inner_class_names(clazz :String, clazz_name :String) -> String:
 	var inner_clazz_name := clazz.split(".")[0]
 	if _scanned_inner_classes.has(inner_clazz_name):
 		return base_clazz + "." + clazz
+	if _script_constants.has(clazz):
+		return clazz_name + "." + clazz
 	return clazz
 
 

--- a/addons/gdUnit4/src/mocking/GdUnitMockImpl.gd
+++ b/addons/gdUnit4/src/mocking/GdUnitMockImpl.gd
@@ -5,7 +5,7 @@
 const __INSTANCE_ID = "${instance_id}"
 const __SOURCE_CLASS = "${source_class}"
 
-var __working_mode := GdUnitMock.RETURN_DEFAULTS
+var __mock_working_mode := GdUnitMock.RETURN_DEFAULTS
 var __excluded_methods :PackedStringArray = []
 var __do_return_value :Variant = null
 var __prepare_return_value := false
@@ -45,96 +45,96 @@ func __is_prepare_return_value() -> bool:
 	return __prepare_return_value
 
 
-func __sort_by_argument_matcher(left_args :Array, _right_args :Array) -> bool:
-	for index in left_args.size():
-		var larg :Variant = left_args[index]
-		if larg is GdUnitArgumentMatcher:
+func __sort_by_argument_matcher(__left_args :Array, __right_args :Array) -> bool:
+	for __index in __left_args.size():
+		var __larg :Variant = __left_args[__index]
+		if __larg is GdUnitArgumentMatcher:
 			return false
 	return true
 
 
 # we need to sort by matcher arguments so that they are all at the end of the list
-func __sort_dictionary(unsorted_args :Dictionary) -> Dictionary:
+func __sort_dictionary(__unsorted_args :Dictionary) -> Dictionary:
 	# only need to sort if contains more than one entry
-	if unsorted_args.size() <= 1:
-		return unsorted_args
-	var sorted_args := unsorted_args.keys()
-	sorted_args.sort_custom(__sort_by_argument_matcher)
-	var sorted_result := {}
-	for index in sorted_args.size():
-		var key :Variant = sorted_args[index]
-		sorted_result[key] = unsorted_args[key]
-	return sorted_result
+	if __unsorted_args.size() <= 1:
+		return __unsorted_args
+	var __sorted_args := __unsorted_args.keys()
+	__sorted_args.sort_custom(__sort_by_argument_matcher)
+	var __sorted_result := {}
+	for __index in __sorted_args.size():
+		var key :Variant = __sorted_args[__index]
+		__sorted_result[key] = __unsorted_args[key]
+	return __sorted_result
 
 
-func __save_function_return_value(args :Array) -> void:
-	var func_name :String = args[0]
-	var func_args :Array = args.slice(1)
-	var mocked_return_value_by_args :Dictionary = __mocked_return_values.get(func_name, {})
-	mocked_return_value_by_args[func_args] = __do_return_value
-	__mocked_return_values[func_name] = __sort_dictionary(mocked_return_value_by_args)
+func __save_function_return_value(__fuction_args :Array) -> void:
+	var __func_name :String = __fuction_args[0]
+	var __func_args :Array = __fuction_args.slice(1)
+	var __mocked_return_value_by_args :Dictionary = __mocked_return_values.get(__func_name, {})
+	__mocked_return_value_by_args[__func_args] = __do_return_value
+	__mocked_return_values[__func_name] = __sort_dictionary(__mocked_return_value_by_args)
 	__do_return_value = null
 	__prepare_return_value = false
 
 
-func __is_mocked_args_match(func_args :Array, mocked_args :Array) -> bool:
-	var is_matching := false
-	for index in mocked_args.size():
-		var args :Variant = mocked_args[index]
-		if func_args.size() != args.size():
+func __is_mocked_args_match(__func_args :Array, __mocked_args :Array) -> bool:
+	var __is_matching := false
+	for __index in __mocked_args.size():
+		var __fuction_args :Variant = __mocked_args[__index]
+		if __func_args.size() != __fuction_args.size():
 			continue
-		is_matching = true
-		for arg_index in func_args.size():
-			var func_arg :Variant = func_args[arg_index]
-			var mock_arg :Variant = args[arg_index]
-			if mock_arg is GdUnitArgumentMatcher:
-				is_matching = is_matching and mock_arg.is_match(func_arg)
+		__is_matching = true
+		for __arg_index in __func_args.size():
+			var __func_arg :Variant = __func_args[__arg_index]
+			var __mock_arg :Variant = __fuction_args[__arg_index]
+			if __mock_arg is GdUnitArgumentMatcher:
+				__is_matching = __is_matching and __mock_arg.is_match(__func_arg)
 			else:
-				is_matching = is_matching and typeof(func_arg) == typeof(mock_arg) and func_arg == mock_arg
-			if not is_matching:
+				__is_matching = __is_matching and typeof(__func_arg) == typeof(__mock_arg) and __func_arg == __mock_arg
+			if not __is_matching:
 				break
-		if is_matching:
+		if __is_matching:
 			break
-	return is_matching
+	return __is_matching
 
 
-func __get_mocked_return_value_or_default(args :Array, default_return_value :Variant) -> Variant:
-	var func_name :String = args[0]
-	if not __mocked_return_values.has(func_name):
-		return default_return_value
-	var func_args :Array = args.slice(1)
-	var mocked_args :Array = __mocked_return_values.get(func_name).keys()
-	for index in mocked_args.size():
-		var margs :Variant = mocked_args[index]
-		if __is_mocked_args_match(func_args, [margs]):
-			return __mocked_return_values[func_name][margs]
-	return default_return_value
+func __get_mocked_return_value_or_default(__fuction_args :Array, __default_return_value :Variant) -> Variant:
+	var __func_name :String = __fuction_args[0]
+	if not __mocked_return_values.has(__func_name):
+		return __default_return_value
+	var __func_args :Array = __fuction_args.slice(1)
+	var __mocked_args :Array = __mocked_return_values.get(__func_name).keys()
+	for __index in __mocked_args.size():
+		var __margs :Variant = __mocked_args[__index]
+		if __is_mocked_args_match(__func_args, [__margs]):
+			return __mocked_return_values[__func_name][__margs]
+	return __default_return_value
 
 
-func __set_script(script :GDScript) -> void:
-	super.set_script(script)
+func __set_script(__script :GDScript) -> void:
+	super.set_script(__script)
 
 
-func __set_mode(working_mode :String) -> Object:
-	__working_mode = working_mode
+func __set_mode(mock_working_mode :String) -> Object:
+	__mock_working_mode = mock_working_mode
 	return self
 
 
-func __do_call_real_func(func_name :String, func_args := []) -> bool:
-	var is_call_real_func := __working_mode == GdUnitMock.CALL_REAL_FUNC  and not __excluded_methods.has(func_name)
+func __do_call_real_func(__func_name :String, __func_args := []) -> bool:
+	var __is_call_real_func := __mock_working_mode == GdUnitMock.CALL_REAL_FUNC  and not __excluded_methods.has(__func_name)
 	# do not call real funcions for mocked functions
-	if is_call_real_func and __mocked_return_values.has(func_name):
-		var args :Array = func_args.slice(1)
-		var mocked_args :Array = __mocked_return_values.get(func_name).keys()
-		return not __is_mocked_args_match(args, mocked_args)
-	return is_call_real_func
+	if __is_call_real_func and __mocked_return_values.has(__func_name):
+		var __fuction_args :Array = __func_args.slice(1)
+		var __mocked_args :Array = __mocked_return_values.get(__func_name).keys()
+		return not __is_mocked_args_match(__fuction_args, __mocked_args)
+	return __is_call_real_func
 
 
 func __exclude_method_call(exluded_methods :PackedStringArray) -> void:
 	__excluded_methods.append_array(exluded_methods)
 
 
-func __do_return(return_value :Variant) -> Object:
-	__do_return_value = return_value
+func __do_return(mock_do_return_value :Variant) -> Object:
+	__do_return_value = mock_do_return_value
 	__prepare_return_value = true
 	return self

--- a/addons/gdUnit4/test/mocker/GdUnitMockBuilderTest.gd
+++ b/addons/gdUnit4/test/mocker/GdUnitMockBuilderTest.gd
@@ -107,6 +107,8 @@ func test_double_int_function_with_varargs() -> void:
 	var expected := [
 		'@warning_ignore("untyped_declaration")' if Engine.get_version_info().hex >= 0x40200 else '',
 		'@warning_ignore("native_method_override")',
+		'@warning_ignore("int_as_enum_without_match")',
+		'@warning_ignore("int_as_enum_without_cast")',
 		'@warning_ignore("shadowed_variable")',
 		'func emit_signal(signal_, vararg0_="__null__", vararg1_="__null__", vararg2_="__null__", vararg3_="__null__", vararg4_="__null__", vararg5_="__null__", vararg6_="__null__", vararg7_="__null__", vararg8_="__null__", vararg9_="__null__") -> Error:',
 		'	var varargs :Array = __filter_vargs([vararg0_, vararg1_, vararg2_, vararg3_, vararg4_, vararg5_, vararg6_, vararg7_, vararg8_, vararg9_])',

--- a/addons/gdUnit4/test/mocker/GdUnitMockerTest.gd
+++ b/addons/gdUnit4/test/mocker/GdUnitMockerTest.gd
@@ -421,8 +421,8 @@ func test_mock_custom_class_func_return_type_enum():
 	assert_that(m).is_not_null()
 	verify(m, 0).get_enum()
 
-	# verify enum return default 0
-	assert_that(m.get_enum()).is_equal(0)
+	# verify enum return default ClassWithEnumReturnTypes.TEST_ENUM.FOO
+	assert_that(m.get_enum()).is_equal(ClassWithEnumReturnTypes.TEST_ENUM.FOO)
 	do_return(ClassWithEnumReturnTypes.TEST_ENUM.BAR).on(m).get_enum()
 	assert_that(m.get_enum()).is_equal(ClassWithEnumReturnTypes.TEST_ENUM.BAR)
 	verify(m, 2).get_enum()
@@ -442,8 +442,8 @@ func test_mock_custom_class_func_return_type_internal_class_enum():
 	assert_that(m).is_not_null()
 	verify(m, 0).get_inner_class_enum()
 
-	# verify enum return default 0
-	assert_that(m.get_inner_class_enum()).is_equal(0)
+	# verify enum return default
+	assert_that(m.get_inner_class_enum()).is_equal(ClassWithEnumReturnTypes.InnerClass.TEST_ENUM.FOO)
 	do_return(ClassWithEnumReturnTypes.InnerClass.TEST_ENUM.BAR).on(m).get_inner_class_enum()
 	assert_that(m.get_inner_class_enum()).is_equal(ClassWithEnumReturnTypes.InnerClass.TEST_ENUM.BAR)
 	verify(m, 2).get_inner_class_enum()
@@ -463,8 +463,8 @@ func test_mock_custom_class_func_return_type_external_class_enum():
 	assert_that(m).is_not_null()
 	verify(m, 0).get_external_class_enum()
 
-	# verify enum return default 0
-	assert_that(m.get_external_class_enum()).is_equal(0)
+	# verify enum return default
+	assert_that(m.get_external_class_enum()).is_equal(CustomEnums.TEST_ENUM.FOO)
 	do_return(CustomEnums.TEST_ENUM.BAR).on(m).get_external_class_enum()
 	assert_that(m.get_external_class_enum()).is_equal(CustomEnums.TEST_ENUM.BAR)
 	verify(m, 2).get_external_class_enum()

--- a/addons/gdUnit4/test/spy/GdUnitSpyBuilderTest.gd
+++ b/addons/gdUnit4/test/spy/GdUnitSpyBuilderTest.gd
@@ -132,6 +132,8 @@ func test_double_return_typed_function_with_args_and_varargs() -> void:
 	var expected := [
 		'@warning_ignore("untyped_declaration")' if Engine.get_version_info().hex >= 0x40200 else '',
 		'@warning_ignore("native_method_override")',
+		'@warning_ignore("int_as_enum_without_match")',
+		'@warning_ignore("int_as_enum_without_cast")',
 		'@warning_ignore("shadowed_variable")',
 		'func emit_signal(signal_, vararg0_="__null__", vararg1_="__null__", vararg2_="__null__", vararg3_="__null__", vararg4_="__null__", vararg5_="__null__", vararg6_="__null__", vararg7_="__null__", vararg8_="__null__", vararg9_="__null__") -> Error:',
 		'	var varargs :Array = __filter_vargs([vararg0_, vararg1_, vararg2_, vararg3_, vararg4_, vararg5_, vararg6_, vararg7_, vararg8_, vararg9_])',


### PR DESCRIPTION
# Why
mocking a class with functions has return type enum was spamming in warnings of type `int_as_enum_without_match` and `int_as_enum_without_cast`

# What
- Do add a ignore warning to the mocked function with return type enum to hide such warnings.
- Improved the default enum detection to return a valid enum value
- Fixes also warnings about shadowed variables by rename all mock intern used variables by adding two underscores

