### PR TITLE
GD-546: Allow to test un-typed values by `assert_that`

### DIFF
--- a/addons/gdUnit4/src/GdUnitFloatAssert.gd
+++ b/addons/gdUnit4/src/GdUnitFloatAssert.gd
@@ -3,15 +3,15 @@ class_name GdUnitFloatAssert
 extends GdUnitAssert
 
 
-## Verifies that the current value is equal to expected one.
+## Verifies that the current String is equal to the given one.
 @warning_ignore("unused_parameter")
-func is_equal(expected :float) -> GdUnitFloatAssert:
+func is_equal(expected :Variant) -> GdUnitFloatAssert:
 	return self
 
 
-## Verifies that the current value is not equal to expected one.
+## Verifies that the current String is not equal to the given one.
 @warning_ignore("unused_parameter")
-func is_not_equal(expected :float) -> GdUnitFloatAssert:
+func is_not_equal(expected :Variant) -> GdUnitFloatAssert:
 	return self
 
 

--- a/addons/gdUnit4/src/GdUnitIntAssert.gd
+++ b/addons/gdUnit4/src/GdUnitIntAssert.gd
@@ -2,16 +2,15 @@
 class_name GdUnitIntAssert
 extends GdUnitAssert
 
-
-## Verifies that the current value is equal to expected one.
+## Verifies that the current String is equal to the given one.
 @warning_ignore("unused_parameter")
-func is_equal(expected :int) -> GdUnitIntAssert:
+func is_equal(expected :Variant) -> GdUnitIntAssert:
 	return self
 
 
-## Verifies that the current value is not equal to expected one.
+## Verifies that the current String is not equal to the given one.
 @warning_ignore("unused_parameter")
-func is_not_equal(expected :int) -> GdUnitIntAssert:
+func is_not_equal(expected :Variant) -> GdUnitIntAssert:
 	return self
 
 

--- a/addons/gdUnit4/src/GdUnitTestSuite.gd
+++ b/addons/gdUnit4/src/GdUnitTestSuite.gd
@@ -492,13 +492,13 @@ func assert_that(current :Variant) -> GdUnitAssert:
 		TYPE_STRING:
 			return assert_str(current)
 		TYPE_VECTOR2, TYPE_VECTOR2I, TYPE_VECTOR3, TYPE_VECTOR3I, TYPE_VECTOR4, TYPE_VECTOR4I:
-			return assert_vector(current)
+			return assert_vector(current, false)
 		TYPE_DICTIONARY:
 			return assert_dict(current)
 		TYPE_ARRAY, TYPE_PACKED_BYTE_ARRAY, TYPE_PACKED_INT32_ARRAY, TYPE_PACKED_INT64_ARRAY,\
 		TYPE_PACKED_FLOAT32_ARRAY, TYPE_PACKED_FLOAT64_ARRAY, TYPE_PACKED_STRING_ARRAY,\
 		TYPE_PACKED_VECTOR2_ARRAY, TYPE_PACKED_VECTOR3_ARRAY, TYPE_PACKED_COLOR_ARRAY:
-			return assert_array(current)
+			return assert_array(current, false)
 		TYPE_OBJECT, TYPE_NIL:
 			return assert_object(current)
 		_:
@@ -531,13 +531,13 @@ func assert_float(current :Variant) -> GdUnitFloatAssert:
 ##     [codeblock]
 ##		assert_vector(Vector2(1.2, 1.000001)).is_equal(Vector2(1.2, 1.000001))
 ##     [/codeblock]
-func assert_vector(current :Variant) -> GdUnitVectorAssert:
-	return __lazy_load("res://addons/gdUnit4/src/asserts/GdUnitVectorAssertImpl.gd").new(current)
+func assert_vector(current :Variant, type_check := true) -> GdUnitVectorAssert:
+	return __lazy_load("res://addons/gdUnit4/src/asserts/GdUnitVectorAssertImpl.gd").new(current, type_check)
 
 
 ## An assertion tool to verify arrays.
-func assert_array(current :Variant) -> GdUnitArrayAssert:
-	return __lazy_load("res://addons/gdUnit4/src/asserts/GdUnitArrayAssertImpl.gd").new(current)
+func assert_array(current :Variant, type_check := true) -> GdUnitArrayAssert:
+	return __lazy_load("res://addons/gdUnit4/src/asserts/GdUnitArrayAssertImpl.gd").new(current, type_check)
 
 
 ## An assertion tool to verify dictionaries.

--- a/addons/gdUnit4/src/asserts/GdAssertMessages.gd
+++ b/addons/gdUnit4/src/asserts/GdAssertMessages.gd
@@ -8,7 +8,10 @@ const SUB_COLOR :=  Color(1, 0, 0, .3)
 const ADD_COLOR :=  Color(0, 1, 0, .3)
 
 
-static func format_dict(value :Dictionary) -> String:
+static func format_dict(value :Variant) -> String:
+	if not value is Dictionary:
+		return str(value)
+
 	if value.is_empty():
 		return "{ }"
 	var as_rows := var_to_str(value).split("\n")

--- a/addons/gdUnit4/src/asserts/GdUnitArrayAssertImpl.gd
+++ b/addons/gdUnit4/src/asserts/GdUnitArrayAssertImpl.gd
@@ -1,11 +1,13 @@
 extends GdUnitArrayAssert
 
 
-var _base :GdUnitAssert
-var _current_value_provider :ValueProvider
+var _base: GdUnitAssert
+var _current_value_provider: ValueProvider
+var _type_check: bool
 
 
-func _init(current :Variant) -> void:
+func _init(current: Variant, type_check := true) -> void:
+	_type_check = type_check
 	_current_value_provider = DefaultValueProvider.new(current)
 	_base = ResourceLoader.load("res://addons/gdUnit4/src/asserts/GdUnitAssertImpl.gd", "GDScript",
 								ResourceLoader.CACHE_MODE_REUSE).new(current)
@@ -60,9 +62,18 @@ func max_length(left :Variant, right :Variant) -> int:
 	return rs if ls < rs else ls
 
 
-func _array_equals_div(current :Array, expected :Array, case_sensitive :bool = false) -> Array:
+# gdlint: disable=function-name
+func _toPackedStringArray(value :Variant) -> PackedStringArray:
+	if GdArrayTools.is_array_type(value):
+		return PackedStringArray(value as Array)
+	var v := PackedStringArray()
+	v.append(str(value))
+	return v
+
+
+func _array_equals_div(current :Array, expected :Variant, case_sensitive :bool = false) -> Array:
 	var current_value := PackedStringArray(current)
-	var expected_value := PackedStringArray(expected)
+	var expected_value := _toPackedStringArray(expected)
 	var index_report := Array()
 	for index in current_value.size():
 		var c := current_value[index]
@@ -173,7 +184,7 @@ func is_not_null() -> GdUnitArrayAssert:
 
 # Verifies that the current String is equal to the given one.
 func is_equal(expected :Variant) -> GdUnitArrayAssert:
-	if not _validate_value_type(expected):
+	if _type_check and not _validate_value_type(expected):
 		return report_error("ERROR: expected value: <%s>\n is not a Array Type!" % GdObjects.typeof_as_string(expected))
 	var current_value :Variant = get_current_value()
 	if current_value == null and expected != null:
@@ -189,7 +200,7 @@ func is_equal(expected :Variant) -> GdUnitArrayAssert:
 
 # Verifies that the current Array is equal to the given one, ignoring case considerations.
 func is_equal_ignoring_case(expected :Variant) -> GdUnitArrayAssert:
-	if not _validate_value_type(expected):
+	if _type_check and not _validate_value_type(expected):
 		return report_error("ERROR: expected value: <%s>\n is not a Array Type!" % GdObjects.typeof_as_string(expected))
 	var current_value :Variant = get_current_value()
 	if current_value == null and expected != null:

--- a/addons/gdUnit4/src/asserts/GdUnitAssertImpl.gd
+++ b/addons/gdUnit4/src/asserts/GdUnitAssertImpl.gd
@@ -15,8 +15,6 @@ func _init(current :Variant) -> void:
 
 
 
-
-
 func failure_message() -> String:
 	return _current_failure_message
 

--- a/addons/gdUnit4/src/asserts/GdUnitFloatAssertImpl.gd
+++ b/addons/gdUnit4/src/asserts/GdUnitFloatAssertImpl.gd
@@ -57,12 +57,12 @@ func is_not_null() -> GdUnitFloatAssert:
 	return self
 
 
-func is_equal(expected :float) -> GdUnitFloatAssert:
+func is_equal(expected :Variant) -> GdUnitFloatAssert:
 	_base.is_equal(expected)
 	return self
 
 
-func is_not_equal(expected :float) -> GdUnitFloatAssert:
+func is_not_equal(expected :Variant) -> GdUnitFloatAssert:
 	_base.is_not_equal(expected)
 	return self
 

--- a/addons/gdUnit4/src/asserts/GdUnitIntAssertImpl.gd
+++ b/addons/gdUnit4/src/asserts/GdUnitIntAssertImpl.gd
@@ -57,12 +57,12 @@ func is_not_null() -> GdUnitIntAssert:
 	return self
 
 
-func is_equal(expected :int) -> GdUnitIntAssert:
+func is_equal(expected :Variant) -> GdUnitIntAssert:
 	_base.is_equal(expected)
 	return self
 
 
-func is_not_equal(expected :int) -> GdUnitIntAssert:
+func is_not_equal(expected :Variant) -> GdUnitIntAssert:
 	_base.is_not_equal(expected)
 	return self
 

--- a/addons/gdUnit4/src/asserts/GdUnitVectorAssertImpl.gd
+++ b/addons/gdUnit4/src/asserts/GdUnitVectorAssertImpl.gd
@@ -1,10 +1,11 @@
 extends GdUnitVectorAssert
 
 var _base: GdUnitAssert
-var _current_type :int
+var _current_type: int
+var _type_check: bool
 
-
-func _init(current :Variant) -> void:
+func _init(current: Variant, type_check := true) -> void:
+	_type_check = type_check
 	_base = ResourceLoader.load("res://addons/gdUnit4/src/asserts/GdUnitAssertImpl.gd", "GDScript",
 								ResourceLoader.CACHE_MODE_REUSE).new(current)
 	# save the actual assert instance on the current thread context
@@ -81,15 +82,15 @@ func is_not_null() -> GdUnitVectorAssert:
 	return self
 
 
-func is_equal(expected :Variant) -> GdUnitVectorAssert:
-	if not _validate_is_vector_type(expected):
+func is_equal(expected: Variant) -> GdUnitVectorAssert:
+	if _type_check and not _validate_is_vector_type(expected):
 		return self
 	_base.is_equal(expected)
 	return self
 
 
-func is_not_equal(expected :Variant) -> GdUnitVectorAssert:
-	if not _validate_is_vector_type(expected):
+func is_not_equal(expected: Variant) -> GdUnitVectorAssert:
+	if _type_check and not _validate_is_vector_type(expected):
 		return self
 	_base.is_not_equal(expected)
 	return self

--- a/addons/gdUnit4/test/asserts/GdUnitVariantAssertThatTest.gd
+++ b/addons/gdUnit4/test/asserts/GdUnitVariantAssertThatTest.gd
@@ -1,0 +1,116 @@
+extends GdUnitTestSuite
+
+
+func test_is_equal_success() -> void:
+	assert_that(3 as Variant).is_equal(3)
+	assert_that(3.14 as Variant).is_equal(3.14)
+	assert_that("3" as Variant).is_equal("3")
+	assert_that(true as Variant).is_equal(true)
+	assert_that(Vector2.ONE as Variant).is_equal(Vector2.ONE)
+	assert_that({a=1, b=2} as Variant).is_equal({a=1, b=2})
+	assert_that([1,2,3] as Variant).is_equal([1,2,3])
+	assert_that(RefCounted.new() as Variant).is_equal(RefCounted.new())
+
+
+func test_is_equal_fail() -> void:
+	# bool vs int
+	assert_failure(func()->void:
+		assert_that(true as Variant).is_equal(1))\
+		.is_failed()
+
+	# bool vs string
+	assert_failure(func()->void:
+		assert_that(true as Variant).is_equal("true"))\
+		.is_failed()
+
+	# int vs string
+	assert_failure(func()->void:
+			assert_that(3 as Variant).is_equal("3"))\
+		.is_failed()
+
+	# float vs string
+	assert_failure(func()->void:
+			assert_that(3.14 as Variant).is_equal("3.14"))\
+		.is_failed()
+
+	# string vs int
+	assert_failure(func()->void:
+			assert_that("3" as Variant).is_equal(3))\
+		.is_failed()
+
+	# string vs float
+	assert_failure(func()->void:
+		assert_that("3.14" as Variant).is_equal(3.14))\
+		.is_failed()
+
+	# vector vs string
+	assert_failure(func()->void:
+		assert_that(Vector2.ONE as Variant).is_equal("ONE"))\
+		.is_failed()
+
+	# dictionary vs string
+	assert_failure(func()->void:
+		assert_that({a=1, b=2} as Variant).is_equal("FOO"))\
+		.is_failed()
+
+	# array vs string
+	assert_failure(func()->void:
+		assert_that([1,2,3] as Variant).is_equal("FOO"))\
+		.is_failed()
+
+	# object vs string
+	assert_failure(func()->void:
+		assert_that(RefCounted.new() as Variant).is_equal("FOO"))\
+		.is_failed()
+
+
+func test_is_not_equal_success() -> void:
+	assert_that(3 as Variant).is_not_equal(4)
+	assert_that(3.14 as Variant).is_not_equal(3.15)
+	assert_that("3" as Variant).is_not_equal("33")
+	assert_that(true as Variant).is_not_equal(false)
+	assert_that(Vector2.ONE as Variant).is_not_equal(Vector2.UP)
+	assert_that({a=1, b=2} as Variant).is_not_equal({a=1, b=3})
+	assert_that([1,2,3] as Variant).is_not_equal([1,2,4])
+	assert_that(RefCounted.new() as Variant).is_not_equal(null)
+
+
+func test_is_not_equal_fail() -> void:
+	# bool vs int
+	assert_failure(func()->void:
+		assert_that(true as Variant).is_not_equal(true)
+		)\
+		.is_failed()
+
+
+	assert_failure(func()->void:
+			assert_that(3 as Variant).is_not_equal(3))\
+		.is_failed()
+
+	assert_failure(func()->void:
+			assert_that(3.14 as Variant).is_not_equal(3.14))\
+		.is_failed()
+
+	assert_failure(func()->void:
+			assert_that("3" as Variant).is_not_equal("3"))\
+		.is_failed()
+
+	# vector vs string
+	assert_failure(func()->void:
+		assert_that(Vector2.ONE as Variant).is_not_equal(Vector2.ONE))\
+		.is_failed()
+
+	# dictionary vs string
+	assert_failure(func()->void:
+		assert_that({a=1, b=2} as Variant).is_not_equal({a=1, b=2}))\
+		.is_failed()
+
+	# array vs string
+	assert_failure(func()->void:
+		assert_that([1,2,3] as Variant).is_not_equal([1,2,3]))\
+		.is_failed()
+
+	# object vs string
+	assert_failure(func()->void:
+		assert_that(RefCounted.new() as Variant).is_not_equal(RefCounted.new()))\
+		.is_failed()

--- a/addons/gdUnit4/test/ui/parts/InspectorProgressBarTest.gd
+++ b/addons/gdUnit4/test/ui/parts/InspectorProgressBarTest.gd
@@ -20,22 +20,22 @@ func before_test() -> void:
 	_style = _runner.get_property("style")
 	# inital state
 	assert_that(_status.text).is_equal("0:0")
-	assert_that(_progress.value).is_equal(0)
-	assert_that(_progress.max_value).is_equal(0)
+	assert_that(_progress.value).is_equal(0.000000)
+	assert_that(_progress.max_value).is_equal(0.000000)
 	_runner.invoke("_on_gdunit_event", GdUnitInit.new(10, 42))
 
 
 func test_progress_init() -> void:
 	_runner.invoke("_on_gdunit_event", GdUnitInit.new(10, 230))
-	assert_that(_progress.value).is_equal(0)
-	assert_that(_progress.max_value).is_equal(230)
+	assert_that(_progress.value).is_equal(0.000000)
+	assert_that(_progress.max_value).is_equal(230.000000)
 	assert_that(_status.text).is_equal("0:230")
 	assert_that(_style.bg_color).is_equal(Color.DARK_GREEN)
 
 
 func test_progress_success() -> void:
 	_runner.invoke("_on_gdunit_event", GdUnitInit.new(10, 42))
-	var expected_progess_index := 0
+	var expected_progess_index :float = 0
 	# simulate execution of 20 success test runs
 	for index in 20:
 		_runner.invoke("_on_gdunit_event", GdUnitEvent.new().test_after("res://test/testA.gd", "TestSuiteA", "test_a%d" % index, {}))
@@ -57,7 +57,7 @@ func test_progress_success() -> void:
 	assert_that(_style.bg_color).is_equal(Color.DARK_GREEN)
 
 	# verify the max progress state is not affected
-	assert_that(_progress.max_value).is_equal(42)
+	assert_that(_progress.max_value).is_equal(42.000000)
 
 
 @warning_ignore("unused_parameter")


### PR DESCRIPTION
# Why
see https://github.com/MikeSchulze/gdUnit4/issues/546

# What
- do allow all Variant types for `is_equal` and `is_not_equal` when using the un-typed `assert_that`
- changed the fixed typed  `is_equal` and `is_not_equal` to accept Variant type
