### PR TITLE
GD-389: The inheritance of a base test class leads to an incorrect test case list.

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -51,7 +51,7 @@ jobs:
       - name: 'Checkout'
         uses: actions/checkout@v4
         with:
-          lfs: true            
+          lfs: true
 
       - shell: bash
         run: |

--- a/addons/gdUnit4/src/core/GdUnitTestSuiteScanner.gd
+++ b/addons/gdUnit4/src/core/GdUnitTestSuiteScanner.gd
@@ -183,7 +183,7 @@ func _handle_test_case_arguments(test_suite, script :GDScript, fd :GdFunctionDes
 
 func _parse_and_add_test_cases(test_suite, script :GDScript, test_case_names :PackedStringArray):
 	var test_cases_to_find = Array(test_case_names)
-	var functions_to_scan := test_case_names
+	var functions_to_scan := test_case_names.duplicate()
 	functions_to_scan.append("before")
 	var source := _script_parser.load_source_code(script, [script.resource_path])
 	var function_descriptors := _script_parser.parse_functions(source, "", [script.resource_path], functions_to_scan)

--- a/addons/gdUnit4/test/core/GdUnitTestSuiteScannerTest.gd
+++ b/addons/gdUnit4/test/core/GdUnitTestSuiteScannerTest.gd
@@ -279,10 +279,12 @@ func test_scan_by_inheritance_class_name() -> void:
 	var test_suites := scanner.scan("res://addons/gdUnit4/test/core/resources/scan_testsuite_inheritance/by_class_name/")
 
 	assert_array(test_suites).has_size(3)
+	# sort by names
+	test_suites.sort_custom(func by_name(a, b): return a.get_name() <= b.get_name())
 	assert_array(test_suites).extract("get_name")\
-		.contains_same_exactly_in_any_order(["BaseTest", "ExtendedTest", "ExtendsExtendedTest"])
+		.contains_exactly(["BaseTest", "ExtendedTest", "ExtendsExtendedTest"])
 	assert_array(test_suites).extract("get_script.get_path")\
-		.contains_same_exactly_in_any_order([
+		.contains_exactly([
 			"res://addons/gdUnit4/test/core/resources/scan_testsuite_inheritance/by_class_name/BaseTest.gd",
 			"res://addons/gdUnit4/test/core/resources/scan_testsuite_inheritance/by_class_name/ExtendedTest.gd",
 			"res://addons/gdUnit4/test/core/resources/scan_testsuite_inheritance/by_class_name/ExtendsExtendedTest.gd"])
@@ -292,13 +294,6 @@ func test_scan_by_inheritance_class_name() -> void:
 		.contains_same_exactly_in_any_order([&"test_foo2", &"test_foo1"])
 	assert_array(test_suites[2].get_children()).extract("name")\
 		.contains_same_exactly_in_any_order([&"test_foo3", &"test_foo2", &"test_foo1"])
-
-	assert_array(test_suites).extractv(extr("get_name"), extr("get_script.get_path"))\
-		.contains_exactly_in_any_order([
-			tuple("BaseTest", "res://addons/gdUnit4/test/core/resources/scan_testsuite_inheritance/by_class_name/BaseTest.gd"),
-			tuple("ExtendedTest","res://addons/gdUnit4/test/core/resources/scan_testsuite_inheritance/by_class_name/ExtendedTest.gd"),
-			tuple("ExtendsExtendedTest", "res://addons/gdUnit4/test/core/resources/scan_testsuite_inheritance/by_class_name/ExtendsExtendedTest.gd")
-		])
 	# finally free all scaned test suites
 	for ts in test_suites:
 		ts.free()
@@ -320,7 +315,7 @@ func test_scan_by_inheritance_class_path() -> void:
 
 
 func test_get_test_case_line_number() -> void:
-	assert_int(GdUnitTestSuiteScanner.get_test_case_line_number("res://addons/gdUnit4/test/core/GdUnitTestSuiteScannerTest.gd", "get_test_case_line_number")).is_equal(322)
+	assert_int(GdUnitTestSuiteScanner.get_test_case_line_number("res://addons/gdUnit4/test/core/GdUnitTestSuiteScannerTest.gd", "get_test_case_line_number")).is_equal(317)
 	assert_int(GdUnitTestSuiteScanner.get_test_case_line_number("res://addons/gdUnit4/test/core/GdUnitTestSuiteScannerTest.gd", "unknown")).is_equal(-1)
 
 

--- a/addons/gdUnit4/test/core/GdUnitTestSuiteScannerTest.gd
+++ b/addons/gdUnit4/test/core/GdUnitTestSuiteScannerTest.gd
@@ -278,11 +278,26 @@ func test_scan_by_inheritance_class_name() -> void:
 	var scanner :GdUnitTestSuiteScanner = auto_free(GdUnitTestSuiteScanner.new())
 	var test_suites := scanner.scan("res://addons/gdUnit4/test/core/resources/scan_testsuite_inheritance/by_class_name/")
 
-	assert_array(test_suites).extractv(extr("get_name"), extr("get_script.get_path"), extr("get_children.get_name"))\
+	assert_array(test_suites).has_size(3)
+	assert_array(test_suites).extract("get_name")\
+		.contains_same_exactly_in_any_order(["BaseTest", "ExtendedTest", "ExtendsExtendedTest"])
+	assert_array(test_suites).extract("get_script.get_path")\
+		.contains_same_exactly_in_any_order([
+			"res://addons/gdUnit4/test/core/resources/scan_testsuite_inheritance/by_class_name/BaseTest.gd",
+			"res://addons/gdUnit4/test/core/resources/scan_testsuite_inheritance/by_class_name/ExtendedTest.gd",
+			"res://addons/gdUnit4/test/core/resources/scan_testsuite_inheritance/by_class_name/ExtendsExtendedTest.gd"])
+	assert_array(test_suites[0].get_children()).extract("name")\
+		.contains_same_exactly_in_any_order([&"test_foo1"])
+	assert_array(test_suites[1].get_children()).extract("name")\
+		.contains_same_exactly_in_any_order([&"test_foo2", &"test_foo1"])
+	assert_array(test_suites[2].get_children()).extract("name")\
+		.contains_same_exactly_in_any_order([&"test_foo3", &"test_foo2", &"test_foo1"])
+
+	assert_array(test_suites).extractv(extr("get_name"), extr("get_script.get_path"))\
 		.contains_exactly_in_any_order([
-			tuple("BaseTest", "res://addons/gdUnit4/test/core/resources/scan_testsuite_inheritance/by_class_name/BaseTest.gd", [&"test_foo1"]),
-			tuple("ExtendedTest","res://addons/gdUnit4/test/core/resources/scan_testsuite_inheritance/by_class_name/ExtendedTest.gd", [&"test_foo2", &"test_foo1"]),
-			tuple("ExtendsExtendedTest", "res://addons/gdUnit4/test/core/resources/scan_testsuite_inheritance/by_class_name/ExtendsExtendedTest.gd", [&"test_foo3", &"test_foo2", &"test_foo1"])
+			tuple("BaseTest", "res://addons/gdUnit4/test/core/resources/scan_testsuite_inheritance/by_class_name/BaseTest.gd"),
+			tuple("ExtendedTest","res://addons/gdUnit4/test/core/resources/scan_testsuite_inheritance/by_class_name/ExtendedTest.gd"),
+			tuple("ExtendsExtendedTest", "res://addons/gdUnit4/test/core/resources/scan_testsuite_inheritance/by_class_name/ExtendsExtendedTest.gd")
 		])
 	# finally free all scaned test suites
 	for ts in test_suites:
@@ -305,7 +320,7 @@ func test_scan_by_inheritance_class_path() -> void:
 
 
 func test_get_test_case_line_number() -> void:
-	assert_int(GdUnitTestSuiteScanner.get_test_case_line_number("res://addons/gdUnit4/test/core/GdUnitTestSuiteScannerTest.gd", "get_test_case_line_number")).is_equal(307)
+	assert_int(GdUnitTestSuiteScanner.get_test_case_line_number("res://addons/gdUnit4/test/core/GdUnitTestSuiteScannerTest.gd", "get_test_case_line_number")).is_equal(322)
 	assert_int(GdUnitTestSuiteScanner.get_test_case_line_number("res://addons/gdUnit4/test/core/GdUnitTestSuiteScannerTest.gd", "unknown")).is_equal(-1)
 
 

--- a/addons/gdUnit4/test/core/resources/scan_testsuite_inheritance/by_class_name/BaseTest.gd
+++ b/addons/gdUnit4/test/core/resources/scan_testsuite_inheritance/by_class_name/BaseTest.gd
@@ -1,5 +1,22 @@
 class_name BaseTest
 extends GdUnitTestSuite
 
+
+func before():
+	pass
+
+
+func after():
+	pass
+
+
+func before_test():
+	pass
+
+
+func after_test():
+	pass
+
+
 func test_foo1() -> void:
 	pass

--- a/addons/gdUnit4/test/core/resources/scan_testsuite_inheritance/by_class_name/ExtendedTest.gd
+++ b/addons/gdUnit4/test/core/resources/scan_testsuite_inheritance/by_class_name/ExtendedTest.gd
@@ -1,5 +1,14 @@
 class_name ExtendedTest
 extends BaseTest
 
+
+func before_test():
+	pass
+
+
+func after_test():
+	pass
+
+
 func test_foo2() -> void:
 	pass


### PR DESCRIPTION
# Why
https://github.com/MikeSchulze/gdUnit4/issues/389

# What
When the scanner is building the function descriptors, it was using the list of tests and adding the `before` function to scan. The list to scan was not a copy and results into side effect of the original test list. Fixed by using a copy before adding the `before` function extended the existing test coverage for test suite inheritance to include the `before` on the base test suite.

