### PR TITLE
GD-486: Fix image size errors at startup

### DIFF
--- a/addons/gdUnit4/src/ui/GdUnitUiTools.gd
+++ b/addons/gdUnit4/src/ui/GdUnitUiTools.gd
@@ -122,12 +122,15 @@ static func _merge_images(image1: Image, offset1: Vector2i, image2: Image, offse
 
 @warning_ignore("narrowing_conversion")
 static func _merge_images_scaled(image1: Image, offset1: Vector2i, image2: Image, offset2: Vector2i) -> Image:
-	if image1.get_height() != image2.get_height():
-		push_error("invalid height:", image1.get_height(), " vs ", image2.get_height())
-		return null
-	if image1.get_width() != image2.get_width():
-		push_error("invalid width:", image1.get_width(), " vs ", image2.get_width())
-		return null
+	## we disable the check for now because the image size of icons are different on macos and produces an error
+	## see issue https://github.com/MikeSchulze/gdUnit4/issues/486
+	if not OS.get_distribution_name().contains("mac"):
+		if image1.get_height() != image2.get_height():
+			push_error("invalid height:", image1.get_height(), " vs ", image2.get_height())
+			return null
+		if image1.get_width() != image2.get_width():
+			push_error("invalid width:", image1.get_width(), " vs ", image2.get_width())
+			return null
 
 	# Create a new Image for the merged result
 	var merged_image := Image.create(image1.get_width(), image1.get_height(), false, image1.get_format())


### PR DESCRIPTION
# Why
On macOS there are errors on startup.
```
Godot Engine v4.2.1.stable.official (c) 2007-present Juan Linietsky, Ariel Manzur & Godot Contributors.
  core/variant/variant_utility.cpp:1091 - invalid height:16 vs 32
  Invalid image: null
  core/variant/variant_utility.cpp:1091 - invalid height:16 vs 32
  Invalid image: null
  core/variant/variant_utility.cpp:1091 - invalid height:16 vs 32
  Invalid image: null
  core/variant/variant_utility.cpp:1091 - invalid height:16 vs 32
  Invalid image: null
  core/variant/variant_utility.cpp:1091 - invalid height:16 vs 32
  Invalid image: null
  core/variant/variant_utility.cpp:1091 - invalid height:16 vs 32
  Invalid image: null
Loading GdUnit4 Plugin success
```

# What
- disable the image size check when merge icons because it has different size on macOS 16vs32 pixels


