### PR TITLE
GD-533: Fixes script error in `TestSuiteTemplate` when Godot was installed for the first time

### DIFF
--- a/addons/gdUnit4/src/ui/templates/TestSuiteTemplate.gd
+++ b/addons/gdUnit4/src/ui/templates/TestSuiteTemplate.gd
@@ -30,10 +30,10 @@ func _notification(what :int) -> void:
 func setup_editor_colors() -> void:
 	if not Engine.is_editor_hint():
 		return
-	var settings := EditorInterface.get_editor_settings()
-	var background_color :Color = settings.get_setting("text_editor/theme/highlighting/background_color")
-	var text_color :Color = settings.get_setting("text_editor/theme/highlighting/text_color")
-	var selection_color :Color = settings.get_setting("text_editor/theme/highlighting/selection_color")
+
+	var background_color := get_editor_color("text_editor/theme/highlighting/background_color", Color(0.1155, 0.132, 0.1595, 1))
+	var text_color := get_editor_color("text_editor/theme/highlighting/text_color", Color(0.8025, 0.81, 0.8225, 1))
+	var selection_color := get_editor_color("text_editor/theme/highlighting/selection_color", Color(0.44, 0.73, 0.98, 0.4))
 
 	for e :CodeEdit in [_template_editor, _tags_editor]:
 		var editor :CodeEdit = e
@@ -41,20 +41,20 @@ func setup_editor_colors() -> void:
 		editor.add_theme_color_override("font_color", text_color)
 		editor.add_theme_color_override("font_readonly_color", text_color)
 		editor.add_theme_color_override("font_selected_color", selection_color)
-		setup_highlighter(editor, settings)
+		setup_highlighter(editor)
 
 
-func setup_highlighter(editor :CodeEdit, settings :EditorSettings) -> void:
+func setup_highlighter(editor :CodeEdit) -> void:
 	var highlighter := CodeHighlighter.new()
 	editor.set_syntax_highlighter(highlighter)
-	var number_color :Color = settings.get_setting("text_editor/theme/highlighting/number_color")
-	var symbol_color :Color = settings.get_setting("text_editor/theme/highlighting/symbol_color")
-	var function_color :Color = settings.get_setting("text_editor/theme/highlighting/function_color")
-	var member_variable_color :Color = settings.get_setting("text_editor/theme/highlighting/member_variable_color")
-	var comment_color :Color = settings.get_setting("text_editor/theme/highlighting/comment_color")
-	var keyword_color :Color = settings.get_setting("text_editor/theme/highlighting/keyword_color")
-	var base_type_color :Color = settings.get_setting("text_editor/theme/highlighting/base_type_color")
-	var annotation_color :Color = settings.get_setting("text_editor/theme/highlighting/gdscript/annotation_color")
+	var number_color := get_editor_color("text_editor/theme/highlighting/number_color", Color(0.63, 1, 0.88, 1))
+	var symbol_color := get_editor_color("text_editor/theme/highlighting/symbol_color", Color(0.67, 0.79, 1, 1))
+	var function_color := get_editor_color("text_editor/theme/highlighting/function_color", Color(0.34, 0.7, 1, 1))
+	var member_variable_color := get_editor_color("text_editor/theme/highlighting/member_variable_color", Color(0.736, 0.88, 1, 1))
+	var comment_color := get_editor_color("text_editor/theme/highlighting/comment_color", Color(0.8025, 0.81, 0.8225, 0.5))
+	var keyword_color := get_editor_color("text_editor/theme/highlighting/keyword_color", Color(1, 0.44, 0.52, 1))
+	var base_type_color := get_editor_color("text_editor/theme/highlighting/base_type_color", Color(0.26, 1, 0.76, 1))
+	var annotation_color := get_editor_color("text_editor/theme/highlighting/gdscript/annotation_color", Color(1, 0.7, 0.45, 1))
 
 	highlighter.clear_color_regions()
 	highlighter.clear_keyword_colors()
@@ -72,6 +72,13 @@ func setup_highlighter(editor :CodeEdit, settings :EditorSettings) -> void:
 		highlighter.add_keyword_color(word, keyword_color)
 	for word in gdunit_key_words:
 		highlighter.add_keyword_color(word, base_type_color)
+
+
+## Using this function to avoid null references to colors on inital Godot installations.
+## For more details show https://github.com/MikeSchulze/gdUnit4/issues/533
+func get_editor_color(property_name: String, default: Color) -> Color:
+	var settings := EditorInterface.get_editor_settings()
+	return settings.get_setting(property_name) if settings.has_setting(property_name) else default
 
 
 func setup_fonts() -> void:


### PR DESCRIPTION
# Why
see https://github.com/MikeSchulze/gdUnit4/issues/533

# What
We do use a default color if the editor settings have the default color not set.


