### PR TITLE
Improve settings UI

### DIFF
--- a/addons/gdUnit4/src/core/GdUnitSettings.gd
+++ b/addons/gdUnit4/src/core/GdUnitSettings.gd
@@ -14,7 +14,7 @@ const SERVER_TIMEOUT = GROUP_COMMON + "/server_connection_timeout_minutes"
 const GROUP_TEST = COMMON_SETTINGS + "/test"
 const TEST_TIMEOUT = GROUP_TEST + "/test_timeout_seconds"
 const TEST_LOOKUP_FOLDER = GROUP_TEST + "/test_lookup_folder"
-const TEST_SITE_NAMING_CONVENTION = GROUP_TEST + "/test_suite_naming_convention"
+const TEST_SUITE_NAMING_CONVENTION = GROUP_TEST + "/test_suite_naming_convention"
 const TEST_DISCOVER_ENABLED = GROUP_TEST + "/test_discovery"
 
 
@@ -81,7 +81,7 @@ const DEFAULT_TEST_TIMEOUT :int = 60*5
 const DEFAULT_TEST_LOOKUP_FOLDER := "test"
 
 # help texts
-const HELP_TEST_LOOKUP_FOLDER := "Sets the subfolder for the search/creation of test suites. (leave empty to use source folder)"
+const HELP_TEST_LOOKUP_FOLDER := "Subfolder where test suites are located (or empty to use source folder directly)"
 
 enum NAMING_CONVENTIONS {
 	AUTO_DETECT,
@@ -94,28 +94,28 @@ const _VALUE_SET_SEPARATOR = "\f" # ASCII Form-feed character (AKA page break)
 
 
 static func setup() -> void:
-	create_property_if_need(UPDATE_NOTIFICATION_ENABLED, true, "Enables/Disables the update notification checked startup.")
-	create_property_if_need(SERVER_TIMEOUT, DEFAULT_SERVER_TIMEOUT, "Sets the server connection timeout in minutes.")
-	create_property_if_need(TEST_TIMEOUT, DEFAULT_TEST_TIMEOUT, "Sets the test case runtime timeout in seconds.")
+	create_property_if_need(UPDATE_NOTIFICATION_ENABLED, true, "Show notification if new gdUnit4 version is found")
+	create_property_if_need(SERVER_TIMEOUT, DEFAULT_SERVER_TIMEOUT, "Server connection timeout in minutes")
+	create_property_if_need(TEST_TIMEOUT, DEFAULT_TEST_TIMEOUT, "Test case runtime timeout in seconds")
 	create_property_if_need(TEST_LOOKUP_FOLDER, DEFAULT_TEST_LOOKUP_FOLDER, HELP_TEST_LOOKUP_FOLDER)
-	create_property_if_need(TEST_SITE_NAMING_CONVENTION, NAMING_CONVENTIONS.AUTO_DETECT, "Sets test-suite genrate script name convention.", NAMING_CONVENTIONS.keys())
-	create_property_if_need(TEST_DISCOVER_ENABLED, false, "Enables/Disables the automatic detection of tests by finding tests in test lookup folders at runtime.")
-	create_property_if_need(REPORT_PUSH_ERRORS, false, "Enables/Disables report of push_error() as failure!")
-	create_property_if_need(REPORT_SCRIPT_ERRORS, true, "Enables/Disables report of script errors as failure!")
-	create_property_if_need(REPORT_ORPHANS, true, "Enables/Disables orphan reporting.")
-	create_property_if_need(REPORT_ASSERT_ERRORS, true, "Enables/Disables error reporting checked asserts.")
-	create_property_if_need(REPORT_ASSERT_WARNINGS, true, "Enables/Disables warning reporting checked asserts")
-	create_property_if_need(REPORT_ASSERT_STRICT_NUMBER_TYPE_COMPARE, true, "Enabled/disabled number values will be compared strictly by type. (real vs int)")
+	create_property_if_need(TEST_SUITE_NAMING_CONVENTION, NAMING_CONVENTIONS.AUTO_DETECT, "Naming convention to use when generating testsuites", NAMING_CONVENTIONS.keys())
+	create_property_if_need(TEST_DISCOVER_ENABLED, false, "Automatically detect new tests in test lookup folders at runtime")
+	create_property_if_need(REPORT_PUSH_ERRORS, false, "Report push_error() as failure")
+	create_property_if_need(REPORT_SCRIPT_ERRORS, true, "Report script errors as failure")
+	create_property_if_need(REPORT_ORPHANS, true, "Report orphaned nodes after tests finish")
+	create_property_if_need(REPORT_ASSERT_ERRORS, true, "Report assertion failures as errors")
+	create_property_if_need(REPORT_ASSERT_WARNINGS, true, "Report assertion failures as warnings")
+	create_property_if_need(REPORT_ASSERT_STRICT_NUMBER_TYPE_COMPARE, true, "Compare number values strictly by type (real vs int)")
 	# inspector
 	create_property_if_need(INSPECTOR_NODE_COLLAPSE, true,
-		"Enables/Disables that the testsuite node is closed after a successful test run.")
+		"Close testsuite node after a successful test run.")
 	create_property_if_need(INSPECTOR_TREE_VIEW_MODE, GdUnitInspectorTreeConstants.TREE_VIEW_MODE.TREE,
-		"Sets the inspector panel presentation.", GdUnitInspectorTreeConstants.TREE_VIEW_MODE.keys())
+		"Inspector panel presentation mode", GdUnitInspectorTreeConstants.TREE_VIEW_MODE.keys())
 	create_property_if_need(INSPECTOR_TREE_SORT_MODE, GdUnitInspectorTreeConstants.SORT_MODE.UNSORTED,
-		"Sets the inspector panel presentation.", GdUnitInspectorTreeConstants.SORT_MODE.keys())
+		"Inspector panel sorting mode", GdUnitInspectorTreeConstants.SORT_MODE.keys())
 	create_property_if_need(INSPECTOR_TOOLBAR_BUTTON_RUN_OVERALL, false,
-		"Shows/Hides the 'Run overall Tests' button in the inspector toolbar.")
-	create_property_if_need(TEMPLATE_TS_GD, GdUnitTestSuiteTemplate.default_GD_template(), "Defines the test suite template")
+		"Show 'Run overall Tests' button in the inspector toolbar")
+	create_property_if_need(TEMPLATE_TS_GD, GdUnitTestSuiteTemplate.default_GD_template(), "Test suite template to use")
 	create_shortcut_properties_if_need()
 	migrate_properties()
 
@@ -132,17 +132,17 @@ static func migrate_properties() -> void:
 
 static func create_shortcut_properties_if_need() -> void:
 	# inspector
-	create_property_if_need(SHORTCUT_INSPECTOR_RERUN_TEST, GdUnitShortcut.default_keys(GdUnitShortcut.ShortCut.RERUN_TESTS), "Rerun of the last tests performed.")
-	create_property_if_need(SHORTCUT_INSPECTOR_RERUN_TEST_DEBUG, GdUnitShortcut.default_keys(GdUnitShortcut.ShortCut.RERUN_TESTS_DEBUG), "Rerun of the last tests performed (Debug).")
-	create_property_if_need(SHORTCUT_INSPECTOR_RUN_TEST_OVERALL, GdUnitShortcut.default_keys(GdUnitShortcut.ShortCut.RUN_TESTS_OVERALL), "Runs all tests (Debug).")
-	create_property_if_need(SHORTCUT_INSPECTOR_RUN_TEST_STOP, GdUnitShortcut.default_keys(GdUnitShortcut.ShortCut.STOP_TEST_RUN), "Stops the current test execution.")
+	create_property_if_need(SHORTCUT_INSPECTOR_RERUN_TEST, GdUnitShortcut.default_keys(GdUnitShortcut.ShortCut.RERUN_TESTS), "Rerun the most recently executed tests")
+	create_property_if_need(SHORTCUT_INSPECTOR_RERUN_TEST_DEBUG, GdUnitShortcut.default_keys(GdUnitShortcut.ShortCut.RERUN_TESTS_DEBUG), "Rerun the most recently executed tests (Debug mode)")
+	create_property_if_need(SHORTCUT_INSPECTOR_RUN_TEST_OVERALL, GdUnitShortcut.default_keys(GdUnitShortcut.ShortCut.RUN_TESTS_OVERALL), "Runs all tests (Debug mode)")
+	create_property_if_need(SHORTCUT_INSPECTOR_RUN_TEST_STOP, GdUnitShortcut.default_keys(GdUnitShortcut.ShortCut.STOP_TEST_RUN), "Stop the current test execution")
 	# script editor
-	create_property_if_need(SHORTCUT_EDITOR_RUN_TEST, GdUnitShortcut.default_keys(GdUnitShortcut.ShortCut.RUN_TESTCASE), "Runs the currently selected test.")
-	create_property_if_need(SHORTCUT_EDITOR_RUN_TEST_DEBUG, GdUnitShortcut.default_keys(GdUnitShortcut.ShortCut.RUN_TESTCASE_DEBUG), "Runs the currently selected test (Debug).")
-	create_property_if_need(SHORTCUT_EDITOR_CREATE_TEST, GdUnitShortcut.default_keys(GdUnitShortcut.ShortCut.CREATE_TEST), "Creates a new test case for the currently selected function.")
+	create_property_if_need(SHORTCUT_EDITOR_RUN_TEST, GdUnitShortcut.default_keys(GdUnitShortcut.ShortCut.RUN_TESTCASE), "Run the currently selected test")
+	create_property_if_need(SHORTCUT_EDITOR_RUN_TEST_DEBUG, GdUnitShortcut.default_keys(GdUnitShortcut.ShortCut.RUN_TESTCASE_DEBUG), "Run the currently selected test (Debug mode).")
+	create_property_if_need(SHORTCUT_EDITOR_CREATE_TEST, GdUnitShortcut.default_keys(GdUnitShortcut.ShortCut.CREATE_TEST), "Create a new test case for the currently selected function")
 	# filesystem
-	create_property_if_need(SHORTCUT_FILESYSTEM_RUN_TEST, GdUnitShortcut.default_keys(GdUnitShortcut.ShortCut.NONE), "Runs all test suites on the selected folder or file.")
-	create_property_if_need(SHORTCUT_FILESYSTEM_RUN_TEST_DEBUG, GdUnitShortcut.default_keys(GdUnitShortcut.ShortCut.NONE), "Runs all test suites on the selected folder or file (Debug).")
+	create_property_if_need(SHORTCUT_FILESYSTEM_RUN_TEST, GdUnitShortcut.default_keys(GdUnitShortcut.ShortCut.NONE), "Run all test suites in the selected folder or file")
+	create_property_if_need(SHORTCUT_FILESYSTEM_RUN_TEST_DEBUG, GdUnitShortcut.default_keys(GdUnitShortcut.ShortCut.NONE), "Run all test suites in the selected folder or file (Debug)")
 
 
 static func create_property_if_need(name :String, default :Variant, help :="", value_set := PackedStringArray()) -> void:

--- a/addons/gdUnit4/src/core/GdUnitTestSuiteScanner.gd
+++ b/addons/gdUnit4/src/core/GdUnitTestSuiteScanner.gd
@@ -231,7 +231,7 @@ func _validate_argument(fd :GdFunctionDescriptor, test_case :_TestCase) -> void:
 
 # converts given file name by configured naming convention
 static func _to_naming_convention(file_name :String) -> String:
-	var nc :int = GdUnitSettings.get_setting(GdUnitSettings.TEST_SITE_NAMING_CONVENTION, 0)
+	var nc :int = GdUnitSettings.get_setting(GdUnitSettings.TEST_SUITE_NAMING_CONVENTION, 0)
 	match nc:
 		GdUnitSettings.NAMING_CONVENTIONS.AUTO_DETECT:
 			if GdObjects.is_snake_case(file_name):

--- a/addons/gdUnit4/src/ui/settings/GdUnitSettingsDialog.gd
+++ b/addons/gdUnit4/src/ui/settings/GdUnitSettingsDialog.gd
@@ -54,25 +54,30 @@ func setup_properties(properties_parent: Node, property_category: String) -> voi
 	theme_.set_constant("h_separation", "GridContainer", 12)
 	var last_category := "!"
 	var min_size_overall := 0.0
+	var labels := []
+	var inputs := []
+	var info_labels := []
+	var grid: GridContainer = null
 	for p in category_properties:
 		var min_size_ := 0.0
-		var grid := GridContainer.new()
-		grid.columns = 4
-		grid.theme = theme_
 		var property: GdUnitProperty = p
 		var current_category := property.category()
-		if current_category != last_category:
+		if not grid or current_category != last_category:
+			grid = GridContainer.new()
+			grid.columns = 4
+			grid.theme = theme_
+
 			var sub_category: Node = _properties_template.get_child(3).duplicate()
 			sub_category.get_child(0).text = current_category.capitalize()
 			sub_category.custom_minimum_size.y = _font_size + 16
 			properties_parent.add_child(sub_category)
+			properties_parent.add_child(grid)
 			last_category = current_category
 		# property name
 		var label: Label = _properties_template.get_child(0).duplicate()
 		label.text = _to_human_readable(property.name())
-		label.custom_minimum_size = Vector2(_font_size * 20, 0)
+		labels.append(label)
 		grid.add_child(label)
-		min_size_ += label.size.x
 
 		# property reset btn
 		var reset_btn: Button = _properties_template.get_child(1).duplicate()
@@ -83,18 +88,21 @@ func setup_properties(properties_parent: Node, property_category: String) -> voi
 
 		# property type specific input element
 		var input: Node = _create_input_element(property, reset_btn)
-		input.custom_minimum_size = Vector2(_font_size * 15, 0)
+		inputs.append(input)
 		grid.add_child(input)
-		min_size_ += input.size.x
 		reset_btn.pressed.connect(_on_btn_property_reset_pressed.bind(property, input, reset_btn))
 		# property help text
 		var info: Node = _properties_template.get_child(2).duplicate()
 		info.text = property.help()
+		info_labels.append(info)
 		grid.add_child(info)
-		min_size_ += info.text.length() * _font_size
 		if min_size_overall < min_size_:
 			min_size_overall = min_size_
-		properties_parent.add_child(grid)
+	for controls: Array in [labels, inputs, info_labels]:
+		var _size: float = controls.map(func(c: Control) -> float: return c.size.x).max()
+		min_size_overall += _size
+		for control: Control in controls:
+			control.custom_minimum_size.x = _size
 	properties_parent.custom_minimum_size.x = min_size_overall
 
 

--- a/addons/gdUnit4/src/ui/settings/GdUnitSettingsDialog.tscn
+++ b/addons/gdUnit4/src/ui/settings/GdUnitSettingsDialog.tscn
@@ -117,7 +117,7 @@ shadow_offset = Vector2(10, 10)
 [node name="Control" type="Window"]
 disable_3d = true
 gui_embed_subwindows = true
-title = "GdUnitSettings"
+title = "GdUnit4 Settings"
 initial_position = 1
 size = Vector2i(1006, 723)
 visible = false
@@ -157,7 +157,6 @@ offset_right = 590.0
 offset_bottom = 25.0
 size_flags_horizontal = 3
 text = "Enables/disables the update notification "
-clip_text = true
 max_lines_visible = 1
 
 [node name="sub_category" type="Panel" parent="property_template"]
@@ -310,7 +309,6 @@ layout_mode = 2
 [node name="common-content" type="VBoxContainer" parent="Panel/PanelContainer/v/MarginContainer/GridContainer/Properties/Common"]
 unique_name_in_owner = true
 clip_contents = true
-custom_minimum_size = Vector2(1557, 0)
 layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 3
@@ -322,7 +320,6 @@ layout_mode = 2
 [node name="ui-content" type="VBoxContainer" parent="Panel/PanelContainer/v/MarginContainer/GridContainer/Properties/UI"]
 unique_name_in_owner = true
 clip_contents = true
-custom_minimum_size = Vector2(1361, 0)
 layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 3
@@ -334,7 +331,6 @@ layout_mode = 2
 [node name="shortcut-content" type="VBoxContainer" parent="Panel/PanelContainer/v/MarginContainer/GridContainer/Properties/Shortcuts"]
 unique_name_in_owner = true
 clip_contents = true
-custom_minimum_size = Vector2(983, 0)
 layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 3
@@ -346,7 +342,6 @@ layout_mode = 2
 [node name="report-content" type="VBoxContainer" parent="Panel/PanelContainer/v/MarginContainer/GridContainer/Properties/Report"]
 unique_name_in_owner = true
 clip_contents = true
-custom_minimum_size = Vector2(1249, 0)
 layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 3

--- a/addons/gdUnit4/test/core/GdUnitSettingsTest.gd
+++ b/addons/gdUnit4/test/core/GdUnitSettingsTest.gd
@@ -71,7 +71,7 @@ func test_enum_property() -> void:
 	assert_that(property.default()).is_equal(GdUnitSettings.NAMING_CONVENTIONS.AUTO_DETECT)
 	assert_that(property.value()).is_equal(GdUnitSettings.NAMING_CONVENTIONS.AUTO_DETECT)
 	assert_that(property.type()).is_equal(TYPE_INT)
-	assert_that(property.help()).is_equal('help ["AUTO_DETECT", "SNAKE_CASE", "PASCAL_CASE"]')
+	assert_that(property.help()).is_equal('help')
 	assert_that(property.value_set()).is_equal(value_set)
 
 

--- a/addons/gdUnit4/test/core/GdUnitTestSuiteScannerTest.gd
+++ b/addons/gdUnit4/test/core/GdUnitTestSuiteScannerTest.gd
@@ -8,7 +8,7 @@ extends GdUnitTestSuite
 const __source = 'res://addons/gdUnit4/src/core/GdUnitTestSuiteScanner.gd'
 
 func before_test() -> void:
-	ProjectSettings.set_setting(GdUnitSettings.TEST_SITE_NAMING_CONVENTION, GdUnitSettings.NAMING_CONVENTIONS.AUTO_DETECT)
+	ProjectSettings.set_setting(GdUnitSettings.TEST_SUITE_NAMING_CONVENTION, GdUnitSettings.NAMING_CONVENTIONS.AUTO_DETECT)
 	clean_temp_dir()
 
 
@@ -320,17 +320,17 @@ func test_get_test_case_line_number() -> void:
 
 
 func test__to_naming_convention() -> void:
-	ProjectSettings.set_setting(GdUnitSettings.TEST_SITE_NAMING_CONVENTION, GdUnitSettings.NAMING_CONVENTIONS.AUTO_DETECT)
+	ProjectSettings.set_setting(GdUnitSettings.TEST_SUITE_NAMING_CONVENTION, GdUnitSettings.NAMING_CONVENTIONS.AUTO_DETECT)
 	assert_str(GdUnitTestSuiteScanner._to_naming_convention("MyClass")).is_equal("MyClassTest")
 	assert_str(GdUnitTestSuiteScanner._to_naming_convention("my_class")).is_equal("my_class_test")
 	assert_str(GdUnitTestSuiteScanner._to_naming_convention("myclass")).is_equal("myclass_test")
 
-	ProjectSettings.set_setting(GdUnitSettings.TEST_SITE_NAMING_CONVENTION, GdUnitSettings.NAMING_CONVENTIONS.SNAKE_CASE)
+	ProjectSettings.set_setting(GdUnitSettings.TEST_SUITE_NAMING_CONVENTION, GdUnitSettings.NAMING_CONVENTIONS.SNAKE_CASE)
 	assert_str(GdUnitTestSuiteScanner._to_naming_convention("MyClass")).is_equal("my_class_test")
 	assert_str(GdUnitTestSuiteScanner._to_naming_convention("my_class")).is_equal("my_class_test")
 	assert_str(GdUnitTestSuiteScanner._to_naming_convention("myclass")).is_equal("myclass_test")
 
-	ProjectSettings.set_setting(GdUnitSettings.TEST_SITE_NAMING_CONVENTION, GdUnitSettings.NAMING_CONVENTIONS.PASCAL_CASE)
+	ProjectSettings.set_setting(GdUnitSettings.TEST_SUITE_NAMING_CONVENTION, GdUnitSettings.NAMING_CONVENTIONS.PASCAL_CASE)
 	assert_str(GdUnitTestSuiteScanner._to_naming_convention("MyClass")).is_equal("MyClassTest")
 	assert_str(GdUnitTestSuiteScanner._to_naming_convention("my_class")).is_equal("MyClassTest")
 	assert_str(GdUnitTestSuiteScanner._to_naming_convention("myclass")).is_equal("MyclassTest")


### PR DESCRIPTION
Hi, this PR improves the settings dialogue UI, making it significantly more compact, and IMHO, also easier to understand and nicer to look at.

Before:
![gdunit-before](https://github.com/MikeSchulze/gdUnit4/assets/179487/cae07ac3-3065-4f41-802d-ecde475a95a7)

After:
![gdunit-after](https://github.com/MikeSchulze/gdUnit4/assets/179487/0265e7e3-e75c-46cc-9da5-892940597bcb)


The changes are split into three commits

1. Remove the value sets of settings from the user-facing help strings. Fixes #539 
2. Improve the wording of the help strings themselves (more detailed description in the commit message). Fixes #540 
3. Improved sizing logic for the grid views displaying the settings, meaning less space is wasted, and huge amounts of unused space don't make the scrollbars huge unnecessarily. Not every tab in the dialogue is currently able to fit in without scrolling on my laptop, but some of them are, and it's generally much nicer. Fixes #541


I did not make any changes to the settings themselves, everything is as it was before and split across tabs in the same way. I did a full test suite run locally, and everything works aside from the C# tests, which I did not run, as I'm not using Godot Mono.