### PR TITLE
GD-579: `Part3:` Minimize `unsafe_property_access` warnings

### DIFF
--- a/addons/gdUnit4/src/GdUnitAwaiter.gd
+++ b/addons/gdUnit4/src/GdUnitAwaiter.gd
@@ -16,7 +16,7 @@ func await_signal_on(source :Object, signal_name :String, args :Array = [], time
 	if not is_instance_valid(source):
 		@warning_ignore("return_value_discarded")
 		assert_that.report_error(GdAssertMessages.error_await_signal_on_invalid_instance(source, signal_name, args), line_number)
-		return await Engine.get_main_loop().process_frame
+		return await (Engine.get_main_loop() as SceneTree).process_frame
 	# fail fast if the given source instance invalid
 	if not is_instance_valid(source):
 		@warning_ignore("return_value_discarded")
@@ -61,7 +61,7 @@ func await_signal_idle_frames(source :Object, signal_name :String, args :Array =
 func await_millis(milliSec :int) -> void:
 	var timer :Timer = Timer.new()
 	timer.set_name("gdunit_await_millis_timer_%d" % timer.get_instance_id())
-	Engine.get_main_loop().root.add_child(timer)
+	(Engine.get_main_loop() as SceneTree).root.add_child(timer)
 	timer.add_to_group("GdUnitTimers")
 	timer.set_one_shot(true)
 	timer.start(milliSec / 1000.0)
@@ -71,4 +71,4 @@ func await_millis(milliSec :int) -> void:
 
 # Waits until the next idle frame
 func await_idle_frame() -> void:
-	await Engine.get_main_loop().process_frame
+	await (Engine.get_main_loop() as SceneTree).process_frame

--- a/addons/gdUnit4/src/GdUnitFuncAssert.gd
+++ b/addons/gdUnit4/src/GdUnitFuncAssert.gd
@@ -5,39 +5,39 @@ extends GdUnitAssert
 
 ## Verifies that the current value is null.
 func is_null() -> GdUnitFuncAssert:
-	await Engine.get_main_loop().process_frame
+	await (Engine.get_main_loop() as SceneTree).process_frame
 	return self
 
 
 ## Verifies that the current value is not null.
 func is_not_null() -> GdUnitFuncAssert:
-	await Engine.get_main_loop().process_frame
+	await (Engine.get_main_loop() as SceneTree).process_frame
 	return self
 
 
 ## Verifies that the current value is equal to the given one.
 @warning_ignore("unused_parameter")
 func is_equal(expected :Variant) -> GdUnitFuncAssert:
-	await Engine.get_main_loop().process_frame
+	await (Engine.get_main_loop() as SceneTree).process_frame
 	return self
 
 
 ## Verifies that the current value is not equal to the given one.
 @warning_ignore("unused_parameter")
 func is_not_equal(expected :Variant) -> GdUnitFuncAssert:
-	await Engine.get_main_loop().process_frame
+	await (Engine.get_main_loop() as SceneTree).process_frame
 	return self
 
 
 ## Verifies that the current value is true.
 func is_true() -> GdUnitFuncAssert:
-	await Engine.get_main_loop().process_frame
+	await (Engine.get_main_loop() as SceneTree).process_frame
 	return self
 
 
 ## Verifies that the current value is false.
 func is_false() -> GdUnitFuncAssert:
-	await Engine.get_main_loop().process_frame
+	await (Engine.get_main_loop() as SceneTree).process_frame
 	return self
 
 

--- a/addons/gdUnit4/src/GdUnitGodotErrorAssert.gd
+++ b/addons/gdUnit4/src/GdUnitGodotErrorAssert.gd
@@ -9,7 +9,7 @@ extends GdUnitAssert
 ##		await assert_error(<callable>).is_success()
 ##     [/codeblock]
 func is_success() -> GdUnitGodotErrorAssert:
-	await Engine.get_main_loop().process_frame
+	await (Engine.get_main_loop() as SceneTree).process_frame
 	return self
 
 
@@ -20,7 +20,7 @@ func is_success() -> GdUnitGodotErrorAssert:
 ##     [/codeblock]
 @warning_ignore("unused_parameter")
 func is_runtime_error(expected_error :String) -> GdUnitGodotErrorAssert:
-	await Engine.get_main_loop().process_frame
+	await (Engine.get_main_loop() as SceneTree).process_frame
 	return self
 
 
@@ -31,7 +31,7 @@ func is_runtime_error(expected_error :String) -> GdUnitGodotErrorAssert:
 ##     [/codeblock]
 @warning_ignore("unused_parameter")
 func is_push_warning(expected_warning :String) -> GdUnitGodotErrorAssert:
-	await Engine.get_main_loop().process_frame
+	await (Engine.get_main_loop() as SceneTree).process_frame
 	return self
 
 
@@ -42,5 +42,5 @@ func is_push_warning(expected_warning :String) -> GdUnitGodotErrorAssert:
 ##     [/codeblock]
 @warning_ignore("unused_parameter")
 func is_push_error(expected_error :String) -> GdUnitGodotErrorAssert:
-	await Engine.get_main_loop().process_frame
+	await (Engine.get_main_loop() as SceneTree).process_frame
 	return self

--- a/addons/gdUnit4/src/GdUnitSceneRunner.gd
+++ b/addons/gdUnit4/src/GdUnitSceneRunner.gd
@@ -39,7 +39,7 @@ func simulate_action_release(action: String) -> GdUnitSceneRunner:
 ## [/codeblock]
 @warning_ignore("unused_parameter")
 func simulate_key_pressed(key_code: int, shift_pressed := false, ctrl_pressed := false) -> GdUnitSceneRunner:
-	await Engine.get_main_loop().process_frame
+	await (Engine.get_main_loop() as SceneTree).process_frame
 	return self
 
 
@@ -105,7 +105,7 @@ func simulate_mouse_move(position: Vector2) -> GdUnitSceneRunner:
 ## [/codeblock]
 @warning_ignore("unused_parameter")
 func simulate_mouse_move_relative(relative: Vector2, time: float = 1.0, trans_type: Tween.TransitionType = Tween.TRANS_LINEAR) -> GdUnitSceneRunner:
-	await Engine.get_main_loop().process_frame
+	await (Engine.get_main_loop() as SceneTree).process_frame
 	return self
 
 
@@ -122,7 +122,7 @@ func simulate_mouse_move_relative(relative: Vector2, time: float = 1.0, trans_ty
 ## [/codeblock]
 @warning_ignore("unused_parameter")
 func simulate_mouse_move_absolute(position: Vector2, time: float = 1.0, trans_type: Tween.TransitionType = Tween.TRANS_LINEAR) -> GdUnitSceneRunner:
-	await Engine.get_main_loop().process_frame
+	await (Engine.get_main_loop() as SceneTree).process_frame
 	return self
 
 
@@ -192,7 +192,7 @@ func simulate_screen_touch_release(index: int, double_tap := false) -> GdUnitSce
 ## [/codeblock]
 @warning_ignore("unused_parameter")
 func simulate_screen_touch_drag_relative(index: int, relative: Vector2, time: float = 1.0, trans_type: Tween.TransitionType = Tween.TRANS_LINEAR) -> GdUnitSceneRunner:
-	await Engine.get_main_loop().process_frame
+	await (Engine.get_main_loop() as SceneTree).process_frame
 	return self
 
 
@@ -213,7 +213,7 @@ func simulate_screen_touch_drag_relative(index: int, relative: Vector2, time: fl
 ## [/codeblock]
 @warning_ignore("unused_parameter")
 func simulate_screen_touch_drag_absolute(index: int, position: Vector2, time: float = 1.0, trans_type: Tween.TransitionType = Tween.TRANS_LINEAR) -> GdUnitSceneRunner:
-	await Engine.get_main_loop().process_frame
+	await (Engine.get_main_loop() as SceneTree).process_frame
 	return self
 
 
@@ -234,7 +234,7 @@ func simulate_screen_touch_drag_absolute(index: int, position: Vector2, time: fl
 ## [/codeblock]
 @warning_ignore("unused_parameter")
 func simulate_screen_touch_drag_drop(index: int, position: Vector2, drop_position: Vector2, time: float = 1.0, trans_type: Tween.TransitionType = Tween.TRANS_LINEAR) -> GdUnitSceneRunner:
-	await Engine.get_main_loop().process_frame
+	await (Engine.get_main_loop() as SceneTree).process_frame
 	return self
 
 
@@ -273,7 +273,7 @@ func set_time_factor(time_factor: float = 1.0) -> GdUnitSceneRunner:
 ## [member delta_milli] : the time delta between a frame in milliseconds
 @warning_ignore("unused_parameter")
 func simulate_frames(frames: int, delta_milli: int = -1) -> GdUnitSceneRunner:
-	await Engine.get_main_loop().process_frame
+	await (Engine.get_main_loop() as SceneTree).process_frame
 	return self
 
 
@@ -293,7 +293,7 @@ func simulate_until_signal(
 	arg7: Variant = NO_ARG,
 	arg8: Variant = NO_ARG,
 	arg9: Variant = NO_ARG) -> GdUnitSceneRunner:
-	await Engine.get_main_loop().process_frame
+	await (Engine.get_main_loop() as SceneTree).process_frame
 	return self
 
 
@@ -315,7 +315,7 @@ func simulate_until_object_signal(
 	arg7: Variant = NO_ARG,
 	arg8: Variant = NO_ARG,
 	arg9: Variant = NO_ARG) -> GdUnitSceneRunner:
-	await Engine.get_main_loop().process_frame
+	await (Engine.get_main_loop() as SceneTree).process_frame
 	return self
 
 
@@ -334,8 +334,8 @@ func simulate_until_object_signal(
 func await_input_processed() -> void:
 	if scene() != null and scene().process_mode != Node.PROCESS_MODE_DISABLED:
 		Input.flush_buffered_events()
-	await Engine.get_main_loop().process_frame
-	await Engine.get_main_loop().physics_frame
+	await (Engine.get_main_loop() as SceneTree).process_frame
+	await (Engine.get_main_loop() as SceneTree).physics_frame
 
 
 ## The await_func function pauses execution until a specified function in the scene returns a value.[br]
@@ -377,7 +377,7 @@ func await_func_on(source: Object, func_name: String, args := []) -> GdUnitFuncA
 ## [member timeout] : The maximum duration (in milliseconds) to wait for the signal to be emitted before failing
 @warning_ignore("unused_parameter")
 func await_signal(signal_name: String, args := [], timeout := 2000 ) -> void:
-	await Engine.get_main_loop().process_frame
+	await (Engine.get_main_loop() as SceneTree).process_frame
 	pass
 
 

--- a/addons/gdUnit4/src/GdUnitSignalAssert.gd
+++ b/addons/gdUnit4/src/GdUnitSignalAssert.gd
@@ -6,14 +6,14 @@ extends GdUnitAssert
 ## Verifies that given signal is emitted until waiting time
 @warning_ignore("unused_parameter")
 func is_emitted(name :String, args := []) -> GdUnitSignalAssert:
-	await Engine.get_main_loop().process_frame
+	await (Engine.get_main_loop() as SceneTree).process_frame
 	return self
 
 
 ## Verifies that given signal is NOT emitted until waiting time
 @warning_ignore("unused_parameter")
 func is_not_emitted(name :String, args := []) -> GdUnitSignalAssert:
-	await Engine.get_main_loop().process_frame
+	await (Engine.get_main_loop() as SceneTree).process_frame
 	return self
 
 

--- a/addons/gdUnit4/src/asserts/GdAssertMessages.gd
+++ b/addons/gdUnit4/src/asserts/GdAssertMessages.gd
@@ -25,15 +25,22 @@ static func format_dict(value :Variant) -> String:
 static func input_event_as_text(event :InputEvent) -> String:
 	var text := ""
 	if event is InputEventKey:
+		var key_event := event as InputEventKey
 		text += "InputEventKey : key='%s', pressed=%s, keycode=%d, physical_keycode=%s" % [
-					event.as_text(), event.pressed, event.keycode, event.physical_keycode]
+					event.as_text(), key_event.pressed, key_event.keycode, key_event.physical_keycode]
 	else:
 		text += event.as_text()
 	if event is InputEventMouse:
-		text += ", global_position %s" % event.global_position
+		var mouse_event := event as InputEventMouse
+		text += ", global_position %s" % mouse_event.global_position
 	if event is InputEventWithModifiers:
+		var mouse_event := event as InputEventWithModifiers
 		text += ", shift=%s, alt=%s, control=%s, meta=%s, command=%s" % [
-					event.shift_pressed, event.alt_pressed, event.ctrl_pressed, event.meta_pressed, event.command_or_control_autoremap]
+					mouse_event.shift_pressed,
+					mouse_event.alt_pressed,
+					mouse_event.ctrl_pressed,
+					mouse_event.meta_pressed,
+					mouse_event.command_or_control_autoremap]
 	return text
 
 

--- a/addons/gdUnit4/src/asserts/GdUnitFuncAssertImpl.gd
+++ b/addons/gdUnit4/src/asserts/GdUnitFuncAssertImpl.gd
@@ -34,7 +34,7 @@ func _notification(_what :int) -> void:
 		_current_value_provider.dispose()
 		_current_value_provider = null
 	if is_instance_valid(_sleep_timer):
-		Engine.get_main_loop().root.remove_child(_sleep_timer)
+		(Engine.get_main_loop() as SceneTree).root.remove_child(_sleep_timer)
 		_sleep_timer.stop()
 		_sleep_timer.free()
 		_sleep_timer = null
@@ -121,7 +121,8 @@ func _validate_callback(predicate :Callable, expected :Variant = null) -> void:
 	var time_scale := Engine.get_time_scale()
 	var timer := Timer.new()
 	timer.set_name("gdunit_funcassert_interrupt_timer_%d" % timer.get_instance_id())
-	Engine.get_main_loop().root.add_child(timer)
+	var scene_tree := Engine.get_main_loop() as SceneTree
+	scene_tree.root.add_child(timer)
 	timer.add_to_group("GdUnitTimers")
 	@warning_ignore("return_value_discarded")
 	timer.timeout.connect(func do_interrupt() -> void:
@@ -131,7 +132,7 @@ func _validate_callback(predicate :Callable, expected :Variant = null) -> void:
 	timer.start((_timeout/1000.0)*time_scale)
 	_sleep_timer = Timer.new()
 	_sleep_timer.set_name("gdunit_funcassert_sleep_timer_%d" % _sleep_timer.get_instance_id() )
-	Engine.get_main_loop().root.add_child(_sleep_timer)
+	scene_tree.root.add_child(_sleep_timer)
 
 	while true:
 		var current :Variant = await next_current_value()
@@ -143,7 +144,7 @@ func _validate_callback(predicate :Callable, expected :Variant = null) -> void:
 			await _sleep_timer.timeout
 
 	_sleep_timer.stop()
-	await Engine.get_main_loop().process_frame
+	await scene_tree.process_frame
 	if _interrupted:
 		# https://github.com/godotengine/godot/issues/73052
 		#var predicate_name = predicate.get_method()

--- a/addons/gdUnit4/src/asserts/GdUnitSignalAssertImpl.gd
+++ b/addons/gdUnit4/src/asserts/GdUnitSignalAssertImpl.gd
@@ -91,7 +91,7 @@ func _wail_until_signal(signal_name :String, expected_args :Array, expect_not_em
 	_signal_collector.register_emitter(_emitter)
 	var time_scale := Engine.get_time_scale()
 	var timer := Timer.new()
-	Engine.get_main_loop().root.add_child(timer)
+	(Engine.get_main_loop() as SceneTree).root.add_child(timer)
 	timer.add_to_group("GdUnitTimers")
 	timer.set_one_shot(true)
 	@warning_ignore("return_value_discarded")
@@ -99,7 +99,7 @@ func _wail_until_signal(signal_name :String, expected_args :Array, expect_not_em
 	timer.start((_timeout/1000.0)*time_scale)
 	var is_signal_emitted := false
 	while not _interrupted and not is_signal_emitted:
-		await Engine.get_main_loop().process_frame
+		await (Engine.get_main_loop() as SceneTree).process_frame
 		if is_instance_valid(_emitter):
 			is_signal_emitted = _signal_collector.match(_emitter, signal_name, expected_args)
 			if is_signal_emitted and expect_not_emitted:

--- a/addons/gdUnit4/src/core/GdUnit4Version.gd
+++ b/addons/gdUnit4/src/core/GdUnit4Version.gd
@@ -51,9 +51,9 @@ static func init_version_label(label :Control) -> void:
 	config.load('addons/gdUnit4/plugin.cfg')
 	var version :String = config.get_value('plugin', 'version')
 	if label is RichTextLabel:
-		label.text = VERSION_PATTERN.replace('${version}', version)
+		(label as RichTextLabel).text = VERSION_PATTERN.replace('${version}', version)
 	else:
-		label.text = "gdUnit4 " + version
+		(label as Label).text = "gdUnit4 " + version
 
 
 func _to_string() -> String:

--- a/addons/gdUnit4/src/core/GdUnitRunner.gd
+++ b/addons/gdUnit4/src/core/GdUnitRunner.gd
@@ -79,6 +79,7 @@ func _process(_delta :float) -> void:
 				var test_suite :Node = _test_suites_to_process.pop_front()
 				if _cs_executor != null and _cs_executor.IsExecutable(test_suite):
 					_cs_executor.Execute(test_suite)
+					@warning_ignore("unsafe_property_access")
 					await _cs_executor.ExecutionCompleted
 				else:
 					await _executor.execute(test_suite as GdUnitTestSuite)

--- a/addons/gdUnit4/src/core/GdUnitSceneRunnerImpl.gd
+++ b/addons/gdUnit4/src/core/GdUnitSceneRunnerImpl.gd
@@ -184,7 +184,7 @@ func set_mouse_position(pos: Vector2) -> GdUnitSceneRunner:
 
 func get_mouse_position() -> Vector2:
 	if _last_input_event is InputEventMouse:
-		return _last_input_event.position
+		return (_last_input_event as InputEventMouse).position
 	var current_scene := scene()
 	if current_scene != null:
 		return current_scene.get_viewport().get_mouse_position()
@@ -192,7 +192,7 @@ func get_mouse_position() -> Vector2:
 
 
 func get_global_mouse_position() -> Vector2:
-	return Engine.get_main_loop().root.get_mouse_position()
+	return (Engine.get_main_loop() as SceneTree).root.get_mouse_position()
 
 
 func simulate_mouse_move(position: Vector2) -> GdUnitSceneRunner:
@@ -299,7 +299,7 @@ func simulate_screen_touch_release(index: int, double_tap := false) -> GdUnitSce
 	event.index = index
 	event.position = get_screen_touch_drag_position(index)
 	event.pressed = false
-	event.double_tap = _last_input_event.double_tap if _last_input_event is InputEventScreenTouch else double_tap
+	event.double_tap = (_last_input_event as InputEventScreenTouch).double_tap if _last_input_event is InputEventScreenTouch else double_tap
 	_current_scene.get_viewport().push_input(event)
 	return self
 
@@ -528,10 +528,12 @@ func __deactivate_time_factor() -> void:
 # copy over current active modifiers
 func _apply_input_modifiers(event: InputEvent) -> void:
 	if _last_input_event is InputEventWithModifiers and event is InputEventWithModifiers:
-		event.meta_pressed = event.meta_pressed or _last_input_event.meta_pressed
-		event.alt_pressed = event.alt_pressed or _last_input_event.alt_pressed
-		event.shift_pressed = event.shift_pressed or _last_input_event.shift_pressed
-		event.ctrl_pressed = event.ctrl_pressed or _last_input_event.ctrl_pressed
+		var last_input_event := _last_input_event as InputEventWithModifiers
+		var _event := event as InputEventWithModifiers
+		_event.meta_pressed = _event.meta_pressed or last_input_event.meta_pressed
+		_event.alt_pressed = _event.alt_pressed or last_input_event.alt_pressed
+		_event.shift_pressed = _event.shift_pressed or last_input_event.shift_pressed
+		_event.ctrl_pressed = _event.ctrl_pressed or last_input_event.ctrl_pressed
 		# this line results into reset the control_pressed state!!!
 		#event.command_or_control_autoremap = event.command_or_control_autoremap or _last_input_event.command_or_control_autoremap
 
@@ -540,19 +542,20 @@ func _apply_input_modifiers(event: InputEvent) -> void:
 func _apply_input_mouse_mask(event: InputEvent) -> void:
 	# first apply last mask
 	if _last_input_event is InputEventMouse and event is InputEventMouse:
-		event.button_mask |= _last_input_event.button_mask
+		(event as InputEventMouse).button_mask |= (_last_input_event as InputEventMouse).button_mask
 	if event is InputEventMouseButton:
-		var button_mask :int = MAP_MOUSE_BUTTON_MASKS.get(event.get_button_index(), 0)
-		if event.is_pressed():
-			event.button_mask |= button_mask
+		var _event := event as InputEventMouseButton
+		var button_mask :int = MAP_MOUSE_BUTTON_MASKS.get(_event.get_button_index(), 0)
+		if _event.is_pressed():
+			_event.button_mask |= button_mask
 		else:
-			event.button_mask ^= button_mask
+			_event.button_mask ^= button_mask
 
 
 # copy over last mouse position if need
 func _apply_input_mouse_position(event: InputEvent) -> void:
 	if _last_input_event is InputEventMouse and event is InputEventMouseButton:
-		event.position = _last_input_event.position
+		(event as InputEventMouseButton).position = (_last_input_event as InputEventMouse).position
 
 
 ## handle input action via Input modifieres
@@ -571,7 +574,7 @@ func _handle_actions(event: InputEventAction) -> bool:
 @warning_ignore("return_value_discarded")
 func _handle_input_event(event: InputEvent) -> GdUnitSceneRunner:
 	if event is InputEventMouse:
-		Input.warp_mouse(event.position as Vector2)
+		Input.warp_mouse((event as InputEventMouse).position as Vector2)
 	Input.parse_input_event(event)
 
 	if event is InputEventAction:

--- a/addons/gdUnit4/src/core/GdUnitSignalAwaiter.gd
+++ b/addons/gdUnit4/src/core/GdUnitSignalAwaiter.gd
@@ -44,8 +44,9 @@ func on_signal(source :Object, signal_name :String, expected_signal_args :Array)
 	@warning_ignore("return_value_discarded")
 	source.connect(signal_name, _on_signal_emmited)
 	# install timeout timer
+	var scene_tree := Engine.get_main_loop() as SceneTree
 	var timer := Timer.new()
-	Engine.get_main_loop().root.add_child(timer)
+	scene_tree.root.add_child(timer)
 	timer.add_to_group("GdUnitTimers")
 	timer.set_one_shot(true)
 	@warning_ignore("return_value_discarded")
@@ -63,11 +64,11 @@ func on_signal(source :Object, signal_name :String, expected_signal_args :Array)
 			value = [value]
 		if expected_signal_args.size() == 0 or GdObjects.equals(value, expected_signal_args):
 			break
-		await Engine.get_main_loop().process_frame
+		await scene_tree.process_frame
 
 	source.disconnect(signal_name, _on_signal_emmited)
 	_time_left = timer.time_left
-	await Engine.get_main_loop().process_frame
+	await scene_tree.process_frame
 	if value is Array and value.size() == 1:
 		return value[0]
 	return value

--- a/addons/gdUnit4/src/core/GdUnitSignalCollector.gd
+++ b/addons/gdUnit4/src/core/GdUnitSignalCollector.gd
@@ -30,8 +30,8 @@ func register_emitter(emitter :Object) -> void:
 			return
 		_collected_signals[emitter] = Dictionary()
 		# connect to 'tree_exiting' of the emitter to finally release all acquired resources/connections.
-		if emitter is Node and !emitter.tree_exiting.is_connected(unregister_emitter):
-			emitter.tree_exiting.connect(unregister_emitter.bind(emitter))
+		if emitter is Node and !(emitter as Node).tree_exiting.is_connected(unregister_emitter):
+			(emitter as Node).tree_exiting.connect(unregister_emitter.bind(emitter))
 		# connect to all signals of the emitter we want to collect
 		for signal_def in emitter.get_signal_list():
 			var signal_name :String = signal_def["name"]

--- a/addons/gdUnit4/src/core/GdUnitTestSuiteScanner.gd
+++ b/addons/gdUnit4/src/core/GdUnitTestSuiteScanner.gd
@@ -126,7 +126,7 @@ func _parse_test_suite(script: Script) -> GdUnitTestSuite:
 		return GdUnit4CSharpApiLoader.parse_test_suite(script.resource_path)
 
 	# Do pares as GDScript
-	var test_suite :GdUnitTestSuite = script.new()
+	var test_suite: GdUnitTestSuite = script.new()
 	test_suite.set_name(GdUnitTestSuiteScanner.parse_test_suite_name(script))
 	# add test cases to test suite and parse test case line nummber
 	var test_case_names := _extract_test_case_names(script as GDScript)
@@ -144,11 +144,11 @@ static func parse_test_suite_name(script :Script) -> String:
 	return script.resource_path.get_file().replace(".gd", "")
 
 
-func _handle_test_suite_arguments(test_suite :Node, script :GDScript, fd :GdFunctionDescriptor) -> void:
+func _handle_test_suite_arguments(test_suite: GdUnitTestSuite, script: GDScript, fd: GdFunctionDescriptor) -> void:
 	for arg in fd.args():
 		match arg.name():
 			_TestCase.ARGUMENT_SKIP:
-				var result :Variant = _expression_runner.execute(script, arg.plain_value())
+				var result: Variant = _expression_runner.execute(script, arg.plain_value())
 				if result is bool:
 					test_suite.__is_skipped = result
 				else:
@@ -159,13 +159,13 @@ func _handle_test_suite_arguments(test_suite :Node, script :GDScript, fd :GdFunc
 				push_error("Unsuported argument `%s` found on before() at '%s'!" % [arg.name(), script.resource_path])
 
 
-func _handle_test_case_arguments(test_suite :Node, script :GDScript, fd :GdFunctionDescriptor) -> void:
+func _handle_test_case_arguments(test_suite: GdUnitTestSuite, script: GDScript, fd: GdFunctionDescriptor) -> void:
 	var timeout := _TestCase.DEFAULT_TIMEOUT
 	var iterations := Fuzzer.ITERATION_DEFAULT_COUNT
 	var seed_value := -1
 	var is_skipped := false
 	var skip_reason := "Unknown."
-	var fuzzers :Array[GdFunctionArgument] = []
+	var fuzzers: Array[GdFunctionArgument] = []
 	var test := _TestCase.new()
 
 	for arg: GdFunctionArgument in fd.args():
@@ -198,7 +198,7 @@ func _handle_test_case_arguments(test_suite :Node, script :GDScript, fd :GdFunct
 	test_suite.add_child(test)
 
 
-func _parse_and_add_test_cases(test_suite :Node, script :GDScript, test_case_names :PackedStringArray) -> void:
+func _parse_and_add_test_cases(test_suite: GdUnitTestSuite, script: GDScript, test_case_names: PackedStringArray) -> void:
 	var test_cases_to_find := Array(test_case_names)
 	var functions_to_scan := test_case_names.duplicate()
 	@warning_ignore("return_value_discarded")

--- a/addons/gdUnit4/src/core/GdUnitTools.gd
+++ b/addons/gdUnit4/src/core/GdUnitTools.gd
@@ -56,7 +56,7 @@ static func free_instance(instance :Variant, use_call_deferred :bool = false, is
 				instance.call_deferred("free")
 			else:
 				instance.free()
-				await Engine.get_main_loop().process_frame
+				await (Engine.get_main_loop() as SceneTree).process_frame
 			return true
 
 		if instance is Node and instance.get_parent() != null:
@@ -93,12 +93,13 @@ static func _release_connections(instance :Object) -> void:
 
 static func release_timers() -> void:
 	# we go the new way to hold all gdunit timers in group 'GdUnitTimers'
-	if Engine.get_main_loop().root == null:
+	var scene_tree := Engine.get_main_loop() as SceneTree
+	if scene_tree.root == null:
 		return
-	for node :Node in Engine.get_main_loop().root.get_children():
+	for node :Node in scene_tree.root.get_children():
 		if is_instance_valid(node) and node.is_in_group("GdUnitTimers"):
 			if is_instance_valid(node):
-				Engine.get_main_loop().root.remove_child.call_deferred(node)
+				scene_tree.root.remove_child.call_deferred(node)
 				node.stop()
 				node.queue_free()
 

--- a/addons/gdUnit4/src/core/_TestCase.gd
+++ b/addons/gdUnit4/src/core/_TestCase.gd
@@ -85,7 +85,7 @@ func dispose() -> void:
 func _execute_test_case(name: String, test_parameter: Array) -> void:
 	# needs at least on await otherwise it breaks the awaiting chain
 	await get_parent().callv(name, test_parameter)
-	await Engine.get_main_loop().process_frame
+	await (Engine.get_main_loop() as SceneTree).process_frame
 	completed.emit()
 
 

--- a/addons/gdUnit4/src/core/discovery/GdUnitTestDiscoverGuard.gd
+++ b/addons/gdUnit4/src/core/discovery/GdUnitTestDiscoverGuard.gd
@@ -82,7 +82,8 @@ func extract_test_functions(test_suite :Node) -> PackedStringArray:
 func rebuild_project(script: Script) -> void:
 	var class_path := ProjectSettings.globalize_path(script.resource_path)
 	print_rich("[color=CORNFLOWER_BLUE]GdUnitTestDiscoverGuard: CSharpScript change detected on: '%s' [/color]" % class_path)
-	await Engine.get_main_loop().process_frame
+	var scene_tree := Engine.get_main_loop() as SceneTree
+	await scene_tree.process_frame
 
 	var output := []
 	var exit_code := OS.execute("dotnet", ["--version"], output)
@@ -97,4 +98,4 @@ func rebuild_project(script: Script) -> void:
 	print_rich("[color=CORNFLOWER_BLUE]GdUnitTestDiscoverGuard:[/color] [color=DEEP_SKY_BLUE]Rebuild the project ... [/color]")
 	for out:Variant in output:
 		print_rich("[color=DEEP_SKY_BLUE] 		%s" % out.strip_edges())
-	await Engine.get_main_loop().process_frame
+	await scene_tree.process_frame

--- a/addons/gdUnit4/src/core/discovery/GdUnitTestDiscoverer.gd
+++ b/addons/gdUnit4/src/core/discovery/GdUnitTestDiscoverer.gd
@@ -19,7 +19,7 @@ static func run() -> void:
 			_test_suites_to_process.append_array(scanner.scan(test_suite_dir))
 
 		# Do sync the main thread before emit the discovered test suites to the inspector
-		await Engine.get_main_loop().process_frame
+		await (Engine.get_main_loop() as SceneTree).process_frame
 		var test_case_count :int = 0
 		for test_suite in _test_suites_to_process:
 			test_case_count += test_suite.get_child_count()
@@ -33,6 +33,6 @@ static func run() -> void:
 	)
 	# wait unblocked to the tread is finished
 	while t.is_alive():
-		await Engine.get_main_loop().process_frame
+		await (Engine.get_main_loop() as SceneTree).process_frame
 	# needs finally to wait for finish
 	await t.wait_to_finish()

--- a/addons/gdUnit4/src/core/execution/GdUnitMemoryObserver.gd
+++ b/addons/gdUnit4/src/core/execution/GdUnitMemoryObserver.gd
@@ -77,7 +77,7 @@ static func unguard_instance(obj :Object, verbose := true) -> void:
 static func gc_guarded_instance(name :String, instance :Object) -> void:
 	if not _is_instance_guard_enabled():
 		return
-	await Engine.get_main_loop().process_frame
+	await (Engine.get_main_loop() as SceneTree).process_frame
 	unguard_instance(instance, false)
 	if is_instance_valid(instance) and instance is RefCounted:
 		# finally do this very hacky stuff
@@ -90,7 +90,7 @@ static func gc_guarded_instance(name :String, instance :Object) -> void:
 		#		base_script.unreference()
 		debug_observe(name, instance)
 		instance.unreference()
-		await Engine.get_main_loop().process_frame
+		await (Engine.get_main_loop() as SceneTree).process_frame
 
 
 static func gc_on_guarded_instances() -> void:
@@ -115,7 +115,7 @@ func gc() -> void:
 	if _store.is_empty():
 		return
 	# give engine time to free objects to process objects marked by queue_free()
-	await Engine.get_main_loop().process_frame
+	await (Engine.get_main_loop() as SceneTree).process_frame
 	if _is_stdout_verbose:
 		print_verbose("GdUnit4:gc():running", " freeing %d objects .." % _store.size())
 	var tagged_objects := Engine.get_meta(TAG_AUTO_FREE, []) as Array

--- a/addons/gdUnit4/src/core/execution/GdUnitTestSuiteExecutor.gd
+++ b/addons/gdUnit4/src/core/execution/GdUnitTestSuiteExecutor.gd
@@ -17,8 +17,8 @@ func execute(test_suite :GdUnitTestSuite) -> void:
 	if not orphan_detection_enabled:
 		prints("!!! Reporting orphan nodes is disabled. Please check GdUnit settings.")
 
-	Engine.get_main_loop().root.call_deferred("add_child", test_suite)
-	await Engine.get_main_loop().process_frame
+	(Engine.get_main_loop() as SceneTree).root.call_deferred("add_child", test_suite)
+	await (Engine.get_main_loop() as SceneTree).process_frame
 	await _executeStage.execute(GdUnitExecutionContext.of_test_suite(test_suite))
 
 

--- a/addons/gdUnit4/src/core/execution/stages/GdUnitTestSuiteExecutionStage.gd
+++ b/addons/gdUnit4/src/core/execution/stages/GdUnitTestSuiteExecutionStage.gd
@@ -39,14 +39,14 @@ func _execute(context :GdUnitExecutionContext) -> void:
 				context.test_suite = await clone_test_suite(context.test_suite)
 		await _stage_after.execute(context)
 		GdUnitMemoryObserver.unguard_instance(context.test_suite.__awaiter)
-	await Engine.get_main_loop().process_frame
+	await (Engine.get_main_loop() as SceneTree).process_frame
 	context.test_suite.free()
 	context.dispose()
 
 
 # clones a test suite and moves the test cases to new instance
 func clone_test_suite(test_suite :GdUnitTestSuite) -> GdUnitTestSuite:
-	await Engine.get_main_loop().process_frame
+	await (Engine.get_main_loop() as SceneTree).process_frame
 	dispose_timers(test_suite)
 	await GdUnitMemoryObserver.gc_guarded_instance("Manually free on awaiter", test_suite.__awaiter)
 	var parent := test_suite.get_parent()
@@ -61,7 +61,7 @@ func clone_test_suite(test_suite :GdUnitTestSuite) -> GdUnitTestSuite:
 	GdUnitMemoryObserver.guard_instance(_test_suite.__awaiter)
 	# finally free current test suite instance
 	test_suite.free()
-	await Engine.get_main_loop().process_frame
+	await (Engine.get_main_loop() as SceneTree).process_frame
 	return _test_suite
 
 
@@ -102,7 +102,7 @@ func fire_test_suite_skipped(context :GdUnitExecutionContext) -> void:
 	}
 	var report := GdUnitReport.new().create(GdUnitReport.SKIPPED, -1, GdAssertMessages.test_suite_skipped(test_suite.__skip_reason, skip_count))
 	fire_event(GdUnitEvent.new().suite_after(test_suite.get_script().resource_path as String, test_suite.get_name(), statistics, [report]))
-	await Engine.get_main_loop().process_frame
+	await (Engine.get_main_loop() as SceneTree).process_frame
 
 
 func set_debug_mode(debug_mode :bool = false) -> void:

--- a/addons/gdUnit4/src/monitor/GodotGdErrorMonitor.gd
+++ b/addons/gdUnit4/src/monitor/GodotGdErrorMonitor.gd
@@ -42,8 +42,8 @@ static func _to_report(errorLog: ErrorLogEntry) -> GdUnitReport:
 
 
 func scan(force_collect_reports := false) -> Array[ErrorLogEntry]:
-	await Engine.get_main_loop().process_frame
-	await Engine.get_main_loop().physics_frame
+	await (Engine.get_main_loop() as SceneTree).process_frame
+	await (Engine.get_main_loop() as SceneTree).physics_frame
 	_entries.append_array(_collect_log_entries(force_collect_reports))
 	return _entries
 

--- a/addons/gdUnit4/src/ui/GdUnitFonts.gd
+++ b/addons/gdUnit4/src/ui/GdUnitFonts.gd
@@ -33,11 +33,11 @@ static func init_fonts(item: CanvasItem) -> float:
 	return 16.0
 
 
-static func load_and_resize_font(font_resource: String, size: float) -> Font:
+static func load_and_resize_font(font_resource: String, size: float) -> FontFile:
 	var font: FontFile = ResourceLoader.load(font_resource, "FontFile")
 	if font == null:
 		push_error("Can't load font '%s'" % font_resource)
 		return null
-	var resized_font := font.duplicate()
+	var resized_font: FontFile = font.duplicate()
 	resized_font.fixed_size = int(size)
 	return resized_font

--- a/addons/gdUnit4/src/ui/menu/EditorFileSystemContextMenuHandler.gd
+++ b/addons/gdUnit4/src/ui/menu/EditorFileSystemContextMenuHandler.gd
@@ -19,7 +19,7 @@ func _init(context_menus: Array[GdUnitContextMenuItem]) -> void:
 func on_context_menu_show(context_menu: PopupMenu, file_tree: Tree) -> void:
 	context_menu.add_separator()
 	var current_index := context_menu.get_item_count()
-	var selected_test_suites := collect_testsuites(_context_menus.values()[0], file_tree)
+	var selected_test_suites := collect_testsuites(_context_menus.values()[0] as GdUnitContextMenuItem, file_tree)
 
 	for menu_id: int in _context_menus.keys():
 		var menu_item: GdUnitContextMenuItem = _context_menus[menu_id]

--- a/addons/gdUnit4/src/ui/menu/ScriptEditorContextMenuHandler.gd
+++ b/addons/gdUnit4/src/ui/menu/ScriptEditorContextMenuHandler.gd
@@ -27,13 +27,13 @@ func _input(event: InputEvent) -> void:
 
 
 func has_editor_focus() -> bool:
-	return Engine.get_main_loop().root.gui_get_focus_owner() == active_base_editor()
+	return (Engine.get_main_loop() as SceneTree).root.gui_get_focus_owner() == active_base_editor()
 
 
 func on_script_changed(script: Script) -> void:
 	if script is Script:
 		var popups: Array[Node] = GdObjects.find_nodes_by_class(active_editor(), "PopupMenu", true)
-		for popup in popups:
+		for popup: PopupMenu in popups:
 			if not popup.about_to_popup.is_connected(on_context_menu_show):
 				popup.about_to_popup.connect(on_context_menu_show.bind(script, popup))
 			if not popup.id_pressed.is_connected(on_context_menu_pressed):

--- a/addons/gdUnit4/src/ui/parts/InspectorMonitor.gd
+++ b/addons/gdUnit4/src/ui/parts/InspectorMonitor.gd
@@ -6,10 +6,10 @@ signal jump_to_orphan_nodes()
 @onready var ICON_GREEN := GdUnitUiTools.get_icon("Unlinked", Color.WEB_GREEN)
 @onready var ICON_RED := GdUnitUiTools.get_color_animated_icon("Unlinked", Color.YELLOW, Color.ORANGE_RED)
 
-@onready var _button_time := %btn_time
-@onready var _time := %time_value
-@onready var _orphans := %orphan_value
-@onready var _orphan_button := %btn_orphan
+@onready var _button_time: Button = %btn_time
+@onready var _time: Label = %time_value
+@onready var _orphans: Label = %orphan_value
+@onready var _orphan_button: Button = %btn_orphan
 
 var total_elapsed_time := 0
 var total_orphans := 0

--- a/addons/gdUnit4/src/ui/parts/InspectorProgressBar.gd
+++ b/addons/gdUnit4/src/ui/parts/InspectorProgressBar.gd
@@ -1,36 +1,35 @@
 @tool
 extends ProgressBar
 
-@onready var bar := $"."
-@onready var status := $Label
-@onready var style: StyleBoxFlat = bar.get("theme_override_styles/fill")
+@onready var status: Label = $Label
+@onready var style: StyleBoxFlat = get("theme_override_styles/fill")
 
 
 func _ready() -> void:
 	@warning_ignore("return_value_discarded")
 	GdUnitSignals.instance().gdunit_event.connect(_on_gdunit_event)
 	style.bg_color = Color.DARK_GREEN
-	bar.value = 0
-	bar.max_value = 0
+	value = 0
+	max_value = 0
 	update_text()
 
 
 func progress_init(p_max_value: int) -> void:
-	bar.value = 0
-	bar.max_value = p_max_value
+	value = 0
+	max_value = p_max_value
 	style.bg_color = Color.DARK_GREEN
 	update_text()
 
 
 func progress_update(p_value: int, is_failed: bool) -> void:
-	bar.value += p_value
+	value += p_value
 	update_text()
 	if is_failed:
 		style.bg_color = Color.DARK_RED
 
 
 func update_text() -> void:
-	status.text = "%d:%d" % [bar.value, bar.max_value]
+	status.text = "%d:%d" % [value, max_value]
 
 
 func _on_gdunit_event(event: GdUnitEvent) -> void:

--- a/addons/gdUnit4/src/ui/parts/InspectorStatusBar.gd
+++ b/addons/gdUnit4/src/ui/parts/InspectorStatusBar.gd
@@ -12,18 +12,18 @@ signal request_discover_tests()
 @warning_ignore("unused_signal")
 signal tree_view_mode_changed(flat :bool)
 
-@onready var _errors := %error_value
-@onready var _failures := %failure_value
-@onready var _flaky_value := %flaky_value
-@onready var _button_failure_up := %btn_failure_up
-@onready var _button_failure_down := %btn_failure_down
-@onready var _button_sync := %btn_tree_sync
-@onready var _button_view_mode := %btn_tree_mode
-@onready var _button_sort_mode := %btn_tree_sort
+@onready var _errors: Label = %error_value
+@onready var _failures: Label = %failure_value
+@onready var _flaky_value: Label = %flaky_value
+@onready var _button_failure_up: Button = %btn_failure_up
+@onready var _button_failure_down: Button = %btn_failure_down
+@onready var _button_sync: Button = %btn_tree_sync
+@onready var _button_view_mode: Button = %btn_tree_mode
+@onready var _button_sort_mode: Button = %btn_tree_sort
 
-@onready var _icon_errors := %icon_errors
-@onready var _icon_failures := %icon_failures
-@onready var _icon_flaky := %icon_flaky
+@onready var _icon_errors: TextureRect = %icon_errors
+@onready var _icon_failures: TextureRect = %icon_failures
+@onready var _icon_flaky: TextureRect = %icon_flaky
 
 var total_failed := 0
 var total_errors := 0

--- a/addons/gdUnit4/src/ui/parts/InspectorToolBar.gd
+++ b/addons/gdUnit4/src/ui/parts/InspectorToolBar.gd
@@ -5,13 +5,13 @@ signal run_overall_pressed(debug: bool)
 signal run_pressed(debug: bool)
 signal stop_pressed()
 
-@onready var _version_label := %version
-@onready var _button_wiki := %help
-@onready var _tool_button := %tool
-@onready var _button_run_overall := %run_overall
-@onready var _button_run := %run
-@onready var _button_run_debug := %debug
-@onready var _button_stop := %stop
+@onready var _version_label: Control = %version
+@onready var _button_wiki: Button = %help
+@onready var _tool_button: Button = %tool
+@onready var _button_run_overall: Button = %run_overall
+@onready var _button_run: Button = %run
+@onready var _button_run_debug: Button = %debug
+@onready var _button_stop: Button = %stop
 @onready var settings_dlg := preload("res://addons/gdUnit4/src/ui/settings/GdUnitSettingsDialog.tscn").instantiate()
 
 

--- a/addons/gdUnit4/src/ui/parts/InspectorTreeMainPanel.gd
+++ b/addons/gdUnit4/src/ui/parts/InspectorTreeMainPanel.gd
@@ -14,8 +14,8 @@ const CONTEXT_MENU_EXPAND_ALL = 4
 @onready var _report_list: Node = $report/ScrollContainer/list
 @onready var _report_template: RichTextLabel = $report/report_template
 @onready var _context_menu: PopupMenu = $contextMenu
-@onready var _discover_hint := %discover_hint
-@onready var _spinner := %spinner
+@onready var _discover_hint: Control = %discover_hint
+@onready var _spinner: Button = %spinner
 
 # loading tree icons
 @onready var ICON_SPINNER := GdUnitUiTools.get_spinner()

--- a/addons/gdUnit4/src/ui/settings/GdUnitInputCapture.gd
+++ b/addons/gdUnit4/src/ui/settings/GdUnitInputCapture.gd
@@ -27,7 +27,8 @@ func _input(event: InputEvent) -> void:
 	if not is_visible_in_tree():
 		return
 	if event is InputEventKey and event.is_pressed() and not event.is_echo():
-		match event.keycode:
+		var _event := event as InputEventKey
+		match _event.keycode:
 			KEY_CTRL:
 				_input_event.ctrl_pressed = true
 			KEY_SHIFT:
@@ -37,8 +38,8 @@ func _input(event: InputEvent) -> void:
 			KEY_META:
 				_input_event.meta_pressed = true
 			_:
-				_input_event.keycode = event.keycode
-		_apply_input_modifiers(event)
+				_input_event.keycode = _event.keycode
+		_apply_input_modifiers(_event)
 		accept_event()
 
 	if event is InputEventKey and not event.is_pressed():
@@ -48,7 +49,8 @@ func _input(event: InputEvent) -> void:
 
 func _apply_input_modifiers(event: InputEvent) -> void:
 	if event is InputEventWithModifiers:
-		_input_event.meta_pressed = event.meta_pressed or _input_event.meta_pressed
-		_input_event.alt_pressed = event.alt_pressed or _input_event.alt_pressed
-		_input_event.shift_pressed = event.shift_pressed or _input_event.shift_pressed
-		_input_event.ctrl_pressed = event.ctrl_pressed or _input_event.ctrl_pressed
+		var _event := event as InputEventWithModifiers
+		_input_event.meta_pressed = _event.meta_pressed or _input_event.meta_pressed
+		_input_event.alt_pressed = _event.alt_pressed or _input_event.alt_pressed
+		_input_event.shift_pressed = _event.shift_pressed or _input_event.shift_pressed
+		_input_event.ctrl_pressed = _event.ctrl_pressed or _input_event.ctrl_pressed

--- a/addons/gdUnit4/src/update/GdUnitUpdateNotify.gd
+++ b/addons/gdUnit4/src/update/GdUnitUpdateNotify.gd
@@ -92,7 +92,7 @@ func show_update() -> void:
 
 func extract_latest_version(response :GdUnitUpdateClient.HttpResponse) -> GdUnit4Version:
 	var body :Array = response.response()
-	return GdUnit4Version.parse(body[0]["name"])
+	return GdUnit4Version.parse(body[0]["name"] as String)
 
 
 func extract_zip_url(response :GdUnitUpdateClient.HttpResponse) -> String:
@@ -104,7 +104,7 @@ func extract_releases(response :GdUnitUpdateClient.HttpResponse, current_version
 	await get_tree().process_frame
 	var result := ""
 	for release :Dictionary in response.response():
-		if GdUnit4Version.parse(release["tag_name"]).equals(current_version):
+		if GdUnit4Version.parse(release["tag_name"] as String).equals(current_version):
 			break
 		var release_description :String = release["body"]
 		result += await _md_reader.to_bbcode(release_description)
@@ -120,8 +120,8 @@ func rescan() -> void:
 		while fs.is_scanning():
 			if OS.is_stdout_verbose():
 				progressBar(fs.get_scanning_progress() * 100 as int)
-			await Engine.get_main_loop().process_frame
-		await Engine.get_main_loop().process_frame
+			await get_tree().process_frame
+		await get_tree().process_frame
 	await get_tree().create_timer(1).timeout
 
 
@@ -148,9 +148,9 @@ func _on_update_pressed() -> void:
 	var dest := FileAccess.open("res://addons/.gdunit_update/GdUnitUpdate.tscn", FileAccess.WRITE)
 	dest.store_string(content)
 	hide()
-	var update :Variant = load("res://addons/.gdunit_update/GdUnitUpdate.tscn").instantiate()
+	var update: Node = load("res://addons/.gdunit_update/GdUnitUpdate.tscn").instantiate()
 	update.setup(_update_client, _download_zip_url)
-	Engine.get_main_loop().root.add_child(update)
+	(Engine.get_main_loop() as SceneTree).root.add_child(update)
 	update.popup_centered()
 
 
@@ -166,13 +166,13 @@ func _on_content_meta_clicked(meta :String) -> void:
 	var properties :Variant = str_to_var(meta)
 	if properties.has("url"):
 		@warning_ignore("return_value_discarded")
-		OS.shell_open(properties.get("url"))
+		OS.shell_open(properties.get("url") as String)
 
 
 func _on_content_meta_hover_started(meta :String) -> void:
 	var properties :Variant = str_to_var(meta)
 	if properties.has("tool_tip"):
-		_content.set_tooltip_text(properties.get("tool_tip"))
+		_content.set_tooltip_text(properties.get("tool_tip") as String)
 
 
 @warning_ignore("unused_parameter")

--- a/addons/gdUnit4/test/asserts/GdUnitFuncAssertImplTest.gd
+++ b/addons/gdUnit4/test/asserts/GdUnitFuncAssertImplTest.gd
@@ -96,14 +96,14 @@ class TestIterativeValueProvider:
 
 	func has_type(type :int, _recursive :bool = true) -> int:
 		_current_itteration += 1
-		#await Engine.get_main_loop().idle_frame
+		#await (Engine.get_main_loop() as SceneTree).idle_frame
 		if type == _current_itteration:
 			return _final_value
 		return _inital_value
 
 	func await_value() -> int:
 		_current_itteration += 1
-		await Engine.get_main_loop().process_frame
+		await (Engine.get_main_loop() as SceneTree).process_frame
 		prints("yielded_value", _current_itteration)
 		if _current_itteration >= _max_iterations:
 			return _final_value

--- a/addons/gdUnit4/test/asserts/GdUnitGodotErrorAssertImplTest.gd
+++ b/addons/gdUnit4/test/asserts/GdUnitGodotErrorAssertImplTest.gd
@@ -16,7 +16,7 @@ class GodotErrorTestClass:
 				@warning_ignore("assert_always_true")
 				assert(true, "no error" )
 			1: # failing assert
-				await Engine.get_main_loop().process_frame
+				await (Engine.get_main_loop() as SceneTree).process_frame
 				if OS.is_debug_build():
 					# do not break the debug session we simmulate a assert by writing the error manually
 					if Engine.get_version_info().hex >= 0x40400:

--- a/addons/gdUnit4/test/core/GdUnitSceneRunnerInputEventTest.gd
+++ b/addons/gdUnit4/test/core/GdUnitSceneRunnerInputEventTest.gd
@@ -191,6 +191,7 @@ func test_simulate_many_keys_press() -> void:
 	assert_that(Input.is_physical_key_pressed(KEY_Z)).is_true()
 
 
+@warning_ignore("unsafe_property_access")
 func test_simulate_keypressed_as_action() -> void:
 	# add custom action `player_jump` for key 'Space' is pressed
 	var event := InputEventKey.new()

--- a/addons/gdUnit4/test/core/GdUnitSceneRunnerTest.gd
+++ b/addons/gdUnit4/test/core/GdUnitSceneRunnerTest.gd
@@ -257,19 +257,22 @@ func test_simulate_until_object_signal(timeout := 2000) -> void:
 
 
 func test_runner_by_null_instance() -> void:
-	var runner := scene_runner(null)
+	var runner :GdUnitSceneRunnerImpl = scene_runner(null)
 	assert_object(runner._current_scene).is_null()
 
 
 func test_runner_by_invalid_resource_path() -> void:
 	# not existing scene
+	@warning_ignore("unsafe_property_access")
 	assert_object(scene_runner("res://test_scene.tscn")._current_scene).is_null()
 	# not a path to a scene
+	@warning_ignore("unsafe_property_access")
 	assert_object(scene_runner("res://addons/gdUnit4/test/core/resources/scenes/simple_scene.gd")._current_scene).is_null()
 
 
 func test_runner_by_invalid_uid_path() -> void:
 	# not existing scene
+	@warning_ignore("unsafe_property_access")
 	assert_object(scene_runner("uid://invalid_uid")._current_scene).is_null()
 
 
@@ -318,7 +321,7 @@ func test_runner_by_resource_path() -> void:
 
 func test_runner_by_invalid_scene_instance() -> void:
 	var scene := RefCounted.new()
-	var runner := scene_runner(scene)
+	var runner: GdUnitSceneRunnerImpl = scene_runner(scene)
 	assert_object(runner._current_scene).is_null()
 
 

--- a/addons/gdUnit4/test/core/GdUnitTestSuiteScannerTest.gd
+++ b/addons/gdUnit4/test/core/GdUnitTestSuiteScannerTest.gd
@@ -244,7 +244,11 @@ func test_parse_and_add_test_cases() -> void:
 	var scanner :GdUnitTestSuiteScanner = GdUnitTestSuiteScanner.new()
 	# fake a test suite
 	var test_suite :GdUnitTestSuite = auto_free(GdUnitTestSuite.new())
-	test_suite.set_script( load("res://addons/gdUnit4/test/core/resources/test_script_with_arguments.gd"))
+	var source_code := FileAccess.get_file_as_string("res://addons/gdUnit4/test/core/resources/test_script_with_arguments.gd")
+	var script := GDScript.new()
+	script.source_code = source_code.replace("extends Node", "extends GdUnitTestSuite")
+	script.reload()
+	test_suite.set_script(script)
 
 	var test_case_names := PackedStringArray([
 		"test_no_args",
@@ -255,7 +259,7 @@ func test_parse_and_add_test_cases() -> void:
 		"test_multiline_arguments_a",
 		"test_multiline_arguments_b",
 		"test_multiline_arguments_c"])
-	scanner._parse_and_add_test_cases(test_suite, test_suite.get_script() as GDScript, test_case_names)
+	scanner._parse_and_add_test_cases(test_suite, script, test_case_names)
 	assert_array(test_suite.get_children())\
 		.extractv(extr("get_name"), extr("timeout"), extr("fuzzer_arguments"), extr("iterations"))\
 		.contains_exactly([
@@ -315,7 +319,7 @@ func test_scan_by_inheritance_class_path() -> void:
 
 
 func test_get_test_case_line_number() -> void:
-	assert_int(GdUnitTestSuiteScanner.get_test_case_line_number("res://addons/gdUnit4/test/core/GdUnitTestSuiteScannerTest.gd", "get_test_case_line_number")).is_equal(317)
+	assert_int(GdUnitTestSuiteScanner.get_test_case_line_number("res://addons/gdUnit4/test/core/GdUnitTestSuiteScannerTest.gd", "get_test_case_line_number")).is_equal(321)
 	assert_int(GdUnitTestSuiteScanner.get_test_case_line_number("res://addons/gdUnit4/test/core/GdUnitTestSuiteScannerTest.gd", "unknown")).is_equal(-1)
 
 

--- a/addons/gdUnit4/test/core/execution/GdUnitTestSuiteExecutorTest.gd
+++ b/addons/gdUnit4/test/core/execution/GdUnitTestSuiteExecutorTest.gd
@@ -776,6 +776,7 @@ func test_execute_test_case_is_skipped() -> void:
 
 func test_execute_test_case_is_flaky_and_failed() -> void:
 	var test_suite := _load("res://addons/gdUnit4/test/core/resources/testsuites/TestCaseFlaky.resource")
+	@warning_ignore("unsafe_property_access")
 	test_suite._run_with_reries = 5
 	# simulate flaky test suite execution
 	var events := await execute(test_suite)
@@ -897,6 +898,7 @@ func test_execute_test_case_is_flaky_and_failed() -> void:
 
 func test_execute_test_case_is_flaky_and_success() -> void:
 	var test_suite := _load("res://addons/gdUnit4/test/core/resources/testsuites/TestCaseFlaky.resource")
+	@warning_ignore("unsafe_property_access")
 	test_suite._run_with_reries = 6
 	# simulate flaky test suite execution
 	var events := await execute(test_suite)

--- a/addons/gdUnit4/test/core/resources/scenes/drag_and_drop/DragAndDropControl.gd
+++ b/addons/gdUnit4/test/core/resources/scenes/drag_and_drop/DragAndDropControl.gd
@@ -8,7 +8,7 @@ extends PanelContainer
 func _get_drag_data(_position: Vector2) -> Variant:
 	var x :TextureRect = $TextureRect
 	var data: = {texture = x.texture}
-	var drag_texture := x.duplicate()
+	var drag_texture :TextureRect = x.duplicate()
 	drag_texture.size = x.size
 	drag_texture.position = x.global_position * -0.2
 
@@ -30,7 +30,7 @@ func _can_drop_data(_position: Vector2, data :Variant) -> bool:
 func _drop_data(_position: Vector2, data :Variant) -> void:
 	var drag_texture :Texture = data["texture"]
 	if drag_texture != null:
-		$TextureRect.texture = drag_texture
+		($TextureRect as TextureRect).texture = drag_texture
 
 
 # Virtual method to be implemented by the user. Use this method to process and accept inputs on UI elements. See accept_event().

--- a/addons/gdUnit4/test/core/resources/scenes/drag_and_drop/DragAndDropTestScene.gd
+++ b/addons/gdUnit4/test/core/resources/scenes/drag_and_drop/DragAndDropTestScene.gd
@@ -4,7 +4,7 @@ extends Control
 
 func _ready() -> void:
 	# set initial drag texture
-	$left/TextureRect.texture = texture
+	($left/TextureRect as TextureRect).texture = texture
 
 
 # Virtual method to be implemented by the user. Use this method to process and accept inputs on UI elements. See accept_event().

--- a/addons/gdUnit4/test/spy/GdUnitSpyTest.gd
+++ b/addons/gdUnit4/test/spy/GdUnitSpyTest.gd
@@ -219,7 +219,7 @@ func test_verify_fail() -> void:
 			.dedent().trim_prefix("\n")
 	assert_failure(func() -> void: verify(spy_node, 1).set_process(true)) \
 		.is_failed() \
-		.has_line(219) \
+		.has_line(220) \
 		.has_message(expected_error)
 
 
@@ -246,7 +246,7 @@ func test_verify_func_interaction_wiht_PackedStringArray_fail() -> void:
 			.dedent().trim_prefix("\n")
 	assert_failure(func() -> void: verify(spy_instance, 1).set_values([])) \
 		.is_failed() \
-		.has_line(246) \
+		.has_line(247) \
 		.has_message(expected_error)
 
 	reset(spy_instance)
@@ -264,7 +264,7 @@ func test_verify_func_interaction_wiht_PackedStringArray_fail() -> void:
 			.dedent().trim_prefix("\n")
 	assert_failure(func() -> void: verify(spy_instance, 1).set_values([])) \
 		.is_failed() \
-		.has_line(264) \
+		.has_line(265) \
 		.has_message(expected_error)
 
 
@@ -312,7 +312,7 @@ func test_verify_no_interactions_fails() -> void:
 	# it should fail because we have interactions
 	assert_failure(func() -> void: verify_no_interactions(spy_node)) \
 		.is_failed() \
-		.has_line(312) \
+		.has_line(313) \
 		.has_message(expected_error)
 
 
@@ -367,7 +367,7 @@ func test_verify_no_more_interactions_but_has() -> void:
 			.dedent().trim_prefix("\n")
 	assert_failure(func() -> void: verify_no_more_interactions(spy_node)) \
 		.is_failed() \
-		.has_line(367) \
+		.has_line(368) \
 		.has_message(expected_error)
 
 

--- a/addons/gdUnit4/test/spy/GdUnitSpyTest.gd
+++ b/addons/gdUnit4/test/spy/GdUnitSpyTest.gd
@@ -119,6 +119,7 @@ func test_spy_class_with_custom_formattings() -> void:
 		.has_line(117)
 
 
+@warning_ignore("unsafe_property_access")
 func test_spy_copied_class_members() -> void:
 	var instance :Object = auto_free(load("res://addons/gdUnit4/test/mocker/resources/TestPersion.gd").new("user-x", "street", 56616))
 	assert_that(instance._name).is_equal("user-x")

--- a/addons/gdUnit4/test/ui/parts/InspectorProgressBarTest.gd
+++ b/addons/gdUnit4/test/ui/parts/InspectorProgressBarTest.gd
@@ -15,7 +15,7 @@ var _style :StyleBoxFlat
 
 func before_test() -> void:
 	_runner = scene_runner('res://addons/gdUnit4/src/ui/parts/InspectorProgressBar.tscn')
-	_progress = _runner.get_property("bar")
+	_progress = _runner.scene()
 	_status = _runner.get_property("status")
 	_style = _runner.get_property("style")
 	# inital state

--- a/project.godot
+++ b/project.godot
@@ -24,6 +24,7 @@ default_bus_layout=""
 file_logging/enable_file_logging=true
 gdscript/warnings/exclude_addons=false
 gdscript/warnings/untyped_declaration=2
+gdscript/warnings/unsafe_property_access=1
 gdscript/warnings/unsafe_call_argument=1
 
 [dotnet]


### PR DESCRIPTION
# Why
If the default settings for warnings are changed to a more detailed level, many warnings are displayed.

# What
- fix `debug/gdscript/warnings/unsafe_property_access` warnings

