### PR TITLE
GD-306: Do run `gdunit-action` on CI-PR without publish report

### DIFF
--- a/.github/workflows/ci-pr-publish-report.yml
+++ b/.github/workflows/ci-pr-publish-report.yml
@@ -1,0 +1,36 @@
+name: 'Publish Test Report'
+on:
+  workflow_run:
+    workflows: ['ci-pr']                     # runs after CI workflow
+    types:
+      - completed
+
+permissions:
+  contents: read
+  actions: read
+  checks: write
+
+jobs:
+  unit-tests:
+    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      max-parallel: 10
+      matrix:
+        godot-version: ['4.1', '4.1.1', '4.1.2', '4.1.3', '4.1.4', '4.2', '4.2.1', '4.2.2']
+        godot-status: ['stable']
+        godot-net: ['.Net', '']
+        include:
+          - godot-version: '4.3'
+            godot-status: 'dev5'
+
+    steps:
+      - name: 'Publish Test Results'
+        uses: dorny/test-reporter@v1.9.0
+        with:
+          name: report_gdUnit4_Godot${{ matrix.godot-version }}-${{ matrix.godot-status }}
+          artifact: artifact_gdUnit4_Godot${{ matrix.godot-version }}-${{ matrix.godot-status }}
+          path: 'home\runner\work\gdUnit4\gdUnit4\reports\report_1\results.xml'
+          reporter: java-junit
+          fail-on-error: 'false'
+          fail-on-empty: 'false'

--- a/.github/workflows/ci-pr-publish-report.yml
+++ b/.github/workflows/ci-pr-publish-report.yml
@@ -28,8 +28,8 @@ jobs:
       - name: 'Publish Test Results'
         uses: dorny/test-reporter@v1.9.0
         with:
-          name: report_gdUnit4_Godot${{ matrix.godot-version }}-${{ matrix.godot-status }}
-          artifact: artifact_gdUnit4_Godot${{ matrix.godot-version }}-${{ matrix.godot-status }}
+          name: report_gdUnit4_Godot${{ matrix.godot-version }}-${{ matrix.godot-status }}${{ matrix.godot-net }}
+          artifact: artifact_gdUnit4_Godot${{ matrix.godot-version }}-${{ matrix.godot-status }}${{ matrix.godot-net }}
           path: 'home\runner\work\gdUnit4\gdUnit4\reports\report_1\results.xml'
           reporter: java-junit
           fail-on-error: 'false'

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -58,7 +58,7 @@ jobs:
 
       - name: 'Test GdUnit4 dev - Godot_${{ matrix.godot-version }}-${{ matrix.godot-status }}'
         if: ${{ matrix.godot-net == '' }}
-        uses: MikeSchulze/gdUnit4-action@v1.0.5
+        uses: MikeSchulze/gdUnit4-action@v1.0.6
         with:
           godot-version: ${{ matrix.godot-version }}
           godot-status: ${{ matrix.godot-status }}
@@ -66,11 +66,12 @@ jobs:
           paths: |
             res://addons/gdUnit4/test/
           timeout: 10
-          report-name: report_gdUnit4_Godot${{ matrix.godot-version }}-${{ matrix.godot-status }}.xml
+          publish-report: false
+          report-name: gdUnit4_Godot${{ matrix.godot-version }}-${{ matrix.godot-status }}
 
       - name: 'Test GdUnit4 dev - Godot_${{ matrix.godot-version }}-${{ matrix.godot-status }}-net'
         if: ${{ matrix.godot-net == '.Net' }}
-        uses: MikeSchulze/gdUnit4-action@v1.0.5
+        uses: MikeSchulze/gdUnit4-action@v1.0.6
         with:
           godot-version: ${{ matrix.godot-version }}
           godot-status: ${{ matrix.godot-status }}
@@ -80,7 +81,8 @@ jobs:
             res://addons/gdUnit4/test/mono
           timeout: 5
           retries: 3 # We have set the number of repetitions to 3 because Godot mono randomly crashes during C# tests
-          report-name: report_gdUnit4_Godot${{ matrix.godot-version }}-${{ matrix.godot-status }}-net.xml
+          publish-report: false
+          report-name: gdUnit4_Godot${{ matrix.godot-version }}-${{ matrix.godot-status }}-net
 
   finalize:
     if: ${{ !cancelled() }}

--- a/addons/gdUnit4/test/spy/GdUnitSpyTest.gd
+++ b/addons/gdUnit4/test/spy/GdUnitSpyTest.gd
@@ -562,7 +562,7 @@ func test_spy_scene_by_instance():
 		.is_same(instance)\
 		.is_instanceof(Control)
 	assert_object(spy_scene.get_script())\
-		.is_not_null()\
+		.is_null()\
 		.is_instanceof(GDScript)\
 		.is_not_same(original_script)
 	assert_str(spy_scene.get_script().resource_name).is_equal("SpyTestScene.gd")
@@ -609,8 +609,6 @@ class CustomNode extends Node:
 	func only_one_time_call() -> void:
 		pass
 
-
-# just a change
 
 func test_spy_ready_called_once():
 	var spy_node = spy(auto_free(CustomNode.new()))

--- a/addons/gdUnit4/test/spy/GdUnitSpyTest.gd
+++ b/addons/gdUnit4/test/spy/GdUnitSpyTest.gd
@@ -562,7 +562,7 @@ func test_spy_scene_by_instance():
 		.is_same(instance)\
 		.is_instanceof(Control)
 	assert_object(spy_scene.get_script())\
-		.is_null()\
+		.is_not_null()\
 		.is_instanceof(GDScript)\
 		.is_not_same(original_script)
 	assert_str(spy_scene.get_script().resource_name).is_equal("SpyTestScene.gd")

--- a/addons/gdUnit4/test/spy/GdUnitSpyTest.gd
+++ b/addons/gdUnit4/test/spy/GdUnitSpyTest.gd
@@ -610,6 +610,8 @@ class CustomNode extends Node:
 		pass
 
 
+# just a change
+
 func test_spy_ready_called_once():
 	var spy_node = spy(auto_free(CustomNode.new()))
 


### PR DESCRIPTION
# Why
The publishing test report is failing on forked repository.


# What
- use gdunit4-action@v1.0.6 and disable report publishing
- add extra workflow to run after `ci-pr` to publish the reports afterward.
