### PR TITLE
GD-380: Add cmd option to allow running with `--headless` mode

### DIFF
--- a/addons/gdUnit4/src/cmd/CmdCommandHandler.gd
+++ b/addons/gdUnit4/src/cmd/CmdCommandHandler.gd
@@ -82,10 +82,15 @@ func execute(commands :Array) -> GdUnitResult:
 		if _command_cbs.has(cmd_name):
 			var cb_s :Callable = _command_cbs.get(cmd_name)[CB_SINGLE_ARG]
 			var arguments := cmd.arguments()
+			var cmd_option := _cmd_options.get_option(cmd_name)
+			var argument = arguments[0] if arguments.size() > 0 else null
+			match cmd_option.type():
+				TYPE_BOOL:
+					argument = true if argument == "true" else false
 			if cb_s and arguments.size() == 0:
 				cb_s.call()
 			elif cb_s:
-				cb_s.call(arguments[0])
+				cb_s.call(argument)
 			else:
 				var cb_m :Callable = _command_cbs.get(cmd_name)[CB_MULTI_ARGS]
 				# we need to find the method and determin the arguments to call the right function


### PR DESCRIPTION
# Why
For certain reasons, we would like to run the test in headless mode, but the cmd tool does not allow this and ends with an error message.

# What
Added new option `--ignoreHeadlessMode` to ignore this fact and print only a warning and continue the processing.

![image](https://github.com/MikeSchulze/gdUnit4/assets/347037/744a9fbd-5d46-421f-9d42-d331f5e5061e)

