### PR TITLE
GD-490: Fix icon image size errors when using custom editor display scale

### DIFF
--- a/addons/gdUnit4/src/ui/GdUnitUiTools.gd
+++ b/addons/gdUnit4/src/ui/GdUnitUiTools.gd
@@ -106,13 +106,9 @@ static func _modulate_image(image: Image, color: Color) -> Image:
 
 
 static func _merge_images(image1: Image, offset1: Vector2i, image2: Image, offset2: Vector2i) -> Image:
-	if image1.get_height() != image2.get_height():
-		push_error("invalid height:", image1.get_height(), " vs ", image2.get_height())
-		return null
-	if image1.get_width() != image2.get_width():
-		push_error("invalid width:", image1.get_width(), " vs ", image2.get_width())
-		return null
-
+	## we need to fix the image to have the same size to avoid merge conflicts
+	if image1.get_height() < image2.get_height():
+		image1.resize(image2.get_width(), image2.get_height())
 	# Create a new Image for the merged result
 	var merged_image := Image.create(image1.get_width(), image1.get_height(), false, Image.FORMAT_RGBA8)
 	merged_image.blit_rect_mask(image1, image2, Rect2(Vector2.ZERO, image1.get_size()), offset1)
@@ -122,16 +118,9 @@ static func _merge_images(image1: Image, offset1: Vector2i, image2: Image, offse
 
 @warning_ignore("narrowing_conversion")
 static func _merge_images_scaled(image1: Image, offset1: Vector2i, image2: Image, offset2: Vector2i) -> Image:
-	## we disable the check for now because the image size of icons are different on macos and produces an error
-	## see issue https://github.com/MikeSchulze/gdUnit4/issues/486
-	if not OS.get_distribution_name().contains("mac"):
-		if image1.get_height() != image2.get_height():
-			push_error("invalid height:", image1.get_height(), " vs ", image2.get_height())
-			return null
-		if image1.get_width() != image2.get_width():
-			push_error("invalid width:", image1.get_width(), " vs ", image2.get_width())
-			return null
-
+	## we need to fix the image to have the same size to avoid merge conflicts
+	if image1.get_height() < image2.get_height():
+		image1.resize(image2.get_width(), image2.get_height())
 	# Create a new Image for the merged result
 	var merged_image := Image.create(image1.get_width(), image1.get_height(), false, image1.get_format())
 	merged_image.blend_rect(image1, Rect2(Vector2.ZERO, image1.get_size()), offset1)

--- a/addons/gdUnit4/test/ui/GdUnitUiToolsTest.gd
+++ b/addons/gdUnit4/test/ui/GdUnitUiToolsTest.gd
@@ -1,0 +1,40 @@
+# GdUnit generated TestSuite
+class_name GdUnitUiToolsTest
+extends GdUnitTestSuite
+@warning_ignore('unused_parameter')
+@warning_ignore('return_value_discarded')
+
+# TestSuite generated from
+const __source = 'res://addons/gdUnit4/src/ui/GdUnitUiTools.gd'
+
+
+func test__merge_images_same_size() -> void:
+	var image_a := Image.create(16, 16, false, Image.FORMAT_RGBA8)
+	var image_b := Image.create(16, 16, false, Image.FORMAT_RGBA8)
+	var output := GdUnitUiTools._merge_images(image_a, Vector2.ZERO, image_b, Vector2.ZERO)
+
+	assert_that(output.get_size()).is_equal(Vector2i(16, 16))
+
+
+func test__merge_images_different_size() -> void:
+	var image_a := Image.create(8, 8, false, Image.FORMAT_RGBA8)
+	var image_b := Image.create(16, 16, false, Image.FORMAT_RGBA8)
+	var output := GdUnitUiTools._merge_images(image_a, Vector2.ZERO, image_b, Vector2.ZERO)
+
+	assert_that(output.get_size()).is_equal(Vector2i(16, 16))
+
+
+func test__merge_images_scaled() -> void:
+	var image_a := Image.create(16, 16, false, Image.FORMAT_RGBA8)
+	var image_b := Image.create(16, 16, false, Image.FORMAT_RGBA8)
+	var output := GdUnitUiTools._merge_images_scaled(image_a, Vector2.ZERO, image_b, Vector2.ZERO)
+
+	assert_that(output.get_size()).is_equal(Vector2i(16, 16))
+
+
+func test__merge_images_scaled_different_size() -> void:
+	var image_a := Image.create(8, 8, false, Image.FORMAT_RGBA8)
+	var image_b := Image.create(16, 16, false, Image.FORMAT_RGBA8)
+	var output := GdUnitUiTools._merge_images_scaled(image_a, Vector2.ZERO, image_b, Vector2.ZERO)
+
+	assert_that(output.get_size()).is_equal(Vector2i(16, 16))


### PR DESCRIPTION
# Why
see https://github.com/MikeSchulze/gdUnit4/issues/490

# What
Resizes the first image to the same size as the second image before it is merged

