### PR TITLE
Add Uid path support to Scene Runner

### DIFF
--- a/addons/gdUnit4/src/core/GdUnitSceneRunnerImpl.gd
+++ b/addons/gdUnit4/src/core/GdUnitSceneRunnerImpl.gd
@@ -41,11 +41,12 @@ func _init(p_scene, p_verbose :bool, p_hide_push_errors = false):
 	set_time_factor(1)
 	# handle scene loading by resource path
 	if typeof(p_scene) == TYPE_STRING:
-		if !FileAccess.file_exists(p_scene):
+		var is_uid = str(p_scene).begins_with("uid://")
+		if !is_uid and !FileAccess.file_exists(p_scene):
 			if not p_hide_push_errors:
-				push_error("GdUnitSceneRunner: Can't load scene by given resource path: '%s'. The resource not exists." % p_scene)
+				push_error("GdUnitSceneRunner: Can't load scene by given resource path: '%s'. The resource does not exists." % p_scene)
 			return
-		if !str(p_scene).ends_with("tscn"):
+		if !is_uid and !str(p_scene).ends_with(".tscn") and !str(p_scene).ends_with(".scn"):
 			if not p_hide_push_errors:
 				push_error("GdUnitSceneRunner: The given resource: '%s'. is not a scene." % p_scene)
 			return

--- a/addons/gdUnit4/src/core/GdUnitSceneRunnerImpl.gd
+++ b/addons/gdUnit4/src/core/GdUnitSceneRunnerImpl.gd
@@ -41,12 +41,11 @@ func _init(p_scene, p_verbose :bool, p_hide_push_errors = false):
 	set_time_factor(1)
 	# handle scene loading by resource path
 	if typeof(p_scene) == TYPE_STRING:
-		var is_uid = str(p_scene).begins_with("uid://")
-		if !is_uid and !FileAccess.file_exists(p_scene):
+		if !ResourceLoader.exists(p_scene):
 			if not p_hide_push_errors:
 				push_error("GdUnitSceneRunner: Can't load scene by given resource path: '%s'. The resource does not exists." % p_scene)
 			return
-		if !is_uid and !str(p_scene).ends_with(".tscn") and !str(p_scene).ends_with(".scn"):
+		if !str(p_scene).ends_with(".tscn") and !str(p_scene).ends_with(".scn") and !str(p_scene).begins_with("uid://"):
 			if not p_hide_push_errors:
 				push_error("GdUnitSceneRunner: The given resource: '%s'. is not a scene." % p_scene)
 			return

--- a/addons/gdUnit4/test/core/GdUnitSceneRunnerTest.gd
+++ b/addons/gdUnit4/test/core/GdUnitSceneRunnerTest.gd
@@ -268,6 +268,21 @@ func test_runner_by_invalid_resource_path() -> void:
 	assert_object(scene_runner("res://addons/gdUnit4/test/core/resources/scenes/simple_scene.gd")._current_scene).is_null()
 
 
+func test_runner_by_uid_path() -> void:
+	# uid is for res://addons/gdUnit4/test/core/resources/scenes/simple_scene.tscn
+	var runner = scene_runner("uid://cn8ucy2rheu0f")
+	assert_object(runner.scene()).is_instanceof(Node2D)
+
+	# verify the scene is freed when the runner is freed
+	var scene = runner.scene()
+	assert_bool(is_instance_valid(scene)).is_true()
+	runner._notification(NOTIFICATION_PREDELETE)
+	# give engine time to free the resources
+	await await_idle_frame()
+	# verify runner and scene is freed
+	assert_bool(is_instance_valid(scene)).is_false()
+
+
 func test_runner_by_resource_path() -> void:
 	var runner = scene_runner("res://addons/gdUnit4/test/core/resources/scenes/simple_scene.tscn")
 	assert_object(runner.scene()).is_instanceof(Node2D)


### PR DESCRIPTION
# Why
This PR adds `uid://` path support to the Scene Runner per #421.


# What
* Changed the file path exists check from using `FileAccess.file_exists` to `ResourceLoader.exists` since the Resource Loader method works for `uid://` paths.
* Added a check for the binary scene extension `.scn`.
* Added a new test for the `uid://` path. The test was copied from `test_runner_by_resource_path()` but uses the `uid://` path for the test scene instead.

Closes #421