### PR TITLE
GD-573: Fixed the inspector double-click, inherited tests to jump to the script where the test are located

### DIFF
--- a/addons/gdUnit4/src/network/rpc/dtos/GdUnitTestCaseDto.gd
+++ b/addons/gdUnit4/src/network/rpc/dtos/GdUnitTestCaseDto.gd
@@ -2,6 +2,7 @@ class_name GdUnitTestCaseDto
 extends GdUnitResourceDto
 
 var _line_number :int = -1
+var _script_path: String
 var _test_case_names :PackedStringArray = []
 
 
@@ -11,6 +12,12 @@ func serialize(test_case :Node) -> Dictionary:
 		serialized["line_number"] = test_case.line_number()
 	else:
 		serialized["line_number"] = test_case.get("LineNumber")
+	if test_case.has_method("script_path"):
+		serialized["script_path"] = test_case.script_path()
+	else:
+		# TODO 'script_path' needs to be implement in c# the the
+		# serialized["script_path"] = test_case.get("ScriptPath")
+		serialized["script_path"] = serialized["resource_path"]
 	if test_case.has_method("test_case_names"):
 		serialized["test_case_names"] = test_case.test_case_names()
 	elif test_case.has_method("TestCaseNames"):
@@ -21,12 +28,17 @@ func serialize(test_case :Node) -> Dictionary:
 func deserialize(data :Dictionary) -> GdUnitResourceDto:
 	super.deserialize(data)
 	_line_number = data.get("line_number", -1)
+	_script_path = data.get("script_path", data.get("resource_path", ""))
 	_test_case_names = data.get("test_case_names", [])
 	return self
 
 
 func line_number() -> int:
 	return _line_number
+
+
+func script_path() -> String:
+	return _script_path
 
 
 func test_case_names() -> PackedStringArray:


### PR DESCRIPTION
# Why
see https://github.com/MikeSchulze/gdUnit4/issues/573

# What
- use the `script_path` provided by the test case and enrich the inspector item with this metadata `META_SCRIPT_PATH`
- use the `META_SCRIPT_PATH` on select event to jump to the script where the test are located

