### PR TITLE
GD-413: Allow to spy on a class with enum as constructor argument

### DIFF
--- a/addons/gdUnit4/plugin.cfg
+++ b/addons/gdUnit4/plugin.cfg
@@ -3,5 +3,5 @@
 name="gdUnit4"
 description="Unit Testing Framework for Godot Scripts"
 author="Mike Schulze"
-version="4.2.5"
+version="4.2.6"
 script="plugin.gd"

--- a/addons/gdUnit4/src/core/parse/GdScriptParser.gd
+++ b/addons/gdUnit4/src/core/parse/GdScriptParser.gd
@@ -461,6 +461,9 @@ func parse_arguments(input: String) -> Array[GdFunctionArgument]:
 							current_index += token._consumed
 							token = next_token(input, current_index)
 						arg_type = GdObjects.string_as_typeof(token._token)
+						# handle enum detection as argument
+						if arg_type == GdObjects.TYPE_VARIANT and is_class_enum_type(token._token):
+							arg_type = GdObjects.TYPE_ENUM
 					TOKEN_ARGUMENT_TYPE_ASIGNMENT:
 						arg_value = _parse_end_function(input.substr(current_index), true)
 						current_index += arg_value.length()

--- a/addons/gdUnit4/test/spy/GdUnitSpyTest.gd
+++ b/addons/gdUnit4/test/spy/GdUnitSpyTest.gd
@@ -619,3 +619,12 @@ func test_spy_ready_called_once():
 	# ensure _ready is recoreded and onyl once called
 	verify(spy_node, 1)._ready()
 	verify(spy_node, 1).only_one_time_call()
+
+
+func test_spy_with_enum_in_constructor():
+	# this test uses a class with an enum in the constructor
+	var unit = UnitPreset.new(UnitPreset.Rarity.TWO, [])
+	var s :UnitPreset = spy(unit)
+	s.set_rarity(UnitPreset.Rarity.COMMON)
+	# test
+	verify(s, 1).set_rarity(UnitPreset.Rarity.COMMON)

--- a/addons/gdUnit4/test/spy/UnitPreset.gd
+++ b/addons/gdUnit4/test/spy/UnitPreset.gd
@@ -1,0 +1,18 @@
+class_name UnitPreset
+extends RefCounted
+
+enum  Rarity {
+	COMMON = 10,
+	TWO = 20
+}
+
+var _rarity :Rarity
+
+# using an enum in the constructor
+func _init(rarity: Rarity, presets_to_filter_out: PackedStringArray) -> void:
+	_rarity = rarity
+
+
+# using an enum as function argument
+func set_rarity(rarity: Rarity):
+	_rarity = rarity


### PR DESCRIPTION
# Why
The spy runs into an error when try to spy on an instance where has an Enum argument in the constructor.

# What
Fixed the spy builder by evaluate the arg_type is an Enum and set the respective argument type.

