### PR TITLE
GD-401: Support action input events on scene runner

### DIFF
--- a/addons/gdUnit4/src/GdUnitSceneRunner.gd
+++ b/addons/gdUnit4/src/GdUnitSceneRunner.gd
@@ -21,6 +21,27 @@ func get_global_mouse_position() -> Vector2:
 	return Vector2.ZERO
 
 
+## Simulates that an action has been pressed.[br]
+## [member action] : the action e.g. [code]"ui_up"[/code][br]
+@warning_ignore("unused_parameter")
+func simulate_action_pressed(action :String) -> GdUnitSceneRunner:
+	return self
+
+
+## Simulates that an action is pressed.[br]
+## [member action] : the action e.g. [code]"ui_up"[/code][br]
+@warning_ignore("unused_parameter")
+func simulate_action_press(action :String) -> GdUnitSceneRunner:
+	return self
+
+
+## Simulates that an action has been released.[br]
+## [member action] : the action e.g. [code]"ui_up"[/code][br]
+@warning_ignore("unused_parameter")
+func simulate_action_release(action :String) -> GdUnitSceneRunner:
+	return self
+
+
 ## Simulates that a key has been pressed.[br]
 ## [member key_code] : the key code e.g. [constant KEY_ENTER][br]
 ## [member shift_pressed] : false by default set to true if simmulate shift is press[br]

--- a/addons/gdUnit4/src/core/GdUnitSceneRunnerImpl.gd
+++ b/addons/gdUnit4/src/core/GdUnitSceneRunnerImpl.gd
@@ -26,6 +26,7 @@ var _simulate_start_time :LocalTime
 var _last_input_event :InputEvent = null
 var _mouse_button_on_press := []
 var _key_on_press := []
+var _action_on_press := []
 var _curent_mouse_position :Vector2
 
 # time factor settings
@@ -94,6 +95,30 @@ func _notification(what):
 
 func _scene_tree() -> SceneTree:
 	return Engine.get_main_loop() as SceneTree
+
+
+func simulate_action_pressed(action :String) -> GdUnitSceneRunner:
+	simulate_action_press(action)
+	simulate_action_release(action)
+	return self
+
+
+func simulate_action_press(action :String) -> GdUnitSceneRunner:
+	__print_current_focus()
+	var event = InputEventAction.new()
+	event.pressed = true
+	event.action = action
+	_action_on_press.append(action)
+	return _handle_input_event(event)
+
+
+func simulate_action_release(action :String) -> GdUnitSceneRunner:
+	__print_current_focus()
+	var event = InputEventAction.new()
+	event.pressed = false
+	event.action = action
+	_action_on_press.erase(action)
+	return _handle_input_event(event)
 
 
 func simulate_key_pressed(key_code :int, shift_pressed := false, ctrl_pressed := false) -> GdUnitSceneRunner:
@@ -391,6 +416,12 @@ func _reset_input_to_default() -> void:
 		if Input.is_key_pressed(key_scancode):
 			simulate_key_release(key_scancode)
 	_key_on_press.clear()
+
+	for action in _action_on_press.duplicate():
+		if Input.is_action_pressed(action):
+			simulate_action_release(action)
+	_action_on_press.clear()
+
 	Input.flush_buffered_events()
 	_last_input_event = null
 

--- a/addons/gdUnit4/src/core/GdUnitSceneRunnerImpl.gd
+++ b/addons/gdUnit4/src/core/GdUnitSceneRunnerImpl.gd
@@ -372,18 +372,16 @@ func _apply_input_mouse_position(event :InputEvent) -> void:
 		event.position = _last_input_event.position
 
 
-## just for testing maunally event to action handling
-func _handle_actions(event :InputEvent) -> bool:
-	var is_action_match := false
-	for action in InputMap.get_actions():
-		if InputMap.event_is_action(event, action, true):
-			is_action_match = true
-			prints(action, event, event.is_ctrl_pressed())
-			if event.is_pressed():
-				Input.action_press(action, InputMap.action_get_deadzone(action))
-			else:
-				Input.action_release(action)
-	return is_action_match
+## handle input action via Input modifieres
+func _handle_actions(event :InputEventAction) -> bool:
+	if not InputMap.event_is_action(event, event.action, true):
+		return false
+	__print("	process action %s (%s) <- %s" % [scene(), _scene_name(), event.as_text()])
+	if event.is_pressed():
+		Input.action_press(event.action, InputMap.action_get_deadzone(event.action))
+	else:
+		Input.action_release(event.action)
+	return true
 
 
 # for handling read https://docs.godotengine.org/en/stable/tutorials/inputs/inputevent.html?highlight=inputevent#how-does-it-work
@@ -391,6 +389,10 @@ func _handle_input_event(event :InputEvent):
 	if event is InputEventMouse:
 		Input.warp_mouse(event.position)
 	Input.parse_input_event(event)
+
+	if event is InputEventAction:
+		_handle_actions(event)
+
 	Input.flush_buffered_events()
 	var current_scene := scene()
 	if is_instance_valid(current_scene):
@@ -400,6 +402,7 @@ func _handle_input_event(event :InputEvent):
 		if(current_scene.has_method("_unhandled_input")):
 			current_scene._unhandled_input(event)
 		current_scene.get_viewport().set_input_as_handled()
+
 	# save last input event needs to be merged with next InputEventMouseButton
 	_last_input_event = event
 	return self

--- a/addons/gdUnit4/test/core/GdUnitSceneRunnerInputEventTest.gd
+++ b/addons/gdUnit4/test/core/GdUnitSceneRunnerInputEventTest.gd
@@ -81,7 +81,9 @@ func test_reset_to_inital_state_on_release():
 
 func test_simulate_action_press() -> void:
 	# iterate over some example actions
-	for action in ["ui_up", "ui_down", "ui_left", "ui_right"]:
+	var actions_to_simmulate := ["ui_up", "ui_down", "ui_left", "ui_right"]
+	for action in actions_to_simmulate:
+		assert_that(InputMap.has_action(action)).is_true()
 		_runner.simulate_action_press(action)
 		await await_idle_frame()
 
@@ -89,16 +91,17 @@ func test_simulate_action_press() -> void:
 		event.action = action
 		event.pressed = true
 		verify(_scene_spy, 1)._input(event)
-		assert_that(Input.is_action_pressed(action)).is_true()
+		assert_that(Input.is_action_pressed(action))\
+			.override_failure_message("Expect the action '%s' is pressed" % action).is_true()
 	# verify all this actions are still handled as pressed
-	assert_that(Input.is_action_pressed("ui_up")).is_true()
-	assert_that(Input.is_action_pressed("ui_down")).is_true()
-	assert_that(Input.is_action_pressed("ui_left")).is_true()
-	assert_that(Input.is_action_pressed("ui_right")).is_true()
+	for action in actions_to_simmulate:
+		assert_that(Input.is_action_pressed(action))\
+			.override_failure_message("Expect the action '%s' is pressed" % action).is_true()
 	# other actions are not pressed
-	assert_that(Input.is_action_pressed("ui_accept")).is_false()
-	assert_that(Input.is_action_pressed("ui_select")).is_false()
-	assert_that(Input.is_action_pressed("ui_cancel")).is_false()
+	for action in ["ui_accept", "ui_select", "ui_cancel"]:
+		assert_that(Input.is_action_pressed(action))\
+			.override_failure_message("Expect the action '%s' is NOT pressed" % action).is_false()
+
 
 func test_simulate_key_press() -> void:
 	# iterate over some example keys
@@ -206,8 +209,8 @@ func test_simulate_keypressed_as_action() -> void:
 	assert_bool(runner.scene()._player_jump_action_released).is_false()
 
 	# cleanup custom action
-	InputMap.erase_action("player_jump")
 	InputMap.action_erase_events("player_jump")
+	InputMap.erase_action("player_jump")
 
 
 func test_simulate_set_mouse_pos():

--- a/addons/gdUnit4/test/core/GdUnitSceneRunnerTest.gd
+++ b/addons/gdUnit4/test/core/GdUnitSceneRunnerTest.gd
@@ -248,7 +248,6 @@ func test_simulate_until_object_signal(timeout=2000) -> void:
 	# wait until next frame
 	await await_idle_frame()
 	var spell = runner.find_child("Spell")
-	prints(spell)
 
 	# simmulate scene until the spell is explode
 	await runner.simulate_until_object_signal(spell, "spell_explode", spell)

--- a/addons/gdUnit4/test/core/resources/scenes/input_actions/InputEventTestScene.gd
+++ b/addons/gdUnit4/test/core/resources/scenes/input_actions/InputEventTestScene.gd
@@ -11,5 +11,6 @@ func __init():
 
 
 func _input(event):
-	_player_jump_action_released = Input.is_action_just_released("player_jump", true)
+	if InputMap.has_action("player_jump"):
+		_player_jump_action_released = Input.is_action_just_released("player_jump", true)
 	#prints("_input2:player_jump", Input.is_action_just_released("player_jump"), Input.is_action_just_released("player_jump", true))


### PR DESCRIPTION
# Why
<!-- Enter a clean description why we need this changeset -->
Closes #401 

*(as suggested on Discord)*
Using generic action events is better as unit tests don't get tied to a specific key in the project for any given action. Furthermore, it also support actions that only have controller inputs.


# What
<!-- Describe exactly what you have changed and what the effects are -->
Adds methods for a scene runner to also support action events.

~~Oddly though, I'm not getting any luck in implementing unit testing for this feature on the addon's tests. This works as expected on the tests in my project, but for some reason `Input.is_action_pressed` AFAICT never returns true on the unit tests. I also see there is a test `test_simulate_keypressed_as_action` doing something similar and is also failing though.~~ EDIT: Fixed by @MikeSchulze :heart: 