### PR TITLE
GD-471: Support `UTF8` characters on reporting failure messages

### DIFF
--- a/addons/gdUnit4/src/asserts/GdAssertMessages.gd
+++ b/addons/gdUnit4/src/asserts/GdAssertMessages.gd
@@ -35,7 +35,7 @@ static func input_event_as_text(event :InputEvent) -> String:
 
 
 static func _colored_string_div(characters :String) -> String:
-	return colored_array_div(characters.to_ascii_buffer())
+	return colored_array_div(characters.to_utf8_buffer())
 
 
 static func colored_array_div(characters :PackedByteArray) -> String:

--- a/addons/gdUnit4/src/cmd/CmdConsole.gd
+++ b/addons/gdUnit4/src/cmd/CmdConsole.gd
@@ -17,7 +17,6 @@ const CSI_ITALIC = "[3m"
 const CSI_UNDERLINE = "[4m"
 
 # Control Sequence Introducer
-#var csi := PackedByteArray([0x1b]).get_string_from_ascii()
 var _debug_show_color_codes := false
 var _color_mode := COLOR_TABLE
 

--- a/addons/gdUnit4/src/core/GdDiffTool.gd
+++ b/addons/gdUnit4/src/core/GdDiffTool.gd
@@ -71,8 +71,8 @@ static func _buildLookup(lb: PackedByteArray, rb: PackedByteArray) -> Array:
 
 
 static func string_diff(left :Variant, right :Variant) -> Array[PackedByteArray]:
-	var lb := PackedByteArray() if left == null else str(left).to_ascii_buffer()
-	var rb := PackedByteArray() if right == null else str(right).to_ascii_buffer()
+	var lb := PackedByteArray() if left == null else str(left).to_utf8_buffer()
+	var rb := PackedByteArray() if right == null else str(right).to_utf8_buffer()
 	var ldiff := Array()
 	var rdiff := Array()
 	var lookup := _buildLookup(lb, rb);

--- a/addons/gdUnit4/src/core/parse/GdFunctionArgument.gd
+++ b/addons/gdUnit4/src/core/parse/GdFunctionArgument.gd
@@ -78,7 +78,7 @@ func _parse_parameter_set(input :String) -> PackedStringArray:
 	var array_end := 0
 	var current_index := 0
 	var output :PackedStringArray = []
-	var buf := input.to_ascii_buffer()
+	var buf := input.to_utf8_buffer()
 	var collected_characters: = PackedByteArray()
 	var matched :bool = false
 
@@ -106,7 +106,7 @@ func _parse_parameter_set(input :String) -> PackedStringArray:
 
 		# if array closed than collect the element
 		if matched:
-			var parameters := _fix_comma_space.sub(collected_characters.get_string_from_ascii(), ", ", true)
+			var parameters := _fix_comma_space.sub(collected_characters.get_string_from_utf8(), ", ", true)
 			if not parameters.is_empty():
 				output.append(parameters)
 			collected_characters.clear()

--- a/addons/gdUnit4/src/core/parse/GdScriptParser.gd
+++ b/addons/gdUnit4/src/core/parse/GdScriptParser.gd
@@ -236,12 +236,12 @@ class TokenInnerClass extends Token:
 
 
 	static func _strip_leading_spaces(input :String) -> String:
-		var characters := input.to_ascii_buffer()
+		var characters := input.to_utf8_buffer()
 		while not characters.is_empty():
 			if characters[0] != 0x20:
 				break
 			characters.remove_at(0)
-		return characters.get_string_from_ascii()
+		return characters.get_string_from_utf8()
 
 
 	static func _consumed_bytes(row :String) -> int:

--- a/addons/gdUnit4/src/fuzzers/StringFuzzer.gd
+++ b/addons/gdUnit4/src/fuzzers/StringFuzzer.gd
@@ -61,4 +61,4 @@ func next_value() -> String:
 	var length :int = max(_min_length, randi() % _max_length)
 	for i in length:
 		value.append(_charset[randi() % max_char])
-	return value.get_string_from_ascii()
+	return value.get_string_from_utf8()

--- a/addons/gdUnit4/src/network/GdUnitTcpClient.gd
+++ b/addons/gdUnit4/src/network/GdUnitTcpClient.gd
@@ -98,7 +98,7 @@ func process_rpc() -> void:
 func rpc_send(p_rpc :RPC) -> void:
 	if _stream != null:
 		var data := GdUnitServerConstants.JSON_RESPONSE_DELIMITER + p_rpc.serialize() + GdUnitServerConstants.JSON_RESPONSE_DELIMITER
-		_stream.put_data(data.to_ascii_buffer())
+		_stream.put_data(data.to_utf8_buffer())
 
 
 func rpc_receive() -> RPC:
@@ -111,9 +111,9 @@ func rpc_receive() -> RPC:
 			var header := Array(received_data.slice(0, 4))
 			if header == [0, 0, 0, 124]:
 				received_data = received_data.slice(12, available_bytes)
-			var decoded := received_data.get_string_from_ascii()
+			var decoded := received_data.get_string_from_utf8()
 			if decoded == "":
-				#prints("decoded is empty", available_bytes, received_data.get_string_from_ascii())
+				#prints("decoded is empty", available_bytes, received_data.get_string_from_utf8())
 				return null
 			return RPC.deserialize(decoded)
 	return null

--- a/addons/gdUnit4/src/network/GdUnitTcpServer.gd
+++ b/addons/gdUnit4/src/network/GdUnitTcpServer.gd
@@ -72,7 +72,7 @@ class TcpConnection extends Node:
 
 
 	func _read_next_data_packages(data_package :PackedByteArray) -> PackedStringArray:
-		_readBuffer += data_package.get_string_from_ascii()
+		_readBuffer += data_package.get_string_from_utf8()
 		var json_array := _readBuffer.split(GdUnitServerConstants.JSON_RESPONSE_DELIMITER)
 		# We need to check if the current data is terminated by the delemiter (data packets can be split unspecifically).
 		# If not, store the last part in _readBuffer and complete it on the next data packet that is received

--- a/addons/gdUnit4/test/core/GdDiffToolTest.gd
+++ b/addons/gdUnit4/test/core/GdDiffToolTest.gd
@@ -17,8 +17,8 @@ func test_string_diff_empty() -> void:
 
 func test_string_diff_equals() -> void:
 	var diffs := GdDiffTool.string_diff("Abc", "Abc")
-	var expected_l_diff := "Abc".to_ascii_buffer()
-	var expected_r_diff := "Abc".to_ascii_buffer()
+	var expected_l_diff := "Abc".to_utf8_buffer()
+	var expected_r_diff := "Abc".to_utf8_buffer()
 
 	assert_array(diffs).has_size(2)
 	assert_array(diffs[0]).contains_exactly(expected_l_diff)
@@ -28,7 +28,7 @@ func test_string_diff_equals() -> void:
 func test_string_diff() -> void:
 	# tests the result of string diff function like assert_str("Abc").is_equal("abc")
 	var diffs := GdDiffTool.string_diff("Abc", "abc")
-	var chars := "Aabc".to_ascii_buffer()
+	var chars := "Aabc".to_utf8_buffer()
 	var ord_A := chars[0]
 	var ord_a := chars[1]
 	var ord_b := chars[2]

--- a/addons/gdUnit4/test/fuzzers/StringFuzzerTest.gd
+++ b/addons/gdUnit4/test/fuzzers/StringFuzzerTest.gd
@@ -7,18 +7,18 @@ const __source = 'res://addons/gdUnit4/src/fuzzers/StringFuzzer.gd'
 
 
 func test_extract_charset() -> void:
-	assert_str(StringFuzzer.extract_charset("abc").get_string_from_ascii()).is_equal("abc")
-	assert_str(StringFuzzer.extract_charset("abcDXG").get_string_from_ascii()).is_equal("abcDXG")
-	assert_str(StringFuzzer.extract_charset("a-c").get_string_from_ascii()).is_equal("abc")
-	assert_str(StringFuzzer.extract_charset("a-z").get_string_from_ascii()).is_equal("abcdefghijklmnopqrstuvwxyz")
-	assert_str(StringFuzzer.extract_charset("A-Z").get_string_from_ascii()).is_equal("ABCDEFGHIJKLMNOPQRSTUVWXYZ")
+	assert_str(StringFuzzer.extract_charset("abc").get_string_from_utf8()).is_equal("abc")
+	assert_str(StringFuzzer.extract_charset("abcDXG").get_string_from_utf8()).is_equal("abcDXG")
+	assert_str(StringFuzzer.extract_charset("a-c").get_string_from_utf8()).is_equal("abc")
+	assert_str(StringFuzzer.extract_charset("a-z").get_string_from_utf8()).is_equal("abcdefghijklmnopqrstuvwxyz")
+	assert_str(StringFuzzer.extract_charset("A-Z").get_string_from_utf8()).is_equal("ABCDEFGHIJKLMNOPQRSTUVWXYZ")
 
 	# range token at start
-	assert_str(StringFuzzer.extract_charset("-a-dA-D2-8+_").get_string_from_ascii()).is_equal("-abcdABCD2345678+_")
+	assert_str(StringFuzzer.extract_charset("-a-dA-D2-8+_").get_string_from_utf8()).is_equal("-abcdABCD2345678+_")
 	# range token at end
-	assert_str(StringFuzzer.extract_charset("a-dA-D2-8+_-").get_string_from_ascii()).is_equal("abcdABCD2345678+_-")
+	assert_str(StringFuzzer.extract_charset("a-dA-D2-8+_-").get_string_from_utf8()).is_equal("abcdABCD2345678+_-")
 	# range token in the middle
-	assert_str(StringFuzzer.extract_charset("a-d-A-D2-8+_").get_string_from_ascii()).is_equal("abcd-ABCD2345678+_")
+	assert_str(StringFuzzer.extract_charset("a-d-A-D2-8+_").get_string_from_utf8()).is_equal("abcd-ABCD2345678+_")
 
 
 func test_next_value() -> void:

--- a/addons/gdUnit4/test/network/GdUnitTcpServerTest.gd
+++ b/addons/gdUnit4/test/network/GdUnitTcpServerTest.gd
@@ -53,7 +53,7 @@ func test_receive_packages() -> void:
 
 	# mock send RPCMessage
 	var data := DLM + RPCMessage.of("Test Message").serialize() + DLM
-	var package_data := [0, data.to_ascii_buffer()]
+	var package_data := [0, data.to_utf8_buffer()]
 	do_return(data.length()).on(stream).get_available_bytes()
 	do_return(package_data).on(stream).get_partial_data(data.length())
 


### PR DESCRIPTION
# Why
The test messages losing UTF8 characters during reporting. This results for converting UTF8 strings via  `to_utf8_buffer` and `get_string_from_utf8`

# What
fixes by replace `get_string_from_utf8` and `to_utf8_buffer` by the utf8 derivate
