### PR TITLE
GD-409: Fix do skip excluded test suites by runner configuration

### DIFF
--- a/addons/gdUnit4/src/asserts/GdUnitDictionaryAssertImpl.gd
+++ b/addons/gdUnit4/src/asserts/GdUnitDictionaryAssertImpl.gd
@@ -135,7 +135,7 @@ func _contains_key_value(key, value, compare_mode :GdObjects.COMPARE_MODE) -> Gd
 		return report_error(GdAssertMessages.error_is_not_null())
 	var keys_not_found :Array = expected.filter(_filter_by_key.bind(current.keys(), compare_mode))
 	if not keys_not_found.is_empty():
-		return report_error(GdAssertMessages.error_contains_key_value(key, value, current.keys(), compare_mode))
+		return report_error(GdAssertMessages.error_contains_keys(current.keys(), expected, keys_not_found, compare_mode))
 	if not GdObjects.equals(current[key], value, false, compare_mode):
 		return report_error(GdAssertMessages.error_contains_key_value(key, value, current[key], compare_mode))
 	return report_success()

--- a/addons/gdUnit4/src/core/GdUnitRunnerConfig.gd
+++ b/addons/gdUnit4/src/core/GdUnitRunnerConfig.gd
@@ -101,7 +101,7 @@ func to_execute() -> Dictionary:
 
 
 func skipped() -> Dictionary:
-	return _config.get(SKIPPED, PackedStringArray())
+	return _config.get(SKIPPED, {})
 
 
 func save_config(path :String = CONFIG_FILE) -> GdUnitResult:

--- a/addons/gdUnit4/src/report/GdUnitHtmlReport.gd
+++ b/addons/gdUnit4/src/report/GdUnitHtmlReport.gd
@@ -39,10 +39,9 @@ func update_test_suite_report(
 		if report.resource_path() == resource_path_:
 			report.set_duration(duration_)
 			report.set_failed(is_failed_, failed_count_)
+			report.set_skipped(skipped_count_)
 			report.set_orphans(orphan_count_)
 			report.set_reports(reports_)
-	if is_skipped_:
-		_skipped_count = skipped_count_
 
 
 func update_testcase_report(resource_path_ :String, test_report :GdUnitTestCaseReport):

--- a/addons/gdUnit4/src/report/GdUnitReportSummary.gd
+++ b/addons/gdUnit4/src/report/GdUnitReportSummary.gd
@@ -35,11 +35,23 @@ func suite_count() -> int:
 	return _reports.size()
 
 
+func suite_executed_count() -> int:
+	var executed := _reports.size()
+	for report in _reports:
+		if report.test_count() == report.skipped_count():
+			executed -= 1
+	return executed
+
+
 func test_count() -> int:
 	var count := _test_count
 	for report in _reports:
 		count += report.test_count()
 	return count
+
+
+func test_executed_count() -> int:
+	return test_count() - skipped_count()
 
 
 func error_count() -> int:

--- a/addons/gdUnit4/src/report/GdUnitTestCaseReport.gd
+++ b/addons/gdUnit4/src/report/GdUnitTestCaseReport.gd
@@ -19,7 +19,6 @@ func _init(
 	_resource_path = p_resource_path
 	_suite_name = p_suite_name
 	_name = test_name
-	_test_count = 1
 	_error_count = is_error
 	_failure_count = failed_count
 	_orphan_count = orphan_count_

--- a/addons/gdUnit4/src/report/GdUnitTestSuiteReport.gd
+++ b/addons/gdUnit4/src/report/GdUnitTestSuiteReport.gd
@@ -5,10 +5,11 @@ var _time_stamp :int
 var _failure_reports :Array = []
 
 
-func _init(p_resource_path :String, p_name :String):
+func _init(p_resource_path :String, p_name :String, test_count :int):
 	_resource_path = p_resource_path
 	_name = p_name
 	_time_stamp = Time.get_unix_time_from_system() as int
+	_test_count = test_count
 
 
 func create_record(report_link :String) -> String:

--- a/addons/gdUnit4/test/asserts/GdUnitDictionaryAssertImplTest.gd
+++ b/addons/gdUnit4/test/asserts/GdUnitDictionaryAssertImplTest.gd
@@ -408,10 +408,12 @@ func test_contains_same_key_value() -> void:
 	assert_failure(func(): assert_dict({key_a:1, key_b:2, key_c:3}).contains_same_key_value(key_d, 1)) \
 		.is_failed() \
 		.has_message("""
-			Expecting contains SAME key and value:
-			 <class:A:0> : '1'
-			 but contains
-			 <class:A:0> : '[class:A:0, class:B:0, class:C:0]'"""
+			Expecting contains SAME keys:
+			 '[class:A:0, class:B:0, class:C:0]'
+			 to contains:
+			 '[class:A:0]'
+			 but can't find key's:
+			 '[class:A:0]'"""
 			.dedent().trim_prefix("\n")
 		)
 

--- a/addons/gdUnit4/test/core/GdUnitRunnerConfigTest.gd
+++ b/addons/gdUnit4/test/core/GdUnitRunnerConfigTest.gd
@@ -152,14 +152,16 @@ func test_skip_test_suite_and_test_case():
 func test_skip_test_case():
 	var config := GdUnitRunnerConfig.new()
 
-	config.skip_test_case("res://foo1", "testcaseA")
-	assert_dict(config.skipped()).contains_key_value("res://foo1", PackedStringArray(["testcaseA"]))
+	config.skip_test_case("res://foo1.gd", "testcaseA")
+	assert_dict(config.skipped()).contains_key_value("res://foo1.gd", PackedStringArray(["testcaseA"]))
 	# add two more
-	config.skip_test_case("res://foo1", "testcaseB")
-	config.skip_test_case("res://foo2", "testcaseX")
+	config.skip_test_suite("res://foo2/skippedTestsuite.gd")
+	config.skip_test_case("res://foo1.gd", "testcaseB")
+	config.skip_test_case("res://foo2.gd", "testcaseX")
 	assert_dict(config.skipped())\
-		.contains_key_value("res://foo1", PackedStringArray(["testcaseA", "testcaseB"]))\
-		.contains_key_value("res://foo2", PackedStringArray(["testcaseX"]))
+		.contains_key_value("res://foo2/skippedTestsuite.gd", PackedStringArray())\
+		.contains_key_value("res://foo1.gd", PackedStringArray(["testcaseA", "testcaseB"]))\
+		.contains_key_value("res://foo2.gd", PackedStringArray(["testcaseX"]))
 
 
 func test_load_fail():
@@ -168,6 +170,21 @@ func test_load_fail():
 	assert_result(config.load_config("invalid_path"))\
 		.is_error()\
 		.contains_message("Can't find test runner configuration 'invalid_path'! Please select a test to run.")
+
+
+func test_load_example_config():
+	var config := GdUnitRunnerConfig.new()
+	config.load_config("res://addons/gdUnit4/test/core/resources/GdUnitRunner_with_skipped_testsuites.cfg")
+
+	assert_dict(config.to_execute())\
+		.has_size(1)\
+		.contains_key_value("res://addons/gdUnit4/test/asserts/", PackedStringArray())
+	assert_dict(config.skipped())\
+		.has_size(4)\
+		.contains_key_value("res://addons/gdUnit4/test/asserts/GdUnitFailureAssertImplTest.gd", PackedStringArray())\
+		.contains_key_value("res://addons/gdUnit4/test/asserts/GdUnitAssertImplTest.gd", PackedStringArray())\
+		.contains_key_value("res://addons/gdUnit4/test/asserts/GdUnitIntAssertImplTest.gd", PackedStringArray())\
+		.contains_key_value("res://addons/gdUnit4/test/asserts/GdUnitVectorAssertImplTest.gd", PackedStringArray())
 
 
 func test_save_load():

--- a/addons/gdUnit4/test/core/resources/GdUnitRunner_with_skipped_testsuites.cfg
+++ b/addons/gdUnit4/test/core/resources/GdUnitRunner_with_skipped_testsuites.cfg
@@ -1,0 +1,13 @@
+{
+  "included":{
+    "res://addons/gdUnit4/test/asserts/":[]
+  },
+  "server_port":31002,
+  "skipped":{
+    "res://addons/gdUnit4/test/asserts/GdUnitFailureAssertImplTest.gd":[],
+    "res://addons/gdUnit4/test/asserts/GdUnitAssertImplTest.gd":[],
+    "res://addons/gdUnit4/test/asserts/GdUnitIntAssertImplTest.gd":[],
+    "res://addons/gdUnit4/test/asserts/GdUnitVectorAssertImplTest.gd":[]
+  },
+  "version":"1.0"
+}


### PR DESCRIPTION
# Why
https://github.com/MikeSchulze/gdUnit4/issues/409
There was a comprehensive refactoring of the test execution and the cmd tool was forgotten in the process

# What
- fix test suite skipped when is excluded in the runner config
- fix test report summary, it was shown wrong test count
- improve final report summary to show skipped vs executed information
- fix minor assert_dictionary issue, do use the correct error message for missing keys


### new output
* starting messages
![image](https://github.com/MikeSchulze/gdUnit4/assets/347037/a499f8c7-e337-4783-b03d-08cff11f14d3)
* skipped test suite
![image](https://github.com/MikeSchulze/gdUnit4/assets/347037/dcd0e894-b9e4-47e9-9065-befd1ced6b1f)
* partial skipped test suite
![image](https://github.com/MikeSchulze/gdUnit4/assets/347037/30ccc5e5-b015-497e-8c8c-ca2aecd1193d)
* report summary
![image](https://github.com/MikeSchulze/gdUnit4/assets/347037/cb0bfeea-4b25-4715-9da7-bc6baa1d1032)
