### PR TITLE
GD-579: Minimize warnings in debug mode with any warning is configuration

### DIFF
--- a/addons/gdUnit4/src/core/GdUnitProperty.gd
+++ b/addons/gdUnit4/src/core/GdUnitProperty.gd
@@ -44,11 +44,11 @@ func set_value(p_value :Variant) -> void:
 		TYPE_STRING:
 			_value = str(p_value)
 		TYPE_BOOL:
-			_value = bool(p_value)
+			_value = p_value as bool
 		TYPE_INT:
-			_value = int(p_value)
+			_value = p_value as int
 		TYPE_FLOAT:
-			_value = float(p_value)
+			_value = p_value as float
 		_:
 			_value = p_value
 

--- a/addons/gdUnit4/src/core/GdUnitResult.gd
+++ b/addons/gdUnit4/src/core/GdUnitResult.gd
@@ -97,7 +97,7 @@ static func serialize(result :GdUnitResult) -> Dictionary:
 
 static func deserialize(config :Dictionary) -> GdUnitResult:
 	var result := GdUnitResult.new()
-	result._value = str_to_var(config.get("value", ""))
+	result._value = str_to_var(config.get("value", "") as String)
 	result._warn_message = config.get("warn_msg", null)
 	result._error_message = config.get("err_msg", null)
 	result._state = config.get("state")

--- a/addons/gdUnit4/src/core/GdUnitRunnerConfig.gd
+++ b/addons/gdUnit4/src/core/GdUnitRunnerConfig.gd
@@ -72,7 +72,7 @@ func add_test_case(p_resource_path :String, test_name :StringName, test_param_in
 # '/path/path', res://path/path', 'res://path/path/testsuite.gd' or 'testsuite'
 # 'res://path/path/testsuite.gd:test_case' or 'testsuite:test_case'
 func skip_test_suite(value :StringName) -> GdUnitRunnerConfig:
-	var parts :Array =  GdUnitFileAccess.make_qualified_path(value).rsplit(":")
+	var parts :Array[String] =  GdUnitFileAccess.make_qualified_path(value).rsplit(":")
 	if parts[0] == "res":
 		parts.pop_front()
 	parts[0] = GdUnitFileAccess.make_qualified_path(parts[0])
@@ -140,8 +140,8 @@ func fix_value_types() -> void:
 	# fix float value to int json stores all numbers as float
 	var server_port_ :int = _config.get(SERVER_PORT, -1)
 	_config[SERVER_PORT] = server_port_
-	convert_Array_to_PackedStringArray(_config[INCLUDED])
-	convert_Array_to_PackedStringArray(_config[SKIPPED])
+	convert_Array_to_PackedStringArray(_config[INCLUDED] as Dictionary)
+	convert_Array_to_PackedStringArray(_config[SKIPPED] as Dictionary)
 
 
 func convert_Array_to_PackedStringArray(data :Dictionary) -> void:

--- a/addons/gdUnit4/src/core/GdUnitSignals.gd
+++ b/addons/gdUnit4/src/core/GdUnitSignals.gd
@@ -36,7 +36,7 @@ static func dispose() -> void:
 	var signals := instance()
 	# cleanup connected signals
 	for signal_ in signals.get_signal_list():
-		for connection in signals.get_signal_connection_list(signal_["name"]):
+		for connection in signals.get_signal_connection_list(signal_["name"] as StringName):
 			connection["signal"].disconnect(connection["callable"])
 	signals = null
 	Engine.remove_meta(META_KEY)

--- a/addons/gdUnit4/src/core/GdUnitSingleton.gd
+++ b/addons/gdUnit4/src/core/GdUnitSingleton.gd
@@ -44,7 +44,7 @@ static func unregister(p_singleton :String, use_call_deferred :bool = false) -> 
 
 static func dispose(use_call_deferred :bool = false) -> void:
 	# use a copy because unregister is modify the singletons array
-	var singletons := PackedStringArray(Engine.get_meta(MEATA_KEY, PackedStringArray()))
+	var singletons: PackedStringArray = Engine.get_meta(MEATA_KEY, PackedStringArray())
 	GdUnitTools.prints_verbose("----------------------------------------------------------------")
 	GdUnitTools.prints_verbose("Cleanup singletons %s" % singletons)
 	for singleton in singletons:

--- a/addons/gdUnit4/src/core/event/GdUnitEvent.gd
+++ b/addons/gdUnit4/src/core/event/GdUnitEvent.gd
@@ -186,7 +186,7 @@ func deserialize(serialized :Dictionary) -> GdUnitEvent:
 	if serialized.has("reports"):
 		# needs this workaround to copy typed values in the array
 		var reports_to_deserializ :Array[Dictionary] = []
-		reports_to_deserializ.append_array(serialized.get("reports"))
+		reports_to_deserializ.append_array(serialized.get("reports") as Array)
 		_reports = _deserialize_reports(reports_to_deserializ)
 	return self
 

--- a/addons/gdUnit4/src/core/parse/GdFunctionArgument.gd
+++ b/addons/gdUnit4/src/core/parse/GdFunctionArgument.gd
@@ -3,7 +3,7 @@ extends RefCounted
 
 
 const GdUnitTools := preload("res://addons/gdUnit4/src/core/GdUnitTools.gd")
-const UNDEFINED :Variant = "<-NO_ARG->"
+const UNDEFINED: String = "<-NO_ARG->"
 const ARG_PARAMETERIZED_TEST := "test_parameters"
 
 static var _fuzzer_regex: RegEx
@@ -13,11 +13,11 @@ static var _fix_comma_space: RegEx
 var _name: String
 var _type: int
 var _type_hint: int
-var _default_value :Variant
-var _parameter_sets :PackedStringArray = []
+var _default_value: String
+var _parameter_sets: PackedStringArray = []
 
 
-func _init(p_name: String, p_type: int, value: Variant = UNDEFINED, p_type_hint: int = TYPE_NIL) -> void:
+func _init(p_name: String, p_type: int, value: String = UNDEFINED, p_type_hint: int = TYPE_NIL) -> void:
 	_init_static_variables()
 	_name = p_name
 	_type = p_type
@@ -45,7 +45,7 @@ func default() -> Variant:
 	return GodotVersionFixures.convert(_default_value, _type)
 
 
-func set_value(value: Variant) -> void:
+func set_value(value: String) -> void:
 	if _type == TYPE_NIL or _type == GdObjects.TYPE_VARIANT:
 		_type = _extract_value_type(value)
 	if _name == ARG_PARAMETERIZED_TEST:
@@ -64,7 +64,7 @@ func _extract_value_type(value: String) -> int:
 
 func value_as_string() -> String:
 	if has_default():
-		return str(_default_value)
+		return _default_value
 	return ""
 
 
@@ -106,7 +106,7 @@ func _to_string() -> String:
 	if _type_hint != TYPE_NIL:
 		s += "[%s]" % GdObjects.type_as_string(_type_hint)
 	if _default_value != UNDEFINED:
-		s += "=" + str(_default_value)
+		s += "=" + _default_value
 	return s
 
 

--- a/addons/gdUnit4/src/network/rpc/dtos/GdUnitTestCaseDto.gd
+++ b/addons/gdUnit4/src/network/rpc/dtos/GdUnitTestCaseDto.gd
@@ -25,7 +25,7 @@ func serialize(test_case :Node) -> Dictionary:
 	return serialized
 
 
-func deserialize(data :Dictionary) -> GdUnitResourceDto:
+func deserialize(data :Dictionary) -> GdUnitTestCaseDto:
 	super.deserialize(data)
 	_line_number = data.get("line_number", -1)
 	_script_path = data.get("script_path", data.get("resource_path", ""))

--- a/addons/gdUnit4/src/ui/ScriptEditorControls.gd
+++ b/addons/gdUnit4/src/ui/ScriptEditorControls.gd
@@ -82,7 +82,7 @@ static func edit_script(script_path: String, line_number:=-1) -> void:
 	var file_system_dock := EditorInterface.get_file_system_dock()
 	file_system_dock.navigate_to_path(script_path)
 	EditorInterface.select_file(script_path)
-	var script := load(script_path)
+	var script: GDScript = load(script_path)
 	EditorInterface.edit_script(script, line_number)
 
 

--- a/project.godot
+++ b/project.godot
@@ -24,6 +24,7 @@ default_bus_layout=""
 file_logging/enable_file_logging=true
 gdscript/warnings/exclude_addons=false
 gdscript/warnings/untyped_declaration=2
+gdscript/warnings/unsafe_call_argument=1
 
 [dotnet]
 


### PR DESCRIPTION

# Why
If the default settings for warnings are changed to a more detailed level, many warnings are displayed.

# What
- fix `debug/gdscript/warnings/unsafe_call_argument`  warnings

