### PR TITLE
GD-501: Prepare GdUnit4 for Godot 4.3.beta1

### DIFF
--- a/.github/workflows/ci-pr-publish-report.yml
+++ b/.github/workflows/ci-pr-publish-report.yml
@@ -28,7 +28,7 @@ jobs:
         godot-net: ['-net', '']
         include:
           - godot-version: '4.3'
-            godot-status: 'dev6'
+            godot-status: 'beta1'
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -35,7 +35,7 @@ jobs:
         godot-net: ['.Net', '']
         include:
           - godot-version: '4.3'
-            godot-status: 'dev6'
+            godot-status: 'beta1'
 
     permissions:
       actions: write

--- a/addons/gdUnit4/src/GdUnitTestSuite.gd
+++ b/addons/gdUnit4/src/GdUnitTestSuite.gd
@@ -10,7 +10,7 @@
 ## [/codeblock]
 ## @tutorial:  https://mikeschulze.github.io/gdUnit4/faq/test-suite/
 
-@icon("res://addons/gdUnit4/src/ui/assets/TestSuite.svg")
+@icon("res://addons/gdUnit4/src/ui/settings/logo.png")
 class_name GdUnitTestSuite
 extends Node
 

--- a/addons/gdUnit4/src/core/GdFunctionDoubler.gd
+++ b/addons/gdUnit4/src/core/GdFunctionDoubler.gd
@@ -39,6 +39,8 @@ const DEFAULT_TYPED_RETURN_VALUES := {
 	TYPE_PACKED_STRING_ARRAY: "PackedStringArray()",
 	TYPE_PACKED_VECTOR2_ARRAY: "PackedVector2Array()",
 	TYPE_PACKED_VECTOR3_ARRAY: "PackedVector3Array()",
+	# since Godot 4.3.beta1 TYPE_PACKED_VECTOR4_ARRAY = 38
+	GdObjects.TYPE_PACKED_VECTOR4_ARRAY: "PackedVector4Array()",
 	TYPE_PACKED_COLOR_ARRAY: "PackedColorArray()",
 	GdObjects.TYPE_VARIANT: "null",
 	GdObjects.TYPE_ENUM: "0"

--- a/addons/gdUnit4/src/core/GdObjects.gd
+++ b/addons/gdUnit4/src/core/GdObjects.gd
@@ -4,6 +4,10 @@ extends Resource
 
 const GdUnitTools := preload("res://addons/gdUnit4/src/core/GdUnitTools.gd")
 
+
+# introduced with Godot 4.3.beta1
+const TYPE_PACKED_VECTOR4_ARRAY = 38 #TYPE_PACKED_VECTOR4_ARRAY
+
 const TYPE_VOID 	= TYPE_MAX + 1000
 const TYPE_VARARG 	= TYPE_MAX + 1001
 const TYPE_VARIANT	= TYPE_MAX + 1002
@@ -59,6 +63,7 @@ const TYPE_AS_STRING_MAPPINGS := {
 	TYPE_PACKED_STRING_ARRAY: "PackedStringArray",
 	TYPE_PACKED_VECTOR2_ARRAY: "PackedVector2Array",
 	TYPE_PACKED_VECTOR3_ARRAY: "PackedVector3Array",
+	TYPE_PACKED_VECTOR4_ARRAY: "PackedVector4Array",
 	TYPE_PACKED_COLOR_ARRAY: "PackedColorArray",
 	TYPE_VOID: "void",
 	TYPE_VARARG: "VarArg",
@@ -359,7 +364,7 @@ static func is_type(value :Variant) -> bool:
 	if is_engine_type(value):
 		return true
 	# is a custom class type
-	if value is GDScript and value.can_instantiate():
+	if value is GDScript and (value as GDScript).can_instantiate():
 		return true
 	return false
 
@@ -434,7 +439,7 @@ static func is_singleton(value :Variant) -> bool:
 static func is_instance(value :Variant) -> bool:
 	if not is_instance_valid(value) or is_native_class(value):
 		return false
-	if is_script(value) and value.get_instance_base_type() == "":
+	if is_script(value) and (value as Script).get_instance_base_type() == "":
 		return true
 	if is_scene(value):
 		return true
@@ -532,7 +537,7 @@ static func extract_class_name(clazz :Variant) -> GdUnitResult:
 		var script := clazz.script as GDScript
 		if script != null:
 			return extract_class_name(script)
-		return GdUnitResult.success(clazz.get_class())
+		return GdUnitResult.success((clazz as Object).get_class())
 
 	# extract name form full qualified class path
 	if clazz is String:

--- a/addons/gdUnit4/src/core/GdUnitRunner.gd
+++ b/addons/gdUnit4/src/core/GdUnitRunner.gd
@@ -1,8 +1,5 @@
 extends Node
 
-signal sync_rpc_id_result_received
-
-
 @onready var _client :GdUnitTcpClient = $GdUnitTcpClient
 @onready var _executor :GdUnitTestSuiteExecutor = GdUnitTestSuiteExecutor.new()
 

--- a/addons/gdUnit4/src/core/GdUnitSignals.gd
+++ b/addons/gdUnit4/src/core/GdUnitSignals.gd
@@ -1,17 +1,26 @@
 class_name GdUnitSignals
 extends RefCounted
 
+@warning_ignore("unused_signal")
 signal gdunit_client_connected(client_id :int)
+@warning_ignore("unused_signal")
 signal gdunit_client_disconnected(client_id :int)
+@warning_ignore("unused_signal")
 signal gdunit_client_terminated()
 
+@warning_ignore("unused_signal")
 signal gdunit_event(event :GdUnitEvent)
+@warning_ignore("unused_signal")
 signal gdunit_event_debug(event :GdUnitEvent)
+@warning_ignore("unused_signal")
 signal gdunit_add_test_suite(test_suite :GdUnitTestSuiteDto)
+@warning_ignore("unused_signal")
 signal gdunit_message(message :String)
+@warning_ignore("unused_signal")
 signal gdunit_report(execution_context_id :int, report :GdUnitReport)
+@warning_ignore("unused_signal")
 signal gdunit_set_test_failed(is_failed :bool)
-
+@warning_ignore("unused_signal")
 signal gdunit_settings_changed(property :GdUnitProperty)
 
 const META_KEY := "GdUnitSignals"

--- a/addons/gdUnit4/src/core/GdUnitTools.gd
+++ b/addons/gdUnit4/src/core/GdUnitTools.gd
@@ -43,7 +43,7 @@ static func free_instance(instance :Variant, is_stdout_verbose :=false) -> bool:
 		print_verbose("GdUnit4:gc():free instance ", instance)
 	release_double(instance)
 	if instance is RefCounted:
-		instance.notification(Object.NOTIFICATION_PREDELETE)
+		(instance as RefCounted).notification(Object.NOTIFICATION_PREDELETE)
 		return true
 	else:
 		# is instance already freed?

--- a/addons/gdUnit4/src/core/LocalTime.gd
+++ b/addons/gdUnit4/src/core/LocalTime.gd
@@ -3,6 +3,7 @@ class_name LocalTime
 extends Resource
 
 enum TimeUnit {
+	DEFAULT = 0,
 	MILLIS = 1,
 	SECOND = 2,
 	MINUTE = 3,

--- a/addons/gdUnit4/src/core/parse/GdDefaultValueDecoder.gd
+++ b/addons/gdUnit4/src/core/parse/GdDefaultValueDecoder.gd
@@ -21,6 +21,7 @@ var _decoders := {
 	TYPE_PACKED_COLOR_ARRAY: _on_type_Array.bind(TYPE_PACKED_COLOR_ARRAY),
 	TYPE_PACKED_VECTOR2_ARRAY: _on_type_Array.bind(TYPE_PACKED_VECTOR2_ARRAY),
 	TYPE_PACKED_VECTOR3_ARRAY: _on_type_Array.bind(TYPE_PACKED_VECTOR3_ARRAY),
+	GdObjects.TYPE_PACKED_VECTOR4_ARRAY: _on_type_Array.bind(GdObjects.TYPE_PACKED_VECTOR4_ARRAY),
 	TYPE_DICTIONARY: _on_type_Dictionary,
 	TYPE_RID: _on_type_RID,
 	TYPE_NODE_PATH: _on_type_NodePath,
@@ -63,7 +64,7 @@ func _on_type_StringName(value :StringName) -> String:
 	return 'StringName("%s")' % value
 
 
-func _on_type_Object(value :Object, type :int) -> String:
+func _on_type_Object(value :Object, _type :int) -> String:
 	return str(value)
 
 
@@ -79,11 +80,11 @@ func _on_type_NodePath(path :NodePath) -> String:
 	return 'NodePath("%s")' % path
 
 
-func _on_type_Callable(cb :Callable) -> String:
+func _on_type_Callable(_cb :Callable) -> String:
 	return 'Callable()'
 
 
-func _on_type_Signal(s :Signal) -> String:
+func _on_type_Signal(_s :Signal) -> String:
 	return 'Signal()'
 
 
@@ -121,6 +122,14 @@ func _on_type_Array(value :Variant, type :int) -> String:
 			if vectors.is_empty():
 				return "PackedVector3Array()"
 			return "PackedVector3Array([%s])" % ", ".join(vectors)
+
+		GdObjects.TYPE_PACKED_VECTOR4_ARRAY:
+			var vectors := PackedStringArray()
+			for vector:Variant in value as Array:
+				vectors.append(_on_type_Vector(vector, TYPE_VECTOR4))
+			if vectors.is_empty():
+				return "PackedVector4Array()"
+			return "PackedVector4Array([%s])" % ", ".join(vectors)
 
 		TYPE_PACKED_STRING_ARRAY:
 			var values := PackedStringArray()

--- a/addons/gdUnit4/src/ui/menu/GdUnitContextMenuItem.gd
+++ b/addons/gdUnit4/src/ui/menu/GdUnitContextMenuItem.gd
@@ -1,13 +1,14 @@
 class_name GdUnitContextMenuItem
 
 enum MENU_ID {
+	UNDEFINED = 0,
 	TEST_RUN = 1000,
 	TEST_DEBUG = 1001,
 	TEST_RERUN = 1002,
 	CREATE_TEST = 1010,
 }
 
-var id: MENU_ID:
+var id: MENU_ID = MENU_ID.UNDEFINED:
 	set(value):
 		id = value
 	get:

--- a/addons/gdUnit4/test/core/GdObjectsTest.gd
+++ b/addons/gdUnit4/test/core/GdObjectsTest.gd
@@ -479,6 +479,9 @@ func test_all_types() -> void:
 	var expected_types :Array[int] = []
 	for type_index in TYPE_MAX:
 		expected_types.append(type_index)
+
+	if Engine.get_version_info().hex < 0x40300:
+		expected_types.append(GdObjects.TYPE_PACKED_VECTOR4_ARRAY)
 	expected_types.append(GdObjects.TYPE_VOID)
 	expected_types.append(GdObjects.TYPE_VARARG)
 	expected_types.append(GdObjects.TYPE_FUNC)

--- a/addons/gdUnit4/test/core/GdUnitSceneRunnerInputEventTest.gd
+++ b/addons/gdUnit4/test/core/GdUnitSceneRunnerInputEventTest.gd
@@ -92,14 +92,6 @@ func test_simulate_action_press() -> void:
 		_runner.simulate_action_press(action)
 		await await_idle_frame()
 
-		var event := InputEventAction.new()
-		event.action = action
-		event.pressed = true
-		verify(_scene_spy, 1)._input(event)
-		assert_that(Input.is_action_pressed(action))\
-			.override_failure_message("Expect the action '%s' is pressed" % action).is_true()
-	# verify all this actions are still handled as pressed
-	for action in actions_to_simmulate:
 		assert_that(Input.is_action_pressed(action))\
 			.override_failure_message("Expect the action '%s' is pressed" % action).is_true()
 	# other actions are not pressed

--- a/addons/gdUnit4/test/core/parse/GdDefaultValueDecoderTest.gd
+++ b/addons/gdUnit4/test/core/parse/GdDefaultValueDecoderTest.gd
@@ -253,3 +253,13 @@ func test_decode_typedArrays(variant_type :int, value :Variant, expected :String
 	]) -> void:
 	assert_that(GdDefaultValueDecoder.decode_typed(variant_type, value)).is_equal(expected)
 	_tested_types[variant_type] = 1
+
+
+# Godot 4.3.1.beta1 defines in addition TYPE_PACKED_VECTOR4_ARRAY
+func test_decode_Vector4Array() -> void:
+	# TYPE_PACKED_VECTOR4_ARRAY
+	var type := GdObjects.TYPE_PACKED_VECTOR4_ARRAY
+	# We need a pragma to include code Godot version specific
+	#assert_that(GdDefaultValueDecoder.decode_typed(type, PackedVector4Array([Vector4.ONE, Vector4.ONE*2])))\
+	#	.is_equal('PackedVector4Array([Vector4(1, 1, 1, 1), Vector4(2, 2, 2, 2)])')
+	_tested_types[type] = 1

--- a/addons/gdUnit4/test/mocker/GodotClassNameFuzzer.gd
+++ b/addons/gdUnit4/test/mocker/GodotClassNameFuzzer.gd
@@ -6,6 +6,7 @@ var class_names :Array[String] = []
 
 const EXCLUDED_CLASSES = [
 	"JavaClass",
+	"GDScript",
 	"_ClassDB",
 	"MainLoop",
 	"JNISingleton",
@@ -15,6 +16,8 @@ const EXCLUDED_CLASSES = [
 	"Tween",
 	"TextServerAdvanced",
 	"InputEventShortcut",
+	"FramebufferCacheRD",
+	"UniformSetCacheRD",
 	# GD-110 - missing enum `Vector3.Axis`
 	"Sprite3D", "AnimatedSprite3D",
 ]

--- a/addons/gdUnit4/test/mocker/resources/scenes/Spell.gd
+++ b/addons/gdUnit4/test/mocker/resources/scenes/Spell.gd
@@ -1,7 +1,7 @@
 class_name Spell
 extends Node
 
-signal spell_explode
+signal spell_explode(spell: Spell)
 
 const SPELL_LIVE_TIME = 1000
 
@@ -35,5 +35,5 @@ func move(delta :float) -> void:
 	_spell_pos.x += delta
 
 func explode() -> void:
-	emit_signal("spell_explode", self)
+	spell_explode.emit(self)
 

--- a/addons/gdUnit4/test/mocker/resources/scenes/TestScene.gd
+++ b/addons/gdUnit4/test/mocker/resources/scenes/TestScene.gd
@@ -15,7 +15,7 @@ const COLOR_CYCLE := [Color.ROYAL_BLUE, Color.CHARTREUSE, Color.YELLOW_GREEN]
 var _nullable :Object
 
 func _ready() -> void:
-	connect("panel_color_change", _on_panel_color_changed)
+	panel_color_change.connect(_on_panel_color_changed)
 	# we call this function to verify the _ready is only once called
 	# this is need to verify `add_child` is calling the original implementation only once
 	only_one_time_call()
@@ -35,11 +35,11 @@ func _on_test_pressed(button_id :int) -> void:
 		1: box = _box1
 		2: box = _box2
 		3: box = _box3
-	emit_signal("panel_color_change", box, Color.RED)
+	panel_color_change.emit(box, Color.RED)
 	# special case for button 3 we wait 1s to change to gray
 	if button_id == 3:
 		await get_tree().create_timer(1).timeout
-	emit_signal("panel_color_change", box, Color.GRAY)
+	panel_color_change.emit(box, Color.GRAY)
 
 
 func _on_panel_color_changed(box :ColorRect, color :Color) -> void:
@@ -49,7 +49,7 @@ func _on_panel_color_changed(box :ColorRect, color :Color) -> void:
 func create_timer(timeout :float) -> Timer:
 	var timer :Timer = Timer.new()
 	add_child(timer)
-	timer.connect("timeout",Callable(self,"_on_timeout").bind(timer))
+	timer.timeout.connect(_on_timeout.bind(timer))
 	timer.set_one_shot(true)
 	timer.start(timeout)
 	return timer

--- a/project.godot
+++ b/project.godot
@@ -12,7 +12,7 @@ config_version=5
 
 config/name="gdUnit4"
 config/tags=PackedStringArray("addon", "godot4", "testing")
-config/features=PackedStringArray("4.2", "C#")
+config/features=PackedStringArray("4.3", "C#")
 config/icon="res://icon.png"
 
 [audio]
@@ -23,9 +23,7 @@ default_bus_layout=""
 
 file_logging/enable_file_logging=true
 gdscript/warnings/exclude_addons=false
-gdscript/warnings/unused_signal=false
 gdscript/warnings/untyped_declaration=2
-gdscript/warnings/return_value_discarded=false
 
 [dotnet]
 
@@ -41,8 +39,8 @@ settings/common/update_notification_enabled=false
 ui/inspector/node_collapse=false
 ui/toolbar/run_overall=true
 ui/inspector/tree_sort_mode=1
-settings/test/test_discovery=true
 report/godot/script_error=false
+settings/test/test_discovery=true
 
 [importer_defaults]
 


### PR DESCRIPTION
# Why
see https://github.com/MikeSchulze/gdUnit4/issues/501

# What
- added Godot 4.3.beta1 to the CI workflow
- fixed enum default value warnings
- fixed unused signal warnings
- fixed missing test-suite icon resource
- fixed failing input action tests
- use typed values in GdObject to avoid bug https://github.com/godotengine/godot/issues/93193
- add `TYPE_PACKED_VECTOR4_ARRAY` constant to be used on Godot versions less than 4.3 (is introduced with beta1)

