### PR TITLE
GD-549: Fix error if GdUnit4 inspector tab is floating

### DIFF
--- a/addons/gdUnit4/src/ui/GdUnitInspector.gd
+++ b/addons/gdUnit4/src/ui/GdUnitInspector.gd
@@ -12,10 +12,13 @@ func _ready() -> void:
 	if Engine.is_editor_hint():
 		_getEditorThemes()
 	GdUnitCommandHandler.instance().gdunit_runner_start.connect(func() -> void:
-		var tab_container :TabContainer = get_parent_control()
-		for tab_index in tab_container.get_tab_count():
-			if tab_container.get_tab_title(tab_index) == "GdUnit":
-				tab_container.set_current_tab(tab_index)
+		var control :Control = get_parent_control()
+		# if the tab is floating we dont need to set as current
+		if control is TabContainer:
+			var tab_container :TabContainer = control
+			for tab_index in tab_container.get_tab_count():
+				if tab_container.get_tab_title(tab_index) == "GdUnit":
+					tab_container.set_current_tab(tab_index)
 	)
 	if Engine.is_editor_hint():
 		add_script_editor_context_menu()


### PR DESCRIPTION
# Why
Run tests with a floating GdUnit4 inspector tab shows an error: `res://addons/gdUnit4/src/ui/GdUnitInspector.gd:15 - Trying to assign value of type 'MarginContainer' to a variable of type 'TabContainer'.`

# What
Added a check if the inspector is a tab component to avoid this kind of error

