### PR TITLE
GD-443: Fix errors when dock undock the `gdunit` inspector

### DIFF
--- a/addons/gdUnit4/src/ui/GdUnitInspector.gd
+++ b/addons/gdUnit4/src/ui/GdUnitInspector.gd
@@ -15,16 +15,13 @@ func _ready() -> void:
 			if tab_container.get_tab_title(tab_index) == "GdUnit":
 				tab_container.set_current_tab(tab_index)
 	)
-
-
-func _enter_tree() -> void:
 	if Engine.is_editor_hint():
 		add_script_editor_context_menu()
 		add_file_system_dock_context_menu()
 
 
-func _exit_tree() -> void:
-	if Engine.is_editor_hint():
+func _notification(what: int) -> void:
+	if what == NOTIFICATION_PREDELETE:
 		ScriptEditorControls.unregister_context_menu()
 		EditorFileSystemControls.unregister_context_menu()
 


### PR DESCRIPTION
# Why
When undock the `gdunit` inspector, there are errors shown and the `gdunit` context menu is duplicated. These errors results because the register/unregister of context menus is done in the `_enter_tree` and `_exit_tree` block where are called again when undock and dock the inspector

# What
- moved the registration of context menus to the `_ready` block
- moved unregister of context menus to the `_notification` block at state NOTIFICATION_PREDELETE


