### PR TITLE
GD-468: Fix prameterized test argument parsing

### DIFF
--- a/addons/gdUnit4/src/core/parse/GdFunctionArgument.gd
+++ b/addons/gdUnit4/src/core/parse/GdFunctionArgument.gd
@@ -72,7 +72,7 @@ func _parse_parameter_set(input :String) -> PackedStringArray:
 		return []
 
 	input = _cleanup_leading_spaces.sub(input, "", true)
-	input = input.replace("\n", "").trim_prefix("[").trim_suffix("]").trim_prefix(" ")
+	input = input.replace("\n", "").strip_edges().trim_prefix("[").trim_suffix("]").trim_prefix("]")
 	var single_quote := false
 	var double_quote := false
 	var array_end := 0

--- a/addons/gdUnit4/test/core/parse/GdFunctionArgumentTest.gd
+++ b/addons/gdUnit4/test/core/parse/GdFunctionArgumentTest.gd
@@ -95,6 +95,22 @@ func test__parse_argument_as_array_bad_formatted() -> void:
 	)
 
 
+func test_parse_argument_as_array_ends_with_additional_comma() -> void:
+	var test_parameters := """
+			[
+			[true, 'bool'],
+			[42, 'int'],
+			['foo', 'String'],
+		]"""
+	var fa := GdFunctionArgument.new(GdFunctionArgument.ARG_PARAMETERIZED_TEST, TYPE_STRING, test_parameters)
+	assert_array(fa.parameter_sets()).contains_exactly([
+		"""[true, 'bool']""",
+		"""[42, 'int']""",
+		"""['foo', 'String']"""
+		]
+	)
+
+
 func test__parse_argument_as_reference() -> void:
 	var test_parameters := "_test_args()"
 


### PR DESCRIPTION
# Why
See https://github.com/MikeSchulze/gdUnit4/issues/468

# What
We first trim the input by removing edges and surrounding brackets and then iterate over possible parameters

