### PR TITLE
GD-465: Parameterized tests are skipped with const Array values

### DIFF
--- a/addons/gdUnit4/src/core/parse/GdUnitTestParameterSetResolver.gd
+++ b/addons/gdUnit4/src/core/parse/GdUnitTestParameterSetResolver.gd
@@ -142,7 +142,7 @@ func load_parameter_sets(test_case: _TestCase, do_validate := false) -> Array:
 	var script := GDScript.new()
 	script.source_code = source_code
 	# enable this lines only for debuging
-	#script.resource_path = GdUnitTools.create_temp_dir("parameter_extract") + "/%s__.gd" % fd.name()
+	#script.resource_path = GdUnitFileAccess.create_temp_dir("parameter_extract") + "/%s__.gd" % test_case.get_name()
 	#DirAccess.remove_absolute(script.resource_path)
 	#ResourceSaver.save(script, script.resource_path)
 	var result := script.reload()

--- a/addons/gdUnit4/test/core/ParameterizedTestCaseTest.gd
+++ b/addons/gdUnit4/test/core/ParameterizedTestCaseTest.gd
@@ -55,6 +55,10 @@ var _expected_tests := {
 		["test_a"],
 		["test_b"],
 		["test_c"]
+	],
+	"test_with_extern_const_parameter_set" : [
+		["aa"],
+		["bb"]
 	]
 }
 
@@ -294,3 +298,13 @@ func test_with_extern_parameter_set(value :String, test_parameters := _test_set)
 	assert_that(value).is_not_empty()
 	assert_that(test_parameters).is_empty()
 	collect_test_call("test_with_extern_parameter_set", [value])
+
+
+const _data1 := ["aa"]
+const _data2 := ["bb"]
+
+@warning_ignore("unused_parameter")
+func test_with_extern_const_parameter_set(value :String, test_parameters := [_data1, _data2]) -> void:
+	assert_that(value).is_not_empty()
+	assert_that(test_parameters).is_empty()
+	collect_test_call("test_with_extern_const_parameter_set", [value])

--- a/addons/gdUnit4/test/core/parse/GdFunctionArgumentTest.gd
+++ b/addons/gdUnit4/test/core/parse/GdFunctionArgumentTest.gd
@@ -69,8 +69,41 @@ func test__parse_argument_as_array_typ2() -> void:
 	)
 
 
+func test__parse_argument_as_array_bad_formatted() -> void:
+	var test_parameters := """[
+		["test_a", null, "LOG", {}],
+		[
+				"test_b",
+			Node2D,
+			null,
+			{Node2D: "ER,ROR"}
+		],
+			[
+			"test_c",
+			Node2D,
+			"LOG",
+			{Node2D: "LOG 1"}
+		]
+
+		  ]"""
+	var fa := GdFunctionArgument.new(GdFunctionArgument.ARG_PARAMETERIZED_TEST, TYPE_STRING, test_parameters)
+	assert_array(fa.parameter_sets()).contains_exactly([
+		"""["test_a", null, "LOG", {}]""",
+		"""["test_b", Node2D, null, {Node2D: "ER,ROR"}]""",
+		"""["test_c", Node2D, "LOG", {Node2D: "LOG 1"}]"""
+		]
+	)
+
+
 func test__parse_argument_as_reference() -> void:
 	var test_parameters := "_test_args()"
 
 	var fa := GdFunctionArgument.new(GdFunctionArgument.ARG_PARAMETERIZED_TEST, TYPE_STRING, test_parameters)
 	assert_array(fa.parameter_sets()).is_empty()
+
+
+func test_parse_parameter_set_with_const_data_in_array() -> void:
+	var test_parameters := "[_data1, _data2]"
+
+	var fa := GdFunctionArgument.new(GdFunctionArgument.ARG_PARAMETERIZED_TEST, TYPE_STRING, test_parameters)
+	assert_array(fa.parameter_sets()).contains_exactly(["_data1", "_data2"])


### PR DESCRIPTION
# Why
The test was marked as skipped when the `test_parameters` contains external const array values.
```
const _data1 := ["aa"]
const _data2 := ["bb"]

@warning_ignore("unused_parameter")
func test_with_extern_const_parameter_set(value :String, test_parameters := [_data1, _data2]) -> void:
```

# What
fix the parameterized argument parsing


