### PR TITLE
GD-579: `Part2`: Minimize `return_value_discarded` warnings

### DIFF
--- a/addons/gdUnit4/bin/GdUnitCmdTool.gd
+++ b/addons/gdUnit4/bin/GdUnitCmdTool.gd
@@ -304,7 +304,7 @@ class CLIRunner:
 			return
 		# build runner config by given commands
 		var commands :Array[CmdCommand] = []
-		commands.append_array(result.value())
+		commands.append_array(result.value() as Array)
 		result = (
 			CmdCommandHandler.new(_cmd_options)
 				.register_cb("-help", Callable(self, "show_help"))

--- a/addons/gdUnit4/bin/GdUnitCopyLog.gd
+++ b/addons/gdUnit4/bin/GdUnitCopyLog.gd
@@ -75,7 +75,7 @@ func _process(_delta: float) -> bool:
 	if result.is_error():
 		write_report(result.error_message(), godot_log_file)
 		return true
-	write_report(result.value(), godot_log_file)
+	write_report(result.value() as String, godot_log_file)
 	return true
 
 

--- a/addons/gdUnit4/plugin.gd
+++ b/addons/gdUnit4/plugin.gd
@@ -5,13 +5,14 @@ const GdUnitTools := preload ("res://addons/gdUnit4/src/core/GdUnitTools.gd")
 const GdUnitTestDiscoverGuard := preload ("res://addons/gdUnit4/src/core/discovery/GdUnitTestDiscoverGuard.gd")
 
 
-var _gd_inspector :Node
-var _gd_console :Node
+var _gd_inspector: Control
+var _gd_console: Control
 var _guard: GdUnitTestDiscoverGuard
 
 
 func _enter_tree() -> void:
 	if check_running_in_test_env():
+		@warning_ignore("return_value_discarded")
 		CmdConsole.new().prints_warning("It was recognized that GdUnit4 is running in a test environment, therefore the GdUnit4 plugin will not be executed!")
 		return
 	if Engine.get_version_info().hex < 0x40200:
@@ -23,6 +24,7 @@ func _enter_tree() -> void:
 	add_control_to_dock(EditorPlugin.DOCK_SLOT_LEFT_UR, _gd_inspector)
 	# install the GdUnit Console
 	_gd_console = load("res://addons/gdUnit4/src/ui/GdUnitConsole.tscn").instantiate()
+	@warning_ignore("return_value_discarded")
 	add_control_to_bottom_panel(_gd_console, "gdUnitConsole")
 	prints("Loading GdUnit4 Plugin success")
 	if GdUnitSettings.is_update_notification_enabled():
@@ -32,6 +34,7 @@ func _enter_tree() -> void:
 		prints("GdUnit4Net version '%s' loaded." % GdUnit4CSharpApiLoader.version())
 	# connect to be notified for script changes to be able to discover new tests
 	_guard = GdUnitTestDiscoverGuard.new()
+	@warning_ignore("return_value_discarded")
 	resource_saved.connect(_on_resource_saved)
 
 
@@ -56,4 +59,4 @@ func check_running_in_test_env() -> bool:
 
 func _on_resource_saved(resource: Resource) -> void:
 	if resource is Script:
-		await _guard.discover(resource)
+		await _guard.discover(resource as Script)

--- a/addons/gdUnit4/src/GdUnitAwaiter.gd
+++ b/addons/gdUnit4/src/GdUnitAwaiter.gd
@@ -14,16 +14,19 @@ func await_signal_on(source :Object, signal_name :String, args :Array = [], time
 	var assert_that := GdUnitAssertImpl.new(signal_name)
 	var line_number := GdUnitAssertions.get_line_number()
 	if not is_instance_valid(source):
+		@warning_ignore("return_value_discarded")
 		assert_that.report_error(GdAssertMessages.error_await_signal_on_invalid_instance(source, signal_name, args), line_number)
 		return await Engine.get_main_loop().process_frame
 	# fail fast if the given source instance invalid
 	if not is_instance_valid(source):
+		@warning_ignore("return_value_discarded")
 		assert_that.report_error(GdAssertMessages.error_await_signal_on_invalid_instance(source, signal_name, args), line_number)
 		return await await_idle_frame()
 	var awaiter := GdUnitSignalAwaiter.new(timeout_millis)
 	var value :Variant = await awaiter.on_signal(source, signal_name, args)
 	if awaiter.is_interrupted():
 		var failure := "await_signal_on(%s, %s) timed out after %sms" % [signal_name, args, timeout_millis]
+		@warning_ignore("return_value_discarded")
 		assert_that.report_error(failure, line_number)
 	return value
 
@@ -37,6 +40,7 @@ func await_signal_idle_frames(source :Object, signal_name :String, args :Array =
 	var line_number := GdUnitAssertions.get_line_number()
 	# fail fast if the given source instance invalid
 	if not is_instance_valid(source):
+		@warning_ignore("return_value_discarded")
 		GdUnitAssertImpl.new(signal_name)\
 			.report_error(GdAssertMessages.error_await_signal_on_invalid_instance(source, signal_name, args), line_number)
 		return await await_idle_frame()
@@ -44,6 +48,7 @@ func await_signal_idle_frames(source :Object, signal_name :String, args :Array =
 	var value :Variant = await awaiter.on_signal(source, signal_name, args)
 	if awaiter.is_interrupted():
 		var failure := "await_signal_idle_frames(%s, %s) timed out after %sms" % [signal_name, args, timeout_millis]
+		@warning_ignore("return_value_discarded")
 		GdUnitAssertImpl.new(signal_name).report_error(failure, line_number)
 	return value
 

--- a/addons/gdUnit4/src/asserts/GdAssertMessages.gd
+++ b/addons/gdUnit4/src/asserts/GdAssertMessages.gd
@@ -54,9 +54,11 @@ static func colored_array_div(characters :PackedByteArray) -> String:
 		match character:
 			GdDiffTool.DIV_ADD:
 				index += 1
+				@warning_ignore("return_value_discarded")
 				additional_chars.append(characters[index])
 			GdDiffTool.DIV_SUB:
 				index += 1
+				@warning_ignore("return_value_discarded")
 				missing_chars.append(characters[index])
 			_:
 				if not missing_chars.is_empty():
@@ -65,6 +67,7 @@ static func colored_array_div(characters :PackedByteArray) -> String:
 				if not additional_chars.is_empty():
 					result.append_array(format_chars(additional_chars, ADD_COLOR))
 					additional_chars = PackedByteArray()
+				@warning_ignore("return_value_discarded")
 				result.append(character)
 		index += 1
 
@@ -547,6 +550,7 @@ static func error_no_more_interactions(summary :Dictionary) -> String:
 	var interactions := PackedStringArray()
 	for args :Array in summary.keys():
 		var times :int = summary[args]
+		@warning_ignore("return_value_discarded")
 		interactions.append(_format_arguments(args, times))
 	return "%s\n%s\n%s" % [_error("Expecting no more interactions!"), _error("But found interactions on:"), "\n".join(interactions)]
 
@@ -555,6 +559,7 @@ static func error_validate_interactions(current_interactions: Dictionary, expect
 	var interactions := PackedStringArray()
 	for args: Array in current_interactions.keys():
 		var times: int = current_interactions[args]
+		@warning_ignore("return_value_discarded")
 		interactions.append(_format_arguments(args, times))
 	var expected_interaction := _format_arguments(expected_interactions.keys()[0] as Array, expected_interactions.values()[0] as int)
 	return "%s\n%s\n%s\n%s" % [
@@ -572,6 +577,7 @@ static func _format_arguments(args :Array, times :int) -> String:
 static func _to_typed_args(args :Array) -> PackedStringArray:
 	var typed := PackedStringArray()
 	for arg :Variant in args:
+		@warning_ignore("return_value_discarded")
 		typed.append(_format_arg(arg) + " :" + GdObjects.type_as_string(typeof(arg)))
 	return typed
 

--- a/addons/gdUnit4/src/asserts/GdUnitArrayAssertImpl.gd
+++ b/addons/gdUnit4/src/asserts/GdUnitArrayAssertImpl.gd
@@ -14,10 +14,11 @@ func _init(current: Variant, type_check := true) -> void:
 	# save the actual assert instance on the current thread context
 	GdUnitThreadManager.get_current_context().set_assert(self)
 	if not _validate_value_type(current):
+		@warning_ignore("return_value_discarded")
 		report_error("GdUnitArrayAssert inital error, unexpected type <%s>" % GdObjects.typeof_as_string(current))
 
 
-func _notification(event :int) -> void:
+func _notification(event: int) -> void:
 	if event == NOTIFICATION_PREDELETE:
 		if _base != null:
 			_base.notification(event)
@@ -29,7 +30,7 @@ func report_success() -> GdUnitArrayAssert:
 	return self
 
 
-func report_error(error :String) -> GdUnitArrayAssert:
+func report_error(error: String) -> GdUnitArrayAssert:
 	_base.report_error(error)
 	return self
 
@@ -38,17 +39,19 @@ func failure_message() -> String:
 	return _base.failure_message()
 
 
-func override_failure_message(message :String) -> GdUnitArrayAssert:
+func override_failure_message(message: String) -> GdUnitArrayAssert:
+	@warning_ignore("return_value_discarded")
 	_base.override_failure_message(message)
 	return self
 
 
-func append_failure_message(message :String) -> GdUnitArrayAssert:
+func append_failure_message(message: String) -> GdUnitArrayAssert:
+	@warning_ignore("return_value_discarded")
 	_base.append_failure_message(message)
 	return self
 
 
-func _validate_value_type(value :Variant) -> bool:
+func _validate_value_type(value: Variant) -> bool:
 	return value == null or GdArrayTools.is_array_type(value)
 
 
@@ -56,14 +59,14 @@ func get_current_value() -> Variant:
 	return _current_value_provider.get_value()
 
 
-func max_length(left :Variant, right :Variant) -> int:
+func max_length(left: Variant, right: Variant) -> int:
 	var ls := str(left).length()
 	var rs := str(right).length()
 	return rs if ls < rs else ls
 
 
 # gdlint: disable=function-name
-func _toPackedStringArray(value :Variant) -> PackedStringArray:
+func _toPackedStringArray(value: Variant) -> PackedStringArray:
 	if GdArrayTools.is_array_type(value):
 		return PackedStringArray(value as Array)
 	return PackedStringArray([str(value)])
@@ -81,15 +84,15 @@ func _array_equals_div(current: Variant, expected: Variant, case_sensitive: bool
 				var length := max_length(c, e)
 				current_value[index] = GdAssertMessages.format_invalid(c.lpad(length))
 				expected_value[index] = e.lpad(length)
-				index_report.push_back({"index" : index, "current" :c, "expected": e})
+				index_report.push_back({"index": index, "current": c, "expected": e})
 		else:
 			current_value[index] = GdAssertMessages.format_invalid(c)
-			index_report.push_back({"index" : index, "current" :c, "expected": "<N/A>"})
+			index_report.push_back({"index": index, "current": c, "expected": "<N/A>"})
 
 	for index in range(current.size(), expected_value.size()):
 		var value := expected_value[index]
 		expected_value[index] = GdAssertMessages.format_invalid(value)
-		index_report.push_back({"index" : index, "current" : "<N/A>", "expected": value})
+		index_report.push_back({"index": index, "current": "<N/A>", "expected": value})
 	return [current_value, expected_value, index_report]
 
 
@@ -97,9 +100,9 @@ func _array_div(compare_mode: GdObjects.COMPARE_MODE, left: Array[Variant], righ
 	var not_expect := left.duplicate(true)
 	var not_found := right.duplicate(true)
 	for index_c in left.size():
-		var c :Variant = left[index_c]
+		var c: Variant = left[index_c]
 		for index_e in right.size():
-			var e :Variant = right[index_e]
+			var e: Variant = right[index_e]
 			if GdObjects.equals(c, e, false, compare_mode):
 				GdArrayTools.erase_value(not_expect, e)
 				GdArrayTools.erase_value(not_found, c)
@@ -111,7 +114,7 @@ func _contains(expected: Variant, compare_mode: GdObjects.COMPARE_MODE) -> GdUni
 	if not _validate_value_type(expected):
 		return report_error("ERROR: expected value: <%s>\n is not a Array Type!" % GdObjects.typeof_as_string(expected))
 	var by_reference := compare_mode == GdObjects.COMPARE_MODE.OBJECT_REFERENCE
-	var current_value :Variant = get_current_value()
+	var current_value: Variant = get_current_value()
 	if current_value == null:
 		return report_error(GdAssertMessages.error_arr_contains(current_value, expected, [], expected, by_reference))
 	var diffs := _array_div(compare_mode, current_value as Array[Variant], expected as Array[Variant])
@@ -125,7 +128,7 @@ func _contains(expected: Variant, compare_mode: GdObjects.COMPARE_MODE) -> GdUni
 func _contains_exactly(expected: Variant, compare_mode: GdObjects.COMPARE_MODE) -> GdUnitArrayAssert:
 	if not _validate_value_type(expected):
 		return report_error("ERROR: expected value: <%s>\n is not a Array Type!" % GdObjects.typeof_as_string(expected))
-	var current_value :Variant = get_current_value()
+	var current_value: Variant = get_current_value()
 	if current_value == null:
 		return report_error(GdAssertMessages.error_arr_contains_exactly(null, expected, [], expected, compare_mode))
 	# has same content in same order
@@ -144,10 +147,10 @@ func _contains_exactly(expected: Variant, compare_mode: GdObjects.COMPARE_MODE) 
 	return report_error(GdAssertMessages.error_arr_contains_exactly(current_value, expected, not_expect, not_found, compare_mode))
 
 
-func _contains_exactly_in_any_order(expected :Variant, compare_mode :GdObjects.COMPARE_MODE) -> GdUnitArrayAssert:
+func _contains_exactly_in_any_order(expected: Variant, compare_mode: GdObjects.COMPARE_MODE) -> GdUnitArrayAssert:
 	if not _validate_value_type(expected):
 		return report_error("ERROR: expected value: <%s>\n is not a Array Type!" % GdObjects.typeof_as_string(expected))
-	var current_value :Variant = get_current_value()
+	var current_value: Variant = get_current_value()
 	if current_value == null:
 		return report_error(GdAssertMessages.error_arr_contains_exactly_in_any_order(current_value, expected, [], expected, compare_mode))
 	# find the difference
@@ -159,10 +162,10 @@ func _contains_exactly_in_any_order(expected :Variant, compare_mode :GdObjects.C
 	return report_error(GdAssertMessages.error_arr_contains_exactly_in_any_order(current_value, expected, not_expect, not_found, compare_mode))
 
 
-func _not_contains(expected :Variant, compare_mode :GdObjects.COMPARE_MODE) -> GdUnitArrayAssert:
+func _not_contains(expected: Variant, compare_mode: GdObjects.COMPARE_MODE) -> GdUnitArrayAssert:
 	if not _validate_value_type(expected):
 		return report_error("ERROR: expected value: <%s>\n is not a Array Type!" % GdObjects.typeof_as_string(expected))
-	var current_value :Variant = get_current_value()
+	var current_value: Variant = get_current_value()
 	if current_value == null:
 		return report_error(GdAssertMessages.error_arr_contains_exactly_in_any_order(current_value, expected, [], expected, compare_mode))
 	var diffs := _array_div(compare_mode, current_value as Array[Variant], expected as Array[Variant])
@@ -174,11 +177,13 @@ func _not_contains(expected :Variant, compare_mode :GdObjects.COMPARE_MODE) -> G
 
 
 func is_null() -> GdUnitArrayAssert:
+	@warning_ignore("return_value_discarded")
 	_base.is_null()
 	return self
 
 
 func is_not_null() -> GdUnitArrayAssert:
+	@warning_ignore("return_value_discarded")
 	_base.is_not_null()
 	return self
 
@@ -215,7 +220,7 @@ func is_equal_ignoring_case(expected: Variant) -> GdUnitArrayAssert:
 	return report_success()
 
 
-func is_not_equal(expected :Variant) -> GdUnitArrayAssert:
+func is_not_equal(expected: Variant) -> GdUnitArrayAssert:
 	if not _validate_value_type(expected):
 		return report_error("ERROR: expected value: <%s>\n is not a Array Type!" % GdObjects.typeof_as_string(expected))
 	var current_value: Variant = get_current_value()
@@ -224,10 +229,10 @@ func is_not_equal(expected :Variant) -> GdUnitArrayAssert:
 	return report_success()
 
 
-func is_not_equal_ignoring_case(expected :Variant) -> GdUnitArrayAssert:
+func is_not_equal_ignoring_case(expected: Variant) -> GdUnitArrayAssert:
 	if not _validate_value_type(expected):
 		return report_error("ERROR: expected value: <%s>\n is not a Array Type!" % GdObjects.typeof_as_string(expected))
-	var current_value :Variant = get_current_value()
+	var current_value: Variant = get_current_value()
 	if _is_equal(current_value, expected, true):
 		var c := GdArrayTools.as_string(current_value)
 		var e := GdArrayTools.as_string(expected)
@@ -236,115 +241,117 @@ func is_not_equal_ignoring_case(expected :Variant) -> GdUnitArrayAssert:
 
 
 func is_empty() -> GdUnitArrayAssert:
-	var current_value :Variant = get_current_value()
+	var current_value: Variant = get_current_value()
 	if current_value == null or current_value.size() > 0:
 		return report_error(GdAssertMessages.error_is_empty(current_value))
 	return report_success()
 
 
 func is_not_empty() -> GdUnitArrayAssert:
-	var current_value :Variant = get_current_value()
+	var current_value: Variant = get_current_value()
 	if current_value != null and current_value.size() == 0:
 		return report_error(GdAssertMessages.error_is_not_empty())
 	return report_success()
 
 
 @warning_ignore("unused_parameter", "shadowed_global_identifier")
-func is_same(expected :Variant) -> GdUnitArrayAssert:
+func is_same(expected: Variant) -> GdUnitArrayAssert:
 	if not _validate_value_type(expected):
 		return report_error("ERROR: expected value: <%s>\n is not a Array Type!" % GdObjects.typeof_as_string(expected))
-	var current :Variant = get_current_value()
+	var current: Variant = get_current_value()
 	if not is_same(current, expected):
+		@warning_ignore("return_value_discarded")
 		report_error(GdAssertMessages.error_is_same(current, expected))
 	return self
 
 
-func is_not_same(expected :Variant) -> GdUnitArrayAssert:
+func is_not_same(expected: Variant) -> GdUnitArrayAssert:
 	if not _validate_value_type(expected):
 		return report_error("ERROR: expected value: <%s>\n is not a Array Type!" % GdObjects.typeof_as_string(expected))
-	var current :Variant = get_current_value()
+	var current: Variant = get_current_value()
 	if is_same(current, expected):
+		@warning_ignore("return_value_discarded")
 		report_error(GdAssertMessages.error_not_same(current, expected))
 	return self
 
 
 func has_size(expected: int) -> GdUnitArrayAssert:
-	var current_value :Variant= get_current_value()
+	var current_value: Variant = get_current_value()
 	if current_value == null or current_value.size() != expected:
 		return report_error(GdAssertMessages.error_has_size(current_value, expected))
 	return report_success()
 
 
-func contains(expected :Variant) -> GdUnitArrayAssert:
+func contains(expected: Variant) -> GdUnitArrayAssert:
 	return _contains(expected, GdObjects.COMPARE_MODE.PARAMETER_DEEP_TEST)
 
 
-func contains_exactly(expected :Variant) -> GdUnitArrayAssert:
+func contains_exactly(expected: Variant) -> GdUnitArrayAssert:
 	return _contains_exactly(expected, GdObjects.COMPARE_MODE.PARAMETER_DEEP_TEST)
 
 
-func contains_exactly_in_any_order(expected :Variant) -> GdUnitArrayAssert:
+func contains_exactly_in_any_order(expected: Variant) -> GdUnitArrayAssert:
 	return _contains_exactly_in_any_order(expected, GdObjects.COMPARE_MODE.PARAMETER_DEEP_TEST)
 
 
-func contains_same(expected :Variant) -> GdUnitArrayAssert:
+func contains_same(expected: Variant) -> GdUnitArrayAssert:
 	return _contains(expected, GdObjects.COMPARE_MODE.OBJECT_REFERENCE)
 
 
-func contains_same_exactly(expected :Variant) -> GdUnitArrayAssert:
+func contains_same_exactly(expected: Variant) -> GdUnitArrayAssert:
 	return _contains_exactly(expected, GdObjects.COMPARE_MODE.OBJECT_REFERENCE)
 
 
-func contains_same_exactly_in_any_order(expected :Variant) -> GdUnitArrayAssert:
+func contains_same_exactly_in_any_order(expected: Variant) -> GdUnitArrayAssert:
 	return _contains_exactly_in_any_order(expected, GdObjects.COMPARE_MODE.OBJECT_REFERENCE)
 
 
-func not_contains(expected :Variant) -> GdUnitArrayAssert:
+func not_contains(expected: Variant) -> GdUnitArrayAssert:
 	return _not_contains(expected, GdObjects.COMPARE_MODE.PARAMETER_DEEP_TEST)
 
 
-func not_contains_same(expected :Variant) -> GdUnitArrayAssert:
+func not_contains_same(expected: Variant) -> GdUnitArrayAssert:
 	return _not_contains(expected, GdObjects.COMPARE_MODE.OBJECT_REFERENCE)
 
 
-func is_instanceof(expected :Variant) -> GdUnitAssert:
+func is_instanceof(expected: Variant) -> GdUnitAssert:
 	_base.is_instanceof(expected)
 	return self
 
 
-func extract(func_name :String, args := Array()) -> GdUnitArrayAssert:
+func extract(func_name: String, args := Array()) -> GdUnitArrayAssert:
 	var extracted_elements := Array()
-	var extractor :GdUnitValueExtractor = ResourceLoader.load("res://addons/gdUnit4/src/extractors/GdUnitFuncValueExtractor.gd",
+	var extractor: GdUnitValueExtractor = ResourceLoader.load("res://addons/gdUnit4/src/extractors/GdUnitFuncValueExtractor.gd",
 		"GDScript", ResourceLoader.CACHE_MODE_REUSE).new(func_name, args)
-	var current :Variant = get_current_value()
+	var current: Variant = get_current_value()
 	if current == null:
 		_current_value_provider = DefaultValueProvider.new(null)
 	else:
-		for element :Variant in current:
+		for element: Variant in current:
 			extracted_elements.append(extractor.extract_value(element))
 		_current_value_provider = DefaultValueProvider.new(extracted_elements)
 	return self
 
 
 func extractv(
-	extr0 :GdUnitValueExtractor,
-	extr1 :GdUnitValueExtractor = null,
-	extr2 :GdUnitValueExtractor = null,
-	extr3 :GdUnitValueExtractor = null,
-	extr4 :GdUnitValueExtractor = null,
-	extr5 :GdUnitValueExtractor = null,
-	extr6 :GdUnitValueExtractor = null,
-	extr7 :GdUnitValueExtractor = null,
-	extr8 :GdUnitValueExtractor = null,
-	extr9 :GdUnitValueExtractor = null) -> GdUnitArrayAssert:
-	var extractors :Variant = GdArrayTools.filter_value([extr0, extr1, extr2, extr3, extr4, extr5, extr6, extr7, extr8, extr9], null)
+	extr0: GdUnitValueExtractor,
+	extr1: GdUnitValueExtractor = null,
+	extr2: GdUnitValueExtractor = null,
+	extr3: GdUnitValueExtractor = null,
+	extr4: GdUnitValueExtractor = null,
+	extr5: GdUnitValueExtractor = null,
+	extr6: GdUnitValueExtractor = null,
+	extr7: GdUnitValueExtractor = null,
+	extr8: GdUnitValueExtractor = null,
+	extr9: GdUnitValueExtractor = null) -> GdUnitArrayAssert:
+	var extractors: Variant = GdArrayTools.filter_value([extr0, extr1, extr2, extr3, extr4, extr5, extr6, extr7, extr8, extr9], null)
 	var extracted_elements := Array()
-	var current :Variant = get_current_value()
+	var current: Variant = get_current_value()
 	if current == null:
 		_current_value_provider = DefaultValueProvider.new(null)
 	else:
 		for element: Variant in current:
-			var ev :Array[Variant] = [
+			var ev: Array[Variant] = [
 				GdUnitTuple.NO_ARG,
 				GdUnitTuple.NO_ARG,
 				GdUnitTuple.NO_ARG,
@@ -356,8 +363,8 @@ func extractv(
 				GdUnitTuple.NO_ARG,
 				GdUnitTuple.NO_ARG
 			]
-			for index :int in extractors.size():
-				var extractor :GdUnitValueExtractor = extractors[index]
+			for index: int in extractors.size():
+				var extractor: GdUnitValueExtractor = extractors[index]
 				ev[index] = extractor.extract_value(element)
 			if extractors.size() > 1:
 				extracted_elements.append(GdUnitTuple.new(ev[0], ev[1], ev[2], ev[3], ev[4], ev[5], ev[6], ev[7], ev[8], ev[9]))

--- a/addons/gdUnit4/src/asserts/GdUnitAssertions.gd
+++ b/addons/gdUnit4/src/asserts/GdUnitAssertions.gd
@@ -3,6 +3,7 @@ class_name GdUnitAssertions
 extends RefCounted
 
 
+@warning_ignore("return_value_discarded")
 func _init() -> void:
 	# preload all gdunit assertions to speedup testsuite loading time
 	# gdlint:disable=private-method-call

--- a/addons/gdUnit4/src/asserts/GdUnitBoolAssertImpl.gd
+++ b/addons/gdUnit4/src/asserts/GdUnitBoolAssertImpl.gd
@@ -9,6 +9,7 @@ func _init(current :Variant) -> void:
 	# save the actual assert instance on the current thread context
 	GdUnitThreadManager.get_current_context().set_assert(self)
 	if not GdUnitAssertions.validate_value_type(current, TYPE_BOOL):
+		@warning_ignore("return_value_discarded")
 		report_error("GdUnitBoolAssert inital error, unexpected type <%s>" % GdObjects.typeof_as_string(current))
 
 
@@ -38,33 +39,39 @@ func failure_message() -> String:
 
 
 func override_failure_message(message :String) -> GdUnitBoolAssert:
+	@warning_ignore("return_value_discarded")
 	_base.override_failure_message(message)
 	return self
 
 
 func append_failure_message(message :String) -> GdUnitBoolAssert:
+	@warning_ignore("return_value_discarded")
 	_base.append_failure_message(message)
 	return self
 
 
 # Verifies that the current value is null.
 func is_null() -> GdUnitBoolAssert:
+	@warning_ignore("return_value_discarded")
 	_base.is_null()
 	return self
 
 
 # Verifies that the current value is not null.
 func is_not_null() -> GdUnitBoolAssert:
+	@warning_ignore("return_value_discarded")
 	_base.is_not_null()
 	return self
 
 
 func is_equal(expected: Variant) -> GdUnitBoolAssert:
+	@warning_ignore("return_value_discarded")
 	_base.is_equal(expected)
 	return self
 
 
 func is_not_equal(expected: Variant) -> GdUnitBoolAssert:
+	@warning_ignore("return_value_discarded")
 	_base.is_not_equal(expected)
 	return self
 

--- a/addons/gdUnit4/src/asserts/GdUnitDictionaryAssertImpl.gd
+++ b/addons/gdUnit4/src/asserts/GdUnitDictionaryAssertImpl.gd
@@ -9,6 +9,7 @@ func _init(current :Variant) -> void:
 	# save the actual assert instance on the current thread context
 	GdUnitThreadManager.get_current_context().set_assert(self)
 	if not GdUnitAssertions.validate_value_type(current, TYPE_DICTIONARY):
+		@warning_ignore("return_value_discarded")
 		report_error("GdUnitDictionaryAssert inital error, unexpected type <%s>" % GdObjects.typeof_as_string(current))
 
 
@@ -34,11 +35,13 @@ func failure_message() -> String:
 
 
 func override_failure_message(message :String) -> GdUnitDictionaryAssert:
+	@warning_ignore("return_value_discarded")
 	_base.override_failure_message(message)
 	return self
 
 
 func append_failure_message(message :String) -> GdUnitDictionaryAssert:
+	@warning_ignore("return_value_discarded")
 	_base.append_failure_message(message)
 	return self
 
@@ -48,11 +51,13 @@ func current_value() -> Variant:
 
 
 func is_null() -> GdUnitDictionaryAssert:
+	@warning_ignore("return_value_discarded")
 	_base.is_null()
 	return self
 
 
 func is_not_null() -> GdUnitDictionaryAssert:
+	@warning_ignore("return_value_discarded")
 	_base.is_not_null()
 	return self
 

--- a/addons/gdUnit4/src/asserts/GdUnitFailureAssertImpl.gd
+++ b/addons/gdUnit4/src/asserts/GdUnitFailureAssertImpl.gd
@@ -15,6 +15,7 @@ func execute_and_await(assertion :Callable, do_await := true) -> GdUnitFailureAs
 	_set_do_expect_fail(true)
 	var thread_context := GdUnitThreadManager.get_current_context()
 	thread_context.set_assert(null)
+	@warning_ignore("return_value_discarded")
 	GdUnitSignals.instance().gdunit_set_test_failed.connect(_on_test_failed)
 	# execute the given assertion as callable
 	if do_await:
@@ -33,6 +34,7 @@ func execute_and_await(assertion :Callable, do_await := true) -> GdUnitFailureAs
 
 
 func execute(assertion :Callable) -> GdUnitFailureAssert:
+	@warning_ignore("return_value_discarded")
 	execute_and_await(assertion, false)
 	return self
 
@@ -79,13 +81,14 @@ func has_line(expected :int) -> GdUnitFailureAssert:
 
 
 func has_message(expected :String) -> GdUnitFailureAssert:
+	@warning_ignore("return_value_discarded")
 	is_failed()
 	var expected_error := GdUnitTools.normalize_text(GdUnitTools.richtext_normalize(expected))
 	var current_error := GdUnitTools.normalize_text(GdUnitTools.richtext_normalize(_failure_message))
 	if current_error != expected_error:
 		var diffs := GdDiffTool.string_diff(current_error, expected_error)
 		var current := GdAssertMessages.colored_array_div(diffs[1])
-		_report_error(GdAssertMessages.error_not_same_error(current, expected_error))
+		return _report_error(GdAssertMessages.error_not_same_error(current, expected_error))
 	return self
 
 
@@ -95,7 +98,7 @@ func contains_message(expected :String) -> GdUnitFailureAssert:
 	if not current_error.contains(expected_error):
 		var diffs := GdDiffTool.string_diff(current_error, expected_error)
 		var current := GdAssertMessages.colored_array_div(diffs[1])
-		_report_error(GdAssertMessages.error_not_same_error(current, expected_error))
+		return _report_error(GdAssertMessages.error_not_same_error(current, expected_error))
 	return self
 
 
@@ -105,7 +108,7 @@ func starts_with_message(expected :String) -> GdUnitFailureAssert:
 	if current_error.find(expected_error) != 0:
 		var diffs := GdDiffTool.string_diff(current_error, expected_error)
 		var current := GdAssertMessages.colored_array_div(diffs[1])
-		_report_error(GdAssertMessages.error_not_same_error(current, expected_error))
+		return _report_error(GdAssertMessages.error_not_same_error(current, expected_error))
 	return self
 
 

--- a/addons/gdUnit4/src/asserts/GdUnitFileAssertImpl.gd
+++ b/addons/gdUnit4/src/asserts/GdUnitFileAssertImpl.gd
@@ -11,6 +11,7 @@ func _init(current :Variant) -> void:
 	# save the actual assert instance on the current thread context
 	GdUnitThreadManager.get_current_context().set_assert(self)
 	if not GdUnitAssertions.validate_value_type(current, TYPE_STRING):
+		@warning_ignore("return_value_discarded")
 		report_error("GdUnitFileAssert inital error, unexpected type <%s>" % GdObjects.typeof_as_string(current))
 
 
@@ -40,21 +41,25 @@ func failure_message() -> String:
 
 
 func override_failure_message(message :String) -> GdUnitFileAssert:
+	@warning_ignore("return_value_discarded")
 	_base.override_failure_message(message)
 	return self
 
 
 func append_failure_message(message :String) -> GdUnitFileAssert:
+	@warning_ignore("return_value_discarded")
 	_base.append_failure_message(message)
 	return self
 
 
 func is_equal(expected :Variant) -> GdUnitFileAssert:
+	@warning_ignore("return_value_discarded")
 	_base.is_equal(expected)
 	return self
 
 
 func is_not_equal(expected :Variant) -> GdUnitFileAssert:
+	@warning_ignore("return_value_discarded")
 	_base.is_not_equal(expected)
 	return self
 

--- a/addons/gdUnit4/src/asserts/GdUnitFloatAssertImpl.gd
+++ b/addons/gdUnit4/src/asserts/GdUnitFloatAssertImpl.gd
@@ -9,6 +9,7 @@ func _init(current :Variant) -> void:
 	# save the actual assert instance on the current thread context
 	GdUnitThreadManager.get_current_context().set_assert(self)
 	if not GdUnitAssertions.validate_value_type(current, TYPE_FLOAT):
+		@warning_ignore("return_value_discarded")
 		report_error("GdUnitFloatAssert inital error, unexpected type <%s>" % GdObjects.typeof_as_string(current))
 
 
@@ -38,31 +39,37 @@ func failure_message() -> String:
 
 
 func override_failure_message(message :String) -> GdUnitFloatAssert:
+	@warning_ignore("return_value_discarded")
 	_base.override_failure_message(message)
 	return self
 
 
 func append_failure_message(message :String) -> GdUnitFloatAssert:
+	@warning_ignore("return_value_discarded")
 	_base.append_failure_message(message)
 	return self
 
 
 func is_null() -> GdUnitFloatAssert:
+	@warning_ignore("return_value_discarded")
 	_base.is_null()
 	return self
 
 
 func is_not_null() -> GdUnitFloatAssert:
+	@warning_ignore("return_value_discarded")
 	_base.is_not_null()
 	return self
 
 
 func is_equal(expected :Variant) -> GdUnitFloatAssert:
+	@warning_ignore("return_value_discarded")
 	_base.is_equal(expected)
 	return self
 
 
 func is_not_equal(expected :Variant) -> GdUnitFloatAssert:
+	@warning_ignore("return_value_discarded")
 	_base.is_not_equal(expected)
 	return self
 

--- a/addons/gdUnit4/src/asserts/GdUnitFuncAssertImpl.gd
+++ b/addons/gdUnit4/src/asserts/GdUnitFuncAssertImpl.gd
@@ -22,6 +22,7 @@ func _init(instance :Object, func_name :String, args := Array()) -> void:
 	GdUnitThreadManager.get_current_context().set_assert(self)
 	# verify at first the function name exists
 	if not instance.has_method(func_name):
+		@warning_ignore("return_value_discarded")
 		report_error("The function '%s' do not exists checked instance '%s'." % [func_name, instance])
 		_interrupted = true
 	else:
@@ -122,6 +123,7 @@ func _validate_callback(predicate :Callable, expected :Variant = null) -> void:
 	timer.set_name("gdunit_funcassert_interrupt_timer_%d" % timer.get_instance_id())
 	Engine.get_main_loop().root.add_child(timer)
 	timer.add_to_group("GdUnitTimers")
+	@warning_ignore("return_value_discarded")
 	timer.timeout.connect(func do_interrupt() -> void:
 		_interrupted = true
 		, CONNECT_DEFERRED)
@@ -146,8 +148,15 @@ func _validate_callback(predicate :Callable, expected :Variant = null) -> void:
 		# https://github.com/godotengine/godot/issues/73052
 		#var predicate_name = predicate.get_method()
 		var predicate_name :String = str(predicate).split('::')[1]
-		report_error(GdAssertMessages.error_interrupted(predicate_name.strip_edges().trim_prefix("cb_"), expected, LocalTime.elapsed(_timeout)))
+		@warning_ignore("return_value_discarded")
+		report_error(GdAssertMessages.error_interrupted(
+			predicate_name.strip_edges().trim_prefix("cb_"),
+			expected,
+			LocalTime.elapsed(_timeout)
+			)
+		)
 	else:
+		@warning_ignore("return_value_discarded")
 		report_success()
 	_sleep_timer.free()
 	timer.free()

--- a/addons/gdUnit4/src/asserts/GdUnitGodotErrorAssertImpl.gd
+++ b/addons/gdUnit4/src/asserts/GdUnitGodotErrorAssertImpl.gd
@@ -17,6 +17,7 @@ func _init(callable :Callable) -> void:
 func _execute() -> Array[ErrorLogEntry]:
 	# execute the given code and monitor for runtime errors
 	if _callable == null or not _callable.is_valid():
+		@warning_ignore("return_value_discarded")
 		_report_error("Invalid Callable '%s'" % _callable)
 	else:
 		await _callable.call()

--- a/addons/gdUnit4/src/asserts/GdUnitIntAssertImpl.gd
+++ b/addons/gdUnit4/src/asserts/GdUnitIntAssertImpl.gd
@@ -9,6 +9,7 @@ func _init(current :Variant) -> void:
 	# save the actual assert instance on the current thread context
 	GdUnitThreadManager.get_current_context().set_assert(self)
 	if not GdUnitAssertions.validate_value_type(current, TYPE_INT):
+		@warning_ignore("return_value_discarded")
 		report_error("GdUnitIntAssert inital error, unexpected type <%s>" % GdObjects.typeof_as_string(current))
 
 
@@ -38,31 +39,37 @@ func failure_message() -> String:
 
 
 func override_failure_message(message :String) -> GdUnitIntAssert:
+	@warning_ignore("return_value_discarded")
 	_base.override_failure_message(message)
 	return self
 
 
 func append_failure_message(message :String) -> GdUnitIntAssert:
+	@warning_ignore("return_value_discarded")
 	_base.append_failure_message(message)
 	return self
 
 
 func is_null() -> GdUnitIntAssert:
+	@warning_ignore("return_value_discarded")
 	_base.is_null()
 	return self
 
 
 func is_not_null() -> GdUnitIntAssert:
+	@warning_ignore("return_value_discarded")
 	_base.is_not_null()
 	return self
 
 
 func is_equal(expected :Variant) -> GdUnitIntAssert:
+	@warning_ignore("return_value_discarded")
 	_base.is_equal(expected)
 	return self
 
 
 func is_not_equal(expected :Variant) -> GdUnitIntAssert:
+	@warning_ignore("return_value_discarded")
 	_base.is_not_equal(expected)
 	return self
 

--- a/addons/gdUnit4/src/asserts/GdUnitObjectAssertImpl.gd
+++ b/addons/gdUnit4/src/asserts/GdUnitObjectAssertImpl.gd
@@ -13,6 +13,7 @@ func _init(current :Variant) -> void:
 		or GdUnitAssertions.validate_value_type(current, TYPE_INT)
 		or GdUnitAssertions.validate_value_type(current, TYPE_FLOAT)
 		or GdUnitAssertions.validate_value_type(current, TYPE_STRING))):
+			@warning_ignore("return_value_discarded")
 			report_error("GdUnitObjectAssert inital error, unexpected type <%s>" % GdObjects.typeof_as_string(current))
 
 
@@ -42,31 +43,37 @@ func failure_message() -> String:
 
 
 func override_failure_message(message :String) -> GdUnitObjectAssert:
+	@warning_ignore("return_value_discarded")
 	_base.override_failure_message(message)
 	return self
 
 
 func append_failure_message(message :String) -> GdUnitObjectAssert:
+	@warning_ignore("return_value_discarded")
 	_base.append_failure_message(message)
 	return self
 
 
 func is_equal(expected :Variant) -> GdUnitObjectAssert:
+	@warning_ignore("return_value_discarded")
 	_base.is_equal(expected)
 	return self
 
 
 func is_not_equal(expected :Variant) -> GdUnitObjectAssert:
+	@warning_ignore("return_value_discarded")
 	_base.is_not_equal(expected)
 	return self
 
 
 func is_null() -> GdUnitObjectAssert:
+	@warning_ignore("return_value_discarded")
 	_base.is_null()
 	return self
 
 
 func is_not_null() -> GdUnitObjectAssert:
+	@warning_ignore("return_value_discarded")
 	_base.is_not_null()
 	return self
 
@@ -75,19 +82,15 @@ func is_not_null() -> GdUnitObjectAssert:
 func is_same(expected :Variant) -> GdUnitObjectAssert:
 	var current :Variant = current_value()
 	if not is_same(current, expected):
-		report_error(GdAssertMessages.error_is_same(current, expected))
-		return self
-	report_success()
-	return self
+		return report_error(GdAssertMessages.error_is_same(current, expected))
+	return report_success()
 
 
 func is_not_same(expected :Variant) -> GdUnitObjectAssert:
 	var current :Variant = current_value()
 	if is_same(current, expected):
-		report_error(GdAssertMessages.error_not_same(current, expected))
-		return self
-	report_success()
-	return self
+		return report_error(GdAssertMessages.error_not_same(current, expected))
+	return report_success()
 
 
 func is_instanceof(type :Object) -> GdUnitObjectAssert:
@@ -95,10 +98,8 @@ func is_instanceof(type :Object) -> GdUnitObjectAssert:
 	if current == null or not is_instance_of(current, type):
 		var result_expected: = GdObjects.extract_class_name(type)
 		var result_current: = GdObjects.extract_class_name(current)
-		report_error(GdAssertMessages.error_is_instanceof(result_current, result_expected))
-		return self
-	report_success()
-	return self
+		return report_error(GdAssertMessages.error_is_instanceof(result_current, result_expected))
+	return report_success()
 
 
 func is_not_instanceof(type :Variant) -> GdUnitObjectAssert:
@@ -106,9 +107,8 @@ func is_not_instanceof(type :Variant) -> GdUnitObjectAssert:
 	if is_instance_of(current, type):
 		var result: = GdObjects.extract_class_name(type)
 		if result.is_success():
-			report_error("Expected not be a instance of <%s>" % result.value())
-		else:
-			push_error("Internal ERROR: %s" % result.error_message())
+			return report_error("Expected not be a instance of <%s>" % result.value())
+
+		push_error("Internal ERROR: %s" % result.error_message())
 		return self
-	report_success()
-	return self
+	return report_success()

--- a/addons/gdUnit4/src/asserts/GdUnitResultAssertImpl.gd
+++ b/addons/gdUnit4/src/asserts/GdUnitResultAssertImpl.gd
@@ -9,6 +9,7 @@ func _init(current :Variant) -> void:
 	# save the actual assert instance on the current thread context
 	GdUnitThreadManager.get_current_context().set_assert(self)
 	if not validate_value_type(current):
+		@warning_ignore("return_value_discarded")
 		report_error("GdUnitResultAssert inital error, unexpected type <%s>" % GdObjects.typeof_as_string(current))
 
 
@@ -42,21 +43,25 @@ func failure_message() -> String:
 
 
 func override_failure_message(message :String) -> GdUnitResultAssert:
+	@warning_ignore("return_value_discarded")
 	_base.override_failure_message(message)
 	return self
 
 
 func append_failure_message(message :String) -> GdUnitResultAssert:
+	@warning_ignore("return_value_discarded")
 	_base.append_failure_message(message)
 	return self
 
 
 func is_null() -> GdUnitResultAssert:
+	@warning_ignore("return_value_discarded")
 	_base.is_null()
 	return self
 
 
 func is_not_null() -> GdUnitResultAssert:
+	@warning_ignore("return_value_discarded")
 	_base.is_not_null()
 	return self
 
@@ -64,63 +69,50 @@ func is_not_null() -> GdUnitResultAssert:
 func is_empty() -> GdUnitResultAssert:
 	var result := current_value()
 	if result == null or not result.is_empty():
-		report_error(GdAssertMessages.error_result_is_empty(result))
-	else:
-		report_success()
-	return self
+		return report_error(GdAssertMessages.error_result_is_empty(result))
+	return report_success()
 
 
 func is_success() -> GdUnitResultAssert:
 	var result := current_value()
 	if result == null or not result.is_success():
-		report_error(GdAssertMessages.error_result_is_success(result))
-	else:
-		report_success()
-	return self
+		return report_error(GdAssertMessages.error_result_is_success(result))
+	return report_success()
 
 
 func is_warning() -> GdUnitResultAssert:
 	var result := current_value()
 	if result == null or not result.is_warn():
-		report_error(GdAssertMessages.error_result_is_warning(result))
-	else:
-		report_success()
-	return self
+		return report_error(GdAssertMessages.error_result_is_warning(result))
+	return report_success()
 
 
 func is_error() -> GdUnitResultAssert:
 	var result := current_value()
 	if result == null or not result.is_error():
-		report_error(GdAssertMessages.error_result_is_error(result))
-	else:
-		report_success()
-	return self
+		return report_error(GdAssertMessages.error_result_is_error(result))
+	return report_success()
 
 
 func contains_message(expected :String) -> GdUnitResultAssert:
 	var result := current_value()
 	if result == null:
-		report_error(GdAssertMessages.error_result_has_message("<null>", expected))
-		return self
+		return report_error(GdAssertMessages.error_result_has_message("<null>", expected))
 	if result.is_success():
-		report_error(GdAssertMessages.error_result_has_message_on_success(expected))
-	elif result.is_error() and result.error_message() != expected:
-		report_error(GdAssertMessages.error_result_has_message(result.error_message(), expected))
-	elif result.is_warn() and result.warn_message() != expected:
-		report_error(GdAssertMessages.error_result_has_message(result.warn_message(), expected))
-	else:
-		report_success()
-	return self
+		return report_error(GdAssertMessages.error_result_has_message_on_success(expected))
+	if result.is_error() and result.error_message() != expected:
+		return report_error(GdAssertMessages.error_result_has_message(result.error_message(), expected))
+	if result.is_warn() and result.warn_message() != expected:
+		return report_error(GdAssertMessages.error_result_has_message(result.warn_message(), expected))
+	return report_success()
 
 
 func is_value(expected :Variant) -> GdUnitResultAssert:
 	var result := current_value()
 	var value :Variant = null if result == null else result.value()
 	if not GdObjects.equals(value, expected):
-		report_error(GdAssertMessages.error_result_is_value(value, expected))
-	else:
-		report_success()
-	return self
+		return report_error(GdAssertMessages.error_result_is_value(value, expected))
+	return report_success()
 
 
 func is_equal(expected :Variant) -> GdUnitResultAssert:

--- a/addons/gdUnit4/src/asserts/GdUnitSignalAssertImpl.gd
+++ b/addons/gdUnit4/src/asserts/GdUnitSignalAssertImpl.gd
@@ -54,6 +54,7 @@ func append_failure_message(message :String) -> GdUnitSignalAssert:
 
 func wait_until(timeout := 2000) -> GdUnitSignalAssert:
 	if timeout <= 0:
+		@warning_ignore("return_value_discarded")
 		report_warning("Invalid timeout parameter, allowed timeouts must be greater than 0, use default timeout instead!")
 		_timeout = DEFAULT_TIMEOUT
 	else:
@@ -64,6 +65,7 @@ func wait_until(timeout := 2000) -> GdUnitSignalAssert:
 # Verifies the signal exists checked the emitter
 func is_signal_exists(signal_name :String) -> GdUnitSignalAssert:
 	if not _emitter.has_signal(signal_name):
+		@warning_ignore("return_value_discarded")
 		report_error("The signal '%s' not exists checked object '%s'." % [signal_name, _emitter.get_class()])
 	return self
 
@@ -82,18 +84,17 @@ func is_not_emitted(name :String, args := []) -> GdUnitSignalAssert:
 
 func _wail_until_signal(signal_name :String, expected_args :Array, expect_not_emitted: bool) -> GdUnitSignalAssert:
 	if _emitter == null:
-		report_error("Can't wait for signal checked a NULL object.")
-		return self
+		return report_error("Can't wait for signal checked a NULL object.")
 	# first verify the signal is defined
 	if not _emitter.has_signal(signal_name):
-		report_error("Can't wait for non-existion signal '%s' checked object '%s'." % [signal_name,_emitter.get_class()])
-		return self
+		return report_error("Can't wait for non-existion signal '%s' checked object '%s'." % [signal_name,_emitter.get_class()])
 	_signal_collector.register_emitter(_emitter)
 	var time_scale := Engine.get_time_scale()
 	var timer := Timer.new()
 	Engine.get_main_loop().root.add_child(timer)
 	timer.add_to_group("GdUnitTimers")
 	timer.set_one_shot(true)
+	@warning_ignore("return_value_discarded")
 	timer.timeout.connect(func on_timeout() -> void: _interrupted = true)
 	timer.start((_timeout/1000.0)*time_scale)
 	var is_signal_emitted := false
@@ -102,9 +103,11 @@ func _wail_until_signal(signal_name :String, expected_args :Array, expect_not_em
 		if is_instance_valid(_emitter):
 			is_signal_emitted = _signal_collector.match(_emitter, signal_name, expected_args)
 			if is_signal_emitted and expect_not_emitted:
+				@warning_ignore("return_value_discarded")
 				report_error(GdAssertMessages.error_signal_emitted(signal_name, expected_args, LocalTime.elapsed(int(_timeout-timer.time_left*1000))))
 
 	if _interrupted and not expect_not_emitted:
+		@warning_ignore("return_value_discarded")
 		report_error(GdAssertMessages.error_wait_signal(signal_name, expected_args, LocalTime.elapsed(_timeout)))
 	timer.free()
 	if is_instance_valid(_emitter):

--- a/addons/gdUnit4/src/asserts/GdUnitStringAssertImpl.gd
+++ b/addons/gdUnit4/src/asserts/GdUnitStringAssertImpl.gd
@@ -9,6 +9,7 @@ func _init(current :Variant) -> void:
 	# save the actual assert instance on the current thread context
 	GdUnitThreadManager.get_current_context().set_assert(self)
 	if current != null and typeof(current) != TYPE_STRING and typeof(current) != TYPE_STRING_NAME:
+		@warning_ignore("return_value_discarded")
 		report_error("GdUnitStringAssert inital error, unexpected type <%s>" % GdObjects.typeof_as_string(current))
 
 
@@ -38,21 +39,25 @@ func report_error(error :String) -> GdUnitStringAssert:
 
 
 func override_failure_message(message :String) -> GdUnitStringAssert:
+	@warning_ignore("return_value_discarded")
 	_base.override_failure_message(message)
 	return self
 
 
 func append_failure_message(message :String) -> GdUnitStringAssert:
+	@warning_ignore("return_value_discarded")
 	_base.append_failure_message(message)
 	return self
 
 
 func is_null() -> GdUnitStringAssert:
+	@warning_ignore("return_value_discarded")
 	_base.is_null()
 	return self
 
 
 func is_not_null() -> GdUnitStringAssert:
+	@warning_ignore("return_value_discarded")
 	_base.is_not_null()
 	return self
 

--- a/addons/gdUnit4/src/asserts/GdUnitVectorAssertImpl.gd
+++ b/addons/gdUnit4/src/asserts/GdUnitVectorAssertImpl.gd
@@ -11,6 +11,7 @@ func _init(current: Variant, type_check := true) -> void:
 	# save the actual assert instance on the current thread context
 	GdUnitThreadManager.get_current_context().set_assert(self)
 	if not _validate_value_type(current):
+		@warning_ignore("return_value_discarded")
 		report_error("GdUnitVectorAssert error, the type <%s> is not supported." % GdObjects.typeof_as_string(current))
 	_current_type = typeof(current)
 
@@ -40,6 +41,7 @@ func _validate_is_vector_type(value :Variant) -> bool:
 	var type := typeof(value)
 	if type == _current_type or _current_type == TYPE_NIL:
 		return true
+	@warning_ignore("return_value_discarded")
 	report_error(GdAssertMessages.error_is_wrong_type(_current_type, type))
 	return false
 
@@ -63,21 +65,25 @@ func failure_message() -> String:
 
 
 func override_failure_message(message :String) -> GdUnitVectorAssert:
+	@warning_ignore("return_value_discarded")
 	_base.override_failure_message(message)
 	return self
 
 
 func append_failure_message(message :String) -> GdUnitVectorAssert:
+	@warning_ignore("return_value_discarded")
 	_base.append_failure_message(message)
 	return self
 
 
 func is_null() -> GdUnitVectorAssert:
+	@warning_ignore("return_value_discarded")
 	_base.is_null()
 	return self
 
 
 func is_not_null() -> GdUnitVectorAssert:
+	@warning_ignore("return_value_discarded")
 	_base.is_not_null()
 	return self
 
@@ -85,6 +91,7 @@ func is_not_null() -> GdUnitVectorAssert:
 func is_equal(expected: Variant) -> GdUnitVectorAssert:
 	if _type_check and not _validate_is_vector_type(expected):
 		return self
+	@warning_ignore("return_value_discarded")
 	_base.is_equal(expected)
 	return self
 
@@ -92,6 +99,7 @@ func is_equal(expected: Variant) -> GdUnitVectorAssert:
 func is_not_equal(expected: Variant) -> GdUnitVectorAssert:
 	if _type_check and not _validate_is_vector_type(expected):
 		return self
+	@warning_ignore("return_value_discarded")
 	_base.is_not_equal(expected)
 	return self
 

--- a/addons/gdUnit4/src/cmd/CmdCommand.gd
+++ b/addons/gdUnit4/src/cmd/CmdCommand.gd
@@ -19,6 +19,7 @@ func arguments() -> PackedStringArray:
 
 
 func add_argument(arg :String) -> void:
+	@warning_ignore("return_value_discarded")
 	_arguments.append(arg)
 
 

--- a/addons/gdUnit4/src/cmd/CmdCommandHandler.gd
+++ b/addons/gdUnit4/src/cmd/CmdCommandHandler.gd
@@ -57,14 +57,17 @@ func _validate() -> GdUnitResult:
 			if _command_cbs[cmd_name][CB_SINGLE_ARG]
 			else _command_cbs[cmd_name][CB_MULTI_ARGS])
 		if cb != NO_CB and not cb.is_valid():
+			@warning_ignore("return_value_discarded")
 			errors.append("Invalid function reference for command '%s', Check the function reference!" % cmd_name)
 		if _cmd_options.get_option(cmd_name) == null:
+			@warning_ignore("return_value_discarded")
 			errors.append("The command '%s' is unknown, verify your CmdOptions!" % cmd_name)
 		# verify for multiple registered command callbacks
 		if _enhanced_fr_test and cb != NO_CB:
 			var cb_method: = cb.get_method()
 			if registered_cbs.has(cb_method):
 				var already_registered_cmd :String = registered_cbs[cb_method]
+				@warning_ignore("return_value_discarded")
 				errors.append("The function reference '%s' already registerd for command '%s'!" % [cb_method, already_registered_cmd])
 			else:
 				registered_cbs[cb_method] = cmd_name

--- a/addons/gdUnit4/src/cmd/CmdConsole.gd
+++ b/addons/gdUnit4/src/cmd/CmdConsole.gd
@@ -59,6 +59,7 @@ func scroll_area(from :int, to :int) -> CmdConsole:
 	return self
 
 
+@warning_ignore("return_value_discarded")
 func progress_bar(p_progress :int, p_color :Color = Color.POWDER_BLUE) -> CmdConsole:
 	if p_progress < 0:
 		p_progress = 0
@@ -123,6 +124,7 @@ func print_color(p_message :String, p_color :Color, p_flags := 0) -> CmdConsole:
 		.end_color()
 
 
+@warning_ignore("return_value_discarded")
 func print_color_table() -> void:
 	prints_color("Color Table 6x6x6", Color.ANTIQUE_WHITE)
 	_debug_show_color_codes = true

--- a/addons/gdUnit4/src/core/GdDiffTool.gd
+++ b/addons/gdUnit4/src/core/GdDiffTool.gd
@@ -41,9 +41,11 @@ static func _diff(lb: PackedByteArray, rb: PackedByteArray, lookup: Array, ldiff
 # lookup[i][j] stores the length of LCS of substring X[0..i-1], Y[0..j-1]
 static func _createLookUp(lb: PackedByteArray, rb: PackedByteArray) -> Array:
 	var lookup := Array()
+	@warning_ignore("return_value_discarded")
 	lookup.resize(lb.size() + 1)
 	for i in lookup.size():
 		var x := []
+		@warning_ignore("return_value_discarded")
 		x.resize(rb.size() + 1)
 		lookup[i] = x
 	return lookup
@@ -105,6 +107,7 @@ static func longestCommonSubsequence(text1 :String, text2 :String) -> PackedStri
 	var lcsResultList := PackedStringArray();
 	while (i < text1WordCount && j < text2WordCount):
 		if text1Words[i] == text2Words[j]:
+			@warning_ignore("return_value_discarded")
 			lcsResultList.append(text2Words[j])
 			i += 1
 			j += 1

--- a/addons/gdUnit4/src/core/GdFunctionDoubler.gd
+++ b/addons/gdUnit4/src/core/GdFunctionDoubler.gd
@@ -82,6 +82,7 @@ static func get_enum_default(value :String) -> Variant:
 		return %s.values()[0]
 
 	""".dedent() % value
+	@warning_ignore("return_value_discarded")
 	script.reload()
 	return script.new().call("get_enum_default")
 
@@ -161,6 +162,7 @@ func double(func_descriptor: GdFunctionDescriptor, is_callable: bool = false) ->
 func extract_arg_names(argument_signatures: Array[GdFunctionArgument], add_suffix := false) -> PackedStringArray:
 	var arg_names := PackedStringArray()
 	for arg in argument_signatures:
+		@warning_ignore("return_value_discarded")
 		arg_names.append(arg._name + ("_" if add_suffix else ""))
 	return arg_names
 
@@ -171,8 +173,10 @@ static func extract_constructor_args(args :Array[GdFunctionArgument]) -> PackedS
 		var arg_name := arg._name + "_"
 		var default_value := get_default(arg)
 		if default_value == "null":
+			@warning_ignore("return_value_discarded")
 			constructor_args.append(arg_name + ":Variant=" + default_value)
 		else:
+			@warning_ignore("return_value_discarded")
 			constructor_args.append(arg_name + ":=" + default_value)
 	return constructor_args
 
@@ -192,10 +196,13 @@ static func typeless_args(descriptor: GdFunctionDescriptor) -> String:
 	var collect := PackedStringArray()
 	for arg in descriptor.args():
 		if arg.has_default():
+			@warning_ignore("return_value_discarded")
 			collect.push_back(arg.name() + "_" + "=" + arg.value_as_string())
 		else:
+			@warning_ignore("return_value_discarded")
 			collect.push_back(arg.name() + "_")
 	for arg in descriptor.varargs():
+		@warning_ignore("return_value_discarded")
 		collect.push_back(arg.name() + "=" + arg.value_as_string())
 	return ", ".join(collect)
 

--- a/addons/gdUnit4/src/core/GdObjects.gd
+++ b/addons/gdUnit4/src/core/GdObjects.gd
@@ -304,6 +304,7 @@ static func to_pascal_case(value :String) -> String:
 	return value.capitalize().replace(" ", "")
 
 
+@warning_ignore("return_value_discarded")
 static func to_snake_case(value :String) -> String:
 	var result := PackedStringArray()
 	for ch in value:
@@ -498,6 +499,7 @@ static func create_instance(clazz :Variant) -> GdUnitResult:
 	return GdUnitResult.error("Can't create instance for class '%s'." % clazz)
 
 
+@warning_ignore("return_value_discarded")
 static func extract_class_path(clazz :Variant) -> PackedStringArray:
 	var clazz_path := PackedStringArray()
 	if clazz is String:
@@ -575,6 +577,7 @@ static func extract_class_name(clazz :Variant) -> GdUnitResult:
 	if instance == null:
 		return GdUnitResult.error("Can't create a instance for class '%s'" % clazz)
 	var result := extract_class_name(instance)
+	@warning_ignore("return_value_discarded")
 	GdUnitTools.free_instance(instance)
 	return result
 
@@ -590,6 +593,7 @@ static func extract_inner_clazz_names(clazz_name :String, script_path :PackedStr
 		var value :Variant = map.get(key)
 		if value is GDScript:
 			var class_path := extract_class_path(value)
+			@warning_ignore("return_value_discarded")
 			inner_classes.append(class_path[1])
 	return inner_classes
 

--- a/addons/gdUnit4/src/core/GdUnit4Version.gd
+++ b/addons/gdUnit4/src/core/GdUnit4Version.gd
@@ -16,6 +16,7 @@ func _init(major :int, minor :int, patch :int) -> void:
 
 static func parse(value :String) -> GdUnit4Version:
 	var regex := RegEx.new()
+	@warning_ignore("return_value_discarded")
 	regex.compile("[a-zA-Z:,-]+")
 	var cleaned := regex.sub(value, "", true)
 	var parts := cleaned.split(".")
@@ -27,6 +28,7 @@ static func parse(value :String) -> GdUnit4Version:
 
 static func current() -> GdUnit4Version:
 	var config := ConfigFile.new()
+	@warning_ignore("return_value_discarded")
 	config.load('addons/gdUnit4/plugin.cfg')
 	return parse(config.get_value('plugin', 'version') as String)
 
@@ -45,6 +47,7 @@ func is_greater(other :GdUnit4Version) -> bool:
 
 static func init_version_label(label :Control) -> void:
 	var config := ConfigFile.new()
+	@warning_ignore("return_value_discarded")
 	config.load('addons/gdUnit4/plugin.cfg')
 	var version :String = config.get_value('plugin', 'version')
 	if label is RichTextLabel:

--- a/addons/gdUnit4/src/core/GdUnitClassDoubler.gd
+++ b/addons/gdUnit4/src/core/GdUnitClassDoubler.gd
@@ -42,7 +42,9 @@ static func load_template(template :String, class_info :Dictionary, instance :Ob
 		.replace("${source_class}", class_info.get("class_name") as String)
 	var lines := GdScriptParser.to_unix_format(source_code).split("\n")
 	# replace template class_name with Doubled<class> name and extends form source class
+	@warning_ignore("return_value_discarded")
 	lines.insert(0, "class_name Doubled%s" % class_info.get("class_name").replace(".", "_"))
+	@warning_ignore("return_value_discarded")
 	lines.insert(1, extends_clazz(class_info))
 	# append Object interactions stuff
 	lines.append_array(GdScriptParser.to_unix_format(DOUBLER_TEMPLATE.source_code).split("\n"))

--- a/addons/gdUnit4/src/core/GdUnitFileAccess.gd
+++ b/addons/gdUnit4/src/core/GdUnitFileAccess.gd
@@ -23,6 +23,7 @@ static func create_temp_file(relative_path :String, file_name :String, mode := F
 
 static func temp_dir() -> String:
 	if not DirAccess.dir_exists_absolute(GDUNIT_TEMP):
+		@warning_ignore("return_value_discarded")
 		DirAccess.make_dir_recursive_absolute(GDUNIT_TEMP)
 	return GDUNIT_TEMP
 
@@ -30,6 +31,7 @@ static func temp_dir() -> String:
 static func create_temp_dir(folder_name :String) -> String:
 	var new_folder := temp_dir() + "/" + folder_name
 	if not DirAccess.dir_exists_absolute(new_folder):
+		@warning_ignore("return_value_discarded")
 		DirAccess.make_dir_recursive_absolute(new_folder)
 	return new_folder
 
@@ -61,6 +63,7 @@ static func copy_directory(from_dir :String, to_dir :String, recursive :bool = f
 	var source_dir := DirAccess.open(from_dir)
 	var dest_dir := DirAccess.open(to_dir)
 	if source_dir != null:
+		@warning_ignore("return_value_discarded")
 		source_dir.list_dir_begin()
 		var next := "."
 
@@ -72,6 +75,7 @@ static func copy_directory(from_dir :String, to_dir :String, recursive :bool = f
 			var dest := dest_dir.get_current_dir() + "/" + next
 			if source_dir.current_is_dir():
 				if recursive:
+					@warning_ignore("return_value_discarded")
 					copy_directory(source + "/", dest, recursive)
 				continue
 			var err := source_dir.copy(source, dest)
@@ -88,6 +92,7 @@ static func copy_directory(from_dir :String, to_dir :String, recursive :bool = f
 static func delete_directory(path :String, only_content := false) -> void:
 	var dir := DirAccess.open(path)
 	if dir != null:
+		@warning_ignore("return_value_discarded")
 		dir.list_dir_begin()
 		var file_name := "."
 		while file_name != "":
@@ -113,6 +118,7 @@ static func delete_path_index_lower_equals_than(path :String, prefix :String, in
 	if dir == null:
 		return 0
 	var deleted := 0
+	@warning_ignore("return_value_discarded")
 	dir.list_dir_begin()
 	var next := "."
 	while next != "":
@@ -134,6 +140,7 @@ static func find_last_path_index(path :String, prefix :String) -> int:
 	if dir == null:
 		return 0
 	var last_iteration := 0
+	@warning_ignore("return_value_discarded")
 	dir.list_dir_begin()
 	var next := "."
 	while next != "":
@@ -152,12 +159,14 @@ static func scan_dir(path :String) -> PackedStringArray:
 	if dir == null or not dir.dir_exists(path):
 		return PackedStringArray()
 	var content := PackedStringArray()
+	@warning_ignore("return_value_discarded")
 	dir.list_dir_begin()
 	var next := "."
 	while next != "":
 		next = dir.get_next()
 		if next.is_empty() or next == "." or next == "..":
 			continue
+		@warning_ignore("return_value_discarded")
 		content.append(next)
 	return content
 
@@ -169,6 +178,7 @@ static func resource_as_array(resource_path :String) -> PackedStringArray:
 		return PackedStringArray()
 	var file_content := PackedStringArray()
 	while not file.eof_reached():
+		@warning_ignore("return_value_discarded")
 		file_content.append(file.get_line())
 	return file_content
 
@@ -203,9 +213,11 @@ static func extract_zip(zip_package :String, dest_path :String) -> GdUnitResult:
 	for zip_entry in zip_entries:
 		var new_file_path: String = dest_path + "/" + zip_entry.replace(archive_path, "")
 		if zip_entry.ends_with("/"):
+			@warning_ignore("return_value_discarded")
 			DirAccess.make_dir_recursive_absolute(new_file_path)
 			continue
 		var file: FileAccess = FileAccess.open(new_file_path, FileAccess.WRITE)
 		file.store_buffer(zip.read_file(zip_entry))
+	@warning_ignore("return_value_discarded")
 	zip.close()
 	return GdUnitResult.success(dest_path)

--- a/addons/gdUnit4/src/core/GdUnitObjectInteractionsTemplate.gd
+++ b/addons/gdUnit4/src/core/GdUnitObjectInteractionsTemplate.gd
@@ -47,8 +47,10 @@ func __verify_interactions(function_args :Array[Variant]) -> void:
 			__error_message = GdAssertMessages.error_validate_interactions(__current_summary, __expected_summary)
 		else:
 			__error_message = GdAssertMessages.error_validate_interactions(__summary, __expected_summary)
+		@warning_ignore("return_value_discarded")
 		__gd_assert.report_error(__error_message)
 	else:
+		@warning_ignore("return_value_discarded")
 		__gd_assert.report_success()
 	__expected_interactions = -1
 

--- a/addons/gdUnit4/src/core/GdUnitRunner.gd
+++ b/addons/gdUnit4/src/core/GdUnitRunner.gd
@@ -36,7 +36,9 @@ func _ready() -> void:
 		push_error(config_result.error_message())
 		_state = EXIT
 		return
+	@warning_ignore("return_value_discarded")
 	_client.connect("connection_failed", _on_connection_failed)
+	@warning_ignore("return_value_discarded")
 	GdUnitSignals.instance().gdunit_event.connect(_on_gdunit_event)
 	var result := _client.start("127.0.0.1", _config.server_port())
 	if result.is_error():

--- a/addons/gdUnit4/src/core/GdUnitRunnerConfig.gd
+++ b/addons/gdUnit4/src/core/GdUnitRunnerConfig.gd
@@ -38,6 +38,7 @@ func server_port() -> int:
 	return _config.get(SERVER_PORT, -1)
 
 
+@warning_ignore("return_value_discarded")
 func self_test() -> GdUnitRunnerConfig:
 	add_test_suite("res://addons/gdUnit4/test/")
 	add_test_suite("res://addons/gdUnit4/mono/test/")
@@ -52,6 +53,7 @@ func add_test_suite(p_resource_path :String) -> GdUnitRunnerConfig:
 
 func add_test_suites(resource_paths :PackedStringArray) -> GdUnitRunnerConfig:
 	for resource_path_ in resource_paths:
+		@warning_ignore("return_value_discarded")
 		add_test_suite(resource_path_)
 	return self
 
@@ -60,8 +62,10 @@ func add_test_case(p_resource_path :String, test_name :StringName, test_param_in
 	var to_execute_ := to_execute()
 	var test_cases :PackedStringArray = to_execute_.get(p_resource_path, PackedStringArray())
 	if test_param_index != -1:
+		@warning_ignore("return_value_discarded")
 		test_cases.append("%s:%d" % [test_name, test_param_index])
 	else:
+		@warning_ignore("return_value_discarded")
 		test_cases.append(test_name)
 	to_execute_[p_resource_path] = test_cases
 	return self
@@ -77,13 +81,17 @@ func skip_test_suite(value :StringName) -> GdUnitRunnerConfig:
 		parts.remove_at(0)
 	parts[0] = GdUnitFileAccess.make_qualified_path(parts[0])
 	match parts.size():
-		1: skipped()[parts[0]] = PackedStringArray()
-		2: skip_test_case(parts[0], parts[1])
+		1:
+			skipped()[parts[0]] = PackedStringArray()
+		2:
+			@warning_ignore("return_value_discarded")
+			skip_test_case(parts[0], parts[1])
 	return self
 
 
 func skip_test_suites(resource_paths :PackedStringArray) -> GdUnitRunnerConfig:
 	for resource_path_ in resource_paths:
+		@warning_ignore("return_value_discarded")
 		skip_test_suite(resource_path_)
 	return self
 
@@ -91,6 +99,7 @@ func skip_test_suites(resource_paths :PackedStringArray) -> GdUnitRunnerConfig:
 func skip_test_case(p_resource_path :String, test_name :StringName) -> GdUnitRunnerConfig:
 	var to_ignore := skipped()
 	var test_cases :PackedStringArray = to_ignore.get(p_resource_path, PackedStringArray())
+	@warning_ignore("return_value_discarded")
 	test_cases.append(test_name)
 	to_ignore[p_resource_path] = test_cases
 	return self

--- a/addons/gdUnit4/src/core/GdUnitSceneRunnerImpl.gd
+++ b/addons/gdUnit4/src/core/GdUnitSceneRunnerImpl.gd
@@ -43,6 +43,7 @@ var _scene_auto_free := false
 func _init(p_scene: Variant, p_verbose: bool, p_hide_push_errors := false) -> void:
 	_verbose = p_verbose
 	_saved_iterations_per_second = Engine.get_physics_ticks_per_second()
+	@warning_ignore("return_value_discarded")
 	set_time_factor(1)
 	# handle scene loading by resource path
 	if typeof(p_scene) == TYPE_STRING:
@@ -70,6 +71,7 @@ func _init(p_scene: Variant, p_verbose: bool, p_hide_push_errors := false) -> vo
 
 	_scene_tree().root.add_child(_current_scene)
 	# do finally reset all open input events when the scene is removed
+	@warning_ignore("return_value_discarded")
 	_scene_tree().root.child_exiting_tree.connect(func f(child :Node) -> void:
 		if child == _current_scene:
 			# we need to disable the processing to avoid input flush buffer errors
@@ -103,6 +105,7 @@ func _scene_tree() -> SceneTree:
 	return Engine.get_main_loop() as SceneTree
 
 
+@warning_ignore("return_value_discarded")
 func simulate_action_pressed(action: String) -> GdUnitSceneRunner:
 	simulate_action_press(action)
 	simulate_action_release(action)
@@ -131,6 +134,7 @@ func simulate_action_release(action: String) -> GdUnitSceneRunner:
 	return _handle_input_event(event)
 
 
+@warning_ignore("return_value_discarded")
 func simulate_key_pressed(key_code: int, shift_pressed := false, ctrl_pressed := false) -> GdUnitSceneRunner:
 	simulate_key_press(key_code, shift_pressed, ctrl_pressed)
 	await _scene_tree().process_frame
@@ -201,6 +205,7 @@ func simulate_mouse_move(position: Vector2) -> GdUnitSceneRunner:
 	return _handle_input_event(event)
 
 
+@warning_ignore("return_value_discarded")
 func simulate_mouse_move_relative(relative: Vector2, time: float = 1.0, trans_type: Tween.TransitionType = Tween.TRANS_LINEAR) -> GdUnitSceneRunner:
 	var tween := _scene_tree().create_tween()
 	_curent_mouse_position = get_mouse_position()
@@ -214,6 +219,7 @@ func simulate_mouse_move_relative(relative: Vector2, time: float = 1.0, trans_ty
 	return self
 
 
+@warning_ignore("return_value_discarded")
 func simulate_mouse_move_absolute(position: Vector2, time: float = 1.0, trans_type: Tween.TransitionType = Tween.TRANS_LINEAR) -> GdUnitSceneRunner:
 	var tween := _scene_tree().create_tween()
 	_curent_mouse_position = get_mouse_position()
@@ -226,6 +232,7 @@ func simulate_mouse_move_absolute(position: Vector2, time: float = 1.0, trans_ty
 	return self
 
 
+@warning_ignore("return_value_discarded")
 func simulate_mouse_button_pressed(button_index: MouseButton, double_click := false) -> GdUnitSceneRunner:
 	simulate_mouse_button_press(button_index, double_click)
 	simulate_mouse_button_release(button_index)
@@ -255,12 +262,14 @@ func simulate_mouse_button_release(button_index: MouseButton) -> GdUnitSceneRunn
 	return _handle_input_event(event)
 
 
+@warning_ignore("return_value_discarded")
 func simulate_screen_touch_pressed(index: int, position: Vector2, double_tap := false) -> GdUnitSceneRunner:
 	simulate_screen_touch_press(index, position, double_tap)
 	simulate_screen_touch_release(index)
 	return self
 
 
+@warning_ignore("return_value_discarded")
 func simulate_screen_touch_press(index: int, position: Vector2, double_tap := false) -> GdUnitSceneRunner:
 	if is_emulate_mouse_from_touch():
 		# we need to simulate in addition to the touch the mouse events
@@ -279,6 +288,7 @@ func simulate_screen_touch_press(index: int, position: Vector2, double_tap := fa
 	return self
 
 
+@warning_ignore("return_value_discarded")
 func simulate_screen_touch_release(index: int, double_tap := false) -> GdUnitSceneRunner:
 	if is_emulate_mouse_from_touch():
 		# we need to simulate in addition to the touch the mouse events
@@ -302,11 +312,13 @@ func simulate_screen_touch_drag_absolute(index: int, position: Vector2, time: fl
 	return await _do_touch_drag_at(index, position, time, trans_type)
 
 
+@warning_ignore("return_value_discarded")
 func simulate_screen_touch_drag_drop(index: int, position: Vector2, drop_position: Vector2, time: float = 1.0, trans_type: Tween.TransitionType = Tween.TRANS_LINEAR) -> GdUnitSceneRunner:
 	simulate_screen_touch_press(index, position)
 	return await _do_touch_drag_at(index, drop_position, time, trans_type)
 
 
+@warning_ignore("return_value_discarded")
 func simulate_screen_touch_drag(index: int, position: Vector2) -> GdUnitSceneRunner:
 	if is_emulate_mouse_from_touch():
 		simulate_mouse_move(position)
@@ -339,6 +351,7 @@ func _get_screen_touch_drag_position_or_default(index: int, default_position: Ve
 	return default_position
 
 
+@warning_ignore("return_value_discarded")
 func _do_touch_drag_at(index: int, drag_position: Vector2, time: float, trans_type: Tween.TransitionType) -> GdUnitSceneRunner:
 	# start draging
 	var event := InputEventScreenDrag.new()
@@ -555,6 +568,7 @@ func _handle_actions(event: InputEventAction) -> bool:
 
 
 # for handling read https://docs.godotengine.org/en/stable/tutorials/inputs/inputevent.html?highlight=inputevent#how-does-it-work
+@warning_ignore("return_value_discarded")
 func _handle_input_event(event: InputEvent) -> GdUnitSceneRunner:
 	if event is InputEventMouse:
 		Input.warp_mouse(event.position as Vector2)
@@ -580,6 +594,7 @@ func _handle_input_event(event: InputEvent) -> GdUnitSceneRunner:
 	return self
 
 
+@warning_ignore("return_value_discarded")
 func _reset_input_to_default() -> void:
 	# reset all mouse button to inital state if need
 	for m_button :int in _mouse_button_on_press.duplicate():

--- a/addons/gdUnit4/src/core/GdUnitSettings.gd
+++ b/addons/gdUnit4/src/core/GdUnitSettings.gd
@@ -184,6 +184,7 @@ static func is_update_notification_enabled() -> bool:
 
 static func set_update_notification(enable :bool) -> void:
 	ProjectSettings.set_setting(UPDATE_NOTIFICATION_ENABLED, enable)
+	@warning_ignore("return_value_discarded")
 	ProjectSettings.save()
 
 
@@ -194,6 +195,7 @@ static func get_log_path() -> String:
 static func set_log_path(path :String) -> void:
 	ProjectSettings.set_setting(STDOUT_ENABLE_TO_FILE, true)
 	ProjectSettings.set_setting(STDOUT_WITE_TO_FILE, path)
+	@warning_ignore("return_value_discarded")
 	ProjectSettings.save()
 
 
@@ -303,6 +305,7 @@ static func extract_value_set_from_help(value :String) -> PackedStringArray:
 		return PackedStringArray()
 
 	var regex := RegEx.new()
+	@warning_ignore("return_value_discarded")
 	regex.compile("\\[(.+)\\]")
 	var matches := regex.search_all(split_value[1])
 	if matches.is_empty():
@@ -397,8 +400,10 @@ static func migrate_property(old_property :String, new_property :String, default
 
 
 static func dump_to_tmp() -> void:
+	@warning_ignore("return_value_discarded")
 	ProjectSettings.save_custom("user://project_settings.godot")
 
 
 static func restore_dump_from_tmp() -> void:
+	@warning_ignore("return_value_discarded")
 	DirAccess.copy_absolute("user://project_settings.godot", "res://project.godot")

--- a/addons/gdUnit4/src/core/GdUnitSignalAwaiter.gd
+++ b/addons/gdUnit4/src/core/GdUnitSignalAwaiter.gd
@@ -41,12 +41,14 @@ func elapsed_time() -> float:
 
 func on_signal(source :Object, signal_name :String, expected_signal_args :Array) -> Variant:
 	# register checked signal to wait for
+	@warning_ignore("return_value_discarded")
 	source.connect(signal_name, _on_signal_emmited)
 	# install timeout timer
 	var timer := Timer.new()
 	Engine.get_main_loop().root.add_child(timer)
 	timer.add_to_group("GdUnitTimers")
 	timer.set_one_shot(true)
+	@warning_ignore("return_value_discarded")
 	timer.timeout.connect(_do_interrupt, CONNECT_DEFERRED)
 	timer.start(_timeout_millis * 0.001 * Engine.get_time_scale())
 

--- a/addons/gdUnit4/src/core/GdUnitSignalCollector.gd
+++ b/addons/gdUnit4/src/core/GdUnitSignalCollector.gd
@@ -54,6 +54,7 @@ func unregister_emitter(emitter :Object) -> void:
 			var signal_name :String = signal_def["name"]
 			if emitter.is_connected(signal_name, _on_signal_emmited):
 				emitter.disconnect(signal_name, _on_signal_emmited.bind(emitter, signal_name))
+		@warning_ignore("return_value_discarded")
 		_collected_signals.erase(emitter)
 
 

--- a/addons/gdUnit4/src/core/GdUnitSingleton.gd
+++ b/addons/gdUnit4/src/core/GdUnitSingleton.gd
@@ -23,6 +23,7 @@ static func instance(name :String, clazz :Callable) -> Variant:
 	Engine.set_meta(name, singleton)
 	GdUnitTools.prints_verbose("Register singleton '%s:%s'" % [name, singleton])
 	var singletons :PackedStringArray = Engine.get_meta(MEATA_KEY, PackedStringArray())
+	@warning_ignore("return_value_discarded")
 	singletons.append(name)
 	Engine.set_meta(MEATA_KEY, singletons)
 	return singleton
@@ -36,6 +37,7 @@ static func unregister(p_singleton :String, use_call_deferred :bool = false) -> 
 		singletons.remove_at(index)
 		var instance_ :Object = Engine.get_meta(p_singleton)
 		GdUnitTools.prints_verbose("	Free singleton instance '%s:%s'" % [p_singleton, instance_])
+		@warning_ignore("return_value_discarded")
 		GdUnitTools.free_instance(instance_, use_call_deferred)
 		Engine.remove_meta(p_singleton)
 		GdUnitTools.prints_verbose("	Successfully freed '%s'" % p_singleton)

--- a/addons/gdUnit4/src/core/GdUnitTestSuiteBuilder.gd
+++ b/addons/gdUnit4/src/core/GdUnitTestSuiteBuilder.gd
@@ -5,7 +5,9 @@ extends RefCounted
 static func create(source :Script, line_number :int) -> GdUnitResult:
 	var test_suite_path := GdUnitTestSuiteScanner.resolve_test_suite_path(source.resource_path, GdUnitSettings.test_root_folder())
 	# we need to save and close the testsuite and source if is current opened before modify
+	@warning_ignore("return_value_discarded")
 	ScriptEditorControls.save_an_open_script(source.resource_path)
+	@warning_ignore("return_value_discarded")
 	ScriptEditorControls.save_an_open_script(test_suite_path, true)
 	if GdObjects.is_cs_script(source):
 		return GdUnit4CSharpApiLoader.create_test_suite(source.resource_path, line_number+1, test_suite_path)

--- a/addons/gdUnit4/src/core/GdUnitTestSuiteScanner.gd
+++ b/addons/gdUnit4/src/core/GdUnitTestSuiteScanner.gd
@@ -30,8 +30,10 @@ func prescan_testsuite_classes() -> void:
 		var base_class :String = script_meta["base"]
 		var resource_path :String = script_meta["path"]
 		if base_class == "GdUnitTestSuite":
+			@warning_ignore("return_value_discarded")
 			_included_resources.append(resource_path)
 		elif ClassDB.class_exists(base_class):
+			@warning_ignore("return_value_discarded")
 			_excluded_resources.append(resource_path)
 
 
@@ -54,6 +56,7 @@ func _scan_test_suites(dir :DirAccess, collected_suites :Array[Node]) -> Array[N
 	if exclude_scan_directories.has(dir.get_current_dir()):
 		return collected_suites
 	prints("Scanning for test suites in:", dir.get_current_dir())
+	@warning_ignore("return_value_discarded")
 	dir.list_dir_begin() # TODOGODOT4 fill missing arguments https://github.com/godotengine/godot/pull/40547
 	var file_name := dir.get_next()
 	while file_name != "":
@@ -61,6 +64,7 @@ func _scan_test_suites(dir :DirAccess, collected_suites :Array[Node]) -> Array[N
 		if dir.current_is_dir():
 			var sub_dir := DirAccess.open(resource_path)
 			if sub_dir != null:
+				@warning_ignore("return_value_discarded")
 				_scan_test_suites(sub_dir, collected_suites)
 		else:
 			var time := LocalTime.now()
@@ -186,6 +190,7 @@ func _handle_test_case_arguments(test_suite :Node, script :GDScript, fd :GdFunct
 				Fuzzer.ARGUMENT_SEED:
 					seed_value = arg.default()
 	# create new test
+	@warning_ignore("return_value_discarded")
 	test.configure(fd.name(), fd.line_number(), fd.source_path(), timeout, fuzzers, iterations, seed_value)
 	test.set_function_descriptor(fd)
 	test.skip(is_skipped, skip_reason)
@@ -196,6 +201,7 @@ func _handle_test_case_arguments(test_suite :Node, script :GDScript, fd :GdFunct
 func _parse_and_add_test_cases(test_suite :Node, script :GDScript, test_case_names :PackedStringArray) -> void:
 	var test_cases_to_find := Array(test_case_names)
 	var functions_to_scan := test_case_names.duplicate()
+	@warning_ignore("return_value_discarded")
 	functions_to_scan.append("before")
 
 	var function_descriptors := _script_parser.get_function_descriptors(script, functions_to_scan)

--- a/addons/gdUnit4/src/core/GdUnitTools.gd
+++ b/addons/gdUnit4/src/core/GdUnitTools.gd
@@ -30,6 +30,7 @@ static func prints_verbose(message :String) -> void:
 static func free_instance(instance :Variant, use_call_deferred :bool = false, is_stdout_verbose := false) -> bool:
 	if instance is Array:
 		for element :Variant in instance:
+			@warning_ignore("return_value_discarded")
 			free_instance(element)
 		instance.clear()
 		return true

--- a/addons/gdUnit4/src/core/LocalTime.gd
+++ b/addons/gdUnit4/src/core/LocalTime.gd
@@ -61,6 +61,7 @@ func plus(time_unit :TimeUnit, value :int) -> LocalTime:
 			addValue = value * MILLIS_PER_MINUTE
 		TimeUnit.HOUR:
 			addValue = value * MILLIS_PER_HOUR
+	@warning_ignore("return_value_discarded")
 	_init(_time + addValue)
 	return self
 

--- a/addons/gdUnit4/src/core/_TestCase.gd
+++ b/addons/gdUnit4/src/core/_TestCase.gd
@@ -102,6 +102,7 @@ func set_timeout() -> void:
 	_timer = Timer.new()
 	add_child(_timer)
 	_timer.set_name("gdunit_test_case_timer_%d" % _timer.get_instance_id())
+	@warning_ignore("return_value_discarded")
 	_timer.timeout.connect(do_interrupt, CONNECT_DEFERRED)
 	_timer.set_one_shot(true)
 	_timer.set_wait_time(time)
@@ -124,6 +125,7 @@ func do_interrupt() -> void:
 
 func _set_failure_handler() -> void:
 	if not GdUnitSignals.instance().gdunit_set_test_failed.is_connected(_failure_received):
+		@warning_ignore("return_value_discarded")
 		GdUnitSignals.instance().gdunit_set_test_failed.connect(_failure_received)
 
 

--- a/addons/gdUnit4/src/core/command/GdUnitCommandHandler.gd
+++ b/addons/gdUnit4/src/core/command/GdUnitCommandHandler.gd
@@ -50,6 +50,7 @@ static func instance() -> GdUnitCommandHandler:
 	return GdUnitSingleton.instance("GdUnitCommandHandler", func() -> GdUnitCommandHandler: return GdUnitCommandHandler.new())
 
 
+@warning_ignore("return_value_discarded")
 func _init() -> void:
 	assert_shortcut_mappings(SETTINGS_SHORTCUT_MAPPING)
 
@@ -58,6 +59,7 @@ func _init() -> void:
 	GdUnitSignals.instance().gdunit_client_disconnected.connect(_on_client_disconnected)
 	GdUnitSignals.instance().gdunit_settings_changed.connect(_on_settings_changed)
 	# preload previous test execution
+	@warning_ignore("return_value_discarded")
 	_runner_config.load_config()
 
 	init_shortcuts()
@@ -76,6 +78,7 @@ func _init() -> void:
 	# schedule discover tests if enabled and running inside the editor
 	if Engine.is_editor_hint() and GdUnitSettings.is_test_discover_enabled():
 		var timer :SceneTreeTimer = Engine.get_main_loop().create_timer(5)
+		@warning_ignore("return_value_discarded")
 		timer.timeout.connect(cmd_discover_tests)
 
 
@@ -239,6 +242,7 @@ func cmd_editor_run_test(debug :bool) -> void:
 	var cursor_line := active_base_editor().get_caret_line()
 	#run test case?
 	var regex := RegEx.new()
+	@warning_ignore("return_value_discarded")
 	regex.compile("(^func[ ,\t])(test_[a-zA-Z0-9_]*)")
 	var result := regex.search(active_base_editor().get_line(cursor_line))
 	if result:
@@ -276,8 +280,10 @@ static func scan_test_directorys(base_directory :String, test_directory: String,
 		if GdUnitTestSuiteScanner.exclude_scan_directories.has(current_directory):
 			continue
 		if match_test_directory(directory, test_directory):
+			@warning_ignore("return_value_discarded")
 			test_suite_paths.append(current_directory)
 		else:
+			@warning_ignore("return_value_discarded")
 			scan_test_directorys(current_directory, test_directory, test_suite_paths)
 	return test_suite_paths
 
@@ -344,6 +350,7 @@ func _on_settings_changed(property :GdUnitProperty) -> void:
 		register_shortcut(shortcut, input_event)
 	if property.name() == GdUnitSettings.TEST_DISCOVER_ENABLED:
 		var timer :SceneTreeTimer = Engine.get_main_loop().create_timer(3)
+		@warning_ignore("return_value_discarded")
 		timer.timeout.connect(cmd_discover_tests)
 
 

--- a/addons/gdUnit4/src/core/discovery/GdUnitTestDiscoverGuard.gd
+++ b/addons/gdUnit4/src/core/discovery/GdUnitTestDiscoverGuard.gd
@@ -8,6 +8,7 @@ var _discover_cache := {}
 
 func _init() -> void:
 	# Register for discovery events to sync the cache
+	@warning_ignore("return_value_discarded")
 	GdUnitSignals.instance().gdunit_add_test_suite.connect(sync_cache)
 
 
@@ -45,6 +46,7 @@ func discover(script: Script) -> void:
 		var tests_removed := PackedStringArray()
 		for test_case in discovered_test_cases:
 			if not script_test_cases.has(test_case):
+				@warning_ignore("return_value_discarded")
 				tests_removed.append(test_case)
 		# second detect new added tests
 		var tests_added :Array[String] = []

--- a/addons/gdUnit4/src/core/discovery/GdUnitTestDiscoverer.gd
+++ b/addons/gdUnit4/src/core/discovery/GdUnitTestDiscoverer.gd
@@ -9,6 +9,7 @@ static func run() -> void:
 
 	# We run the test discovery in an extra thread so that the main thread is not blocked
 	var t:= Thread.new()
+	@warning_ignore("return_value_discarded")
 	t.start(func () -> void:
 		var test_suite_directories :PackedStringArray = GdUnitCommandHandler.scan_test_directorys("res://" , GdUnitSettings.test_root_folder(), [])
 		var scanner := GdUnitTestSuiteScanner.new()

--- a/addons/gdUnit4/src/core/execution/GdUnitMemoryObserver.gd
+++ b/addons/gdUnit4/src/core/execution/GdUnitMemoryObserver.gd
@@ -54,7 +54,7 @@ static func debug_observe(name :String, obj :Object, indent :int = 0) -> void:
 		prints(name, obj, obj.get_class(), obj.get_name())
 
 
-static func guard_instance(obj :Object) -> Object:
+static func guard_instance(obj :Object) -> void:
 	if not _is_instance_guard_enabled():
 		return
 	var tag := TAG_OBSERVE_INSTANCE + str(abs(obj.get_instance_id()))
@@ -62,7 +62,6 @@ static func guard_instance(obj :Object) -> Object:
 		return
 	debug_observe("Gard on instance", obj)
 	Engine.set_meta(tag, obj)
-	return obj
 
 
 static func unguard_instance(obj :Object, verbose := true) -> void:

--- a/addons/gdUnit4/src/core/execution/stages/GdUnitTestCaseAfterStage.gd
+++ b/addons/gdUnit4/src/core/execution/stages/GdUnitTestCaseAfterStage.gd
@@ -4,14 +4,14 @@ class_name GdUnitTestCaseAfterStage
 extends IGdUnitExecutionStage
 
 
-var _call_stage :bool
+var _call_stage: bool
 
 
 func _init(call_stage := true) -> void:
 	_call_stage = call_stage
 
 
-func _execute(context :GdUnitExecutionContext) -> void:
+func _execute(context: GdUnitExecutionContext) -> void:
 	var test_suite := context.test_suite
 
 	if _call_stage:
@@ -27,7 +27,7 @@ func _execute(context :GdUnitExecutionContext) -> void:
 	if context.is_skipped():
 		fire_test_skipped(context)
 	else:
-		fire_event(GdUnitEvent.new()\
+		fire_event(GdUnitEvent.new() \
 			.test_after(test_suite.get_script().resource_path as String,
 				context.get_test_suite_name(),
 				context.get_test_case_name(),
@@ -35,7 +35,7 @@ func _execute(context :GdUnitExecutionContext) -> void:
 				reports))
 
 
-func fire_test_skipped(context :GdUnitExecutionContext) -> void:
+func fire_test_skipped(context: GdUnitExecutionContext) -> void:
 	var test_suite := context.test_suite
 	var test_case := context.test_case
 	var statistics := {
@@ -49,9 +49,9 @@ func fire_test_skipped(context :GdUnitExecutionContext) -> void:
 		GdUnitEvent.SKIPPED: true,
 		GdUnitEvent.SKIPPED_COUNT: 1,
 	}
-	var report := GdUnitReport.new()\
+	var report := GdUnitReport.new() \
 		.create(GdUnitReport.SKIPPED, test_case.line_number(), GdAssertMessages.test_skipped(test_case.skip_info()))
-	fire_event(GdUnitEvent.new()\
+	fire_event(GdUnitEvent.new() \
 		.test_after(test_suite.get_script().resource_path as String,
 			context.get_test_suite_name(),
 			context.get_test_case_name(),

--- a/addons/gdUnit4/src/core/execution/stages/GdUnitTestSuiteExecutionStage.gd
+++ b/addons/gdUnit4/src/core/execution/stages/GdUnitTestSuiteExecutionStage.gd
@@ -19,6 +19,7 @@ func _execute(context :GdUnitExecutionContext) -> void:
 	if context.test_suite.__is_skipped:
 		await fire_test_suite_skipped(context)
 	else:
+		@warning_ignore("return_value_discarded")
 		GdUnitMemoryObserver.guard_instance(context.test_suite.__awaiter)
 		await _stage_before.execute(context)
 		for test_case_index in context.test_suite.get_child_count():
@@ -56,6 +57,7 @@ func clone_test_suite(test_suite :GdUnitTestSuite) -> GdUnitTestSuite:
 		test_suite.remove_child(child)
 		_test_suite.add_child(child)
 	parent.add_child(_test_suite)
+	@warning_ignore("return_value_discarded")
 	GdUnitMemoryObserver.guard_instance(_test_suite.__awaiter)
 	# finally free current test suite instance
 	test_suite.free()

--- a/addons/gdUnit4/src/core/execution/stages/fuzzed/GdUnitTestCaseFuzzedExecutionStage.gd
+++ b/addons/gdUnit4/src/core/execution/stages/fuzzed/GdUnitTestCaseFuzzedExecutionStage.gd
@@ -16,6 +16,7 @@ func _execute(context :GdUnitExecutionContext) -> void:
 		await _stage_after.execute(test_context)
 		if test_context.is_success() or test_context.is_skipped() or test_context.is_interupted():
 			break
+	@warning_ignore("return_value_discarded")
 	context.evaluate_test_retry_status()
 
 

--- a/addons/gdUnit4/src/core/execution/stages/fuzzed/GdUnitTestCaseFuzzedTestStage.gd
+++ b/addons/gdUnit4/src/core/execution/stages/fuzzed/GdUnitTestCaseFuzzedTestStage.gd
@@ -15,6 +15,7 @@ func _execute(context :GdUnitExecutionContext) -> void:
 
 	# guard on fuzzers
 	for fuzzer in fuzzers:
+		@warning_ignore("return_value_discarded")
 		GdUnitMemoryObserver.guard_instance(fuzzer)
 
 	for iteration in test_case.iterations():

--- a/addons/gdUnit4/src/core/execution/stages/single/GdUnitTestCaseSingleExecutionStage.gd
+++ b/addons/gdUnit4/src/core/execution/stages/single/GdUnitTestCaseSingleExecutionStage.gd
@@ -17,6 +17,7 @@ func _execute(context :GdUnitExecutionContext) -> void:
 		await _stage_after.execute(test_context)
 		if test_context.is_success() or test_context.is_skipped() or test_context.is_interupted():
 			break
+	@warning_ignore("return_value_discarded")
 	context.evaluate_test_retry_status()
 
 

--- a/addons/gdUnit4/src/core/parse/GdDefaultValueDecoder.gd
+++ b/addons/gdUnit4/src/core/parse/GdDefaultValueDecoder.gd
@@ -102,6 +102,7 @@ func _on_type_Array(value :Variant, type :int) -> String:
 		TYPE_PACKED_COLOR_ARRAY:
 			var colors := PackedStringArray()
 			for color in value as PackedColorArray:
+				@warning_ignore("return_value_discarded")
 				colors.append(_on_type_Color(color))
 			if colors.is_empty():
 				return "PackedColorArray()"
@@ -110,6 +111,7 @@ func _on_type_Array(value :Variant, type :int) -> String:
 		TYPE_PACKED_VECTOR2_ARRAY:
 			var vectors := PackedStringArray()
 			for vector in value as PackedVector2Array:
+				@warning_ignore("return_value_discarded")
 				vectors.append(_on_type_Vector(vector, TYPE_VECTOR2))
 			if vectors.is_empty():
 				return "PackedVector2Array()"
@@ -118,6 +120,7 @@ func _on_type_Array(value :Variant, type :int) -> String:
 		TYPE_PACKED_VECTOR3_ARRAY:
 			var vectors := PackedStringArray()
 			for vector in value as PackedVector3Array:
+				@warning_ignore("return_value_discarded")
 				vectors.append(_on_type_Vector(vector, TYPE_VECTOR3))
 			if vectors.is_empty():
 				return "PackedVector3Array()"
@@ -126,6 +129,7 @@ func _on_type_Array(value :Variant, type :int) -> String:
 		GdObjects.TYPE_PACKED_VECTOR4_ARRAY:
 			var vectors := PackedStringArray()
 			for vector:Variant in value as Array:
+				@warning_ignore("return_value_discarded")
 				vectors.append(_on_type_Vector(vector, TYPE_VECTOR4))
 			if vectors.is_empty():
 				return "PackedVector4Array()"
@@ -134,6 +138,7 @@ func _on_type_Array(value :Variant, type :int) -> String:
 		TYPE_PACKED_STRING_ARRAY:
 			var values := PackedStringArray()
 			for v in value as PackedStringArray:
+				@warning_ignore("return_value_discarded")
 				values.append('"%s"' % v)
 			if values.is_empty():
 				return "PackedStringArray()"
@@ -146,6 +151,7 @@ func _on_type_Array(value :Variant, type :int) -> String:
 		TYPE_PACKED_INT64_ARRAY:
 			var vectors := PackedStringArray()
 			for vector :Variant in value as Array:
+				@warning_ignore("return_value_discarded")
 				vectors.append(str(vector))
 			if vectors.is_empty():
 				return GdObjects.type_as_string(type) + "()"

--- a/addons/gdUnit4/src/core/parse/GdFunctionArgument.gd
+++ b/addons/gdUnit4/src/core/parse/GdFunctionArgument.gd
@@ -141,6 +141,7 @@ func _parse_parameter_set(input :String) -> PackedStringArray:
 	for c in buf:
 		current_index += 1
 		matched = current_index == buf.size()
+		@warning_ignore("return_value_discarded")
 		collected_characters.push_back(c)
 
 		match c:
@@ -164,6 +165,7 @@ func _parse_parameter_set(input :String) -> PackedStringArray:
 		if matched:
 			var parameters := _fix_comma_space.sub(collected_characters.get_string_from_utf8(), ", ", true)
 			if not parameters.is_empty():
+				@warning_ignore("return_value_discarded")
 				output.append(parameters)
 			collected_characters.clear()
 			matched = false

--- a/addons/gdUnit4/src/core/parse/GdFunctionDescriptor.gd
+++ b/addons/gdUnit4/src/core/parse/GdFunctionDescriptor.gd
@@ -128,8 +128,10 @@ func varargs() -> Array[GdFunctionArgument]:
 func typed_args() -> String:
 	var collect := PackedStringArray()
 	for arg in args():
+		@warning_ignore("return_value_discarded")
 		collect.push_back(arg._to_string())
 	for arg in varargs():
+		@warning_ignore("return_value_discarded")
 		collect.push_back(arg._to_string())
 	return ", ".join(collect)
 

--- a/addons/gdUnit4/src/core/parse/GdScriptParser.gd
+++ b/addons/gdUnit4/src/core/parse/GdScriptParser.gd
@@ -258,6 +258,7 @@ class TokenInnerClass extends Token:
 
 	func parse(source_rows :PackedStringArray, offset :int) -> void:
 		# add class signature
+		@warning_ignore("return_value_discarded")
 		_content.append(source_rows[offset])
 		# parse class content
 		for row_index in range(offset+1, source_rows.size()):
@@ -270,8 +271,10 @@ class TokenInnerClass extends Token:
 					source_row = source_row.trim_prefix("\t")
 				# refomat invalid empty lines
 				if source_row.dedent().is_empty():
+					@warning_ignore("return_value_discarded")
 					_content.append("")
 				else:
+					@warning_ignore("return_value_discarded")
 					_content.append(source_row)
 				continue
 			break
@@ -599,6 +602,7 @@ func _enrich_function_descriptor(script: GDScript, fds: Array[GdFunctionDescript
 				).pop_front()
 				if fd != null:
 					# add as enriched function to exclude from next iteration (could be inherited)
+					@warning_ignore("return_value_discarded")
 					enriched_functions.append(fd.name())
 					var func_signature := extract_func_signature(rows, rowIndex)
 					var func_arguments := _parse_function_arguments(func_signature)
@@ -654,6 +658,7 @@ func _prescan_script(script: GDScript) -> void:
 	for key :String in _script_constants.keys():
 		var value :Variant = _script_constants.get(key)
 		if value is GDScript:
+			@warning_ignore("return_value_discarded")
 			_scanned_inner_classes.append(key)
 
 

--- a/addons/gdUnit4/src/core/parse/GdUnitExpressionRunner.gd
+++ b/addons/gdUnit4/src/core/parse/GdUnitExpressionRunner.gd
@@ -34,6 +34,7 @@ func execute(src_script: GDScript, value: Variant) -> Variant:
 		.replace("${clazz_path}", resource_path)\
 		.replace("$expression", expression)
 	#script.take_over_path(resource_path)
+	@warning_ignore("return_value_discarded")
 	script.reload(true)
 	var runner :Variant = script.new()
 	if runner.has_method("queue_free"):

--- a/addons/gdUnit4/src/core/parse/GdUnitTestParameterSetResolver.gd
+++ b/addons/gdUnit4/src/core/parse/GdUnitTestParameterSetResolver.gd
@@ -97,6 +97,7 @@ func build_test_case_names(test_case: _TestCase) -> PackedStringArray:
 		for parameter_set_index in parameter_sets.size():
 			var parameter_set := parameter_sets[parameter_set_index]
 			_static_sets_by_index[parameter_set_index] = _is_static_parameter_set(parameter_set, property_names)
+			@warning_ignore("return_value_discarded")
 			_test_case_names_cache.append(GdUnitTestParameterSetResolver._build_test_case_name(test_case, parameter_set, parameter_set_index))
 			parameter_set_index += 1
 	return _test_case_names_cache
@@ -121,6 +122,7 @@ func _extract_test_names_by_reflection(test_case: _TestCase) -> PackedStringArra
 	var parameter_sets := load_parameter_sets(test_case)
 	var test_case_names: PackedStringArray = []
 	for index in parameter_sets.size():
+		@warning_ignore("return_value_discarded")
 		test_case_names.append(GdUnitTestParameterSetResolver._build_test_case_name(test_case, str(parameter_sets[index]), index))
 	return test_case_names
 
@@ -174,6 +176,7 @@ func load_parameter_sets(test_case: _TestCase, do_validate := false) -> Array:
 			.add_report(GdUnitReport.new().create(GdUnitReport.INTERUPTED, test_case.line_number(), error))
 		test_case.skip(true, error)
 		test_case._interupted = true
+	@warning_ignore("return_value_discarded")
 	fixure_typed_parameters(parameter_sets, _fd.args())
 	return parameter_sets
 

--- a/addons/gdUnit4/src/core/thread/GdUnitThreadContext.gd
+++ b/addons/gdUnit4/src/core/thread/GdUnitThreadContext.gd
@@ -29,9 +29,8 @@ func dispose() -> void:
 	_thread = null
 
 
-func set_assert(value :GdUnitAssert) -> GdUnitThreadContext:
+func set_assert(value :GdUnitAssert) -> void:
 	_assert = value
-	return self
 
 
 func get_assert() -> GdUnitAssert:

--- a/addons/gdUnit4/src/core/thread/GdUnitThreadManager.gd
+++ b/addons/gdUnit4/src/core/thread/GdUnitThreadManager.gd
@@ -36,6 +36,7 @@ func _run(name :String, cb :Callable) -> Variant:
 	var save_current_thread_id := _current_thread_id
 	var thread := Thread.new()
 	thread.set_meta("name", name)
+	@warning_ignore("return_value_discarded")
 	thread.start(cb)
 	_current_thread_id = thread.get_id() as int
 	_register_thread(thread, _current_thread_id)
@@ -54,6 +55,7 @@ func _register_thread(thread :Thread, thread_id :int) -> void:
 func _unregister_thread(thread_id :int) -> void:
 	var context := _thread_context_by_id.get(thread_id) as GdUnitThreadContext
 	if context:
+		@warning_ignore("return_value_discarded")
 		_thread_context_by_id.erase(thread_id)
 		context.dispose()
 

--- a/addons/gdUnit4/src/fuzzers/StringFuzzer.gd
+++ b/addons/gdUnit4/src/fuzzers/StringFuzzer.gd
@@ -60,5 +60,6 @@ func next_value() -> String:
 	var max_char := len(_charset)
 	var length :int = max(_min_length, randi() % _max_length)
 	for i in length:
+		@warning_ignore("return_value_discarded")
 		value.append(_charset[randi() % max_char])
 	return value.get_string_from_utf8()

--- a/addons/gdUnit4/src/mocking/GdUnitMockBuilder.gd
+++ b/addons/gdUnit4/src/mocking/GdUnitMockBuilder.gd
@@ -61,6 +61,7 @@ static func mock_on_scene(scene :PackedScene, debug_write :bool) -> Variant:
 	if scene_instance.get_script() == null:
 		if push_errors:
 			push_error("Can't create a mockable instance for a scene without script '%s'" % scene.resource_path)
+		@warning_ignore("return_value_discarded")
 		GdUnitTools.free_instance(scene_instance)
 		return null
 
@@ -99,7 +100,9 @@ static func mock_on_script(instance :Object, clazz :Variant, function_excludes :
 	mock.resource_path = "%s/%s"  % [GdUnitFileAccess.create_temp_dir("mock"), mock.resource_name]
 
 	if debug_write:
+		@warning_ignore("return_value_discarded")
 		DirAccess.remove_absolute(mock.resource_path)
+		@warning_ignore("return_value_discarded")
 		ResourceSaver.save(mock, mock.resource_path)
 	var error := mock.reload(true)
 	if error != OK:

--- a/addons/gdUnit4/src/monitor/GodotGdErrorMonitor.gd
+++ b/addons/gdUnit4/src/monitor/GodotGdErrorMonitor.gd
@@ -57,6 +57,7 @@ func _collect_log_entries(force_collect_reports: bool) -> Array[ErrorLogEntry]:
 	file.seek(_eof)
 	var records := PackedStringArray()
 	while not file.eof_reached():
+		@warning_ignore("return_value_discarded")
 		records.append(file.get_line())
 	file.seek_end(0)
 	_eof = file.get_length()

--- a/addons/gdUnit4/src/network/GdUnitServer.gd
+++ b/addons/gdUnit4/src/network/GdUnitServer.gd
@@ -4,6 +4,7 @@ extends Node
 @onready var _server :GdUnitTcpServer = $TcpServer
 
 
+@warning_ignore("return_value_discarded")
 func _ready() -> void:
 	var result := _server.start()
 	if result.is_error():

--- a/addons/gdUnit4/src/network/GdUnitTcpClient.gd
+++ b/addons/gdUnit4/src/network/GdUnitTcpClient.gd
@@ -51,6 +51,7 @@ func _process(_delta :float) -> void:
 			set_process(false)
 			# wait until client is connected to server
 			for retry in 10:
+				@warning_ignore("return_value_discarded")
 				_stream.poll()
 				console("wait to connect ..")
 				if _stream.get_status() == StreamPeerTCP.STATUS_CONNECTING:
@@ -98,6 +99,7 @@ func process_rpc() -> void:
 func rpc_send(p_rpc :RPC) -> void:
 	if _stream != null:
 		var data := GdUnitServerConstants.JSON_RESPONSE_DELIMITER + p_rpc.serialize() + GdUnitServerConstants.JSON_RESPONSE_DELIMITER
+		@warning_ignore("return_value_discarded")
 		_stream.put_data(data.to_utf8_buffer())
 
 

--- a/addons/gdUnit4/src/network/GdUnitTcpServer.gd
+++ b/addons/gdUnit4/src/network/GdUnitTcpServer.gd
@@ -96,6 +96,7 @@ class TcpConnection extends Node:
 		pass
 
 
+@warning_ignore("return_value_discarded")
 func _ready() -> void:
 	_server = TCPServer.new()
 	client_connected.connect(_on_client_connected)

--- a/addons/gdUnit4/src/network/rpc/dtos/GdUnitTestCaseDto.gd
+++ b/addons/gdUnit4/src/network/rpc/dtos/GdUnitTestCaseDto.gd
@@ -26,6 +26,7 @@ func serialize(test_case :Node) -> Dictionary:
 
 
 func deserialize(data :Dictionary) -> GdUnitTestCaseDto:
+	@warning_ignore("return_value_discarded")
 	super.deserialize(data)
 	_line_number = data.get("line_number", -1)
 	_script_path = data.get("script_path", data.get("resource_path", ""))

--- a/addons/gdUnit4/src/network/rpc/dtos/GdUnitTestSuiteDto.gd
+++ b/addons/gdUnit4/src/network/rpc/dtos/GdUnitTestSuiteDto.gd
@@ -21,6 +21,7 @@ func serialize(test_suite :Node) -> Dictionary:
 
 
 func deserialize(data :Dictionary) -> GdUnitResourceDto:
+	@warning_ignore("return_value_discarded")
 	super.deserialize(data)
 	var test_cases_ :Array = data.get("test_cases", [])
 	for test_case :Dictionary in test_cases_:

--- a/addons/gdUnit4/src/report/GdUnitByPathReport.gd
+++ b/addons/gdUnit4/src/report/GdUnitByPathReport.gd
@@ -35,6 +35,7 @@ func write(report_dir :String) -> String:
 	var output_path := "%s/path/%s.html" % [report_dir, path().replace("/", ".")]
 	var dir := output_path.get_base_dir()
 	if not DirAccess.dir_exists_absolute(dir):
+		@warning_ignore("return_value_discarded")
 		DirAccess.make_dir_recursive_absolute(dir)
 	FileAccess.open(output_path, FileAccess.WRITE).store_string(path_report)
 	return output_path
@@ -44,6 +45,7 @@ func apply_testsuite_reports(report_dir :String, template :String, test_suite_re
 	var table_records := PackedStringArray()
 	for report:GdUnitTestSuiteReport in test_suite_reports:
 		var report_link := report.output_path(report_dir).replace(report_dir, "..")
+		@warning_ignore("return_value_discarded")
 		table_records.append(report.create_record(report_link))
 	return template.replace(GdUnitHtmlPatterns.TABLE_BY_TESTSUITES, "\n".join(table_records))
 

--- a/addons/gdUnit4/src/report/GdUnitHtmlReport.gd
+++ b/addons/gdUnit4/src/report/GdUnitHtmlReport.gd
@@ -13,6 +13,7 @@ func _init(report_path :String, max_reports: int) -> void:
 	else:
 		_iteration = 1
 	_report_path = "%s/%s%d" % [report_path, REPORT_DIR_PREFIX, _iteration]
+	@warning_ignore("return_value_discarded")
 	DirAccess.make_dir_recursive_absolute(_report_path)
 
 
@@ -107,6 +108,7 @@ func write() -> String:
 	# write report
 	var index_file := "%s/index.html" % _report_path
 	FileAccess.open(index_file, FileAccess.WRITE).store_string(to_write)
+	@warning_ignore("return_value_discarded")
 	GdUnitFileAccess.copy_directory("res://addons/gdUnit4/src/report/template/css/", _report_path + "/css")
 	return index_file
 
@@ -123,8 +125,9 @@ func apply_path_reports(report_dir :String, template :String, report_summaries :
 	paths.append_array(path_report_mapping.keys())
 	paths.sort()
 	for report_path in paths:
-		var report := GdUnitByPathReport.new(report_path, path_report_mapping.get(report_path))
+		var report := GdUnitByPathReport.new(report_path, path_report_mapping.get(report_path) as Array[GdUnitReportSummary])
 		var report_link :String = report.write(report_dir).replace(report_dir, ".")
+		@warning_ignore("return_value_discarded")
 		table_records.append(report.create_record(report_link))
 	return template.replace(GdUnitHtmlPatterns.TABLE_BY_PATHS, "\n".join(table_records))
 
@@ -133,7 +136,8 @@ func apply_testsuite_reports(report_dir :String, template :String, test_suite_re
 	var table_records := PackedStringArray()
 	for report in test_suite_reports:
 		var report_link :String = report.write(report_dir).replace(report_dir, ".")
-		table_records.append(report.create_record(report_link))
+		@warning_ignore("return_value_discarded")
+		table_records.append(report.create_record(report_link) as String)
 	return template.replace(GdUnitHtmlPatterns.TABLE_BY_TESTSUITES, "\n".join(table_records))
 
 

--- a/addons/gdUnit4/src/report/GdUnitTestSuiteReport.gd
+++ b/addons/gdUnit4/src/report/GdUnitTestSuiteReport.gd
@@ -43,14 +43,17 @@ func write(report_dir :String) -> String:
 	var report_output_path := output_path(report_dir)
 	var test_report_table := PackedStringArray()
 	if not _failure_reports.is_empty():
+		@warning_ignore("return_value_discarded")
 		test_report_table.append(test_suite_failure_report())
 	for test_report: GdUnitTestCaseReport in _reports:
+		@warning_ignore("return_value_discarded")
 		test_report_table.append(test_report.create_record(report_output_path))
 
 	template = template.replace(GdUnitHtmlPatterns.TABLE_BY_TESTCASES, "\n".join(test_report_table))
 
 	var dir := report_output_path.get_base_dir()
 	if not DirAccess.dir_exists_absolute(dir):
+		@warning_ignore("return_value_discarded")
 		DirAccess.make_dir_recursive_absolute(dir)
 	FileAccess.open(report_output_path, FileAccess.WRITE).store_string(template)
 	return report_output_path

--- a/addons/gdUnit4/src/report/XmlElement.gd
+++ b/addons/gdUnit4/src/report/XmlElement.gd
@@ -39,6 +39,7 @@ func add_child(child :XmlElement) -> XmlElement:
 
 func add_childs(childs :Array[XmlElement]) -> XmlElement:
 	for child in childs:
+		@warning_ignore("return_value_discarded")
 		add_child(child)
 	return self
 

--- a/addons/gdUnit4/src/spy/GdUnitSpyBuilder.gd
+++ b/addons/gdUnit4/src/spy/GdUnitSpyBuilder.gd
@@ -37,6 +37,7 @@ static func build(to_spy: Variant, debug_write := false) -> Variant:
 		return null
 	var spy_instance :Object = spy.new()
 	copy_properties(to_spy as Object, spy_instance)
+	@warning_ignore("return_value_discarded")
 	GdUnitObjectInteractions.reset(spy_instance)
 	spy_instance.__set_singleton(to_spy)
 	# we do not call the original implementation for _ready and all input function, this is actualy done by the engine
@@ -74,7 +75,9 @@ static func spy_on_script(instance :Variant, function_excludes :PackedStringArra
 	spy.resource_path = GdUnitFileAccess.create_temp_dir("spy") + "/Spy%s_%d.gd" % [clazz_name, Time.get_ticks_msec()]
 
 	if debug_write:
+		@warning_ignore("return_value_discarded")
 		DirAccess.remove_absolute(spy.resource_path)
+		@warning_ignore("return_value_discarded")
 		ResourceSaver.save(spy, spy.resource_path)
 	var error := spy.reload(true)
 	if error != OK:

--- a/addons/gdUnit4/src/ui/GdUnitConsole.gd
+++ b/addons/gdUnit4/src/ui/GdUnitConsole.gd
@@ -21,6 +21,7 @@ var _summary := {
 }
 
 
+@warning_ignore("return_value_discarded")
 func _ready() -> void:
 	init_colors()
 	GdUnitFonts.init_fonts(output)

--- a/addons/gdUnit4/src/ui/GdUnitInspector.gd
+++ b/addons/gdUnit4/src/ui/GdUnitInspector.gd
@@ -11,6 +11,7 @@ var _command_handler := GdUnitCommandHandler.instance()
 func _ready() -> void:
 	if Engine.is_editor_hint():
 		_getEditorThemes()
+	@warning_ignore("return_value_discarded")
 	GdUnitCommandHandler.instance().gdunit_runner_start.connect(func() -> void:
 		var control :Control = get_parent_control()
 		# if the tab is floating we dont need to set as current

--- a/addons/gdUnit4/src/ui/menu/EditorFileSystemContextMenuHandler.gd
+++ b/addons/gdUnit4/src/ui/menu/EditorFileSystemContextMenuHandler.gd
@@ -10,7 +10,9 @@ func _init(context_menus: Array[GdUnitContextMenuItem]) -> void:
 		_context_menus[menu.id] = menu
 	var popup := _menu_popup()
 	var file_tree := _file_tree()
+	@warning_ignore("return_value_discarded")
 	popup.about_to_popup.connect(on_context_menu_show.bind(popup, file_tree))
+	@warning_ignore("return_value_discarded")
 	popup.id_pressed.connect(on_context_menu_pressed.bind(file_tree))
 
 
@@ -48,12 +50,14 @@ func collect_testsuites(_menu_item: GdUnitContextMenuItem, file_tree: Tree) -> P
 		var file_type := file_system.get_file_type(resource_path)
 		var is_dir := DirAccess.dir_exists_absolute(resource_path)
 		if is_dir:
+			@warning_ignore("return_value_discarded")
 			selected_test_suites.append(resource_path)
 		elif is_dir or file_type == "GDScript" or file_type == "CSharpScript":
 			# find a performant way to check if the selected item a testsuite
 			#var resource := ResourceLoader.load(resource_path, "GDScript", ResourceLoader.CACHE_MODE_REUSE)
 			#prints("loaded", resource)
 			#if resource is GDScript and menu_item.is_visible(resource):
+			@warning_ignore("return_value_discarded")
 			selected_test_suites.append(resource_path)
 		selected_item = file_tree.get_next_selected(selected_item)
 	return selected_test_suites

--- a/addons/gdUnit4/src/ui/menu/ScriptEditorContextMenuHandler.gd
+++ b/addons/gdUnit4/src/ui/menu/ScriptEditorContextMenuHandler.gd
@@ -10,6 +10,7 @@ func _init(context_menus: Array[GdUnitContextMenuItem]) -> void:
 	for menu in context_menus:
 		_context_menus[menu.id] = menu
 	_editor = EditorInterface.get_script_editor()
+	@warning_ignore("return_value_discarded")
 	_editor.editor_script_changed.connect(on_script_changed)
 	on_script_changed(active_script())
 

--- a/addons/gdUnit4/src/ui/parts/InspectorMonitor.gd
+++ b/addons/gdUnit4/src/ui/parts/InspectorMonitor.gd
@@ -16,6 +16,7 @@ var total_orphans := 0
 
 
 func _ready() -> void:
+	@warning_ignore("return_value_discarded")
 	GdUnitSignals.instance().gdunit_event.connect(_on_gdunit_event)
 	_time.text = ""
 	_orphans.text = "0"

--- a/addons/gdUnit4/src/ui/parts/InspectorProgressBar.gd
+++ b/addons/gdUnit4/src/ui/parts/InspectorProgressBar.gd
@@ -7,6 +7,7 @@ extends ProgressBar
 
 
 func _ready() -> void:
+	@warning_ignore("return_value_discarded")
 	GdUnitSignals.instance().gdunit_event.connect(_on_gdunit_event)
 	style.bg_color = Color.DARK_GREEN
 	bar.value = 0

--- a/addons/gdUnit4/src/ui/parts/InspectorStatusBar.gd
+++ b/addons/gdUnit4/src/ui/parts/InspectorStatusBar.gd
@@ -42,6 +42,7 @@ var icon_mappings := {
 }
 
 
+@warning_ignore("return_value_discarded")
 func _ready() -> void:
 	_failures.text = "0"
 	_errors.text = "0"
@@ -69,6 +70,7 @@ func _set_sort_mode_menu_options() -> void:
 	context_menu.clear()
 
 	if not context_menu.index_pressed.is_connected(_on_sort_mode_changed):
+		@warning_ignore("return_value_discarded")
 		context_menu.index_pressed.connect(_on_sort_mode_changed)
 
 	var configured_sort_mode := GdUnitSettings.get_inspector_tree_sort_mode()
@@ -86,6 +88,7 @@ func _set_view_mode_menu_options() -> void:
 	context_menu.clear()
 
 	if not context_menu.index_pressed.is_connected(_on_tree_view_mode_changed):
+		@warning_ignore("return_value_discarded")
 		context_menu.index_pressed.connect(_on_tree_view_mode_changed)
 
 	var configured_tree_view_mode := GdUnitSettings.get_inspector_tree_view_mode()

--- a/addons/gdUnit4/src/ui/parts/InspectorToolBar.gd
+++ b/addons/gdUnit4/src/ui/parts/InspectorToolBar.gd
@@ -23,6 +23,7 @@ const SETTINGS_SHORTCUT_MAPPING := {
 }
 
 
+@warning_ignore("return_value_discarded")
 func _ready() -> void:
 	GdUnit4Version.init_version_label(_version_label)
 	var command_handler := GdUnitCommandHandler.instance()
@@ -53,6 +54,7 @@ func init_shortcuts(command_handler: GdUnitCommandHandler) -> void:
 	_button_run_debug.shortcut = command_handler.get_shortcut(GdUnitShortcut.ShortCut.RERUN_TESTS_DEBUG)
 	_button_stop.shortcut = command_handler.get_shortcut(GdUnitShortcut.ShortCut.STOP_TEST_RUN)
 	# register for shortcut changes
+	@warning_ignore("return_value_discarded")
 	GdUnitSignals.instance().gdunit_settings_changed.connect(_on_settings_changed.bind(command_handler))
 
 
@@ -87,6 +89,7 @@ func _on_gdunit_settings_changed(_property: GdUnitProperty) -> void:
 
 
 func _on_wiki_pressed() -> void:
+	@warning_ignore("return_value_discarded")
 	OS.shell_open("https://mikeschulze.github.io/gdUnit4/")
 
 

--- a/addons/gdUnit4/src/ui/parts/InspectorTreeMainPanel.gd
+++ b/addons/gdUnit4/src/ui/parts/InspectorTreeMainPanel.gd
@@ -179,6 +179,7 @@ func is_folder(item: TreeItem) -> bool:
 	return item.has_meta(META_GDUNIT_TYPE) and item.get_meta(META_GDUNIT_TYPE) == GdUnitType.FOLDER
 
 
+@warning_ignore("return_value_discarded")
 func _ready() -> void:
 	_context_menu.set_item_icon(CONTEXT_MENU_RUN_ID, GdUnitUiTools.get_icon("Play"))
 	_context_menu.set_item_icon(CONTEXT_MENU_DEBUG_ID, GdUnitUiTools.get_icon("PlayStart"))
@@ -362,6 +363,7 @@ func set_state_running(item: TreeItem) -> void:
 	if parent != _tree_root:
 		set_state_running(parent)
 	# force scrolling to current test case
+	@warning_ignore("return_value_discarded")
 	select_item(item)
 
 
@@ -529,6 +531,7 @@ func select_first_orphan() -> void:
 			for item in parent.get_children():
 				if is_item_state_orphan(item):
 					parent.set_collapsed(false)
+					@warning_ignore("return_value_discarded")
 					select_item(item)
 					return
 
@@ -809,6 +812,7 @@ func discover_test_removed(event: GdUnitEventTestDiscoverTestRemoved) -> void:
 	parent.set_meta(META_GDUNIT_TOTAL_TESTS, test_count - 1)
 	init_item_counter(parent)
 	# finally remove the test
+	@warning_ignore("return_value_discarded")
 	remove_tree_item(resource_path, event.test_name())
 
 
@@ -980,6 +984,7 @@ func _on_gdunit_runner_stop(_client_id: int) -> void:
 	sort_tree_items(_tree_root)
 	# wait until the tree redraw
 	await get_tree().process_frame
+	@warning_ignore("return_value_discarded")
 	select_first_failure()
 
 

--- a/addons/gdUnit4/src/ui/settings/GdUnitInputCapture.gd
+++ b/addons/gdUnit4/src/ui/settings/GdUnitInputCapture.gd
@@ -13,7 +13,9 @@ func _ready() -> void:
 	reset()
 	self_modulate = Color.WHITE
 	_tween = create_tween()
+	@warning_ignore("return_value_discarded")
 	_tween.set_loops()
+	@warning_ignore("return_value_discarded")
 	_tween.tween_property(%Label, "self_modulate", Color(1, 1, 1, .8), 1.0).from_current().set_trans(Tween.TRANS_BACK).set_ease(Tween.EASE_IN_OUT)
 
 

--- a/addons/gdUnit4/src/ui/settings/GdUnitSettingsDialog.gd
+++ b/addons/gdUnit4/src/ui/settings/GdUnitSettingsDialog.gd
@@ -27,6 +27,7 @@ func _ready() -> void:
 		GdUnitSettings.setup()
 	GdUnit4Version.init_version_label(_version_label)
 	_font_size = GdUnitFonts.init_fonts(_version_label)
+	@warning_ignore("return_value_discarded")
 	about_to_popup.connect(_do_setup_properties)
 
 
@@ -90,6 +91,7 @@ func setup_properties(properties_parent: Node, property_category: String) -> voi
 		var input: Node = _create_input_element(property, reset_btn)
 		inputs.append(input)
 		grid.add_child(input)
+		@warning_ignore("return_value_discarded")
 		reset_btn.pressed.connect(_on_btn_property_reset_pressed.bind(property, input, reset_btn))
 		# property help text
 		var info: Node = _properties_template.get_child(2).duplicate()
@@ -106,6 +108,7 @@ func setup_properties(properties_parent: Node, property_category: String) -> voi
 	properties_parent.custom_minimum_size.x = min_size_overall
 
 
+@warning_ignore("return_value_discarded")
 func _create_input_element(property: GdUnitProperty, reset_btn: Button) -> Node:
 	if property.is_selectable_value():
 		var options := OptionButton.new()
@@ -149,6 +152,7 @@ func to_shortcut(keys: PackedInt32Array) -> String:
 	return input_event.as_text()
 
 
+@warning_ignore("return_value_discarded")
 func to_keys(input_event: InputEventKey) -> PackedInt32Array:
 	var keys := PackedInt32Array()
 	if input_event.ctrl_pressed:
@@ -214,10 +218,12 @@ func rescan(update_scripts:=false) -> void:
 
 
 func _on_btn_report_bug_pressed() -> void:
+	@warning_ignore("return_value_discarded")
 	OS.shell_open("https://github.com/MikeSchulze/gdUnit4/issues/new?assignees=MikeSchulze&labels=bug&projects=projects%2F5&template=bug_report.yml&title=GD-XXX%3A+Describe+the+issue+briefly")
 
 
 func _on_btn_request_feature_pressed() -> void:
+	@warning_ignore("return_value_discarded")
 	OS.shell_open("https://github.com/MikeSchulze/gdUnit4/issues/new?assignees=MikeSchulze&labels=enhancement&projects=&template=feature_request.md&title=")
 
 

--- a/addons/gdUnit4/src/ui/templates/TestSuiteTemplate.gd
+++ b/addons/gdUnit4/src/ui/templates/TestSuiteTemplate.gd
@@ -83,6 +83,7 @@ func get_editor_color(property_name: String, default: Color) -> Color:
 
 func setup_fonts() -> void:
 	if _template_editor:
+		@warning_ignore("return_value_discarded")
 		GdUnitFonts.init_fonts(_template_editor)
 		var font_size := GdUnitFonts.init_fonts(_tags_editor)
 		_title_bar.size.y = font_size + 16

--- a/addons/gdUnit4/src/update/GdMarkDownReader.gd
+++ b/addons/gdUnit4/src/update/GdMarkDownReader.gd
@@ -109,6 +109,7 @@ func regex(pattern :String) -> RegEx:
 
 
 func _init() -> void:
+	@warning_ignore("return_value_discarded")
 	_img_replace_regex.compile("\\[img\\]((.*?))\\[/img\\]")
 
 
@@ -116,6 +117,7 @@ func set_http_client(client :GdUnitUpdateClient) -> void:
 	_client = client
 
 
+@warning_ignore("return_value_discarded")
 func _notification(what :int) -> void:
 	if what == NOTIFICATION_PREDELETE:
 		# finally remove_at the downloaded images
@@ -162,6 +164,7 @@ func process_tables(input: String) -> String:
 		if is_table(lines[0]):
 			bbcode.append_array(parse_table(lines))
 			continue
+		@warning_ignore("return_value_discarded")
 		bbcode.append(lines.pop_front() as String)
 	return "\n".join(bbcode)
 
@@ -176,6 +179,7 @@ class Table:
 		func _init(cells :PackedStringArray, columns :int) -> void:
 			_cells = cells
 			for i in range(_cells.size(), columns):
+				@warning_ignore("return_value_discarded")
 				_cells.append("")
 
 		func to_bbcode(cell_sizes :PackedInt32Array, bold :bool) -> String:
@@ -186,6 +190,7 @@ class Table:
 					cell = create_line(cell_sizes[cell_index])
 				if bold:
 					cell = "[b]%s[/b]" % cell
+				@warning_ignore("return_value_discarded")
 				cells.append("[cell]%s[/cell]" % cell)
 			return "|".join(cells)
 
@@ -208,6 +213,7 @@ class Table:
 	func calculate_max_cell_sizes() -> PackedInt32Array:
 		var cells_size := PackedInt32Array()
 		for column in _columns:
+			@warning_ignore("return_value_discarded")
 			cells_size.append(0)
 
 		for row_index in _rows.size():
@@ -219,6 +225,7 @@ class Table:
 					cells_size[cell_index] = size
 		return cells_size
 
+	@warning_ignore("return_value_discarded")
 	func to_bbcode() -> PackedStringArray:
 		var cell_sizes := calculate_max_cell_sizes()
 		var bb_code := PackedStringArray()
@@ -292,6 +299,7 @@ func process_image_references(p_regex :RegEx, p_input :String) -> String:
 	return extracted_references
 
 
+@warning_ignore("return_value_discarded")
 func process_image(p_regex :RegEx, p_input :String) -> String:
 	var to_replace := PackedStringArray()
 	var tool_tips :=  PackedStringArray()
@@ -312,6 +320,7 @@ func process_image(p_regex :RegEx, p_input :String) -> String:
 
 
 func _process_external_image_resources(input :String) -> String:
+	@warning_ignore("return_value_discarded")
 	DirAccess.make_dir_recursive_absolute(image_download_folder)
 	# scan all img for external resources and download it
 	for value in _img_replace_regex.search_all(input):
@@ -334,6 +343,7 @@ func _process_external_image_resources(input :String) -> String:
 					var err := image.save_png(new_url)
 					if err:
 						push_error("Can't save image to '%s'. Error: %s" % [new_url, error_string(err)])
+					@warning_ignore("return_value_discarded")
 					_image_urls.append(new_url)
 					input = input.replace(image_url, new_url)
 	return input

--- a/addons/gdUnit4/src/update/GdUnitPatcher.gd
+++ b/addons/gdUnit4/src/update/GdUnitPatcher.gd
@@ -42,6 +42,7 @@ func _collect_patch_versions(scan_path :String, current :GdUnit4Version) -> Pack
 	var patches := Array()
 	var dir := DirAccess.open(scan_path)
 	if dir != null:
+		@warning_ignore("return_value_discarded")
 		dir.list_dir_begin() # TODO GODOT4 fill missing arguments https://github.com/godotengine/godot/pull/40547
 		var next := "."
 		while next != "":
@@ -59,6 +60,7 @@ func _scan_patches(path :String) -> PackedStringArray:
 	var patches := Array()
 	var dir := DirAccess.open(path)
 	if dir != null:
+		@warning_ignore("return_value_discarded")
 		dir.list_dir_begin() # TODOGODOT4 fill missing arguments https://github.com/godotengine/godot/pull/40547
 		var next := "."
 		while next != "":

--- a/addons/gdUnit4/src/update/GdUnitUpdate.gd
+++ b/addons/gdUnit4/src/update/GdUnitUpdate.gd
@@ -50,6 +50,7 @@ func message_h4(message :String, color :Color) -> void:
 	_progress_content.append_text("[font_size=16]%s[/font_size]" % _colored(message, color))
 
 
+@warning_ignore("return_value_discarded")
 func run_update() -> void:
 	get_cancel_button().disabled = true
 	get_ok_button().disabled = true
@@ -92,6 +93,7 @@ func restart_godot() -> void:
 	EditorInterface.restart_editor(true)
 
 
+@warning_ignore("return_value_discarded")
 func enable_gdUnit() -> void:
 	var enabled_plugins := PackedStringArray()
 	if ProjectSettings.has_setting("editor_plugins/enabled"):
@@ -110,6 +112,7 @@ const GDUNIT_TEMP := "user://tmp"
 
 func temp_dir() -> String:
 	if not DirAccess.dir_exists_absolute(GDUNIT_TEMP):
+		@warning_ignore("return_value_discarded")
 		DirAccess.make_dir_recursive_absolute(GDUNIT_TEMP)
 	return GDUNIT_TEMP
 
@@ -118,6 +121,7 @@ func create_temp_dir(folder_name :String) -> String:
 	var new_folder := temp_dir() + "/" + folder_name
 	delete_directory(new_folder)
 	if not DirAccess.dir_exists_absolute(new_folder):
+		@warning_ignore("return_value_discarded")
 		DirAccess.make_dir_recursive_absolute(new_folder)
 	return new_folder
 
@@ -125,6 +129,7 @@ func create_temp_dir(folder_name :String) -> String:
 func delete_directory(path :String, only_content := false) -> void:
 	var dir := DirAccess.open(path)
 	if dir != null:
+		@warning_ignore("return_value_discarded")
 		dir.list_dir_begin()
 		var file_name := "."
 		while file_name != "":
@@ -159,6 +164,7 @@ func copy_directory(from_dir :String, to_dir :String) -> bool:
 	var source_dir := DirAccess.open(from_dir)
 	var dest_dir := DirAccess.open(to_dir)
 	if source_dir != null:
+		@warning_ignore("return_value_discarded")
 		source_dir.list_dir_begin()
 		var next := "."
 
@@ -169,6 +175,7 @@ func copy_directory(from_dir :String, to_dir :String) -> bool:
 			var source := source_dir.get_current_dir() + "/" + next
 			var dest := dest_dir.get_current_dir() + "/" + next
 			if source_dir.current_is_dir():
+				@warning_ignore("return_value_discarded")
 				copy_directory(source + "/", dest)
 				continue
 			var err := source_dir.copy(source, dest)
@@ -195,10 +202,12 @@ func extract_zip(zip_package :String, dest_path :String) -> Variant:
 	for zip_entry in zip_entries:
 		var new_file_path: String = dest_path + "/" + zip_entry.replace(archive_path, "")
 		if zip_entry.ends_with("/"):
+			@warning_ignore("return_value_discarded")
 			DirAccess.make_dir_recursive_absolute(new_file_path)
 			continue
 		var file: FileAccess = FileAccess.open(new_file_path, FileAccess.WRITE)
 		file.store_buffer(zip.read_file(zip_entry))
+	@warning_ignore("return_value_discarded")
 	zip.close()
 	return dest_path
 

--- a/addons/gdUnit4/src/update/GdUnitUpdateClient.gd
+++ b/addons/gdUnit4/src/update/GdUnitUpdateClient.gd
@@ -17,6 +17,7 @@ class HttpResponse:
 
 	func response() -> Variant:
 		var test_json_conv := JSON.new()
+		@warning_ignore("return_value_discarded")
 		test_json_conv.parse(_body.get_string_from_utf8())
 		return test_json_conv.get_data()
 
@@ -28,6 +29,7 @@ var _http_request :HTTPRequest = HTTPRequest.new()
 
 func _ready() -> void:
 	add_child(_http_request)
+	@warning_ignore("return_value_discarded")
 	_http_request.request_completed.connect(_on_request_completed)
 
 

--- a/addons/gdUnit4/src/update/GdUnitUpdateNotify.gd
+++ b/addons/gdUnit4/src/update/GdUnitUpdateNotify.gd
@@ -21,6 +21,7 @@ var _download_zip_url :String
 func _ready() -> void:
 	_update_button.disabled = true
 	_md_reader.set_http_client(_update_client)
+	@warning_ignore("return_value_discarded")
 	GdUnitFonts.init_fonts(_content)
 	await request_releases()
 
@@ -132,6 +133,7 @@ func progressBar(p_progress :int) -> void:
 	printraw("scan [%-50s] %-3d%%\r" % ["".lpad(int(p_progress/2.0), "#").rpad(50, "-"), p_progress])
 
 
+@warning_ignore("return_value_discarded")
 func _on_update_pressed() -> void:
 	_update_button.set_disabled(true)
 	# close all opend scripts before start the update
@@ -163,6 +165,7 @@ func _on_cancel_pressed() -> void:
 func _on_content_meta_clicked(meta :String) -> void:
 	var properties :Variant = str_to_var(meta)
 	if properties.has("url"):
+		@warning_ignore("return_value_discarded")
 		OS.shell_open(properties.get("url"))
 
 


### PR DESCRIPTION

# Why
If the default settings for warnings are changed to a more detailed level, many warnings are displayed.

# What
- fix debug/gdscript/warnings/return_value_discarded warnings

**But we have to deactivate it in the end, because the fluent style of the asserts leads to many of these warnings.** Unfortunately, setting the annotation `@warning_ignore(“return_value_discarded”)` at class level in the test still doesn't work.
