### PR TITLE
GD-544: Add Spy support for `Callable`

### DIFF
--- a/addons/gdUnit4/src/core/GdFunctionDoubler.gd
+++ b/addons/gdUnit4/src/core/GdFunctionDoubler.gd
@@ -113,14 +113,13 @@ func _init(push_errors :bool = false) -> void:
 
 
 @warning_ignore("unused_parameter")
-func get_template(return_type :Variant, is_vararg :bool) -> String:
-	push_error("Must be implemented!")
+func get_template(return_type: GdFunctionDescriptor, is_callable: bool) -> String:
+	assert(false, "'get_template' must be implemented!")
 	return ""
 
-func double(func_descriptor :GdFunctionDescriptor) -> PackedStringArray:
+func double(func_descriptor: GdFunctionDescriptor, is_callable: bool = false) -> PackedStringArray:
 	var func_signature := func_descriptor.typeless()
 	var is_static := func_descriptor.is_static()
-	var is_vararg := func_descriptor.is_vararg()
 	var is_coroutine := func_descriptor.is_coroutine()
 	var func_name := func_descriptor.name()
 	var args := func_descriptor.args()
@@ -145,7 +144,7 @@ func double(func_descriptor :GdFunctionDescriptor) -> PackedStringArray:
 	double_src += '@warning_ignore("shadowed_variable")\n'
 	double_src += func_signature
 	# fix to  unix format, this is need when the template is edited under windows than the template is stored with \r\n
-	var func_template := get_template(func_descriptor.return_type(), is_vararg).replace("\r\n", "\n")
+	var func_template := get_template(func_descriptor, is_callable).replace("\r\n", "\n")
 	double_src += func_template\
 		.replace("$(arguments)", ", ".join(arg_names))\
 		.replace("$(varargs)", ", ".join(vararg_names))\

--- a/addons/gdUnit4/src/core/GdObjects.gd
+++ b/addons/gdUnit4/src/core/GdObjects.gd
@@ -661,6 +661,7 @@ static func default_value_by_type(type :int) -> Variant:
 		TYPE_NODE_PATH: return NodePath()
 		TYPE_RID: return RID()
 		TYPE_OBJECT: return null
+		TYPE_CALLABLE: return Callable()
 		TYPE_ARRAY: return []
 		TYPE_DICTIONARY: return {}
 		TYPE_PACKED_BYTE_ARRAY: return PackedByteArray()

--- a/addons/gdUnit4/src/core/GdUnitClassDoubler.gd
+++ b/addons/gdUnit4/src/core/GdUnitClassDoubler.gd
@@ -81,7 +81,7 @@ static func double_functions(instance :Object, clazz_name :String, clazz_path :P
 					continue
 				if functions.has(func_descriptor.name()) or exclude_override_functions.has(func_descriptor.name()):
 					continue
-				doubled_source += func_doubler.double(func_descriptor)
+				doubled_source += func_doubler.double(func_descriptor, instance is CallableDoubler)
 				functions.append(func_descriptor.name())
 			class_descriptor = class_descriptor.parent()
 
@@ -103,7 +103,7 @@ static func double_functions(instance :Object, clazz_name :String, clazz_path :P
 			#prints("no virtual func implemented",clazz_name, func_descriptor.name() )
 			continue
 		functions.append(func_descriptor.name())
-		doubled_source.append_array(func_doubler.double(func_descriptor))
+		doubled_source.append_array(func_doubler.double(func_descriptor, instance is CallableDoubler))
 	return doubled_source
 
 

--- a/addons/gdUnit4/src/doubler/CallableDoubler.gd
+++ b/addons/gdUnit4/src/doubler/CallableDoubler.gd
@@ -1,0 +1,210 @@
+## The helper class to allow to double Callable
+## Is just a wrapper to the original callable with the same function signature.
+##
+## Due to interface conflicts between 'Callable' and 'Object',
+## it is not possible to stub the 'call' and 'call_deferred' methods.
+##
+## The Callable interface and the Object class have overlapping method signatures,
+## which causes conflicts when attempting to stub these methods.
+## As a result, you cannot create stubs for 'call' and 'call_deferred' methods.
+
+class_name CallableDoubler
+
+
+const doubler_script :Script =  preload("res://addons/gdUnit4/src/doubler/CallableDoubler.gd")
+
+var _cb: Callable
+
+
+func _init(cb: Callable) -> void:
+	assert(cb!=null, "Invalid argument <cb> must not be null")
+	_cb = cb
+
+## --- helpers -----------------------------------------------------------------------------------------------------------------------------
+static func map_func_name(method_info: Dictionary) -> String:
+	return method_info["name"]
+
+
+## We do not want to double all functions based on Object for this class
+## Is used on SpyBuilder to excluding functions to be doubled for Callable
+static func excluded_functions() -> PackedStringArray:
+	return ClassDB.class_get_method_list("Object")\
+		.map(CallableDoubler.map_func_name)\
+		.filter(func (name: String) -> bool:
+			return !CallableDoubler.callable_functions().has(name))
+
+
+static func non_callable_functions(name: String) -> bool:
+	return ![
+		# we allow "_init", is need to construct it,
+		"excluded_functions",
+		"non_callable_functions",
+		"callable_functions",
+		"map_func_name"
+		].has(name)
+
+
+## Returns the list of supported Callable functions
+static func callable_functions() -> PackedStringArray:
+	var supported_functions :Array = doubler_script.get_script_method_list()\
+		.map(CallableDoubler.map_func_name)\
+		.filter(CallableDoubler.non_callable_functions)
+	# We manually add these functions that we cannot/may not overwrite in this class
+	supported_functions.append_array(["call_deferred", "callv"])
+	return supported_functions
+
+
+## -----------------------------------------------------------------------------------------------------------------------------------------
+## Callable functions stubing
+## -----------------------------------------------------------------------------------------------------------------------------------------
+
+@warning_ignore("untyped_declaration")
+func bind(arg0=GdObjects.TYPE_VARARG_PLACEHOLDER_VALUE,
+	arg1=GdObjects.TYPE_VARARG_PLACEHOLDER_VALUE,
+	arg2=GdObjects.TYPE_VARARG_PLACEHOLDER_VALUE,
+	arg3=GdObjects.TYPE_VARARG_PLACEHOLDER_VALUE,
+	arg4=GdObjects.TYPE_VARARG_PLACEHOLDER_VALUE,
+	arg5=GdObjects.TYPE_VARARG_PLACEHOLDER_VALUE,
+	arg6=GdObjects.TYPE_VARARG_PLACEHOLDER_VALUE,
+	arg7=GdObjects.TYPE_VARARG_PLACEHOLDER_VALUE,
+	arg8=GdObjects.TYPE_VARARG_PLACEHOLDER_VALUE,
+	arg9=GdObjects.TYPE_VARARG_PLACEHOLDER_VALUE) -> Callable:
+	# save
+	var bind_values = GdArrayTools.filter_value([arg0,arg1,arg2,arg3,arg4,arg5,arg6,arg7,arg8,arg9], GdObjects.TYPE_VARARG_PLACEHOLDER_VALUE)
+	_cb = _cb.bindv(bind_values)
+	return _cb
+
+
+func bindv(caller_args: Array) -> Callable:
+	_cb = _cb.bindv(caller_args)
+	return _cb
+
+
+@warning_ignore("untyped_declaration", "native_method_override", "unused_parameter")
+func call(arg0=null,
+	arg1=GdObjects.TYPE_VARARG_PLACEHOLDER_VALUE,
+	arg2=GdObjects.TYPE_VARARG_PLACEHOLDER_VALUE,
+	arg3=GdObjects.TYPE_VARARG_PLACEHOLDER_VALUE,
+	arg4=GdObjects.TYPE_VARARG_PLACEHOLDER_VALUE,
+	arg5=GdObjects.TYPE_VARARG_PLACEHOLDER_VALUE,
+	arg6=GdObjects.TYPE_VARARG_PLACEHOLDER_VALUE,
+	arg7=GdObjects.TYPE_VARARG_PLACEHOLDER_VALUE,
+	arg8=GdObjects.TYPE_VARARG_PLACEHOLDER_VALUE,
+	arg9=GdObjects.TYPE_VARARG_PLACEHOLDER_VALUE) -> Variant:
+
+	# This is a placeholder function signanture without any functionallity!
+	# It is used by the function doubler to double function signature of Callable:call()
+	# The doubled function calls direct _cb.callv(<arguments>) see GdUnitSpyFunctionDoubler:TEMPLATE_CALLABLE_CALL template
+	assert(false)
+	return null
+
+
+# Is not supported, see class description
+#func call_deferred(a) -> void:
+#	pass
+
+
+# Is not supported, see class description
+#func callv(a) -> void:
+#	pass
+
+
+
+func get_bound_arguments() -> Array:
+	return _cb.get_bound_arguments()
+
+
+func get_bound_arguments_count() -> int:
+	return _cb.get_bound_arguments_count()
+
+
+func get_method() -> StringName:
+	return _cb.get_method()
+
+
+func get_object() -> Object:
+	return _cb.get_object()
+
+
+func get_object_id() -> int:
+	return _cb.get_object_id()
+
+
+func hash() -> int:
+	return _cb.hash()
+
+
+func is_custom() -> bool:
+	return _cb.is_custom()
+
+
+func is_null() -> bool:
+	return _cb.is_null()
+
+
+func is_standard() -> bool:
+	return _cb.is_standard()
+
+
+func is_valid() -> bool:
+	return _cb.is_valid()
+
+
+@warning_ignore("untyped_declaration")
+func rpc(arg0=GdObjects.TYPE_VARARG_PLACEHOLDER_VALUE,
+	arg1=GdObjects.TYPE_VARARG_PLACEHOLDER_VALUE,
+	arg2=GdObjects.TYPE_VARARG_PLACEHOLDER_VALUE,
+	arg3=GdObjects.TYPE_VARARG_PLACEHOLDER_VALUE,
+	arg4=GdObjects.TYPE_VARARG_PLACEHOLDER_VALUE,
+	arg5=GdObjects.TYPE_VARARG_PLACEHOLDER_VALUE,
+	arg6=GdObjects.TYPE_VARARG_PLACEHOLDER_VALUE,
+	arg7=GdObjects.TYPE_VARARG_PLACEHOLDER_VALUE,
+	arg8=GdObjects.TYPE_VARARG_PLACEHOLDER_VALUE,
+	arg9=GdObjects.TYPE_VARARG_PLACEHOLDER_VALUE) -> void:
+
+	var args = GdArrayTools.filter_value([arg0,arg1,arg2,arg3,arg4,arg5,arg6,arg7,arg8,arg9], GdObjects.TYPE_VARARG_PLACEHOLDER_VALUE)
+	match args.size():
+		0: _cb.rpc(0)
+		1: _cb.rpc(args[0])
+		2: _cb.rpc(args[0], args[1])
+		3: _cb.rpc(args[0], args[1], args[2])
+		4: _cb.rpc(args[0], args[1], args[2], args[3])
+		5: _cb.rpc(args[0], args[1], args[2], args[3], args[4])
+		6: _cb.rpc(args[0], args[1], args[2], args[3], args[4], args[5])
+		7: _cb.rpc(args[0], args[1], args[2], args[3], args[4], args[5], args[6])
+		8: _cb.rpc(args[0], args[1], args[2], args[3], args[4], args[5], args[6], args[7])
+		9: _cb.rpc(args[0], args[1], args[2], args[3], args[4], args[5], args[6], args[7], args[8])
+		10: _cb.rpc(args[0], args[1], args[2], args[3], args[4], args[5], args[6], args[7], args[8], args[9])
+
+
+@warning_ignore("untyped_declaration")
+func rpc_id(peer_id: int,
+	arg0=GdObjects.TYPE_VARARG_PLACEHOLDER_VALUE,
+	arg1=GdObjects.TYPE_VARARG_PLACEHOLDER_VALUE,
+	arg2=GdObjects.TYPE_VARARG_PLACEHOLDER_VALUE,
+	arg3=GdObjects.TYPE_VARARG_PLACEHOLDER_VALUE,
+	arg4=GdObjects.TYPE_VARARG_PLACEHOLDER_VALUE,
+	arg5=GdObjects.TYPE_VARARG_PLACEHOLDER_VALUE,
+	arg6=GdObjects.TYPE_VARARG_PLACEHOLDER_VALUE,
+	arg7=GdObjects.TYPE_VARARG_PLACEHOLDER_VALUE,
+	arg8=GdObjects.TYPE_VARARG_PLACEHOLDER_VALUE,
+	arg9=GdObjects.TYPE_VARARG_PLACEHOLDER_VALUE) -> void:
+
+	var args = GdArrayTools.filter_value([arg0,arg1,arg2,arg3,arg4,arg5,arg6,arg7,arg8,arg9], GdObjects.TYPE_VARARG_PLACEHOLDER_VALUE)
+	match args.size():
+		0: _cb.rpc_id(peer_id)
+		1: _cb.rpc_id(peer_id, args[0])
+		2: _cb.rpc_id(peer_id, args[0], args[1])
+		3: _cb.rpc_id(peer_id, args[0], args[1], args[2])
+		4: _cb.rpc_id(peer_id, args[0], args[1], args[2], args[3])
+		5: _cb.rpc_id(peer_id, args[0], args[1], args[2], args[3], args[4])
+		6: _cb.rpc_id(peer_id, args[0], args[1], args[2], args[3], args[4], args[5])
+		7: _cb.rpc_id(peer_id, args[0], args[1], args[2], args[3], args[4], args[5], args[6])
+		8: _cb.rpc_id(peer_id, args[0], args[1], args[2], args[3], args[4], args[5], args[6], args[7])
+		9: _cb.rpc_id(peer_id, args[0], args[1], args[2], args[3], args[4], args[5], args[6], args[7], args[8])
+		10: _cb.rpc_id(peer_id, args[0], args[1], args[2], args[3], args[4], args[5], args[6], args[7], args[8], args[9])
+
+
+func unbind(argcount: int) -> Callable:
+	_cb = _cb.unbind(argcount)
+	return _cb

--- a/addons/gdUnit4/src/mocking/GdUnitMockFunctionDoubler.gd
+++ b/addons/gdUnit4/src/mocking/GdUnitMockFunctionDoubler.gd
@@ -77,9 +77,10 @@ func _init(push_errors :bool = false) -> void:
 	super._init(push_errors)
 
 
-func get_template(return_type :Variant, is_vararg :bool) -> String:
-	if is_vararg:
+func get_template(fd: GdFunctionDescriptor, _is_callable: bool) -> String:
+	if fd.is_vararg():
 		return TEMPLATE_FUNC_VARARG_RETURN_VALUE
+	var return_type :Variant = fd.return_type()
 	if return_type is StringName:
 		return TEMPLATE_FUNC_WITH_RETURN_VALUE
 	return TEMPLATE_FUNC_WITH_RETURN_VOID if (return_type == TYPE_NIL or return_type == GdObjects.TYPE_VOID) else TEMPLATE_FUNC_WITH_RETURN_VALUE

--- a/addons/gdUnit4/src/spy/GdUnitSpyBuilder.gd
+++ b/addons/gdUnit4/src/spy/GdUnitSpyBuilder.gd
@@ -3,9 +3,10 @@ extends GdUnitClassDoubler
 
 const GdUnitTools := preload("res://addons/gdUnit4/src/core/GdUnitTools.gd")
 const SPY_TEMPLATE :GDScript = preload("res://addons/gdUnit4/src/spy/GdUnitSpyImpl.gd")
+const EXCLUDE_PROPERTIES_TO_COPY = ["script", "type"]
 
 
-static func build(to_spy :Variant, debug_write := false) -> Variant:
+static func build(to_spy: Variant, debug_write := false) -> Variant:
 	if GdObjects.is_singleton(to_spy):
 		push_error("Spy on a Singleton is not allowed! '%s'" % to_spy.get_class())
 		return null
@@ -22,7 +23,12 @@ static func build(to_spy :Variant, debug_write := false) -> Variant:
 	if GdObjects.is_instance_scene(to_spy):
 		return spy_on_scene(to_spy, debug_write)
 
-	var spy := spy_on_script(to_spy, [], debug_write)
+	var excluded_functions := []
+	if to_spy is Callable:
+		to_spy = CallableDoubler.new(to_spy)
+		excluded_functions = CallableDoubler.excluded_functions()
+
+	var spy := spy_on_script(to_spy, excluded_functions, debug_write)
 	if spy == null:
 		return null
 	var spy_instance :Variant = spy.new()
@@ -87,9 +93,6 @@ static func spy_on_scene(scene :Node, debug_write :bool) -> Object:
 	# replace original script whit spy
 	scene.set_script(spy)
 	return register_auto_free(scene)
-
-
-const EXCLUDE_PROPERTIES_TO_COPY = ["script", "type"]
 
 
 static func copy_properties(source :Object, dest :Object) -> void:

--- a/addons/gdUnit4/test/core/GdUnitClassDoublerTest.gd
+++ b/addons/gdUnit4/test/core/GdUnitClassDoublerTest.gd
@@ -1,13 +1,8 @@
 # GdUnit generated TestSuite
-class_name GdUnitClassDoublerTest
 extends GdUnitTestSuite
 
-# TestSuite generated from
-const __source = 'res://addons/gdUnit4/src/core/GdUnitClassDoubler.gd'
 
 # simple function doubler whitout any modifications
 class TestFunctionDoubler extends GdFunctionDoubler:
-	func double(_func_descriptor :GdFunctionDescriptor) -> PackedStringArray:
+	func double(_func_descriptor :GdFunctionDescriptor, _is_callable: bool = false) -> PackedStringArray:
 		return PackedStringArray([])
-
-

--- a/addons/gdUnit4/test/core/discovery/GdUnitTestDiscoverGuardTest.gd
+++ b/addons/gdUnit4/test/core/discovery/GdUnitTestDiscoverGuardTest.gd
@@ -49,6 +49,7 @@ func test_discover_on_GDScript() -> void:
 	assert_dict(discoverer._discover_cache).contains_key_value("res://addons/gdUnit4/test/core/discovery/resources/DiscoverExampleTestSuite.gd", ["test_case1", "test_case2"])
 
 
+@warning_ignore("unused_parameter")
 func test_discover_on_CSharpScript(do_skip := !GdUnit4CSharpApiLoader.is_mono_supported()) -> void:
 	var discoverer :GdUnitTestDiscoverGuard = spy(GdUnitTestDiscoverGuard.new())
 

--- a/addons/gdUnit4/test/core/parse/GdScriptParserTest.gd
+++ b/addons/gdUnit4/test/core/parse/GdScriptParserTest.gd
@@ -266,38 +266,38 @@ func test_parse_func_name() -> void:
 	assert_str(_parser.parse_func_name("var x")).is_empty()
 
 
-func test_extract_source_code() -> void:
+func test_load_source_code() -> void:
 	var path := GdObjects.extract_class_path(AdvancedTestClass)
-	var rows := _parser.extract_source_code(path)
+	var rows := _parser.load_source_code(load(path[0]), path)
 
 	var file_content := resource_as_array(path[0])
 	assert_array(rows).contains_exactly(file_content)
 
 
-func test_extract_source_code_inner_class_AtmosphereData() -> void:
+func test_load_source_code_inner_class_AtmosphereData() -> void:
 	var path := GdObjects.extract_class_path(AdvancedTestClass.AtmosphereData)
-	var rows := _parser.extract_source_code(path)
+	var rows := _parser.load_source_code(load(path[0]), path)
 	var file_content := resource_as_array("res://addons/gdUnit4/test/core/resources/AtmosphereData.txt")
 	assert_array(rows).contains_exactly(file_content)
 
 
-func test_extract_source_code_inner_class_SoundData() -> void:
+func test_load_source_code_inner_class_SoundData() -> void:
 	var path := GdObjects.extract_class_path(AdvancedTestClass.SoundData)
-	var rows := _parser.extract_source_code(path)
+	var rows := _parser.load_source_code(load(path[0]), path)
 	var file_content := resource_as_array("res://addons/gdUnit4/test/core/resources/SoundData.txt")
 	assert_array(rows).contains_exactly(file_content)
 
 
-func test_extract_source_code_inner_class_Area4D() -> void:
+func test_load_source_code_inner_class_Area4D() -> void:
 	var path := GdObjects.extract_class_path(AdvancedTestClass.Area4D)
-	var rows := _parser.extract_source_code(path)
+	var rows := _parser.load_source_code(load(path[0]), path)
 	var file_content := resource_as_array("res://addons/gdUnit4/test/core/resources/Area4D.txt")
-	assert_array(rows).contains_exactly(file_content)
+	assert_array(rows).contains(file_content)
 
 
 func test_extract_function_signature() -> void:
 	var path := GdObjects.extract_class_path("res://addons/gdUnit4/test/mocker/resources/ClassWithCustomFormattings.gd")
-	var rows := _parser.extract_source_code(path)
+	var rows := _parser.load_source_code(load(path[0]), path)
 
 	assert_that(_parser.extract_func_signature(rows, 12))\
 		.is_equal("""
@@ -344,8 +344,8 @@ func test_strip_leading_spaces() -> void:
 
 
 func test_extract_clazz_name() -> void:
-	assert_str(_parser.extract_clazz_name("classSoundData:\n")).is_equal("SoundData")
-	assert_str(_parser.extract_clazz_name("classSoundDataextendsNode:\n")).is_equal("SoundData")
+	assert_str(_parser.extract_clazz_name("class SoundData:\n")).is_equal("SoundData")
+	assert_str(_parser.extract_clazz_name("class SoundData extends Node:\n")).is_equal("SoundData")
 
 
 func test_is_virtual_func() -> void:

--- a/addons/gdUnit4/test/mocker/GdUnitMockerTest.gd
+++ b/addons/gdUnit4/test/mocker/GdUnitMockerTest.gd
@@ -708,6 +708,8 @@ func test_mock_class_with_inner_classs() -> void:
 	var mock_b := mock(AdvancedTestClass.AtmosphereData) as AdvancedTestClass.AtmosphereData
 	assert_object(mock_b).is_not_null()
 
+
+func test_mock_class_with_inner_classs_() -> void:
 	var mock_c := mock(AdvancedTestClass.Area4D) as AdvancedTestClass.Area4D
 	assert_object(mock_c).is_not_null()
 

--- a/addons/gdUnit4/test/spy/ClassWithEnumConstructor.gd
+++ b/addons/gdUnit4/test/spy/ClassWithEnumConstructor.gd
@@ -10,7 +10,7 @@ var _value :MyEnumValue
 
 
 # using an enum in the constructor
-func _init(value :MyEnumValue, second_parameter :PackedStringArray) -> void:
+func _init(value :MyEnumValue, _second_parameter :PackedStringArray) -> void:
 	_value = value
 
 

--- a/addons/gdUnit4/test/spy/GdUnitSpyBuilderTest.gd
+++ b/addons/gdUnit4/test/spy/GdUnitSpyBuilderTest.gd
@@ -326,7 +326,8 @@ class NodeWithOutVirtualFunc extends Node:
 
 	#func _input(event :InputEvent) -> void:
 
+
 func test_spy_on_script_respect_virtual_functions() -> void:
-	var do_spy :Node = auto_free(GdUnitSpyBuilder.spy_on_script(auto_free(NodeWithOutVirtualFunc.new()), [], true).new())
+	var do_spy :Variant = auto_free(GdUnitSpyBuilder.spy_on_script(auto_free(NodeWithOutVirtualFunc.new()), [], false).new())
 	assert_that(do_spy.has_method("_ready")).is_true()
 	assert_that(do_spy.has_method("_input")).is_false()

--- a/addons/gdUnit4/test/spy/GdUnitSpyCallableTest.gd
+++ b/addons/gdUnit4/test/spy/GdUnitSpyCallableTest.gd
@@ -1,0 +1,275 @@
+extends GdUnitTestSuite
+
+var _rpc_called: String = ""
+
+
+@rpc("call_local")
+func do_rpc(rpc_name: String, value: Variant) -> void:
+	_rpc_called = rpc_name + str(value)
+
+
+@rpc("call_local", "any_peer", "unreliable", 1)
+func do_rpc_on_peer(arg1: Variant, arg2: Variant) -> void:
+	_rpc_called = str(arg1) + str(arg2)
+
+
+func test_callable_functions() -> void:
+	# supported Callable functions to double see https://docs.godotengine.org/en/stable/classes/class_callable.html#methods
+	assert_array(CallableDoubler.callable_functions()).contains_exactly_in_any_order([
+		# we allow to default constructor, is need to create at least the spy
+		"_init",
+		"bind",
+		"bindv",
+		"call",
+		"call_deferred",
+		"callv",
+		"get_bound_arguments",
+		"get_bound_arguments_count",
+		"get_method",
+		"get_object",
+		"get_object_id",
+		"hash",
+		"is_custom",
+		"is_null",
+		"is_standard",
+		"is_valid",
+		"rpc",
+		"rpc_id",
+		"unbind"])
+
+
+func test_exclude_functions() -> void:
+	assert_array(CallableDoubler.excluded_functions())\
+		# it should not exclude callable function
+		.not_contains(CallableDoubler.callable_functions())
+
+
+func test_call() -> void:
+	var cb := func(x: int) -> String:
+		return "is_called %s" % x
+	var cb_spy :Variant = spy(cb)
+
+	# do use the spy to call the callable
+	var result :Variant = cb_spy.call(42)
+	# verify is called by validate the result
+	assert_that(result).is_equal("is_called 42")
+	# verify should be successfull
+	verify(cb_spy).call(42)
+	# verify with a not used argument must fail
+	assert_failure(func() -> void: verify(cb_spy).call(23)).is_failed()
+
+
+func test_call_with_binded_value() -> void:
+	var cb := func(x: int, y: int) -> String:
+		return "is_called %s.%s" % [x, y]
+	var cb_spy :Variant = spy(cb.bind(24))
+
+	# do use the spy to call the callable
+	var result :Variant = cb_spy.call(42)
+	# verify is called by validate the result
+	assert_that(result).is_equal("is_called 42.24")
+	# verify should be successfull
+	verify(cb_spy).call(42, 24)
+	# verify with a not used argument must fail
+	assert_failure(func() -> void: verify(cb_spy).call(23)).is_failed()
+
+
+# we not able to stub on callv because the original signature of Callabe:callv and Object:callv are different
+# and a spy is a specialized object delegator to the original implementation as object instance
+# a Callable is not inherits form object so it makes it impossible to spy/mock on `callv`
+func _test_callv() -> void:
+	var cb := func(x: int, y: int) -> String:
+		return "is_called %s.%s" % [x, y]
+	var cb_spy :Variant = spy(cb.bind(24))
+
+	# do use the spy to call the callable
+	var result :Variant = cb_spy.callv([42])
+	# verify is called by validate the result
+	assert_that(result).is_equal("is_called 42.24")
+	# verify should be successfull
+	verify(cb_spy).callv([42, 24])
+
+
+func test_bind() -> void:
+	var cb := func(x: int, y: int) -> String:
+		return "is_called %s.%s" % [x, y]
+	var cb_spy :Variant = spy(cb)
+	cb_spy.bind(24)
+
+	# verify bind is called
+	verify(cb_spy).bind(24)
+	# verify bind is not called with 33
+	assert_failure(func() -> void: verify(cb_spy).bind(23)).is_failed()
+
+	# do use the spy to call the callable
+	var result :Variant = cb_spy.call(42)
+	# verify is called by validate the result
+	assert_that(result).is_equal("is_called 42.24")
+	# verify should be successfull
+	verify(cb_spy).call(42, 24)
+
+
+func test_bindv() -> void:
+	var cb := func(a1: int, a2: int, a3: int, a4: int) -> String:
+		return "is_called %s %s %s %s" % [a1, a2, a3, a4]
+	var cb_spy :Variant = spy(cb)
+	cb_spy.bindv([21,22,23])
+
+	# verify bindv is called
+	verify(cb_spy).bindv([21,22,23])
+	# verify bindv is not called with [21,22,27]
+	assert_failure(func() -> void: verify(cb_spy).bindv([21,22,27])).is_failed()
+	# finally check via call it resolves all values
+	assert_str(cb_spy.call(42)).is_equal("is_called 42 21 22 23")
+
+
+func test_unbind() -> void:
+	var cb := func(a1: int, a2: int, a3: int) -> String:
+		return "is_called %s %s %s" % [a1, a2, a3]
+	var cb_spy :Variant = spy(cb.bindv([21,22,23]))
+	cb_spy.unbind(1)
+
+	# verify unbind is called
+	verify(cb_spy).unbind(1)
+	# verify unbind is not called with argument 2
+	assert_failure(func() -> void: verify(cb_spy).unbind(2)).is_failed()
+	# finally check via call it resolves all values
+	assert_str(cb_spy.call(42)).is_equal("is_called 21 22 23")
+
+
+func test_rpc() -> void:
+	_rpc_called = ""
+	var cb_spy :Variant = spy(do_rpc)
+	cb_spy.rpc("abc", 23)
+	# verify the callable @rpc is called
+	assert_that(_rpc_called).is_equal("abc23")
+
+	# verify rpc is called
+	verify(cb_spy).rpc("abc", 23)
+	# verify rpc is not called with this argument s
+	assert_failure(func() -> void: verify(cb_spy).rpc("abc", 43)).is_failed()
+
+
+func test_rpc_id() -> void:
+	_rpc_called = ""
+	var cb_spy :Variant = spy(do_rpc_on_peer)
+	cb_spy.rpc_id(1, "foo", "23")
+	# verify the callable @rpc is called
+	assert_that(_rpc_called).is_equal("foo23")
+
+	# verify rpc_id is called
+	verify(cb_spy).rpc_id(1, "foo", "23")
+	# verify rpc_id is not called with this argument s
+	assert_failure(func() -> void: verify(cb_spy).rpc_id(23, "arg1", "arg2")).is_failed()
+
+
+func test_get_bound_arguments() -> void:
+	var cb := func() -> void: return
+	var cb_syp :Variant = spy(cb)
+
+	verify(cb_syp, 0).get_bound_arguments()
+	cb_syp.bind(1,2,3)
+	assert_array(cb_syp.get_bound_arguments()).contains_exactly([1,2,3])
+	verify(cb_syp, 1).get_bound_arguments()
+
+
+func test_get_bound_arguments_count() -> void:
+	var cb := func() -> void: return
+	var cb_syp :Variant = spy(cb)
+
+	verify(cb_syp, 0).get_bound_arguments_count()
+	cb_syp.bind(1,2,3)
+	assert_that(cb_syp.get_bound_arguments_count()).is_equal(3)
+	verify(cb_syp, 1).get_bound_arguments_count()
+
+
+func test_get_method() -> void:
+	var cb_syp :Variant = spy(do_rpc)
+
+	verify(cb_syp, 0).get_method()
+	assert_that(cb_syp.get_method()).is_equal("do_rpc")
+	verify(cb_syp, 1).get_method()
+
+
+func test_get_object() -> void:
+	var cb_syp :Variant = spy(do_rpc)
+
+	verify(cb_syp, 0).get_object()
+	assert_that(cb_syp.get_object()).is_same(self)
+	verify(cb_syp, 1).get_object()
+
+
+func test_get_object_id() -> void:
+	var cb_syp :Variant = spy(do_rpc)
+
+	verify(cb_syp, 0).get_object_id()
+	assert_that(cb_syp.get_object_id()).is_equal(get_instance_id())
+	verify(cb_syp, 1).get_object_id()
+
+
+func test_hash() -> void:
+	var cb_syp :Variant = spy(do_rpc)
+
+	verify(cb_syp, 0).hash()
+	assert_that(cb_syp.hash()).is_equal(do_rpc.hash())
+	verify(cb_syp, 1).hash()
+
+
+func test_is_custom_is_true() -> void:
+	var cb_syp :Variant = spy(do_rpc)
+	assert_that(do_rpc.is_custom()).is_true()
+
+	verify(cb_syp, 0).is_custom()
+	assert_that(cb_syp.is_custom()).is_true()
+	verify(cb_syp, 1).is_custom()
+
+
+func test_is_custom_is_false() -> void:
+	var cb := Callable(self, "do_rpc")
+	assert_that(cb.is_custom()).is_false()
+
+	var cb_syp :Variant = spy(cb)
+	verify(cb_syp, 0).is_custom()
+	assert_that(cb_syp.is_custom()).is_false()
+	verify(cb_syp, 1).is_custom()
+
+
+func test_is_null() -> void:
+	var cb_syp :Variant = spy(do_rpc)
+
+	verify(cb_syp, 0).is_null()
+	assert_that(cb_syp.is_null()).is_false()
+	verify(cb_syp, 1).is_null()
+
+	cb_syp = spy(Callable())
+	assert_that(cb_syp.is_null()).is_true()
+
+
+func test_is_standard_is_false() -> void:
+	var cb_syp :Variant = spy(do_rpc)
+	assert_that(do_rpc.is_standard()).is_false()
+
+	verify(cb_syp, 0).is_standard()
+	assert_that(cb_syp.is_standard()).is_false()
+	verify(cb_syp, 1).is_standard()
+
+
+func test_is_standard_is_true() -> void:
+	var cb := Callable(self, "do_rpc")
+	assert_that(cb.is_standard()).is_true()
+
+	var cb_syp :Variant = spy(cb)
+	verify(cb_syp, 0).is_standard()
+	assert_that(cb_syp.is_standard()).is_true()
+	verify(cb_syp, 1).is_standard()
+
+
+func test_is_valid() -> void:
+	var cb_syp :Variant = spy(do_rpc)
+
+	verify(cb_syp, 0).is_valid()
+	assert_that(cb_syp.is_valid()).is_true()
+	verify(cb_syp, 1).is_valid()
+
+	cb_syp = spy(Callable())
+	assert_that(cb_syp.is_valid()).is_false()

--- a/addons/gdUnit4/test/spy/GdUnitSpyTest.gd
+++ b/addons/gdUnit4/test/spy/GdUnitSpyTest.gd
@@ -2,6 +2,11 @@ class_name GdUnitSpyTest
 extends GdUnitTestSuite
 
 
+func before() -> void:
+	# we disable the error reporting to do not spam the logs
+	ProjectSettings.set_setting(GdUnitSettings.REPORT_ASSERT_ERRORS, false)
+
+
 func test_spy_instance_id_is_unique() -> void:
 	var m1  :Variant = spy(RefCounted.new())
 	var m2  :Variant = spy(RefCounted.new())
@@ -111,7 +116,7 @@ func test_spy_class_with_custom_formattings() -> void:
 	verify_no_more_interactions(do_spy)
 	assert_failure(func() -> void: verify_no_interactions(do_spy))\
 		.is_failed() \
-		.has_line(112)
+		.has_line(117)
 
 
 func test_spy_copied_class_members() -> void:
@@ -213,7 +218,7 @@ func test_verify_fail() -> void:
 			.dedent().trim_prefix("\n")
 	assert_failure(func() -> void: verify(spy_node, 1).set_process(true)) \
 		.is_failed() \
-		.has_line(214) \
+		.has_line(219) \
 		.has_message(expected_error)
 
 
@@ -240,7 +245,7 @@ func test_verify_func_interaction_wiht_PackedStringArray_fail() -> void:
 			.dedent().trim_prefix("\n")
 	assert_failure(func() -> void: verify(spy_instance, 1).set_values([])) \
 		.is_failed() \
-		.has_line(241) \
+		.has_line(246) \
 		.has_message(expected_error)
 
 	reset(spy_instance)
@@ -258,7 +263,7 @@ func test_verify_func_interaction_wiht_PackedStringArray_fail() -> void:
 			.dedent().trim_prefix("\n")
 	assert_failure(func() -> void: verify(spy_instance, 1).set_values([])) \
 		.is_failed() \
-		.has_line(259) \
+		.has_line(264) \
 		.has_message(expected_error)
 
 
@@ -306,7 +311,7 @@ func test_verify_no_interactions_fails() -> void:
 	# it should fail because we have interactions
 	assert_failure(func() -> void: verify_no_interactions(spy_node)) \
 		.is_failed() \
-		.has_line(307) \
+		.has_line(312) \
 		.has_message(expected_error)
 
 
@@ -361,7 +366,7 @@ func test_verify_no_more_interactions_but_has() -> void:
 			.dedent().trim_prefix("\n")
 	assert_failure(func() -> void: verify_no_more_interactions(spy_node)) \
 		.is_failed() \
-		.has_line(362) \
+		.has_line(367) \
 		.has_message(expected_error)
 
 


### PR DESCRIPTION
# Why
see https://github.com/MikeSchulze/gdUnit4/issues/544

# What
- cleanup parser
  - removed `extract_source_code`, it was only used in tests 
- add support to spy on `Callable`
 - supports to spy on Callable on all functions exclusive `callv` and `call_deferred`
  `call` and `call_deferred` are not possible to stub because of interface conflicts between `Callable` and `Object`
 


