### PR TITLE
GD-383: Fix parsing of test with comments in the signature

### DIFF
--- a/addons/gdUnit4/plugin.cfg
+++ b/addons/gdUnit4/plugin.cfg
@@ -3,5 +3,5 @@
 name="gdUnit4"
 description="Unit Testing Framework for Godot Scripts"
 author="Mike Schulze"
-version="4.2.3"
+version="4.2.4"
 script="plugin.gd"

--- a/addons/gdUnit4/src/core/parse/GdScriptParser.gd
+++ b/addons/gdUnit4/src/core/parse/GdScriptParser.gd
@@ -65,6 +65,7 @@ var TOKENS := [
 ]
 
 var _regex_clazz_name :RegEx
+var _regex_strip_comments := GdUnitTools.to_regex("^([^#\"']|'[^']*'|\"[^\"]*\")*\\K#.*")
 var _base_clazz :String
 var _scanned_inner_classes := PackedStringArray()
 var _script_constants := {}
@@ -615,6 +616,9 @@ func extract_func_signature(rows :PackedStringArray, index :int) -> String:
 
 	for rowIndex in range(index, rows.size()):
 		var row := rows[rowIndex]
+		row = _regex_strip_comments.sub(row, "").strip_edges(false)
+		if row.is_empty():
+			continue
 		signature += row + "\n"
 		if is_func_end(row):
 			return signature.strip_edges()

--- a/addons/gdUnit4/test/core/parse/GdScriptParserTest.gd
+++ b/addons/gdUnit4/test/core/parse/GdScriptParserTest.gd
@@ -47,48 +47,48 @@ func test_parse_argument_timeout():
 func test_parse_arguments():
 	assert_array(_parser.parse_arguments("func foo():")) \
 		.has_size(0)
-	
+
 	assert_array(_parser.parse_arguments("func foo() -> String:\n")) \
 		.has_size(0)
-	
+
 	assert_array(_parser.parse_arguments("func foo(arg1, arg2, name):")) \
 		.contains_exactly([
-			GdFunctionArgument.new("arg1", TYPE_NIL), 
+			GdFunctionArgument.new("arg1", TYPE_NIL),
 			GdFunctionArgument.new("arg2", TYPE_NIL),
 			GdFunctionArgument.new("name", TYPE_NIL)])
-	
+
 	assert_array(_parser.parse_arguments('func foo(arg1 :int, arg2 :bool, name :String = "abc"):')) \
 		.contains_exactly([
-			GdFunctionArgument.new("arg1", TYPE_INT), 
+			GdFunctionArgument.new("arg1", TYPE_INT),
 			GdFunctionArgument.new("arg2", TYPE_BOOL),
 			GdFunctionArgument.new("name", TYPE_STRING, '"abc"')])
-	
+
 	assert_array(_parser.parse_arguments('func bar(arg1 :int, arg2 :int = 23, name :String = "test") -> String:')) \
 		.contains_exactly([
 			GdFunctionArgument.new("arg1", TYPE_INT),
 			GdFunctionArgument.new("arg2", TYPE_INT, "23"),
 			GdFunctionArgument.new("name", TYPE_STRING, '"test"')])
-	
+
 	assert_array(_parser.parse_arguments("func foo(arg1, arg2=value(1,2,3), name:=foo()):")) \
 		.contains_exactly([
-			GdFunctionArgument.new("arg1", TYPE_NIL), 
+			GdFunctionArgument.new("arg1", TYPE_NIL),
 			GdFunctionArgument.new("arg2", GdObjects.TYPE_FUNC, "value(1,2,3)"),
 			GdFunctionArgument.new("name", GdObjects.TYPE_FUNC, "foo()")])
 	# enum as prefix in value name
 	assert_array(_parser.parse_arguments("func get_value( type := ENUM_A) -> int:"))\
 		.contains_exactly([GdFunctionArgument.new("type", TYPE_STRING, "ENUM_A")])
-	
+
 	assert_array(_parser.parse_arguments("func create_timer(timeout :float) -> Timer:")) \
 		.contains_exactly([
 			GdFunctionArgument.new("timeout", TYPE_FLOAT)])
-	
+
 	# array argument
 	assert_array(_parser.parse_arguments("func foo(a :int, b :int, parameters = [[1, 2], [3, 4], [5, 6]]):")) \
 		.contains_exactly([
 			GdFunctionArgument.new("a", TYPE_INT),
 			GdFunctionArgument.new("b", TYPE_INT),
 			GdFunctionArgument.new("parameters", TYPE_ARRAY, "[[1, 2], [3, 4], [5, 6]]")])
-	
+
 	assert_array(_parser.parse_arguments("func test_values(a:Vector2, b:Vector2, expected:Vector2, test_parameters:=[[Vector2.ONE,Vector2.ONE,Vector2(1,1)]]):"))\
 		.contains_exactly([
 			GdFunctionArgument.new("a", TYPE_VECTOR2),
@@ -109,12 +109,12 @@ func test_parse_arguments_default_build_in_type_String():
 		.contains_exactly([
 			GdFunctionArgument.new("arg1", TYPE_STRING),
 			GdFunctionArgument.new("arg2", TYPE_STRING, '"default"')])
-	
+
 	assert_array(_parser.parse_arguments('func foo(arg1 :String, arg2 :="default"):')) \
 		.contains_exactly([
 			GdFunctionArgument.new("arg1", TYPE_STRING),
 			GdFunctionArgument.new("arg2", TYPE_STRING, '"default"')])
-	
+
 	assert_array(_parser.parse_arguments('func foo(arg1 :String, arg2 :String ="default"):')) \
 		.contains_exactly([
 			GdFunctionArgument.new("arg1", TYPE_STRING),
@@ -126,12 +126,12 @@ func test_parse_arguments_default_build_in_type_Boolean():
 		.contains_exactly([
 			GdFunctionArgument.new("arg1", TYPE_STRING),
 			GdFunctionArgument.new("arg2", TYPE_BOOL, "false")])
-	
+
 	assert_array(_parser.parse_arguments("func foo(arg1 :String, arg2 :=false):")) \
 		.contains_exactly([
 			GdFunctionArgument.new("arg1", TYPE_STRING),
 			GdFunctionArgument.new("arg2", TYPE_BOOL, "false")])
-	
+
 	assert_array(_parser.parse_arguments("func foo(arg1 :String, arg2 :bool=false):")) \
 		.contains_exactly([
 			GdFunctionArgument.new("arg1", TYPE_STRING),
@@ -143,12 +143,12 @@ func test_parse_arguments_default_build_in_type_Real():
 		.contains_exactly([
 			GdFunctionArgument.new("arg1", TYPE_STRING),
 			GdFunctionArgument.new("arg2", TYPE_FLOAT, "3.14")])
-	
+
 	assert_array(_parser.parse_arguments("func foo(arg1 :String, arg2 :=3.14):")) \
 		.contains_exactly([
 			GdFunctionArgument.new("arg1", TYPE_STRING),
 			GdFunctionArgument.new("arg2", TYPE_FLOAT, "3.14")])
-	
+
 	assert_array(_parser.parse_arguments("func foo(arg1 :String, arg2 :float=3.14):")) \
 		.contains_exactly([
 			GdFunctionArgument.new("arg1", TYPE_STRING),
@@ -160,27 +160,27 @@ func test_parse_arguments_default_build_in_type_Array():
 		.contains_exactly([
 			GdFunctionArgument.new("arg1", TYPE_STRING),
 			GdFunctionArgument.new("arg2", TYPE_ARRAY, "[]")])
-	
+
 	assert_array(_parser.parse_arguments("func foo(arg1 :String, arg2 :Array=Array()):")) \
 		.contains_exactly([
 			GdFunctionArgument.new("arg1", TYPE_STRING),
 			GdFunctionArgument.new("arg2", TYPE_ARRAY, "Array()")])
-	
+
 	assert_array(_parser.parse_arguments("func foo(arg1 :String, arg2 :Array=[1, 2, 3]):")) \
 		.contains_exactly([
 			GdFunctionArgument.new("arg1", TYPE_STRING),
 			GdFunctionArgument.new("arg2", TYPE_ARRAY, "[1, 2, 3]")])
-	
+
 	assert_array(_parser.parse_arguments("func foo(arg1 :String, arg2 :=[1, 2, 3]):")) \
 		.contains_exactly([
 			GdFunctionArgument.new("arg1", TYPE_STRING),
 			GdFunctionArgument.new("arg2", TYPE_ARRAY, "[1, 2, 3]")])
-	
+
 	assert_array(_parser.parse_arguments("func foo(arg1 :String, arg2=[]):")) \
 		.contains_exactly([
 			GdFunctionArgument.new("arg1", TYPE_STRING),
 			GdFunctionArgument.new("arg2", TYPE_ARRAY, "[]")])
-	
+
 	assert_array(_parser.parse_arguments("func foo(arg1 :String, arg2 :Array=[1, 2, 3], arg3 := false):")) \
 		.contains_exactly([
 			GdFunctionArgument.new("arg1", TYPE_STRING),
@@ -193,12 +193,12 @@ func test_parse_arguments_default_build_in_type_Color():
 		.contains_exactly([
 			GdFunctionArgument.new("arg1", TYPE_STRING),
 			GdFunctionArgument.new("arg2", TYPE_COLOR, "Color.RED")])
-	
+
 	assert_array(_parser.parse_arguments("func foo(arg1 :String, arg2 :=Color.RED):")) \
 		.contains_exactly([
 			GdFunctionArgument.new("arg1", TYPE_STRING),
 			GdFunctionArgument.new("arg2", TYPE_COLOR, "Color.RED")])
-	
+
 	assert_array(_parser.parse_arguments("func foo(arg1 :String, arg2 :Color=Color.RED):")) \
 		.contains_exactly([
 			GdFunctionArgument.new("arg1", TYPE_STRING),
@@ -210,12 +210,12 @@ func test_parse_arguments_default_build_in_type_Vector():
 		.contains_exactly([
 			GdFunctionArgument.new("arg1", TYPE_STRING),
 			GdFunctionArgument.new("arg2", TYPE_VECTOR3, "Vector3.FORWARD")])
-	
+
 	assert_array(_parser.parse_arguments("func bar(arg1 :String, arg2 :=Vector3.FORWARD):")) \
 		.contains_exactly([
 			GdFunctionArgument.new("arg1", TYPE_STRING),
 			GdFunctionArgument.new("arg2", TYPE_VECTOR3, "Vector3.FORWARD")])
-	
+
 	assert_array(_parser.parse_arguments("func bar(arg1 :String, arg2 :Vector3=Vector3.FORWARD):")) \
 		.contains_exactly([
 			GdFunctionArgument.new("arg1", TYPE_STRING),
@@ -227,7 +227,7 @@ func test_parse_arguments_default_build_in_type_AABB():
 		.contains_exactly([
 			GdFunctionArgument.new("arg1", TYPE_STRING),
 			GdFunctionArgument.new("arg2", TYPE_AABB, "AABB()")])
-	
+
 	assert_array(_parser.parse_arguments("func bar(arg1 :String, arg2 :AABB=AABB()):")) \
 		.contains_exactly([
 			GdFunctionArgument.new("arg1", TYPE_STRING),
@@ -306,7 +306,7 @@ func test_parse_func_name():
 func test_extract_source_code():
 	var path := GdObjects.extract_class_path(AdvancedTestClass)
 	var rows = _parser.extract_source_code(path)
-	
+
 	var file_content := resource_as_array(path[0])
 	assert_array(rows).contains_exactly(file_content)
 
@@ -335,20 +335,20 @@ func test_extract_source_code_inner_class_Area4D():
 func test_extract_function_signature() -> void:
 	var path := GdObjects.extract_class_path("res://addons/gdUnit4/test/mocker/resources/ClassWithCustomFormattings.gd")
 	var rows = _parser.extract_source_code(path)
-	
+
 	assert_that(_parser.extract_func_signature(rows, 12))\
 		.is_equal("""
-			func a1(set_name:String, path:String="", load_on_init:bool=false, 
+			func a1(set_name:String, path:String="", load_on_init:bool=false,
 				set_auto_save:bool=false, set_network_sync:bool=false
 			) -> void:""".dedent().trim_prefix("\n"))
 	assert_that(_parser.extract_func_signature(rows, 19))\
 		.is_equal("""
-			func a2(set_name:String, path:String="", load_on_init:bool=false, 
+			func a2(set_name:String, path:String="", load_on_init:bool=false,
 				set_auto_save:bool=false, set_network_sync:bool=false
 			) -> 	void:""".dedent().trim_prefix("\n"))
 	assert_that(_parser.extract_func_signature(rows, 26))\
 		.is_equal("""
-			func a3(set_name:String, path:String="", load_on_init:bool=false, 
+			func a3(set_name:String, path:String="", load_on_init:bool=false,
 				set_auto_save:bool=false, set_network_sync:bool=false
 			) :""".dedent().trim_prefix("\n"))
 	assert_that(_parser.extract_func_signature(rows, 33))\
@@ -412,7 +412,7 @@ func test_parse_func_description():
 	assert_int(fd.return_type()).is_equal(GdObjects.TYPE_VARIANT)
 	assert_array(fd.args()).is_empty()
 	assert_str(fd.typeless()).is_equal("func foo() -> Variant:")
-	
+
 	# static function
 	fd = _parser.parse_func_description("static func foo(arg1 :int, arg2:=false) -> String:", "clazz_name", [""], 22)
 	assert_str(fd.name()).is_equal("foo")
@@ -423,7 +423,7 @@ func test_parse_func_description():
 		GdFunctionArgument.new("arg2", TYPE_BOOL, "false")
 	])
 	assert_str(fd.typeless()).is_equal("static func foo(arg1, arg2=false) -> String:")
-	
+
 	# static function without return type
 	fd = _parser.parse_func_description("static func foo(arg1 :int, arg2:=false):", "clazz_name", [""], 23)
 	assert_str(fd.name()).is_equal("foo")
@@ -439,19 +439,19 @@ func test_parse_func_description():
 func test_parse_func_description_return_type_enum():
 	var result := _parser.parse("ClassWithEnumReturnTypes", ["res://addons/gdUnit4/test/mocker/resources/ClassWithEnumReturnTypes.gd"])
 	assert_result(result).is_success()
-	
+
 	var fd := _parser.parse_func_description("func get_enum() -> TEST_ENUM:", "ClassWithEnumReturnTypes", ["res://addons/gdUnit4/test/mocker/resources/ClassWithEnumReturnTypes.gd"], 33)
 	assert_that(fd.name()).is_equal("get_enum")
 	assert_that(fd.is_static()).is_false()
 	assert_that(fd.return_type()).is_equal(GdObjects.TYPE_ENUM)
-	assert_that(fd._return_class).is_equal("TEST_ENUM")
+	assert_that(fd._return_class).is_equal("ClassWithEnumReturnTypes.TEST_ENUM")
 	assert_that(fd.args()).is_empty()
 
 
 func test_parse_func_description_return_type_internal_class_enum():
 	var result := _parser.parse("ClassWithEnumReturnTypes", ["res://addons/gdUnit4/test/mocker/resources/ClassWithEnumReturnTypes.gd"])
 	assert_result(result).is_success()
-	
+
 	var fd := _parser.parse_func_description("func get_inner_class_enum() -> InnerClass.TEST_ENUM:", "ClassWithEnumReturnTypes", ["res://addons/gdUnit4/test/mocker/resources/ClassWithEnumReturnTypes.gd"], 33)
 	assert_that(fd.name()).is_equal("get_inner_class_enum")
 	assert_that(fd.is_static()).is_false()
@@ -463,7 +463,7 @@ func test_parse_func_description_return_type_internal_class_enum():
 func test_parse_func_description_return_type_external_class_enum():
 	var result := _parser.parse("ClassWithEnumReturnTypes", ["res://addons/gdUnit4/test/mocker/resources/ClassWithEnumReturnTypes.gd"])
 	assert_result(result).is_success()
-	
+
 	var fd := _parser.parse_func_description("func get_external_class_enum() -> CustomEnums.TEST_ENUM:", "ClassWithEnumReturnTypes", ["res://addons/gdUnit4/test/mocker/resources/ClassWithEnumReturnTypes.gd"], 33)
 	assert_that(fd.name()).is_equal("get_external_class_enum")
 	assert_that(fd.is_static()).is_false()
@@ -477,7 +477,7 @@ func test_parse_class_inherits():
 	var clazz_name := GdObjects.extract_class_name_from_class_path(clazz_path)
 	var result := _parser.parse(clazz_name, clazz_path)
 	assert_result(result).is_success()
-	
+
 	# verify class extraction
 	var clazz_desccriptor :GdClassDescriptor = result.value()
 	assert_object(clazz_desccriptor).is_not_null()
@@ -487,7 +487,7 @@ func test_parse_class_inherits():
 		GdFunctionDescriptor.new("foo2", 5, false, false, false, GdObjects.TYPE_VARIANT, "", []),
 		GdFunctionDescriptor.new("bar2", 8, false, false, false, TYPE_STRING, "", [])
 	])
-	
+
 	# extends from CustomResourceTestClass
 	clazz_desccriptor = clazz_desccriptor.parent()
 	assert_object(clazz_desccriptor).is_not_null()
@@ -504,7 +504,7 @@ func test_parse_class_inherits():
 		]),
 		GdFunctionDescriptor.new("foo5", 16, false, false, false, GdObjects.TYPE_VARIANT, "", []),
 	])
-	
+
 	# no other class extends
 	clazz_desccriptor = clazz_desccriptor.parent()
 	assert_object(clazz_desccriptor).is_null()
@@ -540,17 +540,17 @@ func test_is_func_end() -> void:
 
 func test_extract_func_signature_multiline() -> void:
 	var source_code = """
-		
+
 		func test_parameterized(a: int, b :int, c :int, expected :int, parameters = [
 			[1, 2, 3, 6],
 			[3, 4, 5, 11],
 			[6, 7, 8, 21] ]):
-			
+
 			assert_that(a+b+c).is_equal(expected)
 		""".dedent().split("\n")
-	
+
 	var fs = _parser.extract_func_signature(source_code, 0)
-	
+
 	assert_that(fs).is_equal("""
 		func test_parameterized(a: int, b :int, c :int, expected :int, parameters = [
 			[1, 2, 3, 6],
@@ -563,7 +563,7 @@ func test_extract_func_signature_multiline() -> void:
 
 func test_parse_func_description_paramized_test():
 	var fd = _parser.parse_func_description("functest_parameterized(a:int,b:int,c:int,expected:int,parameters=[[1,2,3,6],[3,4,5,11],[6,7,8,21]]):", "class", ["path"], 22)
-	
+
 	assert_that(fd).is_equal(GdFunctionDescriptor.new("test_parameterized", 22, false, false, false, GdObjects.TYPE_VARIANT, "", [
 		GdFunctionArgument.new("a", TYPE_INT),
 		GdFunctionArgument.new("b", TYPE_INT),
@@ -571,6 +571,34 @@ func test_parse_func_description_paramized_test():
 		GdFunctionArgument.new("expected", TYPE_INT),
 		GdFunctionArgument.new("parameters", TYPE_ARRAY, "[[1,2,3,6],[3,4,5,11],[6,7,8,21]]"),
 	]))
+
+
+func test_parse_func_description_paramized_test_with_comments() -> void:
+	var source_code = """
+		func test_parameterized(a: int, b :int, c :int, expected :int, parameters = [
+			# before data set
+			[1, 2, 3, 6], # after data set
+			# between data sets
+			[3, 4, 5, 11],
+			[6, 7, 'string #ABCD', 21], # dataset with [comment] singn
+			[6, 7, "string #ABCD", 21] # dataset with "#comment" singn
+			#eof
+		]):
+			pass
+		""".dedent().split("\n")
+
+	var fs = _parser.extract_func_signature(source_code, 0)
+
+	assert_that(fs).is_equal("""
+		func test_parameterized(a: int, b :int, c :int, expected :int, parameters = [
+			[1, 2, 3, 6],
+			[3, 4, 5, 11],
+			[6, 7, 'string #ABCD', 21],
+			[6, 7, "string #ABCD", 21]
+		]):"""
+			.dedent()
+			.trim_prefix("\n")
+		)
 
 
 func test_parse_func_descriptor_with_fuzzers():
@@ -583,7 +611,7 @@ func test_parse_func_descriptor_with_fuzzers():
 	""".split("\n")
 	var fs = _parser.extract_func_signature(source_code, 0)
 	var fd = _parser.parse_func_description(fs, "class", ["path"], 22)
-	
+
 	assert_that(fd).is_equal(GdFunctionDescriptor.new("test_foo", 22, false, false, false, GdObjects.TYPE_VARIANT, "", [
 		GdFunctionArgument.new("fuzzer_a", GdObjects.TYPE_FUZZER, "fuzz_a()"),
 		GdFunctionArgument.new("fuzzer_b", GdObjects.TYPE_FUZZER, "fuzz_b()"),

--- a/addons/gdUnit4/test/core/parse/GdUnitTestParameterSetResolverTest.gd
+++ b/addons/gdUnit4/test/core/parse/GdUnitTestParameterSetResolverTest.gd
@@ -37,7 +37,7 @@ func test_example_c(a: Object, b: Object, test_parameters=[
 
 
 @warning_ignore("unused_parameter")
-func test_resolve_paramaters_static(a: int, b: int, test_parameters=[
+func test_resolve_parameters_static(a: int, b: int, test_parameters=[
 	[1, 10],
 	[2, 20]
 	]) -> void:
@@ -45,11 +45,24 @@ func test_resolve_paramaters_static(a: int, b: int, test_parameters=[
 
 
 @warning_ignore("unused_parameter")
-func test_resolve_paramaters_at_runtime(a: int, b: int, test_parameters=[
+func test_resolve_parameters_at_runtime(a: int, b: int, test_parameters=[
 	[1, _test_param1],
 	[2, _test_param2],
 	[3, 30]
 	]) -> void:
+	pass
+
+
+@warning_ignore("unused_parameter")
+func test_parameterized_with_comments(a: int, b :int, c :String, expected :int, test_parameters = [
+	# before data set
+	[1, 2, '3', 6], # after data set
+	# between data sets
+	[3, 4, '5', 11],
+	[6, 7, 'string #ABCD', 21], # dataset with [comment] singn
+	[6, 7, "string #ABCD", 21] # dataset with "comment" singn
+	#eof
+]):
 	pass
 
 
@@ -67,10 +80,10 @@ func test_example_d(a: Vector3, b: Vector3, test_parameters=[
 
 class TestObj extends RefCounted:
 	var _value: String
-	
+
 	func _init(value: String):
 		_value = value
-	
+
 	func _to_string() -> String:
 		return _value
 
@@ -86,26 +99,27 @@ func test_load_parameter_sets() -> void:
 	var tc := get_test_case("test_example_a")
 	assert_array(tc.parameter_set_resolver().load_parameter_sets(tc)) \
 		.is_equal([[1, 2], [3, 4]])
-	
+
 	tc = get_test_case("test_example_b")
 	assert_array(tc.parameter_set_resolver().load_parameter_sets(tc)) \
 		.is_equal([[Vector2.ZERO, Vector2.ONE], [Vector2(1.1, 3.2), Vector2.DOWN]])
-	
+
 	tc = get_test_case("test_example_c")
 	assert_array(tc.parameter_set_resolver().load_parameter_sets(tc)) \
 		.is_equal([[Resource.new(), Resource.new()], [Resource.new(), null]])
-	
+
 	tc = get_test_case("test_example_d")
 	assert_array(tc.parameter_set_resolver().load_parameter_sets(tc)) \
 		.is_equal([[Vector3(1, 1, 1), Vector3(3, 3, 3)], [Vector3.BACK, Vector3.UP]])
-	
+
 	tc = get_test_case("test_example_e")
 	assert_array(tc.parameter_set_resolver().load_parameter_sets(tc)) \
 		.is_equal([[TestObj.new("abc"), TestObj.new("def"), "abcdef"]])
 
 
 func test_load_parameter_sets_at_runtime() -> void:
-	var tc := get_test_case("test_resolve_paramaters_at_runtime")
+	var tc := get_test_case("test_resolve_parameters_at_runtime")
+	assert_that(tc).is_not_null()
 	# check the parameters resolved at runtime
 	assert_array(tc.parameter_set_resolver().load_parameter_sets(tc)) \
 		.is_equal([
@@ -117,28 +131,40 @@ func test_load_parameter_sets_at_runtime() -> void:
 			[3, 30]])
 
 
+func test_load_parameter_with_comments() -> void:
+	var tc := get_test_case("test_parameterized_with_comments")
+	assert_that(tc).is_not_null()
+	# check the parameters resolved at runtime
+	assert_array(tc.parameter_set_resolver().load_parameter_sets(tc)) \
+		.is_equal([
+			[1, 2, '3', 6],
+			[3, 4, '5', 11],
+			[6, 7, 'string #ABCD', 21],
+			[6, 7, "string #ABCD", 21]])
+
+
 func test_build_test_case_names_on_static_parameter_set() -> void:
-	var test_case := get_test_case("test_resolve_paramaters_static")
+	var test_case := get_test_case("test_resolve_parameters_static")
 	var resolver := test_case.parameter_set_resolver()
-	
+
 	assert_array(resolver.build_test_case_names(test_case))\
 		.contains_exactly([
-			"test_resolve_paramaters_static:0 [1, 10]",
-			"test_resolve_paramaters_static:1 [2, 20]"])
+			"test_resolve_parameters_static:0 [1, 10]",
+			"test_resolve_parameters_static:1 [2, 20]"])
 	assert_that(resolver.is_parameter_sets_static()).is_true()
 	assert_that(resolver.is_parameter_set_static(0)).is_true()
 	assert_that(resolver.is_parameter_set_static(1)).is_true()
 
 
 func test_build_test_case_names_on_runtime_parameter_set() -> void:
-	var test_case := get_test_case("test_resolve_paramaters_at_runtime")
+	var test_case := get_test_case("test_resolve_parameters_at_runtime")
 	var resolver := test_case.parameter_set_resolver()
-	
+
 	assert_array(resolver.build_test_case_names(test_case))\
 		.contains_exactly([
-			"test_resolve_paramaters_at_runtime:0 [1, _test_param1]",
-			"test_resolve_paramaters_at_runtime:1 [2, _test_param2]",
-			"test_resolve_paramaters_at_runtime:2 [3, 30]"])
+			"test_resolve_parameters_at_runtime:0 [1, _test_param1]",
+			"test_resolve_parameters_at_runtime:1 [2, _test_param2]",
+			"test_resolve_parameters_at_runtime:2 [3, 30]"])
 	assert_that(resolver.is_parameter_sets_static()).is_false()
 	assert_that(resolver.is_parameter_set_static(0)).is_false()
 	assert_that(resolver.is_parameter_set_static(1)).is_false()

--- a/addons/gdUnit4/test/mocker/resources/ClassWithCustomFormattings.gd
+++ b/addons/gdUnit4/test/mocker/resources/ClassWithCustomFormattings.gd
@@ -3,28 +3,28 @@ extends Object
 var _message
 
 @warning_ignore("unused_parameter")
-func _init(message:String, path:String="", load_on_init:bool=false, 
+func _init(message:String, path:String="", load_on_init:bool=false,
 	set_auto_save:bool=false, set_network_sync:bool=false
 ) -> void:
 	_message = message
 
 
 @warning_ignore("unused_parameter")
-func a1(set_name:String, path:String="", load_on_init:bool=false, 
+func a1(set_name:String, path:String="", load_on_init:bool=false,
 	set_auto_save:bool=false, set_network_sync:bool=false
 ) -> void:
 	pass
 
 
 @warning_ignore("unused_parameter")
-func a2(set_name:String, path:String="", load_on_init:bool=false, 
+func a2(set_name:String, path:String="", load_on_init:bool=false,
 	set_auto_save:bool=false, set_network_sync:bool=false
 ) -> 	void:
 	pass
 
 
 @warning_ignore("unused_parameter")
-func a3(set_name:String, path:String="", load_on_init:bool=false, 
+func a3(set_name:String, path:String="", load_on_init:bool=false,
 	set_auto_save:bool=false, set_network_sync:bool=false
 ) :
 	pass

--- a/gdUnit4.csproj
+++ b/gdUnit4.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Godot.NET.Sdk/4.2.1">
   <PropertyGroup>
-    <TargetFrameworks>net7.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
     <LangVersion>11.0</LangVersion>
     <!--Force nullable warnings, you can disable if you want-->
     <Nullable>enable</Nullable>
@@ -10,6 +10,6 @@
   </PropertyGroup>
   <ItemGroup>
     <!--Required for GdUnit4-->
-    <PackageReference Include="gdUnit4.api" Version="4.2.1.1" />
+    <PackageReference Include="gdUnit4.api" Version="4.2.*-*" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
# Why
When we put comments in the test function signature, the test case was not successfully parsed.

# What
- we remove all comment during parsing to finally extract the function signature.
- increase GdUnit4 version to 4.2.4
- update C# project dependencies


