### PR TITLE
GD-385: Fix runtest.sh not working for GODOT_BIN with spaces

### DIFF
--- a/addons/gdUnit4/runtest.sh
+++ b/addons/gdUnit4/runtest.sh
@@ -6,10 +6,10 @@ if [ -z "$GODOT_BIN" ]; then
     exit 1
 fi
 
-$GODOT_BIN --path . -s -d res://addons/gdUnit4/bin/GdUnitCmdTool.gd $*
+"$GODOT_BIN" --path . -s -d res://addons/gdUnit4/bin/GdUnitCmdTool.gd $*
 exit_code=$?
 echo "Run tests ends with $exit_code"
 
-$GODOT_BIN --headless --path . --quiet -s -d res://addons/gdUnit4/bin/GdUnitCopyLog.gd $* > /dev/null
+"$GODOT_BIN" --headless --path . --quiet -s -d res://addons/gdUnit4/bin/GdUnitCopyLog.gd $* > /dev/null
 exit_code2=$?
 exit $exit_code


### PR DESCRIPTION
# Why
So that GODOT_BIN paths with spaces can be used.


# What
Surround GODOT_BIN usage with quotes.

#385 