### PR TITLE
Bump to GdUnit4 v4.3.3

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -20,8 +20,9 @@ body:
       label: The used GdUnit4 version
       description: Which GdUnit4 version are you using?
       options:
-        - 4.3.2 (Pre Release/Master branch)
-        - 4.3.1 (Latest Release)
+        - 4.3.3 (Pre Release/Master branch)
+        - 4.3.2 (Latest Release)
+        - 4.3.1
         - 4.3.0
         - 4.2.5
         - 4.2.4
@@ -43,7 +44,7 @@ body:
     attributes:
       label: The used Godot version
       description: Which Godot version are you using?
-      placeholder: v4.2.1.stable.official [b09f793f5]
+      placeholder: v4.2.2.stable.official [15073afe3]
     validations:
       required: true
 

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -35,7 +35,7 @@ jobs:
         godot-net: ['.Net', '']
         include:
           - godot-version: '4.3'
-            godot-status: 'beta1'
+            godot-status: 'beta2'
 
     permissions:
       actions: write

--- a/addons/gdUnit4/plugin.cfg
+++ b/addons/gdUnit4/plugin.cfg
@@ -3,5 +3,5 @@
 name="gdUnit4"
 description="Unit Testing Framework for Godot Scripts"
 author="Mike Schulze"
-version="4.3.2"
+version="4.3.3"
 script="plugin.gd"


### PR DESCRIPTION

# What
- set new plugin version to v4.3.3
- update bug report template
- add Godot 4.3-beta2 to the CI workflow
