### PR TITLE
GD-505: Move GDUnitServer instantiating and releasing to GdUnitInspector

### DIFF
--- a/addons/gdUnit4/plugin.gd
+++ b/addons/gdUnit4/plugin.gd
@@ -6,7 +6,6 @@ const GdUnitTestDiscoverGuard := preload("res://addons/gdUnit4/src/core/discover
 
 
 var _gd_inspector :Node
-var _server_node :Node
 var _gd_console :Node
 var _guard: GdUnitTestDiscoverGuard
 
@@ -25,8 +24,6 @@ func _enter_tree() -> void:
 	# install the GdUnit Console
 	_gd_console = load("res://addons/gdUnit4/src/ui/GdUnitConsole.tscn").instantiate()
 	add_control_to_bottom_panel(_gd_console, "gdUnitConsole")
-	_server_node = load("res://addons/gdUnit4/src/network/GdUnitServer.tscn").instantiate()
-	Engine.get_main_loop().root.add_child.call_deferred(_server_node)
 	prints("Loading GdUnit4 Plugin success")
 	if GdUnitSettings.is_update_notification_enabled():
 		var update_tool :Node = load("res://addons/gdUnit4/src/update/GdUnitUpdateNotify.tscn").instantiate()
@@ -47,9 +44,6 @@ func _exit_tree() -> void:
 	if is_instance_valid(_gd_console):
 		remove_control_from_bottom_panel(_gd_console)
 		_gd_console.free()
-	if is_instance_valid(_server_node):
-		Engine.get_main_loop().root.remove_child.call_deferred(_server_node)
-		_server_node.queue_free()
 	GdUnitTools.dispose_all.call_deferred()
 	prints("Unload GdUnit4 Plugin success")
 

--- a/addons/gdUnit4/src/ui/GdUnitInspector.tscn
+++ b/addons/gdUnit4/src/ui/GdUnitInspector.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=7 format=3 uid="uid://mpo5o6d4uybu"]
+[gd_scene load_steps=8 format=3 uid="uid://mpo5o6d4uybu"]
 
 [ext_resource type="PackedScene" uid="uid://dx7xy4dgi3wwb" path="res://addons/gdUnit4/src/ui/parts/InspectorToolBar.tscn" id="1"]
 [ext_resource type="PackedScene" uid="uid://dva3tonxsxrlk" path="res://addons/gdUnit4/src/ui/parts/InspectorProgressBar.tscn" id="2"]
@@ -6,6 +6,7 @@
 [ext_resource type="PackedScene" uid="uid://djp8ait0bxpsc" path="res://addons/gdUnit4/src/ui/parts/InspectorMonitor.tscn" id="4"]
 [ext_resource type="Script" path="res://addons/gdUnit4/src/ui/GdUnitInspector.gd" id="5"]
 [ext_resource type="PackedScene" uid="uid://bqfpidewtpeg0" path="res://addons/gdUnit4/src/ui/parts/InspectorTreePanel.tscn" id="7"]
+[ext_resource type="PackedScene" path="res://addons/gdUnit4/src/network/GdUnitServer.tscn" id="7_721no"]
 
 [node name="GdUnit" type="Panel"]
 use_parent_material = true
@@ -50,6 +51,8 @@ layout_mode = 2
 
 [node name="Monitor" parent="VBoxContainer" instance=ExtResource("4")]
 layout_mode = 2
+
+[node name="event_server" parent="." instance=ExtResource("7_721no")]
 
 [connection signal="failure_next" from="VBoxContainer/Header/StatusBar" to="VBoxContainer/MainPanel" method="select_next_failure"]
 [connection signal="failure_prevous" from="VBoxContainer/Header/StatusBar" to="VBoxContainer/MainPanel" method="select_previous_failure"]


### PR DESCRIPTION
# Why
see https://github.com/MikeSchulze/gdUnit4/issues/505

# What
- Moved server loading to the inspector to be handled by the Godot tree itself for adding and releasing the resources
- removed server loading from the `plugin.gd`


