### PR TITLE
GD-529: Fix null value access in the inspector.

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -20,8 +20,9 @@ body:
       label: The used GdUnit4 version
       description: Which GdUnit4 version are you using?
       options:
-        - 4.3.3 (Pre Release/Master branch)
-        - 4.3.2 (Latest Release)
+        - 4.3.4 (Pre Release/Master branch)
+        - 4.3.3 (Latest Release)
+        - 4.3.2
         - 4.3.1
         - 4.3.0
         - 4.2.5

--- a/addons/gdUnit4/plugin.cfg
+++ b/addons/gdUnit4/plugin.cfg
@@ -3,5 +3,5 @@
 name="gdUnit4"
 description="Unit Testing Framework for Godot Scripts"
 author="Mike Schulze"
-version="4.3.3"
+version="4.3.4"
 script="plugin.gd"

--- a/addons/gdUnit4/src/ui/parts/InspectorTreeMainPanel.gd
+++ b/addons/gdUnit4/src/ui/parts/InspectorTreeMainPanel.gd
@@ -876,7 +876,10 @@ func _on_tree_item_mouse_selected(mouse_position: Vector2, mouse_button_index: i
 
 func _on_run_pressed(run_debug: bool) -> void:
 	_context_menu.hide()
-	var item := _tree.get_selected()
+	var item: = _tree.get_selected()
+	if item == null:
+		print_rich("[color=GOLDENROD]Abort Testrun, no test suite selected![/color]")
+		return
 	if item.get_meta(META_GDUNIT_TYPE) == GdUnitType.TEST_SUITE or item.get_meta(META_GDUNIT_TYPE) == GdUnitType.FOLDER:
 		var resource_path: String = item.get_meta(META_RESOURCE_PATH)
 		run_testsuite.emit([resource_path], run_debug)


### PR DESCRIPTION
# Why
A user reported an script error ` res://addons/gdUnit4/src/ui/parts/InspectorTreeMainPanel.gd:880 - Cannot call method 'get_meta' on a null value.` It can only happen when no test/test suite is selected in the inspector.

# What
Added a null check to avoid this kind of error

