### PR TITLE
GD-440: Improve test suite scanner to ignore non test-suite scripts

### DIFF
--- a/addons/gdUnit4/test/core/GdUnitTestSuiteScannerTest.gd
+++ b/addons/gdUnit4/test/core/GdUnitTestSuiteScannerTest.gd
@@ -241,7 +241,7 @@ func test_build_test_suite_path() -> void:
 
 func test_parse_and_add_test_cases() -> void:
 	var default_time := GdUnitSettings.test_timeout()
-	var scanner :GdUnitTestSuiteScanner = auto_free(GdUnitTestSuiteScanner.new())
+	var scanner :GdUnitTestSuiteScanner = GdUnitTestSuiteScanner.new()
 	# fake a test suite
 	var test_suite :GdUnitTestSuite = auto_free(GdUnitTestSuite.new())
 	test_suite.set_script( load("res://addons/gdUnit4/test/core/resources/test_script_with_arguments.gd"))
@@ -275,7 +275,7 @@ func test_parse_and_add_test_cases() -> void:
 
 
 func test_scan_by_inheritance_class_name() -> void:
-	var scanner :GdUnitTestSuiteScanner = auto_free(GdUnitTestSuiteScanner.new())
+	var scanner :GdUnitTestSuiteScanner = GdUnitTestSuiteScanner.new()
 	var test_suites := scanner.scan("res://addons/gdUnit4/test/core/resources/scan_testsuite_inheritance/by_class_name/")
 
 	assert_array(test_suites).has_size(3)
@@ -300,7 +300,7 @@ func test_scan_by_inheritance_class_name() -> void:
 
 
 func test_scan_by_inheritance_class_path() -> void:
-	var scanner :GdUnitTestSuiteScanner = auto_free(GdUnitTestSuiteScanner.new())
+	var scanner :GdUnitTestSuiteScanner = GdUnitTestSuiteScanner.new()
 	var test_suites := scanner.scan("res://addons/gdUnit4/test/core/resources/scan_testsuite_inheritance/by_class_path/")
 
 	assert_array(test_suites).extractv(extr("get_name"), extr("get_script.get_path"), extr("get_children.get_name"))\
@@ -366,7 +366,15 @@ func test_resolve_test_suite_path_with_src_folders() -> void:
 
 
 func test_scan_test_suite_without_tests() -> void:
-	var scanner :GdUnitTestSuiteScanner = auto_free(GdUnitTestSuiteScanner.new())
+	var scanner :GdUnitTestSuiteScanner = GdUnitTestSuiteScanner.new()
 	var test_suites := scanner.scan("res://addons/gdUnit4/test/core/resources/testsuites/TestSuiteWithoutTests.gd")
 
+	assert_that(test_suites).is_empty()
+
+
+func test_scan_test_suite_exclude_non_test_suites() -> void:
+	var scanner :GdUnitTestSuiteScanner = GdUnitTestSuiteScanner.new()
+	var test_suites := scanner.scan("res://addons/gdUnit4/test/core/resources/scan_testsuite_inheritance/plugin/")
+
+	# we expect the scanner do not break on scanning plugin classes
 	assert_that(test_suites).is_empty()

--- a/addons/gdUnit4/test/core/resources/scan_testsuite_inheritance/plugin/inspector_plugin.gd
+++ b/addons/gdUnit4/test/core/resources/scan_testsuite_inheritance/plugin/inspector_plugin.gd
@@ -1,0 +1,18 @@
+extends EditorInspectorPlugin
+
+
+func _ready() -> void:
+	pass
+
+
+func _process(_delta: float) -> void:
+	pass
+
+
+func _can_handle(_object :Object) -> bool:
+	return true
+
+
+@warning_ignore("unused_parameter")
+func _parse_property(object: Object, type: Variant.Type, name: String, hint_type: PropertyHint, hint_string: String, usage_flags: int, wide: bool) -> bool:
+	return false

--- a/addons/gdUnit4/test/core/resources/scan_testsuite_inheritance/plugin/plugin.cfg
+++ b/addons/gdUnit4/test/core/resources/scan_testsuite_inheritance/plugin/plugin.cfg
@@ -1,0 +1,7 @@
+[plugin]
+
+name="TestPlugin"
+description=""
+author=""
+version=""
+script="testplugin.gd"

--- a/addons/gdUnit4/test/core/resources/scan_testsuite_inheritance/plugin/preload.gd
+++ b/addons/gdUnit4/test/core/resources/scan_testsuite_inheritance/plugin/preload.gd
@@ -1,0 +1,2 @@
+
+var plugin := preload("res://addons/gdUnit4/test/core/resources/scan_testsuite_inheritance/plugin/inspector_plugin.gd").new()

--- a/addons/gdUnit4/test/core/resources/scan_testsuite_inheritance/plugin/testplugin.gd
+++ b/addons/gdUnit4/test/core/resources/scan_testsuite_inheritance/plugin/testplugin.gd
@@ -1,0 +1,14 @@
+@tool
+extends EditorPlugin
+
+var plugin: EditorInspectorPlugin
+
+
+func _enter_tree() -> void:
+	plugin = preload("res://addons/gdUnit4/test/core/resources/scan_testsuite_inheritance/plugin/inspector_plugin.gd").new()
+	add_inspector_plugin(plugin)
+	pass
+
+
+func _exit_tree() -> void:
+	pass


### PR DESCRIPTION
# Why
see https://github.com/MikeSchulze/gdUnit4/issues/440

# What
- check if the script to scan extends from `GdUnitTestSuite` without using the resource loader to avoid preload issues
