### PR TITLE
GD-405: Update workflows to support latest Godot versions

### DIFF
--- a/.github/workflows/ci-dev.yml
+++ b/.github/workflows/ci-dev.yml
@@ -22,7 +22,7 @@ jobs:
       fail-fast: false
       max-parallel: 10
       matrix:
-        godot-version: ['4.1', '4.1.1', '4.1.2', '4.1.3', '4.2', '4.2.1']
+        godot-version: ['4.1.2', '4.1.3', '4.1.4', '4.2', '4.2.1', '4.2.2']
         godot-status: ['stable']
         godot-net: ['.Net', '']
 
@@ -46,7 +46,7 @@ jobs:
           # enable selftest on gdUnit4-action
           echo "GDUNIT_SELFTEST=true" >> "$GITHUB_ENV"
 
-      - name: 'Test GdUnit4 ${{ matrix.version }} - Godot_${{ matrix.godot-version }}-${{ matrix.godot-status }}'
+      - name: 'Test GdUnit4 (master) - Godot_${{ matrix.godot-version }}-${{ matrix.godot-status }}'
         if: ${{ matrix.godot-net == '' }}
         uses: MikeSchulze/gdUnit4-action@v1.0.5
         with:
@@ -56,9 +56,9 @@ jobs:
           paths: |
             res://addons/gdUnit4/test/
           timeout: 10
-          report-name: report_gdUnit4-${{ matrix.version }}_Godot${{ matrix.godot-version }}-${{ matrix.godot-status }}.xml
+          report-name: report_gdUnit4_Godot${{ matrix.godot-version }}-${{ matrix.godot-status }}.xml
 
-      - name: 'Test GdUnit4 ${{ matrix.version }} - Godot_${{ matrix.godot-version }}-${{ matrix.godot-status }}-net'
+      - name: 'Test GdUnit4 (master) - Godot_${{ matrix.godot-version }}-${{ matrix.godot-status }}-net'
         if: ${{ matrix.godot-net == '.Net' }}
         uses: MikeSchulze/gdUnit4-action@v1.0.5
         with:
@@ -70,4 +70,4 @@ jobs:
             res://addons/gdUnit4/test/mono
           timeout: 5
           retries: 3 # We have set the number of repetitions to 3 because Godot mono randomly crashes during C# tests
-          report-name: report_gdUnit4-${{ matrix.version }}_Godot${{ matrix.godot-version }}-${{ matrix.godot-status }}-net.xml
+          report-name: report_gdUnit4_Godot${{ matrix.godot-version }}-${{ matrix.godot-status }}-net.xml

--- a/.github/workflows/ci-pr-example.yml
+++ b/.github/workflows/ci-pr-example.yml
@@ -32,7 +32,7 @@ jobs:
           lfs: true
       - uses: MikeSchulze/gdUnit4-action@v1.0.5
         with:
-          godot-version: '4.2.1'
+          godot-version: '4.2.2'
           version: 'v4.2.0'
           paths: |
             res://project/tests/

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -29,14 +29,12 @@ jobs:
       fail-fast: false
       max-parallel: 10
       matrix:
-        godot-version: ['4.1', '4.1.1', '4.1.2', '4.1.3', '4.2', '4.2.1']
+        godot-version: ['4.1', '4.1.1', '4.1.2', '4.1.3', '4.1.4', '4.2', '4.2.1', '4.2.2']
         godot-status: ['stable']
         godot-net: ['.Net', '']
         include:
-          - godot-version: '4.2.2'
-            godot-status: 'rc1'
           - godot-version: '4.3'
-            godot-status: 'dev3'
+            godot-status: 'dev5'
 
     permissions:
       actions: write
@@ -58,7 +56,7 @@ jobs:
           # enable selftest on gdUnit4-action
           echo "GDUNIT_SELFTEST=true" >> "$GITHUB_ENV"
 
-      - name: 'Test GdUnit4 ${{ matrix.version }} - Godot_${{ matrix.godot-version }}-${{ matrix.godot-status }}'
+      - name: 'Test GdUnit4 dev - Godot_${{ matrix.godot-version }}-${{ matrix.godot-status }}'
         if: ${{ matrix.godot-net == '' }}
         uses: MikeSchulze/gdUnit4-action@v1.0.5
         with:
@@ -68,9 +66,9 @@ jobs:
           paths: |
             res://addons/gdUnit4/test/
           timeout: 10
-          report-name: report_gdUnit4-${{ matrix.version }}_Godot${{ matrix.godot-version }}-${{ matrix.godot-status }}.xml
+          report-name: report_gdUnit4_Godot${{ matrix.godot-version }}-${{ matrix.godot-status }}.xml
 
-      - name: 'Test GdUnit4 ${{ matrix.version }} - Godot_${{ matrix.godot-version }}-${{ matrix.godot-status }}-net'
+      - name: 'Test GdUnit4 dev - Godot_${{ matrix.godot-version }}-${{ matrix.godot-status }}-net'
         if: ${{ matrix.godot-net == '.Net' }}
         uses: MikeSchulze/gdUnit4-action@v1.0.5
         with:
@@ -82,7 +80,7 @@ jobs:
             res://addons/gdUnit4/test/mono
           timeout: 5
           retries: 3 # We have set the number of repetitions to 3 because Godot mono randomly crashes during C# tests
-          report-name: report_gdUnit4-${{ matrix.version }}_Godot${{ matrix.godot-version }}-${{ matrix.godot-status }}-net.xml
+          report-name: report_gdUnit4_Godot${{ matrix.godot-version }}-${{ matrix.godot-status }}-net.xml
 
   finalize:
     if: ${{ !cancelled() }}

--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
 <p align="center">This version of GdUnit4 is based on Godot <strong>v4.2.1.stable.official [b09f793f5]</strong> (master branch)</p>
 </h2>
 
-
 ---
 <h1 align="center">Supported Godot Versions</h2>
 <p align="center">
@@ -12,27 +11,28 @@
   <img src="https://img.shields.io/badge/Godot-v4.1.1-%23478cbf?logo=godot-engine&logoColor=cyian&color=green">
   <img src="https://img.shields.io/badge/Godot-v4.1.2-%23478cbf?logo=godot-engine&logoColor=cyian&color=green">
   <img src="https://img.shields.io/badge/Godot-v4.1.3-%23478cbf?logo=godot-engine&logoColor=cyian&color=green">
+  <img src="https://img.shields.io/badge/Godot-v4.1.4-%23478cbf?logo=godot-engine&logoColor=cyian&color=green">
   <img src="https://img.shields.io/badge/Godot-v4.2.0-%23478cbf?logo=godot-engine&logoColor=cyian&color=green">
   <img src="https://img.shields.io/badge/Godot-v4.2.1-%23478cbf?logo=godot-engine&logoColor=cyian&color=green">
+  <img src="https://img.shields.io/badge/Godot-v4.2.2-%23478cbf?logo=godot-engine&logoColor=cyian&color=green">
 </p>
 
 <p align="center"><a href="https://github.com/MikeSchulze/gdUnit4"><img src="https://github.com/MikeSchulze/gdUnit4/blob/master/assets/gdUnit4-animated.gif" width="100%"/></p><br/>
-
 
 <p align="center">
   <img alt="GitHub branch checks state" src="https://img.shields.io/github/checks-status/MikeSchulze/gdunit4/master"></br>
   <img src="https://github.com/MikeSchulze/gdUnit4/actions/workflows/ci-dev.yml/badge.svg?branch=master"></br>
 </p>
 
-
 ## What is GdUnit4?
+
 **Gd**(*Godot*)**Unit**(*Unit Testing*)**4**(*Godot 4.x*)
 
 GdUnit4 is an embedded unit testing framework designed for testing Gd scripts, C# scripts, and scenes in the Godot editor. With GdUnit4, you can easily create and run unit tests to verify the functionality and performance of your code, ensuring that it meets your requirements and specifications.<br>
 GdUnit4 is a powerful tool that supports Test-Driven Development ([TDD](https://en.wikipedia.org/wiki/Test-driven_development)), a popular software development approach that emphasizes creating automated tests before writing any code. By using GdUnit4 for TDD, you can ensure that your code is thoroughly tested and free of bugs, which can save you time and effort in the long run.
 
-
 ## Main Features
+
 * Support for writing and executing tests in GdScript or C#
 * Embedded test Inspector in Godot for easy navigation of your test suites
 * Convenient interface for running test-suites directly from Godot<br>
@@ -56,11 +56,12 @@ GdUnit4 is a powerful tool that supports Test-Driven Development ([TDD](https://
   * Generates JUnit XML report
 * Public marketplace GitHub action to use in your own CI workflow [gdunit4-action](https://github.com/marketplace/actions/gdunit4-test-runner-action)
 * C# support by [gdUnit4Net](https://github.com/MikeSchulze/gdUnit4Net/blob/master/README.md)
-  * Enables to run and debug on **Visual Studio**, **Visual Studio Code** and **JetBrains Rider** via [VSTest adapter support ](https://github.com/MikeSchulze/gdUnit4Net/blob/master/testadapter/README.md) 
+  * Enables to run and debug on **Visual Studio**, **Visual Studio Code** and **JetBrains Rider** via [VSTest adapter support](https://github.com/MikeSchulze/gdUnit4Net/blob/master/testadapter/README.md)
+
 ---
 
-
 ## Basic Test Example
+
  ```
 class_name GdUnitExampleTest
 extends GdUnitTestSuite
@@ -74,6 +75,7 @@ func test_example():
  ---
 
 ## Documentation
+
 <p align="left" style="font-family: Bedrock; font-size:21pt; color:#7253ed; font-style:bold">
   <a href="https://mikeschulze.github.io/gdUnit4/first_steps/install/">How to Install GdUnit</a>
 </p>
@@ -84,23 +86,27 @@ func test_example():
 
 ---
 
-### You Are Welcome To:
-  * [Give Feedback](https://github.com/MikeSchulze/gdUnit4/discussions) on the gdUnit GitHub Discussions page.
-  * [Suggest Improvements](https://github.com/MikeSchulze/gdUnit4/issues/new?assignees=MikeSchulze&labels=enhancement&template=feature_request.md&title=) by creating a new feature request issue on the gdUnit GitHub Issues page.
-  * [Report Bugs](https://github.com/MikeSchulze/gdUnit4/issues/new?assignees=MikeSchulze&labels=bug&projects=projects%2F5&template=bug_report.yml&title=GD-XXX%3A+Describe+the+issue+briefly)  by creating a new bug report issue on the gdUnit GitHub Issues page.
+### You Are Welcome To
+
+* [Give Feedback](https://github.com/MikeSchulze/gdUnit4/discussions) on the gdUnit GitHub Discussions page.
+* [Suggest Improvements](https://github.com/MikeSchulze/gdUnit4/issues/new?assignees=MikeSchulze&labels=enhancement&template=feature_request.md&title=) by creating a new feature request issue on the gdUnit GitHub Issues page.
+* [Report Bugs](https://github.com/MikeSchulze/gdUnit4/issues/new?assignees=MikeSchulze&labels=bug&projects=projects%2F5&template=bug_report.yml&title=GD-XXX%3A+Describe+the+issue+briefly)  by creating a new bug report issue on the gdUnit GitHub Issues page.
 
 ---
 
 ## GdUnit Test Coverage and Code Quality
-### Test Coverage:
+
+### Test Coverage
+
 GdUnit is comprehensively tested to ensure robust functionality.<br>
 Continuous Integration (CI) is in place for every pull request to prevent any potential functionality issues.
 
-### Code Formatting:
+### Code Formatting
+
 🙏 Special Thanks to @Scony for creating [gdlint](https://github.com/Scony/godot-gdscript-toolkit), a valuable tool contributing to code quality.
 
-
 ---
+
 ### Contribution Guidelines
 
 **Thank you for your interest in contributing to GdUnit4!**<br>
@@ -129,8 +135,11 @@ We value your input and appreciate your contributions to make GdUnit4 even bette
   <a href="https://discord.gg/rdq36JwuaJ"><img src="https://discordapp.com/api/guilds/885149082119733269/widget.png?style=banner4" alt="Join GdUnit Server"/></a>
 </p>
 
-### Thank you for supporting my project!
+### Thank you for supporting my project
+
 ---
-## Sponsors:
+
+## Sponsors
+
 [<img src="https://github.com/bitbrain.png" alt="bitbrain" width="125"/>](https://github.com/bitbrain) bitbrain
 [<img src="https://avatars.githubusercontent.com/u/2313134?v=4" alt="bitbrain" width="125"/>](https://github.com/sebastianhutter) sebastianhutter

--- a/addons/gdUnit4/src/GdUnitSceneRunner.gd
+++ b/addons/gdUnit4/src/GdUnitSceneRunner.gd
@@ -167,6 +167,12 @@ func simulate_until_object_signal(source :Object, signal_name :String, arg0=NO_A
 	return self
 
 
+### Waits for all input events are processed
+func await_input_processed() -> void:
+	await Engine.get_main_loop().process_frame
+	await Engine.get_main_loop().physics_frame
+
+
 ## Waits for the function return value until specified timeout or fails.[br]
 ## [member args] : optional function arguments
 @warning_ignore("unused_parameter")

--- a/addons/gdUnit4/src/core/GodotVersionFixures.gd
+++ b/addons/gdUnit4/src/core/GodotVersionFixures.gd
@@ -3,9 +3,8 @@ class_name GodotVersionFixures
 extends RefCounted
 
 
-
 ## Returns the icon property defined by name and theme_type, if it exists.
-static func get_icon(control :Control, icon_name :String) -> Texture2D:
+static func get_icon(control: Control, icon_name: String) -> Texture2D:
 	if Engine.get_version_info().hex >= 040200:
 		return control.get_theme_icon(icon_name, "EditorIcons")
 	return control.theme.get_icon(icon_name, "EditorIcons")
@@ -19,3 +18,11 @@ static func type_convert(value: Variant, type: int):
 @warning_ignore("shadowed_global_identifier")
 static func convert(value: Variant, type: int) -> Variant:
 	return type_convert(value, type)
+
+
+# handle global_position fixed by https://github.com/godotengine/godot/pull/88473
+static func set_event_global_position(event: InputEventMouseMotion, global_position: Vector2):
+	if Engine.get_version_info().hex >= 0x40202 or Engine.get_version_info().hex == 0x40104:
+		event.global_position = event.position
+	else:
+		event.global_position = global_position

--- a/addons/gdUnit4/test/core/GdUnitSceneRunnerInputEventTest.gd
+++ b/addons/gdUnit4/test/core/GdUnitSceneRunnerInputEventTest.gd
@@ -15,6 +15,11 @@ func before_test():
 	assert_initial_action_state()
 	assert_inital_mouse_state()
 	assert_inital_key_state()
+	# do handle outstanding events
+	Input.flush_buffered_events()
+	await _runner.await_input_processed()
+	# reset to inital state
+	reset(_scene_spy)
 
 
 # asserts to action strings
@@ -221,7 +226,7 @@ func test_simulate_set_mouse_pos():
 	await await_idle_frame()
 	var event := InputEventMouseMotion.new()
 	event.position = Vector2(100, 100)
-	event.global_position = gmp
+	GodotVersionFixures.set_event_global_position(event, gmp)
 	verify(_scene_spy, 1)._input(event)
 
 	# set mouse to pos 800, 400
@@ -230,16 +235,17 @@ func test_simulate_set_mouse_pos():
 	await await_idle_frame()
 	event = InputEventMouseMotion.new()
 	event.position = Vector2(800, 400)
-	event.global_position = gmp
+	GodotVersionFixures.set_event_global_position(event, gmp)
 	verify(_scene_spy, 1)._input(event)
 
 	# and again back to 100,100
+	reset(_scene_spy)
 	gmp = _runner.get_global_mouse_position()
 	_runner.set_mouse_pos(Vector2(100, 100))
 	await await_idle_frame()
 	event = InputEventMouseMotion.new()
 	event.position = Vector2(100, 100)
-	event.global_position = gmp
+	GodotVersionFixures.set_event_global_position(event, gmp)
 	verify(_scene_spy, 1)._input(event)
 
 
@@ -285,7 +291,7 @@ func test_simulate_mouse_move():
 
 	var event = InputEventMouseMotion.new()
 	event.position = Vector2(400, 100)
-	event.global_position = gmp
+	GodotVersionFixures.set_event_global_position(event, gmp)
 	event.relative = Vector2(400, 100) - Vector2(10, 10)
 	verify(_scene_spy, 1)._input(event)
 
@@ -296,7 +302,7 @@ func test_simulate_mouse_move():
 
 	event = InputEventMouseMotion.new()
 	event.position = Vector2(55, 42)
-	event.global_position = gmp
+	GodotVersionFixures.set_event_global_position(event, gmp)
 	event.relative = Vector2(55, 42) - Vector2(400, 100)
 	verify(_scene_spy, 1)._input(event)
 


### PR DESCRIPTION
# Why
Godot v4.2.2 and V4.1.4 are out

# What
- update the workflows and added support for Godot v4.2.2 and V4.1.4
- fix workflow errors using invalid matrix parameters
- fix failing test related to the Godot global_position fix https://github.com/godotengine/godot/pull/88473

