### PR TITLE
Update GdUnit4 to work with Godot 4.3 release

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -20,8 +20,9 @@ body:
       label: The used GdUnit4 version
       description: Which GdUnit4 version are you using?
       options:
-        - 4.3.4 (Pre Release/Master branch)
-        - 4.3.3 (Latest Release)
+        - 4.4.0 (Pre Release/Master branch)
+        - 4.3.4 (Latest Release)
+        - 4.3.3
         - 4.3.2
         - 4.3.1
         - 4.3.0

--- a/.github/workflows/ci-dev.yml
+++ b/.github/workflows/ci-dev.yml
@@ -22,7 +22,7 @@ jobs:
       fail-fast: false
       max-parallel: 10
       matrix:
-        godot-version: ['4.2', '4.2.1', '4.2.2']
+        godot-version: ['4.2', '4.2.1', '4.2.2', '4.3']
         godot-status: ['stable']
         godot-net: ['.Net', '']
 

--- a/.github/workflows/ci-pr-publish-report.yml
+++ b/.github/workflows/ci-pr-publish-report.yml
@@ -23,12 +23,12 @@ jobs:
       fail-fast: false
       max-parallel: 10
       matrix:
-        godot-version: ['4.2', '4.2.1', '4.2.2']
+        godot-version: ['4.2', '4.2.1', '4.2.2', '4.3']
         godot-status: ['stable']
         godot-net: ['-net', '']
-        include:
-          - godot-version: '4.3'
-            godot-status: 'beta2'
+    #    include:
+    #      - godot-version: '4.3'
+    #        godot-status: 'beta2'
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -30,12 +30,12 @@ jobs:
       max-parallel: 10
       matrix:
         # If changes are made here, they must be transferred to `.github\workflows\ci-pr-publish-report.yml`
-        godot-version: ['4.2', '4.2.1', '4.2.2']
+        godot-version: ['4.2', '4.2.1', '4.2.2', '4.3']
         godot-status: ['stable']
         godot-net: ['.Net', '']
-        include:
-          - godot-version: '4.3'
-            godot-status: 'beta2'
+    #    include:
+    #      - godot-version: '4.3'
+    #        godot-status: 'beta2'
 
     permissions:
       actions: write

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
   <h1 align="center">GdUnit4 <img alt="GitHub release (latest by date)" src="https://img.shields.io/github/v/release/MikeSchulze/gdunit4" width="14%"> </h1>
 </p>
 <h2 align="center">A Godot Embedded Unit Testing Framework</h2>
-<p align="center">This version of GdUnit4 is based on Godot <strong>v4.2.1.stable.official [b09f793f5]</strong> (master branch)</p>
+<p align="center">This version of GdUnit4 is based on Godot <strong>v4.3.stable.mono.official [77dcf97d8]</strong> (master branch)</p>
 </h2>
 
 ---
@@ -13,6 +13,7 @@
   <img src="https://img.shields.io/badge/Godot-v4.2.0-%23478cbf?logo=godot-engine&logoColor=cyian&color=green">
   <img src="https://img.shields.io/badge/Godot-v4.2.1-%23478cbf?logo=godot-engine&logoColor=cyian&color=green">
   <img src="https://img.shields.io/badge/Godot-v4.2.2-%23478cbf?logo=godot-engine&logoColor=cyian&color=green">
+  <img src="https://img.shields.io/badge/Godot-v4.3-%23478cbf?logo=godot-engine&logoColor=cyian&color=green">
 </p>
 <h1 align="center">Compatibility Overview</h1>
 <table align="center">
@@ -23,6 +24,9 @@
     </tr>
   </thead>
   <tbody>
+    <tr>
+      <td>v4.4.0+</td><td>v4.2.0, v4.3</td>
+    </tr>
     <tr>
       <td>v4.3.2+</td><td>v4.2.0, v4.3-beta2</td>
     </tr>
@@ -37,7 +41,6 @@
     </tr>
   </tbody>
 </table>
-
 
 <p align="center">
   <a target="_blank" href="https://www.youtube.com/watch?v=-iqxs3KPvLQ"><img src="https://github.com/MikeSchulze/gdUnit4/blob/master/assets/gdUnit4-animated.gif" width="100%"/>

--- a/addons/gdUnit4/plugin.cfg
+++ b/addons/gdUnit4/plugin.cfg
@@ -3,5 +3,5 @@
 name="gdUnit4"
 description="Unit Testing Framework for Godot Scripts"
 author="Mike Schulze"
-version="4.3.4"
+version="4.4.0"
 script="plugin.gd"

--- a/addons/gdUnit4/src/GdUnitSceneRunner.gd
+++ b/addons/gdUnit4/src/GdUnitSceneRunner.gd
@@ -46,8 +46,14 @@ func simulate_action_release(action :String) -> GdUnitSceneRunner:
 ## [member key_code] : the key code e.g. [constant KEY_ENTER][br]
 ## [member shift_pressed] : false by default set to true if simmulate shift is press[br]
 ## [member ctrl_pressed] : false by default set to true if simmulate control is press[br]
+## [codeblock]
+##    func test_key_presssed():
+##       var runner = scene_runner("res://scenes/simple_scene.tscn")
+##       await runner.simulate_key_pressed(KEY_SPACE)
+## [/codeblock]
 @warning_ignore("unused_parameter")
 func simulate_key_pressed(key_code :int, shift_pressed := false, ctrl_pressed := false) -> GdUnitSceneRunner:
+	await Engine.get_main_loop().process_frame
 	return self
 
 

--- a/addons/gdUnit4/src/core/GdUnitSceneRunnerImpl.gd
+++ b/addons/gdUnit4/src/core/GdUnitSceneRunnerImpl.gd
@@ -108,6 +108,8 @@ func simulate_action_press(action :String) -> GdUnitSceneRunner:
 	var event := InputEventAction.new()
 	event.pressed = true
 	event.action = action
+	if Engine.get_version_info().hex >= 0x40300:
+		event.event_index = InputMap.get_actions().find(action)
 	_action_on_press.append(action)
 	return _handle_input_event(event)
 
@@ -117,12 +119,15 @@ func simulate_action_release(action :String) -> GdUnitSceneRunner:
 	var event := InputEventAction.new()
 	event.pressed = false
 	event.action = action
+	if Engine.get_version_info().hex >= 0x40300:
+		event.event_index = InputMap.get_actions().find(action)
 	_action_on_press.erase(action)
 	return _handle_input_event(event)
 
 
 func simulate_key_pressed(key_code :int, shift_pressed := false, ctrl_pressed := false) -> GdUnitSceneRunner:
 	simulate_key_press(key_code, shift_pressed, ctrl_pressed)
+	await _scene_tree().process_frame
 	simulate_key_release(key_code, shift_pressed, ctrl_pressed)
 	return self
 

--- a/addons/gdUnit4/src/core/parse/GdFunctionDescriptor.gd
+++ b/addons/gdUnit4/src/core/parse/GdFunctionDescriptor.gd
@@ -97,7 +97,7 @@ func typeless() -> String:
 	if _return_type == TYPE_NIL:
 		func_signature = "func %s(%s) -> void:" % [name(), typeless_args()]
 	elif _return_type == GdObjects.TYPE_VARIANT:
-		func_signature = "func %s(%s) -> Variant:" % [name(), typeless_args()]
+		func_signature = "func %s(%s):" % [name(), typeless_args()]
 	else:
 		func_signature = "func %s(%s) -> %s:" % [name(), typeless_args(), return_type_as_string()]
 	return "static " + func_signature if is_static() else func_signature

--- a/addons/gdUnit4/src/mocking/GdUnitMockBuilder.gd
+++ b/addons/gdUnit4/src/mocking/GdUnitMockBuilder.gd
@@ -95,8 +95,8 @@ static func mock_on_script(instance :Object, clazz :Variant, function_excludes :
 
 	var mock := GDScript.new()
 	mock.source_code = "\n".join(lines)
-	mock.resource_name = "Mock%s.gd" % clazz_name
-	mock.resource_path = GdUnitFileAccess.create_temp_dir("mock") + "/Mock%s_%d.gd" % [clazz_name, Time.get_ticks_msec()]
+	mock.resource_name =  "Mock%s_%d.gd" % [clazz_name, Time.get_ticks_msec()]
+	mock.resource_path = "%s/%s"  % [GdUnitFileAccess.create_temp_dir("mock"), mock.resource_name]
 
 	if debug_write:
 		DirAccess.remove_absolute(mock.resource_path)

--- a/addons/gdUnit4/src/update/assets/fonts/static/RobotoMono-Bold.ttf.import
+++ b/addons/gdUnit4/src/update/assets/fonts/static/RobotoMono-Bold.ttf.import
@@ -15,6 +15,7 @@ dest_files=["res://.godot/imported/RobotoMono-Bold.ttf-ea008af97d359b7630bd27123
 Rendering=null
 antialiasing=1
 generate_mipmaps=false
+disable_embedded_bitmaps=true
 multichannel_signed_distance_field=false
 msdf_pixel_range=8
 msdf_size=48

--- a/addons/gdUnit4/src/update/assets/fonts/static/RobotoMono-BoldItalic.ttf.import
+++ b/addons/gdUnit4/src/update/assets/fonts/static/RobotoMono-BoldItalic.ttf.import
@@ -15,6 +15,7 @@ dest_files=["res://.godot/imported/RobotoMono-BoldItalic.ttf-6e10905211cda810d47
 Rendering=null
 antialiasing=1
 generate_mipmaps=false
+disable_embedded_bitmaps=true
 multichannel_signed_distance_field=false
 msdf_pixel_range=8
 msdf_size=48

--- a/addons/gdUnit4/src/update/assets/fonts/static/RobotoMono-ExtraLight.ttf.import
+++ b/addons/gdUnit4/src/update/assets/fonts/static/RobotoMono-ExtraLight.ttf.import
@@ -15,6 +15,7 @@ dest_files=["res://.godot/imported/RobotoMono-ExtraLight.ttf-c8ac954f2ab584e7652
 Rendering=null
 antialiasing=1
 generate_mipmaps=false
+disable_embedded_bitmaps=true
 multichannel_signed_distance_field=false
 msdf_pixel_range=8
 msdf_size=48

--- a/addons/gdUnit4/src/update/assets/fonts/static/RobotoMono-ExtraLightItalic.ttf.import
+++ b/addons/gdUnit4/src/update/assets/fonts/static/RobotoMono-ExtraLightItalic.ttf.import
@@ -15,6 +15,7 @@ dest_files=["res://.godot/imported/RobotoMono-ExtraLightItalic.ttf-06133dd8b521e
 Rendering=null
 antialiasing=1
 generate_mipmaps=false
+disable_embedded_bitmaps=true
 multichannel_signed_distance_field=false
 msdf_pixel_range=8
 msdf_size=48

--- a/addons/gdUnit4/src/update/assets/fonts/static/RobotoMono-Italic.ttf.import
+++ b/addons/gdUnit4/src/update/assets/fonts/static/RobotoMono-Italic.ttf.import
@@ -15,6 +15,7 @@ dest_files=["res://.godot/imported/RobotoMono-Italic.ttf-328fe6d9b2ac5d629c43c33
 Rendering=null
 antialiasing=1
 generate_mipmaps=false
+disable_embedded_bitmaps=true
 multichannel_signed_distance_field=false
 msdf_pixel_range=8
 msdf_size=48

--- a/addons/gdUnit4/src/update/assets/fonts/static/RobotoMono-Light.ttf.import
+++ b/addons/gdUnit4/src/update/assets/fonts/static/RobotoMono-Light.ttf.import
@@ -15,6 +15,7 @@ dest_files=["res://.godot/imported/RobotoMono-Light.ttf-638f745780c834176c3bf996
 Rendering=null
 antialiasing=1
 generate_mipmaps=false
+disable_embedded_bitmaps=true
 multichannel_signed_distance_field=false
 msdf_pixel_range=8
 msdf_size=48

--- a/addons/gdUnit4/src/update/assets/fonts/static/RobotoMono-LightItalic.ttf.import
+++ b/addons/gdUnit4/src/update/assets/fonts/static/RobotoMono-LightItalic.ttf.import
@@ -15,6 +15,7 @@ dest_files=["res://.godot/imported/RobotoMono-LightItalic.ttf-473f0d613e289d058b
 Rendering=null
 antialiasing=1
 generate_mipmaps=false
+disable_embedded_bitmaps=true
 multichannel_signed_distance_field=false
 msdf_pixel_range=8
 msdf_size=48

--- a/addons/gdUnit4/src/update/assets/fonts/static/RobotoMono-Medium.ttf.import
+++ b/addons/gdUnit4/src/update/assets/fonts/static/RobotoMono-Medium.ttf.import
@@ -15,6 +15,7 @@ dest_files=["res://.godot/imported/RobotoMono-Medium.ttf-f165ecef77d89557a95acac
 Rendering=null
 antialiasing=1
 generate_mipmaps=false
+disable_embedded_bitmaps=true
 multichannel_signed_distance_field=false
 msdf_pixel_range=8
 msdf_size=48

--- a/addons/gdUnit4/src/update/assets/fonts/static/RobotoMono-MediumItalic.ttf.import
+++ b/addons/gdUnit4/src/update/assets/fonts/static/RobotoMono-MediumItalic.ttf.import
@@ -15,6 +15,7 @@ dest_files=["res://.godot/imported/RobotoMono-MediumItalic.ttf-40c40d791914284c8
 Rendering=null
 antialiasing=1
 generate_mipmaps=false
+disable_embedded_bitmaps=true
 multichannel_signed_distance_field=false
 msdf_pixel_range=8
 msdf_size=48

--- a/addons/gdUnit4/src/update/assets/fonts/static/RobotoMono-Regular.ttf.import
+++ b/addons/gdUnit4/src/update/assets/fonts/static/RobotoMono-Regular.ttf.import
@@ -15,6 +15,7 @@ dest_files=["res://.godot/imported/RobotoMono-Regular.ttf-f5a7315540116b55ba9e01
 Rendering=null
 antialiasing=1
 generate_mipmaps=false
+disable_embedded_bitmaps=true
 multichannel_signed_distance_field=false
 msdf_pixel_range=8
 msdf_size=48

--- a/addons/gdUnit4/src/update/assets/fonts/static/RobotoMono-SemiBold.ttf.import
+++ b/addons/gdUnit4/src/update/assets/fonts/static/RobotoMono-SemiBold.ttf.import
@@ -15,6 +15,7 @@ dest_files=["res://.godot/imported/RobotoMono-SemiBold.ttf-6012d0b71d40b9767a7b6
 Rendering=null
 antialiasing=1
 generate_mipmaps=false
+disable_embedded_bitmaps=true
 multichannel_signed_distance_field=false
 msdf_pixel_range=8
 msdf_size=48

--- a/addons/gdUnit4/src/update/assets/fonts/static/RobotoMono-SemiBoldItalic.ttf.import
+++ b/addons/gdUnit4/src/update/assets/fonts/static/RobotoMono-SemiBoldItalic.ttf.import
@@ -15,6 +15,7 @@ dest_files=["res://.godot/imported/RobotoMono-SemiBoldItalic.ttf-12b525223c8f2df
 Rendering=null
 antialiasing=1
 generate_mipmaps=false
+disable_embedded_bitmaps=true
 multichannel_signed_distance_field=false
 msdf_pixel_range=8
 msdf_size=48

--- a/addons/gdUnit4/src/update/assets/fonts/static/RobotoMono-Thin.ttf.import
+++ b/addons/gdUnit4/src/update/assets/fonts/static/RobotoMono-Thin.ttf.import
@@ -15,6 +15,7 @@ dest_files=["res://.godot/imported/RobotoMono-Thin.ttf-a3a6620deea1a01e153a2a60c
 Rendering=null
 antialiasing=1
 generate_mipmaps=false
+disable_embedded_bitmaps=true
 multichannel_signed_distance_field=false
 msdf_pixel_range=8
 msdf_size=48

--- a/addons/gdUnit4/src/update/assets/fonts/static/RobotoMono-ThinItalic.ttf.import
+++ b/addons/gdUnit4/src/update/assets/fonts/static/RobotoMono-ThinItalic.ttf.import
@@ -15,6 +15,7 @@ dest_files=["res://.godot/imported/RobotoMono-ThinItalic.ttf-e9ceff3e4cdfbfedd19
 Rendering=null
 antialiasing=1
 generate_mipmaps=false
+disable_embedded_bitmaps=true
 multichannel_signed_distance_field=false
 msdf_pixel_range=8
 msdf_size=48

--- a/addons/gdUnit4/test/core/GdUnitSceneRunnerInputEventTest.gd
+++ b/addons/gdUnit4/test/core/GdUnitSceneRunnerInputEventTest.gd
@@ -100,6 +100,24 @@ func test_simulate_action_press() -> void:
 			.override_failure_message("Expect the action '%s' is NOT pressed" % action).is_false()
 
 
+func test_simulate_action_release() -> void:
+	# iterate over some example actions
+	var actions_to_simmulate :Array[String] = ["ui_up", "ui_down", "ui_left", "ui_right"]
+	for action in actions_to_simmulate:
+		assert_that(InputMap.has_action(action)).is_true()
+		_runner.simulate_action_press(action)
+		await await_idle_frame()
+		_runner.simulate_action_release(action)
+
+		assert_that(Input.is_action_just_released(action))\
+			.override_failure_message("Expect the action '%s' is released" % action).is_true()
+	# other actions are not pressed
+	for action :String in ["ui_accept", "ui_select", "ui_cancel"]:
+		assert_that(Input.is_action_pressed(action))\
+			.override_failure_message("Expect the action '%s' is NOT pressed" % action).is_false()
+
+
+
 func test_simulate_key_press() -> void:
 	# iterate over some example keys
 	for key :int in [KEY_A, KEY_D, KEY_X, KEY_0]:
@@ -186,9 +204,7 @@ func test_simulate_keypressed_as_action() -> void:
 	assert_bool(Input.is_action_just_released("ui_select", true)).is_false()
 	assert_bool(runner.scene()._player_jump_action_released).is_false()
 
-	# test a key event is trigger action event
-	# simulate press space
-	runner.simulate_key_pressed(KEY_SPACE)
+	await runner.simulate_key_pressed(KEY_SPACE)
 	# it is important do not wait for next frame here, otherwise the input action cache is cleared and can't be use to verify
 	assert_bool(Input.is_action_just_released("player_jump", true)).is_true()
 	assert_bool(Input.is_action_just_released("ui_accept", true)).is_true()

--- a/addons/gdUnit4/test/core/GdUnitSceneRunnerTest.gd
+++ b/addons/gdUnit4/test/core/GdUnitSceneRunnerTest.gd
@@ -130,7 +130,7 @@ func test_simulate_scene_inteaction_in_combination_with_spy() -> void:
 	var runner := scene_runner(spy_)
 
 	# simulate a key event to fire a spell
-	runner.simulate_key_pressed(KEY_ENTER)
+	await runner.simulate_key_pressed(KEY_ENTER)
 	verify(spy_).create_spell()
 
 	var spell := runner.find_child("Spell")

--- a/addons/gdUnit4/test/core/parse/GdFunctionDescriptorTest.gd
+++ b/addons/gdUnit4/test/core/parse/GdFunctionDescriptorTest.gd
@@ -143,4 +143,4 @@ func test_extract_from_func_with_return_type_variant() -> void:
 		GdFunctionArgument.new("property_", TYPE_STRING_NAME),
 	])
 	# Variant get(property: String) const
-	assert_str(fd.typeless()).is_equal("func get(property_) -> Variant:")
+	assert_str(fd.typeless()).is_equal("func get(property_):")

--- a/addons/gdUnit4/test/core/parse/GdScriptParserTest.gd
+++ b/addons/gdUnit4/test/core/parse/GdScriptParserTest.gd
@@ -374,7 +374,7 @@ func test_parse_func_description() -> void:
 	assert_bool(fd.is_static()).is_false()
 	assert_int(fd.return_type()).is_equal(GdObjects.TYPE_VARIANT)
 	assert_array(fd.args()).is_empty()
-	assert_str(fd.typeless()).is_equal("func foo() -> Variant:")
+	assert_str(fd.typeless()).is_equal("func foo():")
 
 	# static function
 	fd = _parser.parse_func_description("static func foo(arg1 :int, arg2:=false) -> String:", "clazz_name", [""], 22)
@@ -396,7 +396,7 @@ func test_parse_func_description() -> void:
 		GdFunctionArgument.new("arg1", TYPE_INT),
 		GdFunctionArgument.new("arg2", TYPE_BOOL, "false")
 	])
-	assert_str(fd.typeless()).is_equal("static func foo(arg1, arg2=false) -> Variant:")
+	assert_str(fd.typeless()).is_equal("static func foo(arg1, arg2=false):")
 
 
 func test_parse_func_description_return_type_enum() -> void:

--- a/addons/gdUnit4/test/mocker/GdUnitMockBuilderTest.gd
+++ b/addons/gdUnit4/test/mocker/GdUnitMockBuilderTest.gd
@@ -249,7 +249,7 @@ func test_double_virtual_script_function_with_arg() -> void:
 func test_mock_on_script_path_without_class_name() -> void:
 	var instance :Object = load("res://addons/gdUnit4/test/mocker/resources/ClassWithoutNameA.gd").new()
 	var script := GdUnitMockBuilder.mock_on_script(instance, "res://addons/gdUnit4/test/mocker/resources/ClassWithoutNameA.gd", [], true);
-	assert_that(script.resource_name).is_equal("MockClassWithoutNameA.gd")
+	assert_that(script.resource_name).starts_with("MockClassWithoutNameA")
 	assert_that(script.get_instance_base_type()).is_equal("Resource")
 	# finally check the mocked script is valid
 	assert_int(script.reload()).is_equal(OK)
@@ -259,7 +259,7 @@ func test_mock_on_script_path_with_custom_class_name() -> void:
 	# the class contains a class_name definition
 	var instance :Object = load("res://addons/gdUnit4/test/mocker/resources/ClassWithCustomClassName.gd").new()
 	var script := GdUnitMockBuilder.mock_on_script(instance, "res://addons/gdUnit4/test/mocker/resources/ClassWithCustomClassName.gd", [], false);
-	assert_that(script.resource_name).is_equal("MockGdUnitTestCustomClassName.gd")
+	assert_that(script.resource_name).starts_with("MockGdUnitTestCustomClassName")
 	assert_that(script.get_instance_base_type()).is_equal("Resource")
 	# finally check the mocked script is valid
 	assert_int(script.reload()).is_equal(OK)
@@ -267,7 +267,7 @@ func test_mock_on_script_path_with_custom_class_name() -> void:
 
 func test_mock_on_class_with_class_name() -> void:
 	var script := GdUnitMockBuilder.mock_on_script(ClassWithNameA.new(), ClassWithNameA, [], false);
-	assert_that(script.resource_name).is_equal("MockClassWithNameA.gd")
+	assert_that(script.resource_name).starts_with("MockClassWithNameA")
 	assert_that(script.get_instance_base_type()).is_equal("Resource")
 	# finally check the mocked script is valid
 	assert_int(script.reload()).is_equal(OK)
@@ -276,7 +276,7 @@ func test_mock_on_class_with_class_name() -> void:
 func test_mock_on_class_with_custom_class_name() -> void:
 	# the class contains a class_name definition
 	var script := GdUnitMockBuilder.mock_on_script(GdUnit_Test_CustomClassName.new(), GdUnit_Test_CustomClassName, [], false);
-	assert_that(script.resource_name).is_equal("MockGdUnitTestCustomClassName.gd")
+	assert_that(script.resource_name).starts_with("MockGdUnitTestCustomClassName")
 	assert_that(script.get_instance_base_type()).is_equal("Resource")
 	# finally check the mocked script is valid
 	assert_int(script.reload()).is_equal(OK)

--- a/addons/gdUnit4/test/mocker/GdUnitMockerTest.gd
+++ b/addons/gdUnit4/test/mocker/GdUnitMockerTest.gd
@@ -1074,7 +1074,7 @@ func test_mock_scene_by_path() -> void:
 	var mocked_scene :Variant = mock("res://addons/gdUnit4/test/mocker/resources/scenes/TestScene.tscn")
 	assert_object(mocked_scene).is_not_null()
 	assert_object(mocked_scene.get_script()).is_not_null()
-	assert_str(mocked_scene.get_script().resource_name).is_equal("MockTestScene.gd")
+	assert_str(mocked_scene.get_script().resource_name).starts_with("MockTestScene")
 	# check is mocked scene registered for auto freeing
 	assert_bool(GdUnitMemoryObserver.is_marked_auto_free(mocked_scene)).is_true()
 
@@ -1084,7 +1084,7 @@ func test_mock_scene_by_resource() -> void:
 	var mocked_scene :Variant = mock(resource)
 	assert_object(mocked_scene).is_not_null()
 	assert_object(mocked_scene.get_script()).is_not_null()
-	assert_str(mocked_scene.get_script().resource_name).is_equal("MockTestScene.gd")
+	assert_str(mocked_scene.get_script().resource_name).starts_with("MockTestScene")
 	# check is mocked scene registered for auto freeing
 	assert_bool(GdUnitMemoryObserver.is_marked_auto_free(mocked_scene)).is_true()
 

--- a/gdUnit4.csproj
+++ b/gdUnit4.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Godot.NET.Sdk/4.2.2">
+<Project Sdk="Godot.NET.Sdk/4.3.0">
   <PropertyGroup>
     <TargetFrameworks>net8.0</TargetFrameworks>
     <LangVersion>11.0</LangVersion>

--- a/gdUnit4.csproj
+++ b/gdUnit4.csproj
@@ -11,7 +11,7 @@
   <ItemGroup>
     <!--Required for GdUnit4-->
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
-    <PackageReference Include="gdUnit4.api" Version="4.2.*-*" />
-    <PackageReference Include="gdUnit4.test.adapter" Version="1.*" />
+    <PackageReference Include="gdUnit4.api" Version="4.3.*-*" />
+    <PackageReference Include="gdUnit4.test.adapter" Version="2.*" />
   </ItemGroup>
 </Project>

--- a/project.godot
+++ b/project.godot
@@ -12,7 +12,7 @@ config_version=5
 
 config/name="gdUnit4"
 config/tags=PackedStringArray("addon", "godot4", "testing")
-config/features=PackedStringArray("4.2")
+config/features=PackedStringArray("4.3", "C#")
 config/icon="res://icon.png"
 
 [audio]


### PR DESCRIPTION
# Why
- We need to add the final release of Godot 4.3 to the CI workflow
- input actions are broken
- mocking of typeless functions are broken


# What
- added version 4.3 to the test matrix
- fixed mocking by do not add `-> Variant` for typeless functions
- fixed input actions to work with Godot 4.3
- increase GdUnit4 version to 4.4.0
- update c# project dependencies