### PR TITLE
GD-569: Add Godot `4.4.dev2` to the CI workflows

### DIFF
--- a/.github/workflows/ci-pr-publish-report.yml
+++ b/.github/workflows/ci-pr-publish-report.yml
@@ -26,9 +26,9 @@ jobs:
         godot-version: ['4.2', '4.2.1', '4.2.2', '4.3']
         godot-status: ['stable']
         godot-net: ['-net', '']
-    #    include:
-    #      - godot-version: '4.3'
-    #        godot-status: 'beta2'
+        include:
+          - godot-version: '4.4'
+            godot-status: 'dev2'
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -33,9 +33,9 @@ jobs:
         godot-version: ['4.2', '4.2.1', '4.2.2', '4.3']
         godot-status: ['stable']
         godot-net: ['.Net', '']
-    #    include:
-    #      - godot-version: '4.3'
-    #        godot-status: 'beta2'
+        include:
+          - godot-version: '4.4'
+            godot-status: 'dev2'
 
     permissions:
       actions: write

--- a/README.md
+++ b/README.md
@@ -4,31 +4,31 @@
   <h1 align="center">GdUnit4 <img alt="GitHub release (latest by date)" src="https://img.shields.io/github/v/release/MikeSchulze/gdunit4" width="14%"> </h1>
 </p>
 <h2 align="center">A Godot Embedded Unit Testing Framework</h2>
-<p align="center">This version of GdUnit4 is based on Godot <strong>v4.3.stable.mono.official [77dcf97d8]</strong> (master branch)</p>
-</h2>
 
----
 <h1 align="center">Supported Godot Versions</h1>
 <p align="center">
   <img src="https://img.shields.io/badge/Godot-v4.2.0-%23478cbf?logo=godot-engine&logoColor=cyian&color=green">
   <img src="https://img.shields.io/badge/Godot-v4.2.1-%23478cbf?logo=godot-engine&logoColor=cyian&color=green">
   <img src="https://img.shields.io/badge/Godot-v4.2.2-%23478cbf?logo=godot-engine&logoColor=cyian&color=green">
   <img src="https://img.shields.io/badge/Godot-v4.3-%23478cbf?logo=godot-engine&logoColor=cyian&color=green">
+  <img src="https://img.shields.io/badge/Godot-v4.4.dev2-%23478cbf?logo=godot-engine&logoColor=cyian&color=green">
 </p>
+
 <h1 align="center">Compatibility Overview</h1>
+<p align="center">The latest version of GdUnit4 (master branch) is based on Godot <strong>v4.4.dev2.official [97ef3c837]</strong></p>
 <table align="center">
   <thead>
-	<tr>
-	  <th>GdUnit4 Version</th>
-	  <th>Minimal required Godot Version</th>
-	</tr>
+ <tr>
+   <th>GdUnit4 Version</th>
+   <th>Godot minimal required/compatible Version</th>
+ </tr>
   </thead>
   <tbody>
     <tr>
-      <td>v4.4.0+</td><td>v4.2.0, v4.3</td>
+      <td>v4.4.0+</td><td>v4.2.0, v4.3, v4.4.dev2</td>
     </tr>
     <tr>
-      <td>v4.3.2+</td><td>v4.2.0, v4.3-beta2</td>
+      <td>v4.3.2+</td><td>v4.2.0, v4.3</td>
     </tr>
     <tr>
       <td>v4.3.0, v4.3.1</td><td>v4.2.0</td>
@@ -89,14 +89,14 @@ GdUnit4 is a powerful tool that supports Test-Driven Development ([TDD](https://
 
 ## Basic Test Example
 
- ```
+ ```gdscript
 class_name GdUnitExampleTest
 extends GdUnitTestSuite
 
 func test_example():
   assert_str("This is a example message")\
-	.has_length(25)\
-	.starts_with("This is a ex")
+    .has_length(25)\
+    .starts_with("This is a ex")
  ```
 
  ---

--- a/addons/gdUnit4/src/monitor/ErrorLogEntry.gd
+++ b/addons/gdUnit4/src/monitor/ErrorLogEntry.gd
@@ -14,37 +14,48 @@ const GdUnitTools := preload("res://addons/gdUnit4/src/core/GdUnitTools.gd")
 const PATTERN_SCRIPT_ERROR := "USER SCRIPT ERROR:"
 const PATTERN_PUSH_ERROR := "USER ERROR:"
 const PATTERN_PUSH_WARNING := "USER WARNING:"
+# With Godot 4.4 the pattern has changed
+const PATTERN_4x4_SCRIPT_ERROR := "SCRIPT ERROR:"
+const PATTERN_4x4_PUSH_ERROR := "ERROR:"
+const PATTERN_4x4_PUSH_WARNING := "WARNING:"
 
 static var _regex_parse_error_line_number: RegEx
 
-var _type :TYPE
-var _line :int
-var _message :String
-var _details :String
+var _type: TYPE
+var _line: int
+var _message: String
+var _details: String
 
 
-func _init(type :TYPE, line :int, message :String, details :String) -> void:
+func _init(type: TYPE, line: int, message: String, details: String) -> void:
 	_type = type
 	_line = line
 	_message = message
 	_details = details
 
 
-static func extract_push_warning(records :PackedStringArray, index :int) -> ErrorLogEntry:
-	return _extract(records, index, TYPE.PUSH_WARNING, PATTERN_PUSH_WARNING)
+static func is_godot4x4() -> bool:
+	return Engine.get_version_info().hex >= 0x40400
 
 
-static func extract_push_error(records :PackedStringArray, index :int) -> ErrorLogEntry:
-	return _extract(records, index, TYPE.PUSH_ERROR, PATTERN_PUSH_ERROR)
+static func extract_push_warning(records: PackedStringArray, index: int) -> ErrorLogEntry:
+	var pattern := PATTERN_4x4_PUSH_WARNING if is_godot4x4() else PATTERN_PUSH_WARNING
+	return _extract(records, index, TYPE.PUSH_WARNING, pattern)
 
 
-static func extract_error(records :PackedStringArray, index :int) -> ErrorLogEntry:
-	return _extract(records, index, TYPE.SCRIPT_ERROR, PATTERN_SCRIPT_ERROR)
+static func extract_push_error(records: PackedStringArray, index: int) -> ErrorLogEntry:
+	var pattern := PATTERN_4x4_PUSH_ERROR if is_godot4x4() else PATTERN_PUSH_ERROR
+	return _extract(records, index, TYPE.PUSH_ERROR, pattern)
 
 
-static func _extract(records :PackedStringArray, index :int, type :TYPE, pattern :String) -> ErrorLogEntry:
+static func extract_error(records: PackedStringArray, index: int) -> ErrorLogEntry:
+	var pattern := PATTERN_4x4_SCRIPT_ERROR if is_godot4x4() else PATTERN_SCRIPT_ERROR
+	return _extract(records, index, TYPE.SCRIPT_ERROR, pattern)
+
+
+static func _extract(records: PackedStringArray, index: int, type: TYPE, pattern: String) -> ErrorLogEntry:
 	var message := records[index]
-	if message.contains(pattern):
+	if message.begins_with(pattern):
 		var error := message.replace(pattern, "").strip_edges()
 		var details := records[index+1].strip_edges()
 		var line := _parse_error_line_number(details)
@@ -52,7 +63,7 @@ static func _extract(records :PackedStringArray, index :int, type :TYPE, pattern
 	return null
 
 
-static func _parse_error_line_number(record :String) -> int:
+static func _parse_error_line_number(record: String) -> int:
 	if _regex_parse_error_line_number == null:
 		_regex_parse_error_line_number = GdUnitTools.to_regex("at: .*res://.*:(\\d+)")
 	var matches := _regex_parse_error_line_number.search(record)

--- a/addons/gdUnit4/src/monitor/GodotGdErrorMonitor.gd
+++ b/addons/gdUnit4/src/monitor/GodotGdErrorMonitor.gd
@@ -1,8 +1,8 @@
 class_name GodotGdErrorMonitor
 extends GdUnitMonitor
 
-var _godot_log_file :String
-var _eof :int
+var _godot_log_file: String
+var _eof: int
 var _report_enabled := false
 var _entries: Array[ErrorLogEntry] = []
 
@@ -25,14 +25,14 @@ func stop() -> void:
 
 
 func to_reports() -> Array[GdUnitReport]:
-	var reports_ :Array[GdUnitReport] = []
+	var reports_: Array[GdUnitReport] = []
 	if _report_enabled:
 		reports_.assign(_entries.map(_to_report))
 	_entries.clear()
 	return reports_
 
 
-static func _to_report(errorLog :ErrorLogEntry) -> GdUnitReport:
+static func _to_report(errorLog: ErrorLogEntry) -> GdUnitReport:
 	var failure := "%s\n\t%s\n%s %s" % [
 		GdAssertMessages._error("Godot Runtime Error !"),
 		GdAssertMessages._colored_value(errorLog._details),
@@ -48,11 +48,11 @@ func scan(force_collect_reports := false) -> Array[ErrorLogEntry]:
 	return _entries
 
 
-func erase_log_entry(entry :ErrorLogEntry) -> void:
+func erase_log_entry(entry: ErrorLogEntry) -> void:
 	_entries.erase(entry)
 
 
-func _collect_log_entries(force_collect_reports :bool) -> Array[ErrorLogEntry]:
+func _collect_log_entries(force_collect_reports: bool) -> Array[ErrorLogEntry]:
 	var file := FileAccess.open(_godot_log_file, FileAccess.READ)
 	file.seek(_eof)
 	var records := PackedStringArray()
@@ -60,7 +60,7 @@ func _collect_log_entries(force_collect_reports :bool) -> Array[ErrorLogEntry]:
 		records.append(file.get_line())
 	file.seek_end(0)
 	_eof = file.get_length()
-	var log_entries :Array[ErrorLogEntry]= []
+	var log_entries: Array[ErrorLogEntry]= []
 	var is_report_errors := force_collect_reports or _is_report_push_errors()
 	var is_report_script_errors := force_collect_reports or _is_report_script_errors()
 	for index in records.size():
@@ -70,7 +70,7 @@ func _collect_log_entries(force_collect_reports :bool) -> Array[ErrorLogEntry]:
 			log_entries.append(ErrorLogEntry.extract_push_error(records, index))
 		if is_report_script_errors:
 			log_entries.append(ErrorLogEntry.extract_error(records, index))
-	return log_entries.filter(func(value :ErrorLogEntry) -> bool: return value != null )
+	return log_entries.filter(func(value: ErrorLogEntry) -> bool: return value != null )
 
 
 func _is_reporting_enabled() -> bool:

--- a/addons/gdUnit4/test/asserts/GdUnitGodotErrorAssertImplTest.gd
+++ b/addons/gdUnit4/test/asserts/GdUnitGodotErrorAssertImplTest.gd
@@ -19,10 +19,16 @@ class GodotErrorTestClass:
 				await Engine.get_main_loop().process_frame
 				if OS.is_debug_build():
 					# do not break the debug session we simmulate a assert by writing the error manually
-					prints("""
-						USER SCRIPT ERROR: Assertion failed: this is an assert error
-						   at: GodotErrorTestClass.test (res://addons/gdUnit4/test/asserts/GdUnitGodotErrorAssertImplTest.gd:18)
-					""".dedent())
+					if Engine.get_version_info().hex >= 0x40400:
+						prints("""
+							SCRIPT ERROR: Assertion failed: this is an assert error
+							   at: GodotErrorTestClass.test (res://addons/gdUnit4/test/asserts/GdUnitGodotErrorAssertImplTest.gd:18)
+						""".dedent())
+					else:
+						prints("""
+							USER SCRIPT ERROR: Assertion failed: this is an assert error
+							   at: GodotErrorTestClass.test (res://addons/gdUnit4/test/asserts/GdUnitGodotErrorAssertImplTest.gd:18)
+						""".dedent())
 				else:
 					assert(false, "this is an assert error" )
 			2: # push_warning
@@ -33,10 +39,16 @@ class GodotErrorTestClass:
 			4: # runtime error
 				if OS.is_debug_build():
 					# do not break the debug session we simmulate a assert by writing the error manually
-					prints("""
-						USER SCRIPT ERROR: Division by zero error in operator '/'.
-						   at: GodotErrorTestClass.test (res://addons/gdUnit4/test/asserts/GdUnitGodotErrorAssertImplTest.gd:32)
-					""".dedent())
+					if Engine.get_version_info().hex >= 0x40400:
+						prints("""
+							SCRIPT ERROR: Division by zero error in operator '/'.
+							   at: GodotErrorTestClass.test (res://addons/gdUnit4/test/asserts/GdUnitGodotErrorAssertImplTest.gd:32)
+						""".dedent())
+					else:
+						prints("""
+							USER SCRIPT ERROR: Division by zero error in operator '/'.
+							   at: GodotErrorTestClass.test (res://addons/gdUnit4/test/asserts/GdUnitGodotErrorAssertImplTest.gd:32)
+						""".dedent())
 				else:
 					var a := 0
 					@warning_ignore("integer_division")

--- a/addons/gdUnit4/test/asserts/GdUnitGodotErrorWithAssertTest.gd
+++ b/addons/gdUnit4/test/asserts/GdUnitGodotErrorWithAssertTest.gd
@@ -18,9 +18,14 @@ func test_assert_method_with_disabled_global_error_report() -> void:
 func do_a_fail() -> void:
 	if OS.is_debug_build():
 		# On debug level we need to simulate the assert log entry, otherwise we stuck on a breakpoint
-		prints("""
-		USER SCRIPT ERROR: Assertion failed: test
-		   at: do_a_fail (res://addons/gdUnit4/test/asserts/GdUnitErrorAssertTest.gd:20)""")
+		if Engine.get_version_info().hex >= 0x40400:
+			prints("""
+			SCRIPT ERROR: Assertion failed: test
+			   at: do_a_fail (res://addons/gdUnit4/test/asserts/GdUnitErrorAssertTest.gd:20)""".dedent())
+		else:
+			prints("""
+			USER SCRIPT ERROR: Assertion failed: test
+			   at: do_a_fail (res://addons/gdUnit4/test/asserts/GdUnitErrorAssertTest.gd:20)""".dedent())
 	else:
 		assert(3 == 1, 'test')
 

--- a/addons/gdUnit4/test/core/parse/GdFunctionDescriptorTest.gd
+++ b/addons/gdUnit4/test/core/parse/GdFunctionDescriptorTest.gd
@@ -119,7 +119,7 @@ func test_extract_from_descriptor_is_virtual_func_full_check() -> void:
 	# since Godot 4.2 there are more virtual functions
 	if Engine.get_version_info().hex >= 0x40200:
 		expected_virtual_functions.append("_validate_property")
-	# since Godot 4.2 there are more virtual functions
+	# since Godot 4.4.x there are more virtual functions
 	if Engine.get_version_info().hex >= 0x40400:
 		expected_virtual_functions.append_array([
 			"_iter_init",

--- a/addons/gdUnit4/test/core/parse/GdFunctionDescriptorTest.gd
+++ b/addons/gdUnit4/test/core/parse/GdFunctionDescriptorTest.gd
@@ -119,6 +119,13 @@ func test_extract_from_descriptor_is_virtual_func_full_check() -> void:
 	# since Godot 4.2 there are more virtual functions
 	if Engine.get_version_info().hex >= 0x40200:
 		expected_virtual_functions.append("_validate_property")
+	# since Godot 4.2 there are more virtual functions
+	if Engine.get_version_info().hex >= 0x40400:
+		expected_virtual_functions.append_array([
+			"_iter_init",
+			"_iter_next",
+			"_iter_get"
+		])
 
 	var _count := 0
 	for method_descriptor in methods:


### PR DESCRIPTION
# Why
see https://github.com/MikeSchulze/gdUnit4/issues/569

# What
- added Godot 4.4.dev2 to the CI
- fixes `GdFunctionDescriptorTest` to take new virtual functions into account
- fixes the `GodotGdErrorMonitor` for `push_error`, `push_warning` and script error scanning, the format has changed.
- update README.md

