### PR TITLE
GD-491: Fix Godot editor crash for Linux systems at exit

### DIFF
--- a/addons/gdUnit4/bin/GdUnitCmdTool.gd
+++ b/addons/gdUnit4/bin/GdUnitCmdTool.gd
@@ -615,6 +615,7 @@ func _initialize() -> void:
 
 # do not use print statements on _finalize it results in random crashes
 func _finalize() -> void:
+	queue_delete(_cli_runner)
 	if OS.is_stdout_verbose():
 		prints("Finallize ..")
 		prints("-Orphan nodes report-----------------------")

--- a/addons/gdUnit4/plugin.gd
+++ b/addons/gdUnit4/plugin.gd
@@ -12,6 +12,9 @@ var _guard: GdUnitTestDiscoverGuard
 
 
 func _enter_tree() -> void:
+	if check_running_in_test_env():
+		CmdConsole.new().prints_warning("It was recognized that GdUnit4 is running in a test environment, therefore the GdUnit4 plugin will not be executed!")
+		return
 	if Engine.get_version_info().hex < 0x40200:
 		prints("GdUnit4 plugin requires a minimum of Godot 4.2.x Version!")
 		return
@@ -36,6 +39,8 @@ func _enter_tree() -> void:
 
 
 func _exit_tree() -> void:
+	if check_running_in_test_env():
+		return
 	if is_instance_valid(_gd_inspector):
 		remove_control_from_docks(_gd_inspector)
 		GodotVersionFixures.free_fix(_gd_inspector)
@@ -47,6 +52,12 @@ func _exit_tree() -> void:
 		_server_node.queue_free()
 	GdUnitTools.dispose_all.call_deferred()
 	prints("Unload GdUnit4 Plugin success")
+
+
+func check_running_in_test_env() -> bool:
+	var args := OS.get_cmdline_args()
+	args.append_array(OS.get_cmdline_user_args())
+	return DisplayServer.get_name() == "headless" or args.has("--selftest") or args.has("--add") or args.has("-a") or args.has("--quit-after") or args.has("--import")
 
 
 func _on_resource_saved(resource :Resource) -> void:

--- a/addons/gdUnit4/src/core/GdUnitSignals.gd
+++ b/addons/gdUnit4/src/core/GdUnitSignals.gd
@@ -31,6 +31,5 @@ static func dispose() -> void:
 	for signal_ in signals.get_signal_list():
 		for connection in signals.get_signal_connection_list(signal_["name"]):
 			connection["signal"].disconnect(connection["callable"])
+	signals = null
 	Engine.remove_meta(META_KEY)
-	while signals.get_reference_count() > 0:
-		signals.unreference()

--- a/addons/gdUnit4/src/core/GdUnitTools.gd
+++ b/addons/gdUnit4/src/core/GdUnitTools.gd
@@ -86,16 +86,16 @@ static func release_timers() -> void:
 	for node :Node in Engine.get_main_loop().root.get_children():
 		if is_instance_valid(node) and node.is_in_group("GdUnitTimers"):
 			if is_instance_valid(node):
-				Engine.get_main_loop().root.remove_child(node)
+				Engine.get_main_loop().root.remove_child.call_deferred(node)
 				node.stop()
-				node.free()
+				node.queue_free()
 
 
 # the finally cleaup unfreed resources and singletons
 static func dispose_all() -> void:
 	release_timers()
-	GdUnitSignals.dispose()
 	GdUnitSingleton.dispose()
+	GdUnitSignals.dispose()
 
 
 # if instance an mock or spy we need manually freeing the self reference

--- a/addons/gdUnit4/src/core/GodotVersionFixures.gd
+++ b/addons/gdUnit4/src/core/GodotVersionFixures.gd
@@ -23,7 +23,9 @@ static func set_event_global_position(event: InputEventMouseMotion, global_posit
 
 # we crash on macOS when using free() inside the plugin _exit_tree
 static func free_fix(instance: Object) -> void:
-	if OS.get_distribution_name().contains("mac"):
+	var distribution_name := OS.get_distribution_name()
+	if distribution_name != "Windows":
+		prints("Using queue_free() hotfix on system:", distribution_name)
 		instance.queue_free()
 	else:
 		instance.free()

--- a/addons/gdUnit4/src/core/command/GdUnitCommandHandler.gd
+++ b/addons/gdUnit4/src/core/command/GdUnitCommandHandler.gd
@@ -73,12 +73,8 @@ func _init() -> void:
 	register_command(GdUnitCommand.new(CMD_CREATE_TESTCASE, is_not_running, cmd_create_test, GdUnitShortcut.ShortCut.CREATE_TEST))
 	register_command(GdUnitCommand.new(CMD_STOP_TEST_RUN, is_running, cmd_stop.bind(_client_id), GdUnitShortcut.ShortCut.STOP_TEST_RUN))
 
-
-	# do not reschedule inside of test run (called on GdUnitCommandHandlerTest)
-	if Engine.has_meta("GdUnitRunner"):
-		return
-	# schedule discover tests if enabled
-	if GdUnitSettings.is_test_discover_enabled():
+	# schedule discover tests if enabled and running inside the editor
+	if Engine.is_editor_hint() and GdUnitSettings.is_test_discover_enabled():
 		var timer :SceneTreeTimer = Engine.get_main_loop().create_timer(5)
 		timer.timeout.connect(cmd_discover_tests)
 

--- a/gdUnit4.csproj
+++ b/gdUnit4.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Godot.NET.Sdk/4.2.1">
+<Project Sdk="Godot.NET.Sdk/4.2.2">
   <PropertyGroup>
     <TargetFrameworks>net8.0</TargetFrameworks>
     <LangVersion>11.0</LangVersion>

--- a/project.godot
+++ b/project.godot
@@ -31,9 +31,18 @@ gdscript/warnings/return_value_discarded=false
 
 project/assembly_name="gdUnit4"
 
+[editor_plugins]
+
+enabled=PackedStringArray("res://addons/gdUnit4/plugin.cfg")
+
 [gdunit4]
 
 settings/common/update_notification_enabled=false
+ui/inspector/node_collapse=false
+ui/toolbar/run_overall=true
+ui/inspector/tree_sort_mode=1
+settings/test/test_discovery=true
+report/godot/script_error=false
 
 [importer_defaults]
 


### PR DESCRIPTION
# Why
The Godot editor crashes if the GdUnit4 plugin enabled at exit.

# What
- Extend the hotfix to run also on Linux systems
- Does not execute the plugin code if the project has the gdunit4 plugin enabled but is running in a test environment. This prevents the loading of UI components that are not required if the Godot program is executed without editor mode.
- Does not execute the scheduled test discovery when you run the cmd tool to avoid overlaps during test execution.
