### PR TITLE
GD-451: Fix script parser to extracting the correct class name

### DIFF
--- a/addons/gdUnit4/src/core/parse/GdScriptParser.gd
+++ b/addons/gdUnit4/src/core/parse/GdScriptParser.gd
@@ -628,10 +628,13 @@ func get_class_name(script :GDScript) -> String:
 	var source_rows := source_code.split("\n")
 
 	for index :int in min(10, source_rows.size()):
-		var input := GdScriptParser.clean_up_row(source_rows[index])
+		var input := source_rows[index]
 		var token := next_token(input, 0)
 		if token == TOKEN_CLASS_NAME:
-			token = tokenize_value(input, token._consumed, token)
+			var current_index := token._consumed
+			token = next_token(input, current_index)
+			current_index += token._consumed
+			token = tokenize_value(input, current_index, token)
 			return token.value()
 	# if no class_name found extract from file name
 	return GdObjects.to_pascal_case(script.resource_path.get_basename().get_file())

--- a/addons/gdUnit4/test/core/parse/GdScriptParserTest.gd
+++ b/addons/gdUnit4/test/core/parse/GdScriptParserTest.gd
@@ -487,6 +487,11 @@ func test_get_class_name_snake_case() -> void:
 		.is_equal("SnakeCaseWithoutClassName")
 
 
+func test_get_class_with_extends_in_same_line() -> void:
+	assert_str(_parser.get_class_name(load("res://addons/gdUnit4/test/core/resources/naming_conventions/extends_on_same_line.gd")))\
+		.is_equal("ClassNameExtendsInSameLine")
+
+
 func test_is_func_end() -> void:
 	assert_bool(_parser.is_func_end("")).is_false()
 	assert_bool(_parser.is_func_end("func test_a():")).is_true()

--- a/addons/gdUnit4/test/core/resources/naming_conventions/extends_on_same_line.gd
+++ b/addons/gdUnit4/test/core/resources/naming_conventions/extends_on_same_line.gd
@@ -1,0 +1,6 @@
+# we do explicit define the class name and extends in a single line
+class_name ClassNameExtendsInSameLine extends Resource
+
+# Called when the node enters the scene tree for the first time.
+func _ready() -> void:
+	pass # Replace with function body.


### PR DESCRIPTION
# Why
When a test script is using `extends` on the same line as the `class_name` the parser do resolves an invalid class name. `class_name ClassNameExtendsInSameLine extends Resource` is resolved as `ClassNameExtendsInSameLineextendsResource`

# What
- fixed the parser to extract the right class name.

