### PR TITLE
GD-506: Revisit the ScriptEditorContextMenuHandler added to the root node

### DIFF
--- a/addons/gdUnit4/src/ui/GdUnitInspector.gd
+++ b/addons/gdUnit4/src/ui/GdUnitInspector.gd
@@ -2,6 +2,7 @@
 class_name GdUnitInspecor
 extends Panel
 
+const ScriptEditorContextMenuHandler = preload("res://addons/gdUnit4/src/ui/menu/ScriptEditorContextMenuHandler.gd")
 
 var _command_handler := GdUnitCommandHandler.instance()
 
@@ -22,7 +23,6 @@ func _ready() -> void:
 
 func _notification(what: int) -> void:
 	if what == NOTIFICATION_PREDELETE:
-		ScriptEditorControls.unregister_context_menu()
 		EditorFileSystemControls.unregister_context_menu()
 
 
@@ -69,7 +69,7 @@ func add_script_editor_context_menu() -> void:
 		GdUnitContextMenuItem.new(GdUnitContextMenuItem.MENU_ID.TEST_DEBUG, "Debug Tests", "PlayStart", is_test_suite.bind(true),_command_handler.command(GdUnitCommandHandler.CMD_RUN_TESTCASE_DEBUG)),
 		GdUnitContextMenuItem.new(GdUnitContextMenuItem.MENU_ID.CREATE_TEST, "Create Test", "New", is_test_suite.bind(false), _command_handler.command(GdUnitCommandHandler.CMD_CREATE_TESTCASE))
 	]
-	ScriptEditorControls.register_context_menu(menu)
+	add_child(ScriptEditorContextMenuHandler.new(menu))
 
 
 func _on_MainPanel_run_testsuite(test_suite_paths: Array, debug: bool) -> void:

--- a/addons/gdUnit4/src/ui/ScriptEditorControls.gd
+++ b/addons/gdUnit4/src/ui/ScriptEditorControls.gd
@@ -86,19 +86,6 @@ static func edit_script(script_path: String, line_number:=-1) -> void:
 	EditorInterface.edit_script(script, line_number)
 
 
-# Register the given context menu to the current script editor
-# Is called when the plugin is activated
-# The active script is connected to the ScriptEditorContextMenuHandler
-static func register_context_menu(menu: Array[GdUnitContextMenuItem]) -> void:
-	Engine.get_main_loop().root.call_deferred("add_child", ScriptEditorContextMenuHandler.new(menu))
-
-
-# Unregisteres all registerend context menus and gives the ScriptEditorContextMenuHandler> free
-# Is called when the plugin is deactivated
-static func unregister_context_menu() -> void:
-	ScriptEditorContextMenuHandler.dispose()
-
-
 static func _menu_popup() -> PopupMenu:
 	return EditorInterface.get_script_editor().get_child(0).get_child(0).get_child(0).get_popup()
 

--- a/addons/gdUnit4/src/ui/menu/ScriptEditorContextMenuHandler.gd
+++ b/addons/gdUnit4/src/ui/menu/ScriptEditorContextMenuHandler.gd
@@ -1,4 +1,3 @@
-class_name ScriptEditorContextMenuHandler
 extends Control
 
 var _context_menus := Dictionary()
@@ -12,17 +11,6 @@ func _init(context_menus: Array[GdUnitContextMenuItem]) -> void:
 	_editor = EditorInterface.get_script_editor()
 	_editor.editor_script_changed.connect(on_script_changed)
 	on_script_changed(active_script())
-
-
-static func dispose() -> void:
-	if  Engine.get_main_loop().root == null:
-		return
-	var handler: ScriptEditorContextMenuHandler = Engine.get_main_loop().root.find_child("ScriptEditorContextMenuHandler*", false, false)
-	if handler:
-		var editor := EditorInterface.get_script_editor()
-		if editor.editor_script_changed.is_connected(handler.on_script_changed):
-			editor.editor_script_changed.disconnect(handler.on_script_changed)
-		GodotVersionFixures.free_fix(handler)
 
 
 func _input(event: InputEvent) -> void:


### PR DESCRIPTION


# Why
https://github.com/MikeSchulze/gdUnit4/issues/506

# What
- simplify adding the `ScriptEditorContextMenuHandler`
- problematic "Dispose" functionality removed, the handler is now released via the standard Godot three-node free mechanism


