### PR TITLE
GD-396: Update C# API bridge to `gdUnit4Net` v4.2.2

### DIFF
--- a/.runsettings
+++ b/.runsettings
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RunSettings>
+    <RunConfiguration>
+        <MaxCpuCount>1</MaxCpuCount>
+        <ResultsDirectory>./TestResults</ResultsDirectory>
+        <TargetFramework>net8.0</TargetFramework>
+        <TestSessionTimeout>180000</TestSessionTimeout>
+        <TreatNoTestsAsError>true</TreatNoTestsAsError>
+    </RunConfiguration>
+
+    <LoggerRunSettings>
+        <Loggers>
+            <Logger friendlyName="console" enabled="True">
+                <Configuration>
+                    <Verbosity>detailed</Verbosity>
+                </Configuration>
+            </Logger>
+            <Logger friendlyName="html" enabled="True">
+                <Configuration>
+                    <LogFileName>test-result.html</LogFileName>
+                </Configuration>
+            </Logger>
+            <Logger friendlyName="trx" enabled="True">
+                <Configuration>
+                    <LogFileName>test-result.trx</LogFileName>
+                </Configuration>
+            </Logger>
+        </Loggers>
+    </LoggerRunSettings>
+
+    <GdUnit4>
+        <!-- Additonal Godot runtime parameters-->
+        <Parameters></Parameters>
+        <!-- Controlls the Display name attribute of the TestCase. Allowed values are SimpleName and FullyQualifiedName.
+             This likely determines how the test names are displayed in the test results.-->
+        <DisplayName>FullyQualifiedName</DisplayName>
+    </GdUnit4>
+</RunSettings>

--- a/.runsettings-ci
+++ b/.runsettings-ci
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RunSettings>
+    <RunConfiguration>
+        <MaxCpuCount>1</MaxCpuCount>
+        <ResultsDirectory>./TestResults</ResultsDirectory>
+        <TargetFramework>net8.0</TargetFramework>
+        <TestSessionTimeout>180000</TestSessionTimeout>
+        <TreatNoTestsAsError>true</TreatNoTestsAsError>
+    </RunConfiguration>
+
+    <LoggerRunSettings>
+        <Loggers>
+            <Logger friendlyName="console" enabled="True">
+                <Configuration>
+                    <Verbosity>detailed</Verbosity>
+                </Configuration>
+            </Logger>
+            <Logger friendlyName="html" enabled="True">
+                <Configuration>
+                    <LogFileName>test-result.html</LogFileName>
+                </Configuration>
+            </Logger>
+            <Logger friendlyName="trx" enabled="True">
+                <Configuration>
+                    <LogFileName>test-result.trx</LogFileName>
+                </Configuration>
+            </Logger>
+        </Loggers>
+    </LoggerRunSettings>
+
+    <GdUnit4>
+        <!-- Additonal Godot runtime parameters-->
+        <!-- These parameters are crucial for configuring the Godot runtime to work in headless environments, such as those used in automated testing or CI/CD pipelines.-->
+        <Parameters>--audio-driver Dummy --display-driver x11 --rendering-driver opengl3 --screen 0</Parameters>
+        <!-- Controlls the Display name attribute of the TestCase. Allowed values are SimpleName and FullyQualifiedName.
+             This likely determines how the test names are displayed in the test results.-->
+        <DisplayName>FullyQualifiedName</DisplayName>
+    </GdUnit4>
+</RunSettings>

--- a/addons/gdUnit4/bin/GdUnitCmdTool.gd
+++ b/addons/gdUnit4/bin/GdUnitCmdTool.gd
@@ -108,7 +108,7 @@ class CLIRunner:
 		# stop checked first test failure to fail fast
 		_executor.fail_fast(true)
 		if GdUnit4CSharpApiLoader.is_mono_supported():
-			prints("GdUnit4Mono Version %s loaded." % GdUnit4CSharpApiLoader.version())
+			prints("GdUnit4Net version '%s' loaded." % GdUnit4CSharpApiLoader.version())
 			_cs_executor = GdUnit4CSharpApiLoader.create_executor(self)
 		var err := GdUnitSignals.instance().gdunit_event.connect(_on_gdunit_event)
 		if err != OK:

--- a/addons/gdUnit4/plugin.gd
+++ b/addons/gdUnit4/plugin.gd
@@ -27,7 +27,7 @@ func _enter_tree() -> void:
 		var update_tool :Node = load("res://addons/gdUnit4/src/update/GdUnitUpdateNotify.tscn").instantiate()
 		Engine.get_main_loop().root.call_deferred("add_child", update_tool)
 	if GdUnit4CSharpApiLoader.is_mono_supported():
-		prints("GdUnit4Mono Version %s loaded." % GdUnit4CSharpApiLoader.version())
+		prints("GdUnit4Net version '%s' loaded." % GdUnit4CSharpApiLoader.version())
 
 
 func _exit_tree() -> void:

--- a/addons/gdUnit4/src/mono/GdUnit4CSharpApi.cs
+++ b/addons/gdUnit4/src/mono/GdUnit4CSharpApi.cs
@@ -1,19 +1,50 @@
+using System;
+using System.Reflection;
+using System.Linq;
+
 using Godot;
 using Godot.Collections;
-
 using GdUnit4;
+
 
 // GdUnit4 GDScript - C# API wrapper
 public partial class GdUnit4CSharpApi : RefCounted
 {
-	public static string Version() => GdUnit4MonoAPI.Version();
-	
-	public static bool IsTestSuite(string classPath) => GdUnit4MonoAPI.IsTestSuite(classPath);
-	
-	public static RefCounted Executor(Node listener) => (RefCounted)GdUnit4MonoAPI.Executor(listener);
-	
-	public static GdUnit4.CsNode? ParseTestSuite(string classPath) => GdUnit4MonoAPI.ParseTestSuite(classPath);
-	
+	private static Type? apiType;
+
+	private static Type GetApiType()
+	{
+		if (apiType == null)
+		{
+			var assembly = Assembly.Load("gdUnit4Api");
+			apiType = GdUnit4NetVersion() < new Version(4, 2, 2) ?
+				assembly.GetType("GdUnit4.GdUnit4MonoAPI") :
+				assembly.GetType("GdUnit4.GdUnit4NetAPI");
+			Godot.GD.PrintS($"GdUnit4CSharpApi type:{apiType} loaded.");
+		}
+		return apiType!;
+	}
+
+	private static Version GdUnit4NetVersion()
+	{
+		var assembly = Assembly.Load("gdUnit4Api");
+		return assembly.GetName().Version!;
+	}
+
+	private static T InvokeApiMethod<T>(string methodName, params object[] args)
+	{
+		var method = GetApiType().GetMethod(methodName)!;
+		return (T)method.Invoke(null, args)!;
+	}
+
+	public static string Version() => GdUnit4NetVersion().ToString();
+
+	public static bool IsTestSuite(string classPath) => InvokeApiMethod<bool>("IsTestSuite", classPath);
+
+	public static RefCounted Executor(Node listener) => InvokeApiMethod<RefCounted>("Executor", listener);
+
+	public static CsNode? ParseTestSuite(string classPath) => InvokeApiMethod<CsNode?>("ParseTestSuite", classPath);
+
 	public static Dictionary CreateTestSuite(string sourcePath, int lineNumber, string testSuitePath) =>
-		GdUnit4MonoAPI.CreateTestSuite(sourcePath, lineNumber, testSuitePath);
+		InvokeApiMethod<Dictionary>("CreateTestSuite", sourcePath, lineNumber, testSuitePath);
 }

--- a/addons/gdUnit4/test/mono/GdUnit4CSharpApiTest.cs
+++ b/addons/gdUnit4/test/mono/GdUnit4CSharpApiTest.cs
@@ -16,7 +16,7 @@ namespace GdUnit4
 		[TestCase]
 		public void GetVersion()
 		{
-			AssertThat(GdUnit4CSharpApi.Version()).IsEqual("4.2.1.0");
+			AssertThat(GdUnit4CSharpApi.Version()).IsEqual("4.2.2.0");
 		}
 	}
 }

--- a/gdUnit4.csproj
+++ b/gdUnit4.csproj
@@ -10,6 +10,8 @@
   </PropertyGroup>
   <ItemGroup>
     <!--Required for GdUnit4-->
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
     <PackageReference Include="gdUnit4.api" Version="4.2.*-*" />
+    <PackageReference Include="gdUnit4.test.adapter" Version="1.*" />
   </ItemGroup>
 </Project>

--- a/project.godot
+++ b/project.godot
@@ -12,7 +12,7 @@ config_version=5
 
 config/name="gdUnit4"
 config/tags=PackedStringArray("addon", "godot4", "testing")
-config/features=PackedStringArray("4.2")
+config/features=PackedStringArray("4.2", "C#")
 config/icon="res://icon.png"
 
 [audio]


### PR DESCRIPTION
# Why
https://github.com/MikeSchulze/gdUnit4/issues/396

# What
* update `gdUnit4.api` dependency to latest gdUnit4Net version
* added dependencies to support the test adapter
* Use based on `gdunit4.api` version the `GdUnit4MonoAPI` or `GdUnit4NetAPI` to call the API


