### PR TITLE
GD-402: Update documentation to GdUnit4 v4.2.5

### DIFF
--- a/_advanced_testing/sceneRunner.md
+++ b/_advanced_testing/sceneRunner.md
@@ -94,6 +94,9 @@ For more advanced example, see [Tutorial - Testing Scenes](/gdUnit4/tutorials/sc
 {% tab scene-runner-overview GdScript %}
 |Function|Description|
 |---|---|
+|[simulate_action_pressed](/gdUnit4/advanced_testing/sceneRunner/#simulate_action_pressed) | Simulates that an action has been pressed. |
+|[simulate_action_press](/gdUnit4/advanced_testing/sceneRunner/#simulate_action_press) | Simulates that an action is press. |
+|[simulate_action_release](/gdUnit4/advanced_testing/sceneRunner/#simulate_action_release) | Simulates that an action has been released. |
 |[simulate_key_pressed](/gdUnit4/advanced_testing/sceneRunner/#simulate_key_pressed) | Simulates that a key has been pressed. |
 |[simulate_key_press](/gdUnit4/advanced_testing/sceneRunner/#simulate_key_press) | Simulates that a key is pressed. |
 |[simulate_key_release](/gdUnit4/advanced_testing/sceneRunner/#simulate_key_release) | Simulates that a key has been released. |
@@ -119,6 +122,9 @@ For more advanced example, see [Tutorial - Testing Scenes](/gdUnit4/tutorials/sc
 {% tab scene-runner-overview C# %}
 |Function|Description|
 |---|---|
+|[SimulateActionPressed](/gdUnit4/advanced_testing/sceneRunner/#simulate_action_pressed) | Simulates that an action has been pressed. |
+|[SimulateActionPress](/gdUnit4/advanced_testing/sceneRunner/#simulate_action_press) | Simulates that an action is press. |
+|[SimulateActionRelease](/gdUnit4/advanced_testing/sceneRunner/#simulate_action_release) | Simulates that an action has been released. |
 |[SimulateKeyPressed](/gdUnit4/advanced_testing/sceneRunner/#simulate_key_pressed) | Simulates that a key has been pressed. |
 |[SimulateKeyPress](/gdUnit4/advanced_testing/sceneRunner/#simulate_key_press) | Simulates that a key is pressed. |
 |[SimulateKeyRelease](/gdUnit4/advanced_testing/sceneRunner/#simulate_key_release) | Simulates that a key has been released. |
@@ -150,6 +156,7 @@ We distinguish between *finalized* and *unfinished* functions.
 
 * Finalized Functions<br>
     A finalized function is used to simulate a key or mouse press and release in combination.
+  * [simulate_action_pressed](/gdUnit4/advanced_testing/sceneRunner/#simulate_action_pressed)
   * [simulate_key_pressed](/gdUnit4/advanced_testing/sceneRunner/#simulate_key_pressed)
   * [simulate_mouse_button_pressed](/gdUnit4/advanced_testing/sceneRunner/#simulate_mouse_button_pressed)
   * [set_mouse_pos](/gdUnit4/advanced_testing/sceneRunner/#set_mouse_pos)
@@ -159,6 +166,8 @@ We distinguish between *finalized* and *unfinished* functions.
 
 * Unfinished Functions<br>
     An unfinished function is used to simulate a key or mouse press. This is typically used to simulate a key-mouse combination, such as pressing a shortcut. The unfinished function is later finalized by a key or mouse release function.
+  * [simulate_action_press](/gdUnit4/advanced_testing/sceneRunner/#simulate_action_press)
+  * [simulate_action_release](/gdUnit4/advanced_testing/sceneRunner/#simulate_action_release)
   * [simulate_key_press](/gdUnit4/advanced_testing/sceneRunner/#simulate_key_press)
   * [simulate_key_release](/gdUnit4/advanced_testing/sceneRunner/#simulate_key_release)
   * [simulate_mouse_button_press](/gdUnit4/advanced_testing/sceneRunner/#simulate_mouse_button_press)
@@ -168,6 +177,156 @@ We distinguish between *finalized* and *unfinished* functions.
 content="To complete the input events, you always need to process a minimum of one frame cycle. You can do this by using the `await await_idle_frame()` function."
 %}
 More details about specific key and mouse functions can be found below in this document.
+
+### simulate_action_pressed
+
+The **simulate_action_pressed** function is used to simulate that a input action has been pressed.
+
+{% tabs scene-runner-simulate_action_pressed %}
+{% tab scene-runner-simulate_action_pressed GdScript %}
+It takes the following arguments:
+
+```ruby
+    # action: the action e.g. "ui_up"
+    func simulate_action_pressed(action :String) -> GdUnitSceneRunner:
+```
+
+Here is an example of how to use simulate_action_pressed:
+
+```ruby
+    var runner := scene_runner("res://test_scene.tscn")
+
+    # Simulate the UP key is pressed by using the input action "ui_up"
+    runner.simulate_action_pressed("ui_up")
+    await await_idle_frame()
+```
+
+{% endtab %}
+{% tab scene-runner-simulate_action_pressed C# %}
+It takes the following arguments:
+
+```cs
+    /// <summary>
+    /// Simulates that an action has been pressed.
+    /// </summary>
+    /// <param name="action">The name of the action, e.g., "ui_up".</param>
+    /// <returns>The SceneRunner instance.</returns>
+    ISceneRunner SimulateActionPressed(string action);
+```
+
+Here is an example of how to use SimulateActionPressed:
+
+```cs
+    ISceneRunner runner = ISceneRunner.Load("res://test_scene.tscn");
+
+    // Simulate the UP key is pressed by using the input action "ui_up"
+    runner.SimulateActionPressed("ui_up");
+    await AwaitIdleFrame();
+```
+
+{% endtab %}
+{% endtabs %}
+In this example, we simulate that the action "ui-up" is pressed. We use **await_idle_frame()** to ensure that the simulation of the action is complete before moving on to the next instruction.
+
+### simulate_action_press
+
+The **simulate_action_press** function is used to simulate that an input action holding down.
+
+{% tabs scene-runner-simulate_action_press %}
+{% tab scene-runner-simulate_action_press GdScript %}
+It takes the following arguments:
+
+```ruby
+    # action: the action e.g. "ui_up"
+    func simulate_action_press(action :String) -> GdUnitSceneRunner:
+```
+
+Here is an example of how to use simulate_action_press:
+
+```ruby
+    var runner := scene_runner("res://test_scene.tscn")
+
+    # Simulate the UP key is press by using the action "ui_up"
+    runner.simulate_action_press("ui_up")
+    await await_idle_frame()
+```
+
+{% endtab %}
+{% tab scene-runner-simulate_action_press C# %}
+It takes the following arguments:
+
+```cs
+    /// <summary>
+    /// Simulates that an action is press.
+    /// </summary>
+    /// <param name="action">The name of the action, e.g., "ui_up".</param>
+    /// <returns>The SceneRunner instance.</returns>
+    ISceneRunner SimulateActionPress(string action);
+```
+
+Here is an example of how to use SimulateActionPress:
+
+```cs
+    ISceneRunner runner = ISceneRunner.Load("res://test_scene.tscn");
+
+    // Simulate the UP key is press by using the action "ui_up"
+    runner.SimulateActionPress("ui_up");
+    await AwaitIdleFrame();
+```
+
+{% endtab %}
+{% endtabs %}
+In this example, we simulate that the action "ui_up" is press. We use **await_idle_frame()** to ensure that the simulation of the action is complete before moving on to the next instruction.
+
+### simulate_action_release
+
+The **simulate_action_release** function is used to simulate that a input action been released.
+
+{% tabs scene-runner-simulate_action_release %}
+{% tab scene-runner-simulate_action_release GdScript %}
+It takes the following arguments:
+
+```ruby
+    # action : the action e.g. "ui_up"
+    func simulate_action_release(action :String) -> GdUnitSceneRunner:
+```
+
+Here is an example of how to use simulate_action_release:
+
+```ruby
+    var runner := scene_runner("res://test_scene.tscn")
+    
+    # Simulate the UP key is released by using the action "ui_up"
+    runner.simulate_action_release("ui-up")
+    await await_idle_frame()
+```
+
+{% endtab %}
+{% tab scene-runner-simulate_action_release C# %}
+It takes the following arguments:
+
+```cs
+    /// <summary>
+    /// Simulates that an action has been released.
+    /// </summary>
+    /// <param name="action">The name of the action, e.g., "ui_up".</param>
+    /// <returns>The SceneRunner instance.</returns>
+    ISceneRunner SimulateActionRelease(string action);
+```
+
+Here is an example of how to use SimulateActionRelease:
+
+```cs
+    ISceneRunner runner = ISceneRunner.Load("res://test_scene.tscn");
+
+    // Simulate the UP key is released by using the action "ui_up"
+    runner.SimulateActionRelease("ui-up");
+    await AwaitIdleFrame();
+```
+
+{% endtab %}
+{% endtabs %}
+In this example, we simulate that the action "ui_up" is released. We use **await_idle_frame()** to ensure that the simulation of the action is complete before moving on to the next instruction.
 
 ### simulate_key_pressed
 
@@ -267,7 +426,7 @@ Here is an example of how to use simulate_key_press:
 ```
 
 {% endtab %}
-{% tab scene-runner-simulate_key_press c# %}
+{% tab scene-runner-simulate_key_press C# %}
 It takes the following arguments:
 
 ```cs
@@ -1300,4 +1459,4 @@ Here is an example of how to use SetTimeFactor:
 {% endtabs %}
 
 ---
-<h4> document version v4.2.1 </h4>
+<h4> document version v4.2.5 </h4>

--- a/_faq/solutions.md
+++ b/_faq/solutions.md
@@ -1,0 +1,86 @@
+---
+layout: default
+title: Problems & Solutions
+nav_order: 10
+---
+
+# Problems & Solutions
+
+This section lists known problems and possible solutions/workarounds.
+
+## Problems
+
+- [Script/Resource Errors after the plugin is installed](/gdUnit4/faq/solutions/#scriptresource-errors-after-the-plugin-is-installed)
+- [Modifying the Game Engine State 'mainLoop.Paused = true' during Tests](/gdUnit4/faq/solutions/#modifying-the-game-engine-state-mainlooppaused--true-during-tests)
+
+---
+
+### Script/Resource Errors after the plugin is installed
+
+When installing the GdUnit4 plugin and activating it, you may encounter a lot of script and resource loading errors. These errors occur due to a cache problem in the Godot Engine.
+
+<h4> Solution </h4>
+
+To solve the errors, you need to restart the Godot Editor. If this does not help, you may need to manually delete the Godot cache folder:
+
+1. Close the Godot Editor.
+2. Delete the `.godot` folder from your working directory.
+3. Start the Godot Editor (you may still see loading errors).
+4. Close and restart the Godot Editor. The loading errors should no longer occur.
+
+---
+
+### Modifying the Game Engine State 'mainLoop.Paused = true' during Tests
+
+When a test modifies the game engine state `Paused` on the `SceneTree`, it can affect the test execution. Setting the main loop to paused will stop the engine running, including the test execution running in the main loop, causing the GdUnit4 test window to remain open even after tests are complete.
+
+<h4> Solution </h4>
+
+When you modify engine states during tests, ensure you restore them to their previous values when the test is finished. You can achieve this by adding an "after test" stage to your test suite.
+
+{% tabs mainloop_paused %}
+{% tab mainloop_paused GDScript %}
+
+```ruby
+# Reset the paused mode back to false after each test
+func after_test() -> void:
+    Engine.get_main_loop().paused = false
+
+# Simple example test to modify the game state
+func test_game_paused() -> void:
+    var mainLoop :SceneTree = Engine.get_main_loop()
+
+    assert_that(mainLoop.paused).is_false()
+    # The following lines cause the GdUnit4 test window to remain open even after tests are complete
+    mainLoop.paused = true
+    assert_that(mainLoop.paused).is_true()
+```
+
+{% endtab %}
+{% tab mainloop_paused C# %}
+
+```cs
+// Reset the paused mode back to false after each test
+[AfterTest]
+public void TearDown() =>
+    ((SceneTree)Engine.GetMainLoop()).Paused = false;
+
+
+[TestCase]
+public void GamePaused()
+{
+    var mainLoop = (SceneTree)Engine.GetMainLoop();
+
+    AssertThat(mainLoop.Paused).IsFalse();
+
+    // The following lines cause the GdUnit4 test window to remain open even after tests are complete
+    mainLoop.Paused = true;
+    AssertThat(mainLoop.Paused).IsTrue();
+}
+```
+
+{% endtab %}
+{% endtabs %}
+
+---
+<h4> document version v4.2.5 </h4>

--- a/_first_steps/install.md
+++ b/_first_steps/install.md
@@ -8,9 +8,10 @@ nav_order: 1
 
 GdUnit4 is a Godot plugin that needs to be installed before it can be used. To install GdUnit4, you can either use the AssetLib within the Godot application or manually download the latest build from the GdUnit4 GitHub repository and install it yourself.
 
-
 ## Installing GdUnit4 from the AssetLib
+
 To install GdUnit4 from the AssetLib, please follow these steps:
+
 1. Open the AssetLib from the top menu bar in the Godot application.
 2. In the search bar, enter "GdUnit4".
 3. Select the GdUnit4 plugin from the search results.
@@ -18,8 +19,13 @@ To install GdUnit4 from the AssetLib, please follow these steps:
 4. Click on the "Download" button to download and install the plugin.
 5. Activate the plugin [follow this steps](/gdUnit4/first_steps/install/#activate-the-plugin)
 
+{% include advice.html
+content="It is recommended to restart the Godot Editor after the plugin installation.<br>
+Godot has an issue with the project cache when installing plugins, for more details <a href=\"/gdUnit4/faq/solutions/#scriptresource-errors-after-the-plugin-is-installed\">see here</a>"
+%}
 
 ## Install the Latest Build from GitHub
+
 Please note that if you install this version, you will be working with a version that has not been officially released yet. The master branch contains the latest development state, and this version may contain bug fixes that have not yet been officially released. To install the latest build from GitHub, follow these steps:
 
 {% include advice.html
@@ -27,15 +33,16 @@ content="Note that installing GdUnit4 from GitHub requires some technical knowle
 %}
 
 To install the latest build from GitHub, follow these steps:
+
 1. Download the latest build from GitHub [here](https://github.com/MikeSchulze/gdUnit4/archive/refs/heads/master.zip).
 2. Disable the current GdUnit4 plugin if you have it installed.
 3. Delete the `addons/gdunit4` folder.
 4. Extract the downloaded package to the `addons` folder.
 
-
-
 ## Activating the Plugin
+
 To activate the GdUnit4 plugin, follow these steps:
+
 1. Open your project settings by navigating to Project -> Project Settings.
 ![](/gdUnit4/assets/images/install/activate-gdunit-step1.png)
 2. Click on the Plugins tab and find GdUnit4 in the list of plugins and click the checkbox to activate it.
@@ -43,13 +50,17 @@ To activate the GdUnit4 plugin, follow these steps:
 3. Once activated, the GdUnit4 inspector will be displayed in the top left corner of the Godot Editor.
 
 Make sure to save your project settings after activating the plugin.
-
+{% include advice.html
+content="It is recommended to restart the Godot Editor after the plugin installation.<br>
+Godot has an issue with the project cache when installing plugins, for more details <a href=\"/gdUnit4/faq/solutions/#scriptresource-errors-after-the-plugin-is-installed\">see here</a>"
+%}
 
 ## GdUnit4 Inspector
+
 After successfully installing and activating the GdUnit4 plugin, you will find the GdUnit4 inspector in the upper left corner of the Godot editor.
+
 * For detailed information about the inspector, please refer to the [GdUnit Inspector](/gdUnit4/faq/inspector/#the-gdunit-test-inspectorexplorer)
 ![](/gdUnit4/assets/images/install/activate-gdunit-step3.png)
 
-
 ---
-<h4> document version v4.1.0 </h4>
+<h4> document version v4.2.5 </h4>

--- a/index.md
+++ b/index.md
@@ -5,7 +5,7 @@ title: Home
 
 
 
-# GdUnit4 V4.2.4
+# GdUnit4 V4.2.5
 
 ![GdUnit4](\gdUnit4\assets\images\background.png)
 build on (v4.2.1.stable.official [b09f793f5])
@@ -97,4 +97,4 @@ public class GdUnitExampleTest
 {% endtabs %}
 
 ---
-<h4> document version v4.2.4 </h4>
+<h4> document version v4.2.5 </h4>


### PR DESCRIPTION
# What
- update `SceneRunner`, added `simulate_action_pressed`, `simulate_action_press`, `simulate_action_release`
- added problems and solution page
- added hint for plugin installing needs restart
