### PR TITLE
GD-392: Fixes missing failure reporting when a test uses unsafe `GdAssertReports.expect_fail()`

### DIFF
--- a/addons/gdUnit4/src/GdUnitAwaiter.gd
+++ b/addons/gdUnit4/src/GdUnitAwaiter.gd
@@ -11,21 +11,20 @@ const GdUnitAssertImpl = preload("res://addons/gdUnit4/src/asserts/GdUnitAssertI
 # timeout: the timeout in ms, default is set to 2000ms
 func await_signal_on(source :Object, signal_name :String, args :Array = [], timeout_millis :int = 2000) -> Variant:
 	# fail fast if the given source instance invalid
+	var assert_that := GdUnitAssertImpl.new(signal_name)
 	var line_number := GdUnitAssertions.get_line_number()
 	if not is_instance_valid(source):
-		GdUnitAssertImpl.new(signal_name)\
-			.report_error(GdAssertMessages.error_await_signal_on_invalid_instance(source, signal_name, args), line_number)
+		assert_that.report_error(GdAssertMessages.error_await_signal_on_invalid_instance(source, signal_name, args), line_number)
 		return await Engine.get_main_loop().process_frame
 	# fail fast if the given source instance invalid
 	if not is_instance_valid(source):
-		GdUnitAssertImpl.new(signal_name)\
-			.report_error(GdAssertMessages.error_await_signal_on_invalid_instance(source, signal_name, args), line_number)
+		assert_that.report_error(GdAssertMessages.error_await_signal_on_invalid_instance(source, signal_name, args), line_number)
 		return await await_idle_frame()
 	var awaiter := GdUnitSignalAwaiter.new(timeout_millis)
 	var value :Variant = await awaiter.on_signal(source, signal_name, args)
 	if awaiter.is_interrupted():
 		var failure = "await_signal_on(%s, %s) timed out after %sms" % [signal_name, args, timeout_millis]
-		GdUnitAssertImpl.new(signal_name).report_error(failure, line_number)
+		assert_that.report_error(failure, line_number)
 	return value
 
 

--- a/addons/gdUnit4/src/GdUnitConstants.gd
+++ b/addons/gdUnit4/src/GdUnitConstants.gd
@@ -2,3 +2,5 @@ class_name GdUnitConstants
 extends RefCounted
 
 const NO_ARG :Variant = "<--null-->"
+
+const EXPECT_ASSERT_REPORT_FAILURES := "expect_assert_report_failures"

--- a/addons/gdUnit4/src/asserts/GdAssertReports.gd
+++ b/addons/gdUnit4/src/asserts/GdAssertReports.gd
@@ -21,7 +21,7 @@ static func report_error(message:String, line_number :int) -> void:
 	GdAssertReports.set_last_error_line_number(line_number)
 	Engine.set_meta(LAST_ERROR, message)
 	# if we expect to fail we handle as success test
-	if is_expect_fail():
+	if _do_expect_assert_failing():
 		return
 	send_report(GdUnitReport.new().create(GdUnitReport.FAILURE, line_number, message))
 
@@ -40,13 +40,9 @@ static func get_last_error_line_number() -> int:
 	return -1
 
 
-static func expect_fail(enabled :bool = true):
-	Engine.set_meta("report_failures", enabled)
-
-
-static func is_expect_fail() -> bool:
-	if Engine.has_meta("report_failures"):
-		return Engine.get_meta("report_failures")
+static func _do_expect_assert_failing() -> bool:
+	if Engine.has_meta(GdUnitConstants.EXPECT_ASSERT_REPORT_FAILURES):
+		return Engine.get_meta(GdUnitConstants.EXPECT_ASSERT_REPORT_FAILURES)
 	return false
 
 

--- a/addons/gdUnit4/test/asserts/GdUnitFuncAssertImplTest.gd
+++ b/addons/gdUnit4/test/asserts/GdUnitFuncAssertImplTest.gd
@@ -14,16 +14,6 @@ func is_skip_fail_await() -> bool:
 	return Engine.get_version_info().hex < 0x40002
 
 
-# using this helper to await for the given callable and assert the failure
-func verify_failed(cb :Callable) -> GdUnitStringAssert:
-	GdAssertReports.expect_fail(true)
-	await cb.call()
-	GdAssertReports.expect_fail(false)
-
-	var error = GdAssertReports.current_failure()
-	return assert_str(GdUnitTools.richtext_normalize(error))
-
-
 class TestValueProvider:
 	var _max_iterations :int
 	var _current_itteration := 0
@@ -149,8 +139,9 @@ func test_is_null(timeout = 2000) -> void:
 	if is_skip_fail_await():
 		return
 	value_provider = TestIterativeValueProvider.new(RefCounted.new(), 1, RefCounted.new())
-	(await verify_failed(func(): await assert_func(value_provider, "obj_value", []).wait_until(100).is_null())) \
-		.is_equal("Expected: is null but timed out after 100ms")
+	(
+		await assert_failure_await(func(): await assert_func(value_provider, "obj_value", []).wait_until(100).is_null())
+	).has_message("Expected: is null but timed out after 100ms")
 
 
 @warning_ignore("unused_parameter")
@@ -171,8 +162,9 @@ func test_is_not_null(timeout = 2000) -> void:
 	value_provider = TestIterativeValueProvider.new(null, 1, null)
 	if is_skip_fail_await():
 		return
-	(await verify_failed(func(): await assert_func(value_provider, "obj_value", []).wait_until(100).is_not_null()))\
-		.is_equal("Expected: is not null but timed out after 100ms")
+	(
+		await assert_failure_await(func(): await assert_func(value_provider, "obj_value", []).wait_until(100).is_not_null())
+	).has_message("Expected: is not null but timed out after 100ms")
 
 
 @warning_ignore("unused_parameter")
@@ -193,8 +185,9 @@ func test_is_true(timeout = 2000) -> void:
 	value_provider = TestIterativeValueProvider.new(false, 1, false)
 	if is_skip_fail_await():
 		return
-	(await verify_failed(func(): await assert_func(value_provider, "bool_value", []).wait_until(100).is_true()))\
-		.is_equal("Expected: is true but timed out after 100ms")
+	(
+		await assert_failure_await(func(): await assert_func(value_provider, "bool_value", []).wait_until(100).is_true())
+	).has_message("Expected: is true but timed out after 100ms")
 
 
 @warning_ignore("unused_parameter")
@@ -215,8 +208,9 @@ func test_is_false(timeout = 2000) -> void:
 	value_provider = TestIterativeValueProvider.new(true, 1, true)
 	if is_skip_fail_await():
 		return
-	(await verify_failed(func(): await assert_func(value_provider, "bool_value", []).wait_until(100).is_false())) \
-		.is_equal("Expected: is false but timed out after 100ms")
+	(
+		await assert_failure_await(func(): await assert_func(value_provider, "bool_value", []).wait_until(100).is_false())
+	).has_message("Expected: is false but timed out after 100ms")
 
 
 @warning_ignore("unused_parameter")
@@ -237,8 +231,9 @@ func test_is_equal(timeout = 2000) -> void:
 	value_provider = TestIterativeValueProvider.new(23, 1, 23)
 	if is_skip_fail_await():
 		return
-	(await verify_failed(func(): await assert_func(value_provider, "int_value", []).wait_until(100).is_equal(25))) \
-		.is_equal("Expected: is equal '25' but timed out after 100ms")
+	(
+		await assert_failure_await(func(): await assert_func(value_provider, "int_value", []).wait_until(100).is_equal(25))
+	).has_message("Expected: is equal '25' but timed out after 100ms")
 
 
 @warning_ignore("unused_parameter")
@@ -259,8 +254,9 @@ func test_is_not_equal(timeout = 2000) -> void:
 	value_provider = TestIterativeValueProvider.new(23, 1, 23)
 	if is_skip_fail_await():
 		return
-	(await verify_failed(func(): await assert_func(value_provider, "int_value", []).wait_until(100).is_not_equal(23))) \
-		.is_equal("Expected: is not equal '23' but timed out after 100ms")
+	(
+		await assert_failure_await(func(): await assert_func(value_provider, "int_value", []).wait_until(100).is_not_equal(23))
+	).has_message("Expected: is not equal '23' but timed out after 100ms")
 
 
 @warning_ignore("unused_parameter")
@@ -307,15 +303,17 @@ func test_timer_yielded_function() -> void:
 	# failure case
 	if is_skip_fail_await():
 		return
-	(await verify_failed(func(): await assert_func(self, "timed_function", []).wait_until(100).is_equal(Color.RED))) \
-		.is_equal("Expected: is equal 'Color(1, 0, 0, 1)' but timed out after 100ms")
+	(
+		await assert_failure_await(func(): await assert_func(self, "timed_function", []).wait_until(100).is_equal(Color.RED))
+	).has_message("Expected: is equal 'Color(1, 0, 0, 1)' but timed out after 100ms")
 
 
 func test_timer_yielded_function_timeout() -> void:
 	if is_skip_fail_await():
 		return
-	(await verify_failed(func(): await assert_func(self, "timed_function", []).wait_until(40).is_equal(Color.BLACK)))\
-		.is_equal("Expected: is equal 'Color()' but timed out after 40ms")
+	(
+		await assert_failure_await(func(): await assert_func(self, "timed_function", []).wait_until(40).is_equal(Color.BLACK))
+	).has_message("Expected: is equal 'Color()' but timed out after 40ms")
 
 
 func yielded_function() -> Color:
@@ -333,34 +331,38 @@ func test_idle_frame_yielded_function() -> void:
 	await assert_func(self, "yielded_function").is_equal(Color.BLACK)
 	if is_skip_fail_await():
 		return
-	(await verify_failed(func(): await assert_func(self, "yielded_function", []).wait_until(500).is_equal(Color.RED))) \
-		.is_equal("Expected: is equal 'Color(1, 0, 0, 1)' but timed out after 500ms")
+	(
+		await assert_failure_await(func(): await assert_func(self, "yielded_function", []).wait_until(500).is_equal(Color.RED))
+	).has_message("Expected: is equal 'Color(1, 0, 0, 1)' but timed out after 500ms")
 
 
 func test_has_failure_message() -> void:
 	if is_skip_fail_await():
 		return
 	var value_provider := TestIterativeValueProvider.new(10, 1, 10)
-	(await verify_failed(func(): await assert_func(value_provider, "int_value", []).wait_until(500).is_equal(42))) \
-		.is_equal("Expected: is equal '42' but timed out after 500ms")
+	(
+		await assert_failure_await(func(): await assert_func(value_provider, "int_value", []).wait_until(500).is_equal(42))
+	).has_message("Expected: is equal '42' but timed out after 500ms")
 
 
 func test_override_failure_message() -> void:
 	if is_skip_fail_await():
 		return
 	var value_provider := TestIterativeValueProvider.new(10, 1, 20)
-	(await verify_failed(func(): await assert_func(value_provider, "int_value", []) \
+	(
+		await assert_failure_await(func(): await assert_func(value_provider, "int_value", []) \
 			.override_failure_message("Custom failure message") \
 			.wait_until(100) \
-			.is_equal(42))) \
-		.is_equal("Custom failure message")
+			.is_equal(42))
+	).has_message("Custom failure message")
 
 
 @warning_ignore("unused_parameter")
 func test_invalid_function(timeout = 100):
 	if is_skip_fail_await():
 		return
-	(await verify_failed(func(): await assert_func(self, "invalid_func_name", [])\
+	(
+		await assert_failure_await(func(): await assert_func(self, "invalid_func_name", [])\
 		.wait_until(1000)\
-		.is_equal(42)))\
-		.starts_with("The function 'invalid_func_name' do not exists checked instance")
+		.is_equal(42))
+	).starts_with_message("The function 'invalid_func_name' do not exists checked instance")

--- a/addons/gdUnit4/test/asserts/GdUnitSignalAssertImplTest.gd
+++ b/addons/gdUnit4/test/asserts/GdUnitSignalAssertImplTest.gd
@@ -46,26 +46,19 @@ func is_skip_fail_await() -> bool:
 	return Engine.get_version_info().hex < 0x40002
 
 
-# using this helper to await for the given callable and assert the failure
-func verify_failed(cb :Callable) -> GdUnitStringAssert:
-	GdAssertReports.expect_fail(true)
-	await cb.call()
-	GdAssertReports.expect_fail(false)
-
-	var a :GdUnitSignalAssert = GdUnitThreadManager.get_current_context().get_assert()
-	return assert_str(GdUnitTools.richtext_normalize(a.failure_message()))
-
-
 func test_invalid_arg() -> void:
-	(await verify_failed(func(): assert_signal(null).wait_until(50).is_emitted("test_signal_counted")))\
-		.is_equal("Can't wait for signal checked a NULL object.")
-	(await verify_failed(func(): await assert_signal(null).wait_until(50).is_not_emitted("test_signal_counted")))\
-		.is_equal("Can't wait for signal checked a NULL object.")
+	(
+		await assert_failure_await(func(): await assert_signal(null).wait_until(50).is_emitted("test_signal_counted"))
+	).has_message("Can't wait for signal checked a NULL object.")
+	(
+		await assert_failure_await(func(): await assert_signal(null).wait_until(50).is_not_emitted("test_signal_counted"))
+	).has_message("Can't wait for signal checked a NULL object.")
 
 
 func test_unknown_signal() -> void:
-	(await verify_failed(func(): await assert_signal(signal_emitter).wait_until(50).is_emitted("unknown"))) \
-		.is_equal("Can't wait for non-existion signal 'unknown' checked object 'Node'.")
+	(
+		await assert_failure_await(func(): await assert_signal(signal_emitter).wait_until(50).is_emitted("unknown"))
+	).has_message("Can't wait for non-existion signal 'unknown' checked object 'Node'.")
 
 
 func test_signal_is_emitted_without_args() -> void:
@@ -76,9 +69,9 @@ func test_signal_is_emitted_without_args() -> void:
 
 	if is_skip_fail_await():
 		return
-
-	(await verify_failed(func(): await assert_signal(signal_emitter).wait_until(500).is_emitted("test_signal_unused")))\
-		.is_equal("Expecting emit signal: 'test_signal_unused()' but timed out after 500ms")
+	(
+		await assert_failure_await(func(): await assert_signal(signal_emitter).wait_until(500).is_emitted("test_signal_unused"))
+	).has_message("Expecting emit signal: 'test_signal_unused()' but timed out after 500ms")
 
 
 func test_signal_is_emitted_with_args() -> void:
@@ -87,8 +80,9 @@ func test_signal_is_emitted_with_args() -> void:
 
 	if is_skip_fail_await():
 		return
-	(await verify_failed(func(): await assert_signal(signal_emitter).wait_until(50).is_emitted("test_signal_counted", [500]))) \
-		.is_equal("Expecting emit signal: 'test_signal_counted([500])' but timed out after 50ms")
+	(
+		await assert_failure_await(func(): await assert_signal(signal_emitter).wait_until(50).is_emitted("test_signal_counted", [500]))
+	).has_message("Expecting emit signal: 'test_signal_counted([500])' but timed out after 50ms")
 
 
 func test_signal_is_emitted_use_argument_matcher() -> void:
@@ -101,10 +95,9 @@ func test_signal_is_emitted_use_argument_matcher() -> void:
 
 	# should fail because the matcher uses the wrong type
 	signal_emitter.reset_trigger()
-	(await verify_failed( func():
-		await assert_signal(signal_emitter).wait_until(50).is_emitted("test_signal_counted", [any_string()])
-		)
-	).is_equal("Expecting emit signal: 'test_signal_counted([any_string()])' but timed out after 50ms")
+	(
+		await assert_failure_await( func(): await assert_signal(signal_emitter).wait_until(50).is_emitted("test_signal_counted", [any_string()]))
+	).has_message("Expecting emit signal: 'test_signal_counted([any_string()])' but timed out after 50ms")
 
 
 func test_signal_is_not_emitted() -> void:
@@ -116,19 +109,21 @@ func test_signal_is_not_emitted() -> void:
 	if is_skip_fail_await():
 		return
 	# until the next 500ms the signal is emitted and ends in a failure
-	(await verify_failed(func(): await assert_signal(signal_emitter).wait_until(1000).is_not_emitted("test_signal_counted", [50]))) \
-		.starts_with("Expecting do not emit signal: 'test_signal_counted([50])' but is emitted after")
+	(
+		await assert_failure_await(func(): await assert_signal(signal_emitter).wait_until(1000).is_not_emitted("test_signal_counted", [50]))
+	).starts_with_message("Expecting do not emit signal: 'test_signal_counted([50])' but is emitted after")
 
 
 func test_override_failure_message() -> void:
 	if is_skip_fail_await():
 		return
 
-	(await verify_failed(func(): await assert_signal(signal_emitter) \
+	(
+		await assert_failure_await(func(): await assert_signal(signal_emitter) \
 		.override_failure_message("Custom failure message")\
 		.wait_until(100)\
-		.is_emitted("test_signal_unused"))) \
-		.is_equal("Custom failure message")
+		.is_emitted("test_signal_unused"))
+	).has_message("Custom failure message")
 
 
 func test_node_changed_emitting_signals():
@@ -143,8 +138,9 @@ func test_node_changed_emitting_signals():
 	# expecting to fail, we not changed the visibility
 	#node.visible = true;
 	if not is_skip_fail_await():
-		(await verify_failed(func(): await assert_signal(node).wait_until(200).is_emitted("visibility_changed")))\
-			.is_equal("Expecting emit signal: 'visibility_changed()' but timed out after 200ms")
+		(
+			await assert_failure_await(func(): await assert_signal(node).wait_until(200).is_emitted("visibility_changed"))
+		).has_message("Expecting emit signal: 'visibility_changed()' but timed out after 200ms")
 
 	node.show()
 	await assert_signal(node).wait_until(200).is_emitted("draw")
@@ -163,8 +159,9 @@ func test_is_signal_exists() -> void:
 	if is_skip_fail_await():
 		return
 
-	(await verify_failed(func(): assert_signal(node).is_signal_exists("not_existing_signal"))) \
-		.is_equal("The signal 'not_existing_signal' not exists checked object 'Node2D'.")
+	(
+		await assert_failure_await(func(): assert_signal(node).is_signal_exists("not_existing_signal"))
+	).has_message("The signal 'not_existing_signal' not exists checked object 'Node2D'.")
 
 
 class MyEmitter extends Node:

--- a/addons/gdUnit4/test/core/GdUnitSceneRunnerTest.gd
+++ b/addons/gdUnit4/test/core/GdUnitSceneRunnerTest.gd
@@ -20,17 +20,6 @@ func after():
 	Engine.set_max_fps(0)
 
 
-## Utility to check if a test has failed in a particular line and if there is an error message
-func assert_failed_at(line_number :int, expected_failure :String) -> bool:
-	var is_failed = is_failure()
-	var last_failure = GdAssertReports.current_failure()
-	var last_failure_line = GdAssertReports.get_last_error_line_number()
-	assert_str(last_failure).is_equal(expected_failure)
-	assert_int(last_failure_line).is_equal(line_number)
-	GdAssertReports.expect_fail(true)
-	return is_failed
-
-
 func test_get_property() -> void:
 	var runner := scene_runner(load_test_scene())
 
@@ -211,13 +200,11 @@ func test_await_signal_without_time_factor() -> void:
 	await runner.await_signal("panel_color_change", [box1, Color.RED])
 	await runner.await_signal("panel_color_change", [box1, Color.BLUE])
 	await runner.await_signal("panel_color_change", [box1, Color.GREEN])
-
-	# should be interrupted is will never change to Color.KHAKI
-	GdAssertReports.expect_fail()
-	await runner.await_signal( "panel_color_change", [box1, Color.KHAKI], 300)
-	if assert_failed_at(201, "await_signal_on(panel_color_change, [%s, %s]) timed out after 300ms" % [str(box1), str(Color.KHAKI)]):
-		return
-	fail("test should failed after 300ms checked 'await_signal'")
+	(
+		# should be interrupted is will never change to Color.KHAKI
+		await assert_failure_await(func x(): await runner.await_signal( "panel_color_change", [box1, Color.KHAKI], 300))
+	).has_message("await_signal_on(panel_color_change, [%s, %s]) timed out after 300ms" % [str(box1), str(Color.KHAKI)])\
+		.has_line(205)
 
 
 func test_await_signal_with_time_factor() -> void:
@@ -230,13 +217,11 @@ func test_await_signal_with_time_factor() -> void:
 	await runner.await_signal("panel_color_change", [box1, Color.RED], 100)
 	await runner.await_signal("panel_color_change", [box1, Color.BLUE], 100)
 	await runner.await_signal("panel_color_change", [box1, Color.GREEN], 100)
-
-	# should be interrupted is will never change to Color.KHAKI
-	GdAssertReports.expect_fail()
-	await runner.await_signal("panel_color_change", [box1, Color.KHAKI], 30)
-	if assert_failed_at(220, "await_signal_on(panel_color_change, [%s, %s]) timed out after 30ms" % [str(box1), str(Color.KHAKI)]):
-		return
-	fail("test should failed after 30ms checked 'await_signal'")
+	(
+		# should be interrupted is will never change to Color.KHAKI
+		await assert_failure_await(func x(): await runner.await_signal("panel_color_change", [box1, Color.KHAKI], 30))
+	).has_message("await_signal_on(panel_color_change, [%s, %s]) timed out after 30ms" % [str(box1), str(Color.KHAKI)])\
+		.has_line(222)
 
 
 func test_simulate_until_signal() -> void:

--- a/addons/gdUnit4/test/core/GdUnitSignalAwaiterTest.gd
+++ b/addons/gdUnit4/test/core/GdUnitSignalAwaiterTest.gd
@@ -38,9 +38,9 @@ func test_on_signal_with_many_args() -> void:
 
 
 func test_on_signal_fail() -> void:
-	GdAssertReports.expect_fail()
 	var monster = auto_free(Monster.new())
 	add_child(monster)
-	await await_signal_on(monster, "move", [4.0])
-	assert_str(GdAssertReports.current_failure()).is_equal("await_signal_on(move, [4]) timed out after 2000ms")
+	(
+		await assert_failure_await( func x(): await await_signal_on(monster, "move", [4.0]))
+	).has_message("await_signal_on(move, [4]) timed out after 2000ms")
 	remove_child(monster)

--- a/addons/gdUnit4/test/core/GdUnitTestSuiteScannerTest.gd
+++ b/addons/gdUnit4/test/core/GdUnitTestSuiteScannerTest.gd
@@ -343,22 +343,6 @@ func test_is_script_format_supported() -> void:
 	assert_bool(GdUnitTestSuiteScanner._is_script_format_supported("res://exampe.tres")).is_false()
 
 
-func test_load_parameterized_test_suite():
-	var test_suite :GdUnitTestSuite = auto_free(GdUnitTestResourceLoader.load_test_suite("res://addons/gdUnit4/test/core/resources/testsuites/TestSuiteInvalidParameterizedTests.resource"))
-
-	assert_that(test_suite.name).is_equal("TestSuiteInvalidParameterizedTests")
-	assert_that(test_suite.get_children()).extractv(extr("get_name"), extr("is_skipped"))\
-		.contains_exactly_in_any_order([
-			tuple("test_no_parameters", false),
-			tuple("test_parameterized_success", false),
-			tuple("test_parameterized_failed", false),
-			tuple("test_parameterized_to_less_args", true),
-			tuple("test_parameterized_to_many_args", true),
-			tuple("test_parameterized_to_less_args_at_index_1", true),
-			tuple("test_parameterized_invalid_struct", true),
-			tuple("test_parameterized_invalid_args", true)])
-
-
 func test_resolve_test_suite_path() -> void:
 	# forcing the use of a test folder next to the source folder
 	assert_str(GdUnitTestSuiteScanner.resolve_test_suite_path("res://project/src/folder/myclass.gd", "test")).is_equal("res://project/test/folder/myclass_test.gd")


### PR DESCRIPTION
# Why
https://github.com/MikeSchulze/gdUnit4/issues/392

# What
* Removed the outdated `assert_failed_at` helper functions from the test suites and switch to `assert_failure_await` to avoid unsafe usage of `GdAssertReports.expect_fail()` An unsafe use of `GdAssertReports.expect_fail()` was resulting into failures not reported.
* renamed `expect_fail` and mark as private
* move and convert finally the failing test to `GdUnitTestParameterSetResolverTest#test_validate_test_parameter_set`
The failure is now reported as expected
![image](https://github.com/MikeSchulze/gdUnit4/assets/347037/fe048ab7-0ad2-44be-a382-ff39843c3a57)


