### PR TITLE
GD-537: Fix comparing objects containing built-in script type members

### DIFF
--- a/addons/gdUnit4/src/core/GdObjects.gd
+++ b/addons/gdUnit4/src/core/GdObjects.gd
@@ -146,7 +146,7 @@ enum COMPARE_MODE {
 
 
 # prototype of better object to dictionary
-static func obj2dict(obj :Object, hashed_objects := Dictionary()) -> Dictionary:
+static func obj2dict(obj: Object, hashed_objects := Dictionary()) -> Dictionary:
 	if obj == null:
 		return {}
 	var clazz_name := obj.get_class()
@@ -154,13 +154,20 @@ static func obj2dict(obj :Object, hashed_objects := Dictionary()) -> Dictionary:
 	var clazz_path := ""
 
 	if is_instance_valid(obj) and obj.get_script() != null:
-		var d := inst_to_dict(obj)
-		clazz_path = d["@path"]
-		if d["@subpath"] != NodePath(""):
-			clazz_name = d["@subpath"]
-			dict["@inner_class"] = true
+		var script: Script = obj.get_script()
+		# handle build-in scripts
+		if script.resource_path != null and script.resource_path.contains(".tscn"):
+			var path_elements := script.resource_path.split(".tscn")
+			clazz_name = path_elements[0].get_file()
+			clazz_path = script.resource_path
 		else:
-			clazz_name = clazz_path.get_file().replace(".gd", "")
+			var d := inst_to_dict(obj)
+			clazz_path = d["@path"]
+			if d["@subpath"] != NodePath(""):
+				clazz_name = d["@subpath"]
+				dict["@inner_class"] = true
+			else:
+				clazz_name = clazz_path.get_file().replace(".gd", "")
 	dict["@path"] = clazz_path
 
 	for property in obj.get_property_list():

--- a/addons/gdUnit4/test/core/GdObjectsTest.gd
+++ b/addons/gdUnit4/test/core/GdObjectsTest.gd
@@ -513,3 +513,18 @@ func test_is_snake_case() -> void:
 	assert_bool(GdObjects.is_snake_case("myclassname")).is_true()
 	assert_bool(GdObjects.is_snake_case("MyClassName")).is_false()
 	assert_bool(GdObjects.is_snake_case("my_class_nameTest")).is_false()
+
+
+class ObjectWithSceneReferece:
+	var _node: Node
+
+	func _init(node: Node) -> void:
+		_node = node
+
+
+func test_is_equal_on_scene_embedded_script() -> void:
+	var node :Variant = auto_free(load("res://addons/gdUnit4/test/core/resources/scenes/SceneWithEmbeddedScript.tscn").instantiate())
+
+	GdObjects.equals(ObjectWithSceneReferece.new(node), ObjectWithSceneReferece.new(node), false)
+	assert_object(ObjectWithSceneReferece.new(node)).is_equal(ObjectWithSceneReferece.new(node))
+

--- a/addons/gdUnit4/test/core/resources/scenes/SceneWithEmbeddedScript.tscn
+++ b/addons/gdUnit4/test/core/resources/scenes/SceneWithEmbeddedScript.tscn
@@ -1,0 +1,18 @@
+[gd_scene load_steps=2 format=3 uid="uid://t87enbab7q2c"]
+
+[sub_resource type="GDScript" id="GDScript_qh6va"]
+script/source = "# build-in script
+extends Control
+
+@warning_ignore(\"unused_private_class_variable\")
+var _a: int
+"
+
+[node name="SceneWithEmbeddedScript" type="Control"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+script = SubResource("GDScript_qh6va")


### PR DESCRIPTION
# Why
see https://github.com/MikeSchulze/gdUnit4/issues/537

# What
fixed the `obj2dict` by add handling built-in scripts to extract the class_name and class_path

