### PR TITLE
Simplify `.gitattributes`

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,23 +1,7 @@
 # Exclude files not needed for AssetLib users.
 
-/.gitattributes        export-ignore
-/.gitignore            export-ignore
-/.gitmodules           export-ignore
-/.github               export-ignore
-/default_env.tres      export-ignore
-/icon.png              export-ignore
-/project.godot         export-ignore
-/process_example.txt   export-ignore
-/README.md             export-ignore
-/gdUnit4.csproj        export-ignore
-/gdUnit4.sln           export-ignore
-/CONTRIBUTING.md       export-ignore
-/LICENSE               export-ignore
-
-
+/**                    export-ignore
+/addons                !export-ignore
+/addons/gdUnit4        !export-ignore
+/addons/gdUnit4/**     !export-ignore
 /addons/gdUnit4/test   export-ignore
-/gdUnit3-examples      export-ignore
-/gdUnit4-examples      export-ignore
-
-# github page assets
-/assets                export-ignore


### PR DESCRIPTION
# Why
I can't tell for sure but it seems like `.runsettings*` and `.gdlintrc` paths were included in the release by mistake since the `.gitattributes` is an excluded list.

The current `.gitattributes` structure looks difficult to maintain. If `.runsettings*` and/or `.gdlintrc` should be kept in the final release, this PR can easily be updated to include them explicitly.

# What
I flipped the `.gitattributes` around to be an includes list by excluding everything first. This approach should keep it more maintainable as you may add other files to the project later that are not needed in the final release.

This is testable by running this command against this branch:
`git archive --format=tar improve-gitattribute | gzip > <replace-this-with-a-path>`

