### PR TITLE
GD-579: `Part4:` Minimize `unsafe_method_access` warnings

### DIFF
--- a/addons/gdUnit4/bin/GdUnitBuildTool.gd
+++ b/addons/gdUnit4/bin/GdUnitBuildTool.gd
@@ -68,7 +68,7 @@ func _idle(_delta :float) -> void:
 			exit(RETURN_ERROR, result.error_message())
 			return
 		_console.prints_color("Added testcase: %s" % result.value(), Color.CORNFLOWER_BLUE)
-		print_json_result(result.value())
+		print_json_result(result.value() as Dictionary)
 		exit(RETURN_SUCCESS)
 
 
@@ -85,7 +85,7 @@ func exit(code :int, message :String = "") -> void:
 
 func print_json_result(result :Dictionary) -> void:
 	# convert back to system path
-	var path := ProjectSettings.globalize_path(result["path"]);
+	var path := ProjectSettings.globalize_path(result["path"] as String)
 	var json := 'JSON_RESULT:{"TestCases" : [{"line":%d, "path": "%s"}]}' % [result["line"], path]
 	prints(json)
 

--- a/addons/gdUnit4/bin/GdUnitCmdTool.gd
+++ b/addons/gdUnit4/bin/GdUnitCmdTool.gd
@@ -124,6 +124,7 @@ class CLIRunner:
 			prints("Finallize .. done")
 
 
+	@warning_ignore("unsafe_method_access")
 	func _process(_delta :float) -> void:
 		match _state:
 			INIT:
@@ -137,13 +138,11 @@ class CLIRunner:
 					set_process(false)
 					# process next test suite
 					var test_suite := _test_suites_to_process.pop_front() as Node
-					@warning_ignore("unsafe_method_access")
+
 					if _cs_executor != null and _cs_executor.IsExecutable(test_suite):
-						@warning_ignore("unsafe_method_access")
 						_cs_executor.Execute(test_suite)
 						await _cs_executor.ExecutionCompleted
 					else:
-						@warning_ignore("unsafe_method_access")
 						await _executor.execute(test_suite)
 					set_process(true)
 			STOP:
@@ -204,13 +203,13 @@ class CLIRunner:
 
 	func show_version() -> void:
 		_console.prints_color(
-			"Godot %s" % Engine.get_version_info().get("string"),
+			"Godot %s" % Engine.get_version_info().get("string") as String,
 			Color.DARK_SALMON
 		)
 		var config := ConfigFile.new()
 		config.load("addons/gdUnit4/plugin.cfg")
 		_console.prints_color(
-			"GdUnit4 %s" % config.get_value("plugin", "version"),
+			"GdUnit4 %s" % config.get_value("plugin", "version") as String,
 			Color.DARK_SALMON
 		)
 		quit(RETURN_SUCCESS)

--- a/addons/gdUnit4/bin/GdUnitCmdTool.gd
+++ b/addons/gdUnit4/bin/GdUnitCmdTool.gd
@@ -106,9 +106,9 @@ class CLIRunner:
 	func _ready() -> void:
 		_state = INIT
 		_report_dir = GdUnitFileAccess.current_dir() + "reports"
-		_executor = load("res://addons/gdUnit4/src/core/execution/GdUnitTestSuiteExecutor.gd").new()
+		_executor = GdUnitTestSuiteExecutor.new()
 		# stop checked first test failure to fail fast
-		_executor.fail_fast(true)
+		(_executor as GdUnitTestSuiteExecutor).fail_fast(true)
 		if GdUnit4CSharpApiLoader.is_mono_supported():
 			prints("GdUnit4Net version '%s' loaded." % GdUnit4CSharpApiLoader.version())
 			_cs_executor = GdUnit4CSharpApiLoader.create_executor(self)
@@ -137,10 +137,13 @@ class CLIRunner:
 					set_process(false)
 					# process next test suite
 					var test_suite := _test_suites_to_process.pop_front() as Node
+					@warning_ignore("unsafe_method_access")
 					if _cs_executor != null and _cs_executor.IsExecutable(test_suite):
+						@warning_ignore("unsafe_method_access")
 						_cs_executor.Execute(test_suite)
 						await _cs_executor.ExecutionCompleted
 					else:
+						@warning_ignore("unsafe_method_access")
 						await _executor.execute(test_suite)
 					set_process(true)
 			STOP:
@@ -186,6 +189,7 @@ class CLIRunner:
 			"Disabled fail fast!",
 			Color.DEEP_SKY_BLUE
 		)
+		@warning_ignore("unsafe_method_access")
 		_executor.fail_fast(false)
 
 
@@ -419,7 +423,9 @@ class CLIRunner:
 				# if no tests skipped test the complete suite is skipped
 				if skipped_tests.is_empty():
 					_console.prints_warning("Mark test suite '%s' as skipped!" % suite_to_skip)
+					@warning_ignore("unsafe_property_access")
 					test_suite.__is_skipped = true
+					@warning_ignore("unsafe_property_access")
 					test_suite.__skip_reason = skip_reason
 				else:
 					# skip tests

--- a/addons/gdUnit4/src/GdUnitAwaiter.gd
+++ b/addons/gdUnit4/src/GdUnitAwaiter.gd
@@ -1,8 +1,6 @@
 class_name GdUnitAwaiter
 extends RefCounted
 
-const GdUnitAssertImpl = preload("res://addons/gdUnit4/src/asserts/GdUnitAssertImpl.gd")
-
 
 # Waits for a specified signal in an interval of 50ms sent from the <source>, and terminates with an error after the specified timeout has elapsed.
 # source: the object from which the signal is emitted

--- a/addons/gdUnit4/src/GdUnitTestSuite.gd
+++ b/addons/gdUnit4/src/GdUnitTestSuite.gd
@@ -99,12 +99,9 @@ func error_as_string(error_number :int) -> String:
 ## A litle helper to auto freeing your created objects after test execution
 func auto_free(obj :Variant) -> Variant:
 	var execution_context := GdUnitThreadManager.get_current_context().get_execution_context()
-	if execution_context != null:
-		return execution_context.register_auto_free(obj)
-	else:
-		if is_instance_valid(obj):
-			obj.queue_free()
-		return obj
+
+	assert(execution_context != null, "INTERNAL ERROR: The current execution_context is null! Please report this as bug.")
+	return execution_context.register_auto_free(obj)
 
 
 @warning_ignore("native_method_override")
@@ -119,6 +116,7 @@ func add_child(node :Node, force_readable_name := false, internal := Node.INTERN
 ## By default, an interrupted test is reported as an error.[br]
 ## This function allows you to change the message to Success when an interrupted error is reported.
 func discard_error_interupted_by_timeout() -> void:
+	@warning_ignore("unsafe_method_access")
 	__gdunit_tools().register_expect_interupted_by_timeout(self, __active_test_case)
 
 
@@ -126,12 +124,14 @@ func discard_error_interupted_by_timeout() -> void:
 ## Useful for storing data during test execution. [br]
 ## The directory is automatically deleted after test suite execution
 func create_temp_dir(relative_path :String) -> String:
+	@warning_ignore("unsafe_method_access")
 	return __gdunit_file_access().create_temp_dir(relative_path)
 
 
 ## Deletes the temporary base directory[br]
 ## Is called automatically after each execution of the test suite
 func clean_temp_dir() -> void:
+	@warning_ignore("unsafe_method_access")
 	__gdunit_file_access().clear_tmp()
 
 
@@ -139,28 +139,26 @@ func clean_temp_dir() -> void:
 ## with given name <file_name> and given file <mode> (default = File.WRITE)[br]
 ## If success the returned File is automatically closed after the execution of the test suite
 func create_temp_file(relative_path :String, file_name :String, mode := FileAccess.WRITE) -> FileAccess:
+	@warning_ignore("unsafe_method_access")
 	return __gdunit_file_access().create_temp_file(relative_path, file_name, mode)
 
 
 ## Reads a resource by given path <resource_path> into a PackedStringArray.
 func resource_as_array(resource_path :String) -> PackedStringArray:
+	@warning_ignore("unsafe_method_access")
 	return __gdunit_file_access().resource_as_array(resource_path)
 
 
 ## Reads a resource by given path <resource_path> and returned the content as String.
 func resource_as_string(resource_path :String) -> String:
+	@warning_ignore("unsafe_method_access")
 	return __gdunit_file_access().resource_as_string(resource_path)
 
 
 ## Reads a resource by given path <resource_path> and return Variand translated by str_to_var
 func resource_as_var(resource_path :String) -> Variant:
+	@warning_ignore("unsafe_method_access")
 	return str_to_var(__gdunit_file_access().resource_as_string(resource_path) as String)
-
-
-## clears the debuger error list[br]
-## PROTOTYPE!!!! Don't use it for now
-func clear_push_errors() -> void:
-	__gdunit_tools().clear_push_errors()
 
 
 ## Waits for given signal is emited by the <source> until a specified timeout to fail[br]
@@ -169,11 +167,13 @@ func clear_push_errors() -> void:
 ## args: the expected signal arguments as an array[br]
 ## timeout: the timeout in ms, default is set to 2000ms
 func await_signal_on(source :Object, signal_name :String, args :Array = [], timeout :int = 2000) -> Variant:
+	@warning_ignore("unsafe_method_access")
 	return await __awaiter.await_signal_on(source, signal_name, args, timeout)
 
 
 ## Waits until the next idle frame
 func await_idle_frame() -> void:
+	@warning_ignore("unsafe_method_access")
 	await __awaiter.await_idle_frame()
 
 
@@ -185,6 +185,7 @@ func await_idle_frame() -> void:
 ## [/codeblock][br]
 ## use this waiter and not `await get_tree().create_timer().timeout to prevent errors when a test case is timed out
 func await_millis(timeout :int) -> void:
+	@warning_ignore("unsafe_method_access")
 	await __awaiter.await_millis(timeout)
 
 
@@ -216,11 +217,13 @@ const RETURN_DEEP_STUB = GdUnitMock.RETURN_DEEP_STUB
 
 ## Creates a mock for given class name
 func mock(clazz :Variant, mock_mode := RETURN_DEFAULTS) -> Variant:
+	@warning_ignore("unsafe_method_access")
 	return __lazy_load("res://addons/gdUnit4/src/mocking/GdUnitMockBuilder.gd").build(clazz, mock_mode)
 
 
 ## Creates a spy checked given object instance
 func spy(instance :Variant) -> Variant:
+	@warning_ignore("unsafe_method_access")
 	return __lazy_load("res://addons/gdUnit4/src/spy/GdUnitSpyBuilder.gd").build(instance)
 
 
@@ -236,21 +239,25 @@ func do_return(value :Variant) -> GdUnitMock:
 
 ## Verifies certain behavior happened at least once or exact number of times
 func verify(obj :Variant, times := 1) -> Variant:
+	@warning_ignore("unsafe_method_access")
 	return __gdunit_object_interactions().verify(obj, times)
 
 
 ## Verifies no interactions is happen checked this mock or spy
 func verify_no_interactions(obj :Variant) -> GdUnitAssert:
+	@warning_ignore("unsafe_method_access")
 	return __gdunit_object_interactions().verify_no_interactions(obj)
 
 
 ## Verifies the given mock or spy has any unverified interaction.
 func verify_no_more_interactions(obj :Variant) -> GdUnitAssert:
+	@warning_ignore("unsafe_method_access")
 	return __gdunit_object_interactions().verify_no_more_interactions(obj)
 
 
 ## Resets the saved function call counters checked a mock or spy
 func reset(obj :Variant) -> void:
+	@warning_ignore("unsafe_method_access")
 	__gdunit_object_interactions().reset(obj)
 
 
@@ -267,6 +274,7 @@ func reset(obj :Variant) -> void:
 ##		await assert_signal(emitter).is_emitted('my_signal')
 ##	[/codeblock]
 func monitor_signals(source :Object, _auto_free := true) -> Object:
+	@warning_ignore("unsafe_method_access")
 	__lazy_load("res://addons/gdUnit4/src/core/thread/GdUnitThreadManager.gd")\
 		.get_current_context()\
 		.get_signal_collector()\
@@ -277,36 +285,43 @@ func monitor_signals(source :Object, _auto_free := true) -> Object:
 # === Argument matchers ========================================================
 ## Argument matcher to match any argument
 func any() -> GdUnitArgumentMatcher:
+	@warning_ignore("unsafe_method_access")
 	return __gdunit_argument_matchers().any()
 
 
 ## Argument matcher to match any boolean value
 func any_bool() -> GdUnitArgumentMatcher:
+	@warning_ignore("unsafe_method_access")
 	return __gdunit_argument_matchers().by_type(TYPE_BOOL)
 
 
 ## Argument matcher to match any integer value
 func any_int() -> GdUnitArgumentMatcher:
+	@warning_ignore("unsafe_method_access")
 	return __gdunit_argument_matchers().by_type(TYPE_INT)
 
 
 ## Argument matcher to match any float value
 func any_float() -> GdUnitArgumentMatcher:
+	@warning_ignore("unsafe_method_access")
 	return __gdunit_argument_matchers().by_type(TYPE_FLOAT)
 
 
 ## Argument matcher to match any string value
 func any_string() -> GdUnitArgumentMatcher:
+	@warning_ignore("unsafe_method_access")
 	return __gdunit_argument_matchers().by_type(TYPE_STRING)
 
 
 ## Argument matcher to match any Color value
 func any_color() -> GdUnitArgumentMatcher:
+	@warning_ignore("unsafe_method_access")
 	return __gdunit_argument_matchers().by_type(TYPE_COLOR)
 
 
 ## Argument matcher to match any Vector typed value
 func any_vector() -> GdUnitArgumentMatcher:
+	@warning_ignore("unsafe_method_access")
 	return __gdunit_argument_matchers().by_types([
 		TYPE_VECTOR2,
 		TYPE_VECTOR2I,
@@ -319,141 +334,169 @@ func any_vector() -> GdUnitArgumentMatcher:
 
 ## Argument matcher to match any Vector2 value
 func any_vector2() -> GdUnitArgumentMatcher:
+	@warning_ignore("unsafe_method_access")
 	return __gdunit_argument_matchers().by_type(TYPE_VECTOR2)
 
 
 ## Argument matcher to match any Vector2i value
 func any_vector2i() -> GdUnitArgumentMatcher:
+	@warning_ignore("unsafe_method_access")
 	return __gdunit_argument_matchers().by_type(TYPE_VECTOR2I)
 
 
 ## Argument matcher to match any Vector3 value
 func any_vector3() -> GdUnitArgumentMatcher:
+	@warning_ignore("unsafe_method_access")
 	return __gdunit_argument_matchers().by_type(TYPE_VECTOR3)
 
 
 ## Argument matcher to match any Vector3i value
 func any_vector3i() -> GdUnitArgumentMatcher:
+	@warning_ignore("unsafe_method_access")
 	return __gdunit_argument_matchers().by_type(TYPE_VECTOR3I)
 
 
 ## Argument matcher to match any Vector4 value
 func any_vector4() -> GdUnitArgumentMatcher:
+	@warning_ignore("unsafe_method_access")
 	return __gdunit_argument_matchers().by_type(TYPE_VECTOR4)
 
 
 ## Argument matcher to match any Vector3i value
 func any_vector4i() -> GdUnitArgumentMatcher:
+	@warning_ignore("unsafe_method_access")
 	return __gdunit_argument_matchers().by_type(TYPE_VECTOR4I)
 
 
 ## Argument matcher to match any Rect2 value
 func any_rect2() -> GdUnitArgumentMatcher:
+	@warning_ignore("unsafe_method_access")
 	return __gdunit_argument_matchers().by_type(TYPE_RECT2)
 
 
 ## Argument matcher to match any Plane value
 func any_plane() -> GdUnitArgumentMatcher:
+	@warning_ignore("unsafe_method_access")
 	return __gdunit_argument_matchers().by_type(TYPE_PLANE)
 
 
 ## Argument matcher to match any Quaternion value
 func any_quat() -> GdUnitArgumentMatcher:
+	@warning_ignore("unsafe_method_access")
 	return __gdunit_argument_matchers().by_type(TYPE_QUATERNION)
 
 
 ## Argument matcher to match any AABB value
 func any_aabb() -> GdUnitArgumentMatcher:
+	@warning_ignore("unsafe_method_access")
 	return __gdunit_argument_matchers().by_type(TYPE_AABB)
 
 
 ## Argument matcher to match any Basis value
 func any_basis() -> GdUnitArgumentMatcher:
+	@warning_ignore("unsafe_method_access")
 	return __gdunit_argument_matchers().by_type(TYPE_BASIS)
 
 
 ## Argument matcher to match any Transform2D value
 func any_transform_2d() -> GdUnitArgumentMatcher:
+	@warning_ignore("unsafe_method_access")
 	return __gdunit_argument_matchers().by_type(TYPE_TRANSFORM2D)
 
 
 ## Argument matcher to match any Transform3D value
 func any_transform_3d() -> GdUnitArgumentMatcher:
+	@warning_ignore("unsafe_method_access")
 	return __gdunit_argument_matchers().by_type(TYPE_TRANSFORM3D)
 
 
 ## Argument matcher to match any NodePath value
 func any_node_path() -> GdUnitArgumentMatcher:
+	@warning_ignore("unsafe_method_access")
 	return __gdunit_argument_matchers().by_type(TYPE_NODE_PATH)
 
 
 ## Argument matcher to match any RID value
 func any_rid() -> GdUnitArgumentMatcher:
+	@warning_ignore("unsafe_method_access")
 	return __gdunit_argument_matchers().by_type(TYPE_RID)
 
 
 ## Argument matcher to match any Object value
 func any_object() -> GdUnitArgumentMatcher:
+	@warning_ignore("unsafe_method_access")
 	return __gdunit_argument_matchers().by_type(TYPE_OBJECT)
 
 
 ## Argument matcher to match any Dictionary value
 func any_dictionary() -> GdUnitArgumentMatcher:
+	@warning_ignore("unsafe_method_access")
 	return __gdunit_argument_matchers().by_type(TYPE_DICTIONARY)
 
 
 ## Argument matcher to match any Array value
 func any_array() -> GdUnitArgumentMatcher:
+	@warning_ignore("unsafe_method_access")
 	return __gdunit_argument_matchers().by_type(TYPE_ARRAY)
 
 
 ## Argument matcher to match any PackedByteArray value
 func any_packed_byte_array() -> GdUnitArgumentMatcher:
+	@warning_ignore("unsafe_method_access")
 	return __gdunit_argument_matchers().by_type(TYPE_PACKED_BYTE_ARRAY)
 
 
 ## Argument matcher to match any PackedInt32Array value
 func any_packed_int32_array() -> GdUnitArgumentMatcher:
+	@warning_ignore("unsafe_method_access")
 	return __gdunit_argument_matchers().by_type(TYPE_PACKED_INT32_ARRAY)
 
 
 ## Argument matcher to match any PackedInt64Array value
 func any_packed_int64_array() -> GdUnitArgumentMatcher:
+	@warning_ignore("unsafe_method_access")
 	return __gdunit_argument_matchers().by_type(TYPE_PACKED_INT64_ARRAY)
 
 
 ## Argument matcher to match any PackedFloat32Array value
 func any_packed_float32_array() -> GdUnitArgumentMatcher:
+	@warning_ignore("unsafe_method_access")
 	return __gdunit_argument_matchers().by_type(TYPE_PACKED_FLOAT32_ARRAY)
 
 
 ## Argument matcher to match any PackedFloat64Array value
 func any_packed_float64_array() -> GdUnitArgumentMatcher:
+	@warning_ignore("unsafe_method_access")
 	return __gdunit_argument_matchers().by_type(TYPE_PACKED_FLOAT64_ARRAY)
 
 
 ## Argument matcher to match any PackedStringArray value
 func any_packed_string_array() -> GdUnitArgumentMatcher:
+	@warning_ignore("unsafe_method_access")
 	return __gdunit_argument_matchers().by_type(TYPE_PACKED_STRING_ARRAY)
 
 
 ## Argument matcher to match any PackedVector2Array value
 func any_packed_vector2_array() -> GdUnitArgumentMatcher:
+	@warning_ignore("unsafe_method_access")
 	return __gdunit_argument_matchers().by_type(TYPE_PACKED_VECTOR2_ARRAY)
 
 
 ## Argument matcher to match any PackedVector3Array value
 func any_packed_vector3_array() -> GdUnitArgumentMatcher:
+	@warning_ignore("unsafe_method_access")
 	return __gdunit_argument_matchers().by_type(TYPE_PACKED_VECTOR3_ARRAY)
 
 
 ## Argument matcher to match any PackedColorArray value
 func any_packed_color_array() -> GdUnitArgumentMatcher:
+	@warning_ignore("unsafe_method_access")
 	return __gdunit_argument_matchers().by_type(TYPE_PACKED_COLOR_ARRAY)
 
 
 ## Argument matcher to match any instance of given class
 func any_class(clazz :Object) -> GdUnitArgumentMatcher:
+	@warning_ignore("unsafe_method_access")
 	return __gdunit_argument_matchers().any_class(clazz)
 
 
@@ -577,6 +620,7 @@ func assert_signal(instance :Object) -> GdUnitSignalAssert:
 ##		    .has_message("Expecting:\n 'true'\n not equal to\n 'true'")
 ##     [/codeblock]
 func assert_failure(assertion :Callable) -> GdUnitFailureAssert:
+	@warning_ignore("unsafe_method_access")
 	return __lazy_load("res://addons/gdUnit4/src/asserts/GdUnitFailureAssertImpl.gd").new().execute(assertion)
 
 
@@ -588,6 +632,7 @@ func assert_failure(assertion :Callable) -> GdUnitFailureAssert:
 ##		    .has_message("Expecting:\n 'true'\n not equal to\n 'true'")
 ##     [/codeblock]
 func assert_failure_await(assertion :Callable) -> GdUnitFailureAssert:
+	@warning_ignore("unsafe_method_access")
 	return await __lazy_load("res://addons/gdUnit4/src/asserts/GdUnitFailureAssertImpl.gd").new().execute_and_await(assertion)
 
 
@@ -608,10 +653,12 @@ func assert_error(current :Callable) -> GdUnitGodotErrorAssert:
 
 
 func assert_not_yet_implemented() -> void:
+	@warning_ignore("unsafe_method_access")
 	__gdunit_assert().new(null).do_fail()
 
 
 func fail(message :String) -> void:
+	@warning_ignore("unsafe_method_access")
 	__gdunit_assert().new(null).report_error(message)
 
 

--- a/addons/gdUnit4/src/asserts/GdAssertMessages.gd
+++ b/addons/gdUnit4/src/asserts/GdAssertMessages.gd
@@ -12,7 +12,7 @@ static func format_dict(value :Variant) -> String:
 	if not value is Dictionary:
 		return str(value)
 
-	if value.is_empty():
+	if (value as Dictionary).is_empty():
 		return "{ }"
 	var as_rows := var_to_str(value).split("\n")
 	for index in range( 1, as_rows.size()-1):
@@ -120,9 +120,9 @@ static func _colored_value(value :Variant) -> String:
 				return "'[color=%s]<null>[/color]'" % [VALUE_COLOR]
 			if value is InputEvent:
 				return "[color=%s]<%s>[/color]" % [VALUE_COLOR, input_event_as_text(value as InputEvent)]
-			if value.has_method("_to_string"):
+			if (value as Object).has_method("_to_string"):
 				return "[color=%s]<%s>[/color]" % [VALUE_COLOR, str(value)]
-			return "[color=%s]<%s>[/color]" % [VALUE_COLOR, value.get_class()]
+			return "[color=%s]<%s>[/color]" % [VALUE_COLOR, (value as Object).get_class()]
 		TYPE_DICTIONARY:
 			return "'[color=%s]%s[/color]'" % [VALUE_COLOR, format_dict(value)]
 		_:
@@ -349,6 +349,7 @@ static func error_ends_with(current :Variant, expected :Variant) -> String:
 
 
 static func error_has_length(current :Variant, expected: int, compare_operator :int) -> String:
+	@warning_ignore("unsafe_method_access")
 	var current_length :Variant = current.length() if current != null else null
 	match compare_operator:
 		Comparator.EQUAL:
@@ -378,10 +379,10 @@ static func error_arr_contains(current: Variant, expected: Variant, not_expect: 
 	var failure_message := "Expecting contains SAME elements:" if by_reference else "Expecting contains elements:"
 	var error := "%s\n %s\n do contains (in any order)\n %s" % [
 					_error(failure_message), _colored_value(current), _colored_value(expected)]
-	if not not_expect.is_empty():
+	if not (not_expect as Array).is_empty():
 		error += "\nbut some elements where not expected:\n %s" % _colored_value(not_expect)
-	if not not_found.is_empty():
-		var prefix := "but" if not_expect.is_empty() else "and"
+	if not (not_found as Array).is_empty():
+		var prefix := "but" if (not_expect as Array).is_empty() else "and"
 		error += "\n%s could not find elements:\n %s" % [prefix, _colored_value(not_found)]
 	return error
 
@@ -395,17 +396,17 @@ static func error_arr_contains_exactly(
 		"Expecting contains exactly elements:" if compare_mode == GdObjects.COMPARE_MODE.PARAMETER_DEEP_TEST
 		else "Expecting contains SAME exactly elements:"
 	)
-	if not_expect.is_empty() and not_found.is_empty():
+	if (not_expect as Array).is_empty() and (not_found as Array).is_empty():
 		var diff := _find_first_diff(current as Array, expected as Array)
 		return "%s\n %s\n do contains (in same order)\n %s\n but has different order %s"  % [
 					_error(failure_message), _colored_value(current), _colored_value(expected), diff]
 
 	var error := "%s\n %s\n do contains (in same order)\n %s" % [
 					_error(failure_message), _colored_value(current), _colored_value(expected)]
-	if not not_expect.is_empty():
+	if not (not_expect as Array).is_empty():
 		error += "\nbut some elements where not expected:\n %s" % _colored_value(not_expect)
-	if not not_found.is_empty():
-		var prefix := "but" if not_expect.is_empty() else "and"
+	if not (not_found as Array).is_empty():
+		var prefix := "but" if (not_expect as Array).is_empty() else "and"
 		error += "\n%s could not find elements:\n %s" % [prefix, _colored_value(not_found)]
 	return error
 
@@ -423,10 +424,10 @@ static func error_arr_contains_exactly_in_any_order(
 	)
 	var error := "%s\n %s\n do contains exactly (in any order)\n %s" % [
 					_error(failure_message), _colored_value(current), _colored_value(expected)]
-	if not not_expect.is_empty():
+	if not (not_expect as Array).is_empty():
 		error += "\nbut some elements where not expected:\n %s" % _colored_value(not_expect)
-	if not not_found.is_empty():
-		var prefix := "but" if not_expect.is_empty() else "and"
+	if not (not_found as Array).is_empty():
+		var prefix := "but" if (not_expect as Array).is_empty() else "and"
 		error += "\n%s could not find elements:\n %s" % [prefix, _colored_value(not_found)]
 	return error
 
@@ -435,7 +436,7 @@ static func error_arr_not_contains(current: Variant, expected: Variant, found: V
 	var failure_message := "Expecting:" if compare_mode == GdObjects.COMPARE_MODE.PARAMETER_DEEP_TEST else "Expecting SAME:"
 	var error := "%s\n %s\n do not contains\n %s" % [
 					_error(failure_message), _colored_value(current), _colored_value(expected)]
-	if not found.is_empty():
+	if not (found as Array).is_empty():
 		error += "\n but found elements:\n %s" % _colored_value(found)
 	return error
 
@@ -605,6 +606,7 @@ static func _find_first_diff(left :Array, right :Array) -> String:
 
 
 static func error_has_size(current :Variant, expected: int) -> String:
+	@warning_ignore("unsafe_method_access")
 	var current_size :Variant = null if current == null else current.size()
 	return "%s\n %s\n but was\n %s" % [_error("Expecting size:"), _colored_value(expected), _colored_value(current_size)]
 

--- a/addons/gdUnit4/src/asserts/GdUnitArrayAssertImpl.gd
+++ b/addons/gdUnit4/src/asserts/GdUnitArrayAssertImpl.gd
@@ -1,7 +1,8 @@
+class_name GdUnitArrayAssertImpl
 extends GdUnitArrayAssert
 
 
-var _base: GdUnitAssert
+var _base: GdUnitAssertImpl
 var _current_value_provider: ValueProvider
 var _type_check: bool
 
@@ -9,8 +10,7 @@ var _type_check: bool
 func _init(current: Variant, type_check := true) -> void:
 	_type_check = type_check
 	_current_value_provider = DefaultValueProvider.new(current)
-	_base = (ResourceLoader.load("res://addons/gdUnit4/src/asserts/GdUnitAssertImpl.gd", "GDScript",
-								ResourceLoader.CACHE_MODE_REUSE) as GDScript).new(current)
+	_base = GdUnitAssertImpl.new(current)
 	# save the actual assert instance on the current thread context
 	GdUnitThreadManager.get_current_context().set_assert(self)
 	if not _validate_value_type(current):
@@ -26,30 +26,25 @@ func _notification(event: int) -> void:
 
 
 func report_success() -> GdUnitArrayAssert:
-	@warning_ignore("unsafe_method_access")
 	_base.report_success()
 	return self
 
 
 func report_error(error: String) -> GdUnitArrayAssert:
-	@warning_ignore("unsafe_method_access")
 	_base.report_error(error)
 	return self
 
 
 func failure_message() -> String:
-	@warning_ignore("unsafe_method_access")
 	return _base.failure_message()
 
 
 func override_failure_message(message: String) -> GdUnitArrayAssert:
-	@warning_ignore("return_value_discarded")
 	_base.override_failure_message(message)
 	return self
 
 
 func append_failure_message(message: String) -> GdUnitArrayAssert:
-	@warning_ignore("return_value_discarded")
 	_base.append_failure_message(message)
 	return self
 
@@ -325,9 +320,8 @@ func is_instanceof(expected: Variant) -> GdUnitAssert:
 
 func extract(func_name: String, args := Array()) -> GdUnitArrayAssert:
 	var extracted_elements := Array()
-	@warning_ignore("unsafe_method_access")
-	var extractor: GdUnitValueExtractor = ResourceLoader.load("res://addons/gdUnit4/src/extractors/GdUnitFuncValueExtractor.gd",
-		"GDScript", ResourceLoader.CACHE_MODE_REUSE).new(func_name, args)
+
+	var extractor := GdUnitFuncValueExtractor.new(func_name, args)
 	var current: Variant = get_current_value()
 	if current == null:
 		_current_value_provider = DefaultValueProvider.new(null)

--- a/addons/gdUnit4/src/asserts/GdUnitArrayAssertImpl.gd
+++ b/addons/gdUnit4/src/asserts/GdUnitArrayAssertImpl.gd
@@ -343,7 +343,7 @@ func extractv(
 	extr7: GdUnitValueExtractor = null,
 	extr8: GdUnitValueExtractor = null,
 	extr9: GdUnitValueExtractor = null) -> GdUnitArrayAssert:
-	var extractors := GdArrayTools.filter_value([extr0, extr1, extr2, extr3, extr4, extr5, extr6, extr7, extr8, extr9], null)
+	var extractors: Variant = GdArrayTools.filter_value([extr0, extr1, extr2, extr3, extr4, extr5, extr6, extr7, extr8, extr9], null)
 	var extracted_elements := Array()
 	var current: Variant = get_current_value()
 	if current == null:
@@ -362,10 +362,10 @@ func extractv(
 				GdUnitTuple.NO_ARG,
 				GdUnitTuple.NO_ARG
 			]
-			for index: int in extractors.size():
+			for index: int in (extractors as Array).size():
 				var extractor: GdUnitValueExtractor = extractors[index]
 				ev[index] = extractor.extract_value(element)
-			if extractors.size() > 1:
+			if (extractors as Array).size() > 1:
 				extracted_elements.append(GdUnitTuple.new(ev[0], ev[1], ev[2], ev[3], ev[4], ev[5], ev[6], ev[7], ev[8], ev[9]))
 			else:
 				extracted_elements.append(ev[0])

--- a/addons/gdUnit4/src/asserts/GdUnitArrayAssertImpl.gd
+++ b/addons/gdUnit4/src/asserts/GdUnitArrayAssertImpl.gd
@@ -9,8 +9,8 @@ var _type_check: bool
 func _init(current: Variant, type_check := true) -> void:
 	_type_check = type_check
 	_current_value_provider = DefaultValueProvider.new(current)
-	_base = ResourceLoader.load("res://addons/gdUnit4/src/asserts/GdUnitAssertImpl.gd", "GDScript",
-								ResourceLoader.CACHE_MODE_REUSE).new(current)
+	_base = (ResourceLoader.load("res://addons/gdUnit4/src/asserts/GdUnitAssertImpl.gd", "GDScript",
+								ResourceLoader.CACHE_MODE_REUSE) as GDScript).new(current)
 	# save the actual assert instance on the current thread context
 	GdUnitThreadManager.get_current_context().set_assert(self)
 	if not _validate_value_type(current):
@@ -26,16 +26,19 @@ func _notification(event: int) -> void:
 
 
 func report_success() -> GdUnitArrayAssert:
+	@warning_ignore("unsafe_method_access")
 	_base.report_success()
 	return self
 
 
 func report_error(error: String) -> GdUnitArrayAssert:
+	@warning_ignore("unsafe_method_access")
 	_base.report_error(error)
 	return self
 
 
 func failure_message() -> String:
+	@warning_ignore("unsafe_method_access")
 	return _base.failure_message()
 
 
@@ -72,7 +75,7 @@ func _toPackedStringArray(value: Variant) -> PackedStringArray:
 	return PackedStringArray([str(value)])
 
 
-func _array_equals_div(current: Variant, expected: Variant, case_sensitive: bool = false) -> Array:
+func _array_equals_div(current: Variant, expected: Variant, case_sensitive: bool = false) -> Array[Array]:
 	var current_value := _toPackedStringArray(current)
 	var expected_value := _toPackedStringArray(expected)
 	var index_report := Array()
@@ -89,7 +92,7 @@ func _array_equals_div(current: Variant, expected: Variant, case_sensitive: bool
 			current_value[index] = GdAssertMessages.format_invalid(c)
 			index_report.push_back({"index": index, "current": c, "expected": "<N/A>"})
 
-	for index in range(current.size(), expected_value.size()):
+	for index in range(current_value.size(), expected_value.size()):
 		var value := expected_value[index]
 		expected_value[index] = GdAssertMessages.format_invalid(value)
 		index_report.push_back({"index": index, "current": "<N/A>", "expected": value})
@@ -170,7 +173,7 @@ func _not_contains(expected: Variant, compare_mode: GdObjects.COMPARE_MODE) -> G
 		return report_error(GdAssertMessages.error_arr_contains_exactly_in_any_order(current_value, expected, [], expected, compare_mode))
 	var diffs := _array_div(compare_mode, current_value as Array[Variant], expected as Array[Variant])
 	var found := diffs[0] as Array
-	if found.size() == current_value.size():
+	if found.size() == (current_value as Array).size():
 		return report_success()
 	var diffs2 := _array_div(compare_mode, expected as Array[Variant], diffs[1] as Array[Variant])
 	return report_error(GdAssertMessages.error_arr_not_contains(current_value, expected, diffs2[0], compare_mode))
@@ -210,7 +213,7 @@ func is_equal_ignoring_case(expected: Variant) -> GdUnitArrayAssert:
 		return report_error("ERROR: expected value: <%s>\n is not a Array Type!" % GdObjects.typeof_as_string(expected))
 	var current_value: Variant = get_current_value()
 	if current_value == null and expected != null:
-		return report_error(GdAssertMessages.error_equal(null, GdArrayTools.as_string(expected)))
+		return report_error(GdAssertMessages.error_equal(null, GdArrayTools.as_string(expected as Array)))
 	if not _is_equal(current_value, expected, true):
 		var diff := _array_equals_div(current_value as Array[Variant], expected as Array[Variant], true)
 		var expected_as_list := GdArrayTools.as_string(diff[0])
@@ -234,22 +237,22 @@ func is_not_equal_ignoring_case(expected: Variant) -> GdUnitArrayAssert:
 		return report_error("ERROR: expected value: <%s>\n is not a Array Type!" % GdObjects.typeof_as_string(expected))
 	var current_value: Variant = get_current_value()
 	if _is_equal(current_value, expected, true):
-		var c := GdArrayTools.as_string(current_value)
-		var e := GdArrayTools.as_string(expected)
+		var c := GdArrayTools.as_string(current_value as Array)
+		var e := GdArrayTools.as_string(expected as Array)
 		return report_error(GdAssertMessages.error_not_equal_case_insensetiv(c, e))
 	return report_success()
 
 
 func is_empty() -> GdUnitArrayAssert:
 	var current_value: Variant = get_current_value()
-	if current_value == null or current_value.size() > 0:
+	if current_value == null or (current_value as Array).size() > 0:
 		return report_error(GdAssertMessages.error_is_empty(current_value))
 	return report_success()
 
 
 func is_not_empty() -> GdUnitArrayAssert:
 	var current_value: Variant = get_current_value()
-	if current_value != null and current_value.size() == 0:
+	if current_value != null and (current_value as Array).size() == 0:
 		return report_error(GdAssertMessages.error_is_not_empty())
 	return report_success()
 
@@ -277,7 +280,7 @@ func is_not_same(expected: Variant) -> GdUnitArrayAssert:
 
 func has_size(expected: int) -> GdUnitArrayAssert:
 	var current_value: Variant = get_current_value()
-	if current_value == null or current_value.size() != expected:
+	if current_value == null or (current_value as Array).size() != expected:
 		return report_error(GdAssertMessages.error_has_size(current_value, expected))
 	return report_success()
 
@@ -315,12 +318,14 @@ func not_contains_same(expected: Variant) -> GdUnitArrayAssert:
 
 
 func is_instanceof(expected: Variant) -> GdUnitAssert:
+	@warning_ignore("unsafe_method_access")
 	_base.is_instanceof(expected)
 	return self
 
 
 func extract(func_name: String, args := Array()) -> GdUnitArrayAssert:
 	var extracted_elements := Array()
+	@warning_ignore("unsafe_method_access")
 	var extractor: GdUnitValueExtractor = ResourceLoader.load("res://addons/gdUnit4/src/extractors/GdUnitFuncValueExtractor.gd",
 		"GDScript", ResourceLoader.CACHE_MODE_REUSE).new(func_name, args)
 	var current: Variant = get_current_value()
@@ -344,7 +349,7 @@ func extractv(
 	extr7: GdUnitValueExtractor = null,
 	extr8: GdUnitValueExtractor = null,
 	extr9: GdUnitValueExtractor = null) -> GdUnitArrayAssert:
-	var extractors: Variant = GdArrayTools.filter_value([extr0, extr1, extr2, extr3, extr4, extr5, extr6, extr7, extr8, extr9], null)
+	var extractors := GdArrayTools.filter_value([extr0, extr1, extr2, extr3, extr4, extr5, extr6, extr7, extr8, extr9], null)
 	var extracted_elements := Array()
 	var current: Variant = get_current_value()
 	if current == null:
@@ -396,7 +401,7 @@ func _is_equals_sorted(
 	compare_mode := GdObjects.COMPARE_MODE.PARAMETER_DEEP_TEST) -> bool:
 
 	return GdObjects.equals_sorted(
-		(left as Array) if GdArrayTools.is_array_type(left) else left,
-		(right as Array) if GdArrayTools.is_array_type(right) else right,
+		left as Array,
+		right as Array,
 		case_sensitive,
 		compare_mode)

--- a/addons/gdUnit4/src/asserts/GdUnitAssertImpl.gd
+++ b/addons/gdUnit4/src/asserts/GdUnitAssertImpl.gd
@@ -1,3 +1,4 @@
+class_name GdUnitAssertImpl
 extends GdUnitAssert
 
 

--- a/addons/gdUnit4/src/asserts/GdUnitBoolAssertImpl.gd
+++ b/addons/gdUnit4/src/asserts/GdUnitBoolAssertImpl.gd
@@ -4,8 +4,8 @@ var _base: GdUnitAssert
 
 
 func _init(current :Variant) -> void:
-	_base = ResourceLoader.load("res://addons/gdUnit4/src/asserts/GdUnitAssertImpl.gd", "GDScript",
-								ResourceLoader.CACHE_MODE_REUSE).new(current)
+	_base = (ResourceLoader.load("res://addons/gdUnit4/src/asserts/GdUnitAssertImpl.gd", "GDScript",
+								ResourceLoader.CACHE_MODE_REUSE) as GDScript).new(current)
 	# save the actual assert instance on the current thread context
 	GdUnitThreadManager.get_current_context().set_assert(self)
 	if not GdUnitAssertions.validate_value_type(current, TYPE_BOOL):
@@ -21,20 +21,24 @@ func _notification(event :int) -> void:
 
 
 func current_value() -> Variant:
+	@warning_ignore("unsafe_method_access")
 	return _base.current_value()
 
 
 func report_success() -> GdUnitBoolAssert:
+	@warning_ignore("unsafe_method_access")
 	_base.report_success()
 	return self
 
 
 func report_error(error :String) -> GdUnitBoolAssert:
+	@warning_ignore("unsafe_method_access")
 	_base.report_error(error)
 	return self
 
 
 func failure_message() -> String:
+	@warning_ignore("unsafe_method_access")
 	return _base.failure_message()
 
 

--- a/addons/gdUnit4/src/asserts/GdUnitBoolAssertImpl.gd
+++ b/addons/gdUnit4/src/asserts/GdUnitBoolAssertImpl.gd
@@ -1,11 +1,10 @@
 extends GdUnitBoolAssert
 
-var _base: GdUnitAssert
+var _base: GdUnitAssertImpl
 
 
 func _init(current :Variant) -> void:
-	_base = (ResourceLoader.load("res://addons/gdUnit4/src/asserts/GdUnitAssertImpl.gd", "GDScript",
-								ResourceLoader.CACHE_MODE_REUSE) as GDScript).new(current)
+	_base = GdUnitAssertImpl.new(current)
 	# save the actual assert instance on the current thread context
 	GdUnitThreadManager.get_current_context().set_assert(self)
 	if not GdUnitAssertions.validate_value_type(current, TYPE_BOOL):
@@ -21,24 +20,20 @@ func _notification(event :int) -> void:
 
 
 func current_value() -> Variant:
-	@warning_ignore("unsafe_method_access")
 	return _base.current_value()
 
 
 func report_success() -> GdUnitBoolAssert:
-	@warning_ignore("unsafe_method_access")
 	_base.report_success()
 	return self
 
 
 func report_error(error :String) -> GdUnitBoolAssert:
-	@warning_ignore("unsafe_method_access")
 	_base.report_error(error)
 	return self
 
 
 func failure_message() -> String:
-	@warning_ignore("unsafe_method_access")
 	return _base.failure_message()
 
 

--- a/addons/gdUnit4/src/asserts/GdUnitDictionaryAssertImpl.gd
+++ b/addons/gdUnit4/src/asserts/GdUnitDictionaryAssertImpl.gd
@@ -1,11 +1,10 @@
 extends GdUnitDictionaryAssert
 
-var _base :GdUnitAssert
+var _base: GdUnitAssertImpl
 
 
 func _init(current :Variant) -> void:
-	_base = (ResourceLoader.load("res://addons/gdUnit4/src/asserts/GdUnitAssertImpl.gd", "GDScript",
-								ResourceLoader.CACHE_MODE_REUSE) as GDScript).new(current)
+	_base = GdUnitAssertImpl.new(current)
 	# save the actual assert instance on the current thread context
 	GdUnitThreadManager.get_current_context().set_assert(self)
 	if not GdUnitAssertions.validate_value_type(current, TYPE_DICTIONARY):
@@ -21,19 +20,16 @@ func _notification(event :int) -> void:
 
 
 func report_success() -> GdUnitDictionaryAssert:
-	@warning_ignore("unsafe_method_access")
 	_base.report_success()
 	return self
 
 
 func report_error(error :String) -> GdUnitDictionaryAssert:
-	@warning_ignore("unsafe_method_access")
 	_base.report_error(error)
 	return self
 
 
 func failure_message() -> String:
-	@warning_ignore("unsafe_method_access")
 	return _base.failure_message()
 
 
@@ -50,7 +46,6 @@ func append_failure_message(message :String) -> GdUnitDictionaryAssert:
 
 
 func current_value() -> Variant:
-	@warning_ignore("unsafe_method_access")
 	return _base.current_value()
 
 

--- a/addons/gdUnit4/src/asserts/GdUnitDictionaryAssertImpl.gd
+++ b/addons/gdUnit4/src/asserts/GdUnitDictionaryAssertImpl.gd
@@ -142,12 +142,12 @@ func _contains_key_value(key :Variant, value :Variant, compare_mode :GdObjects.C
 	var expected := [key]
 	if current == null:
 		return report_error(GdAssertMessages.error_is_not_null())
-	var _current: Dictionary = current
-	var keys_not_found :Array = expected.filter(_filter_by_key.bind(_current.keys(), compare_mode))
+	var dict_current: Dictionary = current
+	var keys_not_found :Array = expected.filter(_filter_by_key.bind(dict_current.keys(), compare_mode))
 	if not keys_not_found.is_empty():
-		return report_error(GdAssertMessages.error_contains_keys(_current.keys() as Array, expected, keys_not_found, compare_mode))
-	if not GdObjects.equals(_current[key], value, false, compare_mode):
-		return report_error(GdAssertMessages.error_contains_key_value(key, value, _current[key], compare_mode))
+		return report_error(GdAssertMessages.error_contains_keys(dict_current.keys() as Array, expected, keys_not_found, compare_mode))
+	if not GdObjects.equals(dict_current[key], value, false, compare_mode):
+		return report_error(GdAssertMessages.error_contains_key_value(key, value, dict_current[key], compare_mode))
 	return report_success()
 
 
@@ -155,10 +155,10 @@ func _not_contains_keys(expected :Array, compare_mode :GdObjects.COMPARE_MODE) -
 	var current :Variant = current_value()
 	if current == null:
 		return report_error(GdAssertMessages.error_is_not_null())
-	var _current: Dictionary = current
-	var keys_found :Array = _current.keys().filter(_filter_by_key.bind(expected, compare_mode, true))
+	var dict_current: Dictionary = current
+	var keys_found :Array = dict_current.keys().filter(_filter_by_key.bind(expected, compare_mode, true))
 	if not keys_found.is_empty():
-		return report_error(GdAssertMessages.error_not_contains_keys(_current.keys() as Array, expected, keys_found, compare_mode))
+		return report_error(GdAssertMessages.error_not_contains_keys(dict_current.keys() as Array, expected, keys_found, compare_mode))
 	return report_success()
 
 

--- a/addons/gdUnit4/src/asserts/GdUnitDictionaryAssertImpl.gd
+++ b/addons/gdUnit4/src/asserts/GdUnitDictionaryAssertImpl.gd
@@ -4,8 +4,8 @@ var _base :GdUnitAssert
 
 
 func _init(current :Variant) -> void:
-	_base = ResourceLoader.load("res://addons/gdUnit4/src/asserts/GdUnitAssertImpl.gd", "GDScript",
-								ResourceLoader.CACHE_MODE_REUSE).new(current)
+	_base = (ResourceLoader.load("res://addons/gdUnit4/src/asserts/GdUnitAssertImpl.gd", "GDScript",
+								ResourceLoader.CACHE_MODE_REUSE) as GDScript).new(current)
 	# save the actual assert instance on the current thread context
 	GdUnitThreadManager.get_current_context().set_assert(self)
 	if not GdUnitAssertions.validate_value_type(current, TYPE_DICTIONARY):
@@ -21,16 +21,19 @@ func _notification(event :int) -> void:
 
 
 func report_success() -> GdUnitDictionaryAssert:
+	@warning_ignore("unsafe_method_access")
 	_base.report_success()
 	return self
 
 
 func report_error(error :String) -> GdUnitDictionaryAssert:
+	@warning_ignore("unsafe_method_access")
 	_base.report_error(error)
 	return self
 
 
 func failure_message() -> String:
+	@warning_ignore("unsafe_method_access")
 	return _base.failure_message()
 
 
@@ -47,6 +50,7 @@ func append_failure_message(message :String) -> GdUnitDictionaryAssert:
 
 
 func current_value() -> Variant:
+	@warning_ignore("unsafe_method_access")
 	return _base.current_value()
 
 
@@ -106,14 +110,14 @@ func is_not_same(expected :Variant) -> GdUnitDictionaryAssert:
 
 func is_empty() -> GdUnitDictionaryAssert:
 	var current :Variant = current_value()
-	if current == null or not current.is_empty():
+	if current == null or not (current as Dictionary).is_empty():
 		return report_error(GdAssertMessages.error_is_empty(current))
 	return report_success()
 
 
 func is_not_empty() -> GdUnitDictionaryAssert:
 	var current :Variant = current_value()
-	if current == null or current.is_empty():
+	if current == null or (current as Dictionary).is_empty():
 		return report_error(GdAssertMessages.error_is_not_empty())
 	return report_success()
 
@@ -122,7 +126,7 @@ func has_size(expected: int) -> GdUnitDictionaryAssert:
 	var current :Variant = current_value()
 	if current == null:
 		return report_error(GdAssertMessages.error_is_not_null())
-	if current.size() != expected:
+	if (current as Dictionary).size() != expected:
 		return report_error(GdAssertMessages.error_has_size(current, expected))
 	return report_success()
 
@@ -132,9 +136,9 @@ func _contains_keys(expected :Array, compare_mode :GdObjects.COMPARE_MODE) -> Gd
 	if current == null:
 		return report_error(GdAssertMessages.error_is_not_null())
 	# find expected keys
-	var keys_not_found :Array = expected.filter(_filter_by_key.bind(current.keys(), compare_mode))
+	var keys_not_found :Array = expected.filter(_filter_by_key.bind((current as Dictionary).keys(), compare_mode))
 	if not keys_not_found.is_empty():
-		return report_error(GdAssertMessages.error_contains_keys(current.keys() as Array, expected, keys_not_found, compare_mode))
+		return report_error(GdAssertMessages.error_contains_keys((current as Dictionary).keys() as Array, expected, keys_not_found, compare_mode))
 	return report_success()
 
 
@@ -143,11 +147,12 @@ func _contains_key_value(key :Variant, value :Variant, compare_mode :GdObjects.C
 	var expected := [key]
 	if current == null:
 		return report_error(GdAssertMessages.error_is_not_null())
-	var keys_not_found :Array = expected.filter(_filter_by_key.bind(current.keys(), compare_mode))
+	var _current: Dictionary = current
+	var keys_not_found :Array = expected.filter(_filter_by_key.bind(_current.keys(), compare_mode))
 	if not keys_not_found.is_empty():
-		return report_error(GdAssertMessages.error_contains_keys(current.keys() as Array, expected, keys_not_found, compare_mode))
-	if not GdObjects.equals(current[key], value, false, compare_mode):
-		return report_error(GdAssertMessages.error_contains_key_value(key, value, current[key], compare_mode))
+		return report_error(GdAssertMessages.error_contains_keys(_current.keys() as Array, expected, keys_not_found, compare_mode))
+	if not GdObjects.equals(_current[key], value, false, compare_mode):
+		return report_error(GdAssertMessages.error_contains_key_value(key, value, _current[key], compare_mode))
 	return report_success()
 
 
@@ -155,9 +160,10 @@ func _not_contains_keys(expected :Array, compare_mode :GdObjects.COMPARE_MODE) -
 	var current :Variant = current_value()
 	if current == null:
 		return report_error(GdAssertMessages.error_is_not_null())
-	var keys_found :Array = current.keys().filter(_filter_by_key.bind(expected, compare_mode, true))
+	var _current: Dictionary = current
+	var keys_found :Array = _current.keys().filter(_filter_by_key.bind(expected, compare_mode, true))
 	if not keys_found.is_empty():
-		return report_error(GdAssertMessages.error_not_contains_keys(current.keys() as Array, expected, keys_found, compare_mode))
+		return report_error(GdAssertMessages.error_not_contains_keys(_current.keys() as Array, expected, keys_found, compare_mode))
 	return report_success()
 
 

--- a/addons/gdUnit4/src/asserts/GdUnitFailureAssertImpl.gd
+++ b/addons/gdUnit4/src/asserts/GdUnitFailureAssertImpl.gd
@@ -29,6 +29,7 @@ func execute_and_await(assertion :Callable, do_await := true) -> GdUnitFailureAs
 		_is_failed = true
 		_failure_message = "Invalid Callable! It must be a callable of 'GdUnitAssert'"
 		return self
+	@warning_ignore("unsafe_method_access")
 	_failure_message = current_assert.failure_message()
 	return self
 

--- a/addons/gdUnit4/src/asserts/GdUnitFileAssertImpl.gd
+++ b/addons/gdUnit4/src/asserts/GdUnitFileAssertImpl.gd
@@ -6,8 +6,8 @@ var _base: GdUnitAssert
 
 
 func _init(current :Variant) -> void:
-	_base = ResourceLoader.load("res://addons/gdUnit4/src/asserts/GdUnitAssertImpl.gd", "GDScript",
-								ResourceLoader.CACHE_MODE_REUSE).new(current)
+	_base = (ResourceLoader.load("res://addons/gdUnit4/src/asserts/GdUnitAssertImpl.gd", "GDScript",
+								ResourceLoader.CACHE_MODE_REUSE) as GDScript).new(current)
 	# save the actual assert instance on the current thread context
 	GdUnitThreadManager.get_current_context().set_assert(self)
 	if not GdUnitAssertions.validate_value_type(current, TYPE_STRING):
@@ -23,20 +23,24 @@ func _notification(event :int) -> void:
 
 
 func current_value() -> String:
+	@warning_ignore("unsafe_method_access")
 	return _base.current_value() as String
 
 
 func report_success() -> GdUnitFileAssert:
+	@warning_ignore("unsafe_method_access")
 	_base.report_success()
 	return self
 
 
 func report_error(error :String) -> GdUnitFileAssert:
+	@warning_ignore("unsafe_method_access")
 	_base.report_error(error)
 	return self
 
 
 func failure_message() -> String:
+	@warning_ignore("unsafe_method_access")
 	return _base.failure_message()
 
 
@@ -98,9 +102,9 @@ func contains_exactly(expected_rows: Array) -> GdUnitFileAssert:
 	if script is GDScript:
 		var source_code := GdScriptParser.to_unix_format(script.source_code)
 		var rows := Array(source_code.split("\n"))
-		ResourceLoader.load("res://addons/gdUnit4/src/asserts/GdUnitArrayAssertImpl.gd",
+		(ResourceLoader.load("res://addons/gdUnit4/src/asserts/GdUnitArrayAssertImpl.gd",
 				"GDScript",
-				ResourceLoader.CACHE_MODE_REUSE)\
+				ResourceLoader.CACHE_MODE_REUSE) as GDScript)\
 			.new(rows)\
 			.contains_exactly(expected_rows)
 	return self

--- a/addons/gdUnit4/src/asserts/GdUnitFileAssertImpl.gd
+++ b/addons/gdUnit4/src/asserts/GdUnitFileAssertImpl.gd
@@ -2,12 +2,11 @@ extends GdUnitFileAssert
 
 const GdUnitTools := preload("res://addons/gdUnit4/src/core/GdUnitTools.gd")
 
-var _base: GdUnitAssert
+var _base: GdUnitAssertImpl
 
 
 func _init(current :Variant) -> void:
-	_base = (ResourceLoader.load("res://addons/gdUnit4/src/asserts/GdUnitAssertImpl.gd", "GDScript",
-								ResourceLoader.CACHE_MODE_REUSE) as GDScript).new(current)
+	_base = GdUnitAssertImpl.new(current)
 	# save the actual assert instance on the current thread context
 	GdUnitThreadManager.get_current_context().set_assert(self)
 	if not GdUnitAssertions.validate_value_type(current, TYPE_STRING):
@@ -23,24 +22,20 @@ func _notification(event :int) -> void:
 
 
 func current_value() -> String:
-	@warning_ignore("unsafe_method_access")
 	return _base.current_value() as String
 
 
 func report_success() -> GdUnitFileAssert:
-	@warning_ignore("unsafe_method_access")
 	_base.report_success()
 	return self
 
 
 func report_error(error :String) -> GdUnitFileAssert:
-	@warning_ignore("unsafe_method_access")
 	_base.report_error(error)
 	return self
 
 
 func failure_message() -> String:
-	@warning_ignore("unsafe_method_access")
 	return _base.failure_message()
 
 
@@ -102,9 +97,5 @@ func contains_exactly(expected_rows: Array) -> GdUnitFileAssert:
 	if script is GDScript:
 		var source_code := GdScriptParser.to_unix_format(script.source_code)
 		var rows := Array(source_code.split("\n"))
-		(ResourceLoader.load("res://addons/gdUnit4/src/asserts/GdUnitArrayAssertImpl.gd",
-				"GDScript",
-				ResourceLoader.CACHE_MODE_REUSE) as GDScript)\
-			.new(rows)\
-			.contains_exactly(expected_rows)
+		GdUnitArrayAssertImpl.new(rows).contains_exactly(expected_rows)
 	return self

--- a/addons/gdUnit4/src/asserts/GdUnitFloatAssertImpl.gd
+++ b/addons/gdUnit4/src/asserts/GdUnitFloatAssertImpl.gd
@@ -4,8 +4,8 @@ var _base: GdUnitAssert
 
 
 func _init(current :Variant) -> void:
-	_base = ResourceLoader.load("res://addons/gdUnit4/src/asserts/GdUnitAssertImpl.gd", "GDScript",
-								ResourceLoader.CACHE_MODE_REUSE).new(current)
+	_base = (ResourceLoader.load("res://addons/gdUnit4/src/asserts/GdUnitAssertImpl.gd", "GDScript",
+								ResourceLoader.CACHE_MODE_REUSE) as GDScript).new(current)
 	# save the actual assert instance on the current thread context
 	GdUnitThreadManager.get_current_context().set_assert(self)
 	if not GdUnitAssertions.validate_value_type(current, TYPE_FLOAT):
@@ -21,20 +21,24 @@ func _notification(event :int) -> void:
 
 
 func current_value() -> Variant:
+	@warning_ignore("unsafe_method_access")
 	return _base.current_value()
 
 
 func report_success() -> GdUnitFloatAssert:
+	@warning_ignore("unsafe_method_access")
 	_base.report_success()
 	return self
 
 
 func report_error(error :String) -> GdUnitFloatAssert:
+	@warning_ignore("unsafe_method_access")
 	_base.report_error(error)
 	return self
 
 
 func failure_message() -> String:
+	@warning_ignore("unsafe_method_access")
 	return _base.failure_message()
 
 

--- a/addons/gdUnit4/src/asserts/GdUnitFloatAssertImpl.gd
+++ b/addons/gdUnit4/src/asserts/GdUnitFloatAssertImpl.gd
@@ -1,11 +1,10 @@
 extends GdUnitFloatAssert
 
-var _base: GdUnitAssert
+var _base: GdUnitAssertImpl
 
 
 func _init(current :Variant) -> void:
-	_base = (ResourceLoader.load("res://addons/gdUnit4/src/asserts/GdUnitAssertImpl.gd", "GDScript",
-								ResourceLoader.CACHE_MODE_REUSE) as GDScript).new(current)
+	_base = GdUnitAssertImpl.new(current)
 	# save the actual assert instance on the current thread context
 	GdUnitThreadManager.get_current_context().set_assert(self)
 	if not GdUnitAssertions.validate_value_type(current, TYPE_FLOAT):
@@ -21,24 +20,20 @@ func _notification(event :int) -> void:
 
 
 func current_value() -> Variant:
-	@warning_ignore("unsafe_method_access")
 	return _base.current_value()
 
 
 func report_success() -> GdUnitFloatAssert:
-	@warning_ignore("unsafe_method_access")
 	_base.report_success()
 	return self
 
 
 func report_error(error :String) -> GdUnitFloatAssert:
-	@warning_ignore("unsafe_method_access")
 	_base.report_error(error)
 	return self
 
 
 func failure_message() -> String:
-	@warning_ignore("unsafe_method_access")
 	return _base.failure_message()
 
 

--- a/addons/gdUnit4/src/asserts/GdUnitIntAssertImpl.gd
+++ b/addons/gdUnit4/src/asserts/GdUnitIntAssertImpl.gd
@@ -1,11 +1,10 @@
 extends GdUnitIntAssert
 
-var _base: GdUnitAssert
+var _base: GdUnitAssertImpl
 
 
 func _init(current :Variant) -> void:
-	_base = (ResourceLoader.load("res://addons/gdUnit4/src/asserts/GdUnitAssertImpl.gd", "GDScript",
-								ResourceLoader.CACHE_MODE_REUSE) as GDScript).new(current)
+	_base = GdUnitAssertImpl.new(current)
 	# save the actual assert instance on the current thread context
 	GdUnitThreadManager.get_current_context().set_assert(self)
 	if not GdUnitAssertions.validate_value_type(current, TYPE_INT):
@@ -21,24 +20,20 @@ func _notification(event :int) -> void:
 
 
 func current_value() -> Variant:
-	@warning_ignore("unsafe_method_access")
 	return _base.current_value()
 
 
 func report_success() -> GdUnitIntAssert:
-	@warning_ignore("unsafe_method_access")
 	_base.report_success()
 	return self
 
 
 func report_error(error :String) -> GdUnitIntAssert:
-	@warning_ignore("unsafe_method_access")
 	_base.report_error(error)
 	return self
 
 
 func failure_message() -> String:
-	@warning_ignore("unsafe_method_access")
 	return _base.failure_message()
 
 

--- a/addons/gdUnit4/src/asserts/GdUnitIntAssertImpl.gd
+++ b/addons/gdUnit4/src/asserts/GdUnitIntAssertImpl.gd
@@ -4,8 +4,8 @@ var _base: GdUnitAssert
 
 
 func _init(current :Variant) -> void:
-	_base = ResourceLoader.load("res://addons/gdUnit4/src/asserts/GdUnitAssertImpl.gd", "GDScript",
-								ResourceLoader.CACHE_MODE_REUSE).new(current)
+	_base = (ResourceLoader.load("res://addons/gdUnit4/src/asserts/GdUnitAssertImpl.gd", "GDScript",
+								ResourceLoader.CACHE_MODE_REUSE) as GDScript).new(current)
 	# save the actual assert instance on the current thread context
 	GdUnitThreadManager.get_current_context().set_assert(self)
 	if not GdUnitAssertions.validate_value_type(current, TYPE_INT):
@@ -21,20 +21,24 @@ func _notification(event :int) -> void:
 
 
 func current_value() -> Variant:
+	@warning_ignore("unsafe_method_access")
 	return _base.current_value()
 
 
 func report_success() -> GdUnitIntAssert:
+	@warning_ignore("unsafe_method_access")
 	_base.report_success()
 	return self
 
 
 func report_error(error :String) -> GdUnitIntAssert:
+	@warning_ignore("unsafe_method_access")
 	_base.report_error(error)
 	return self
 
 
 func failure_message() -> String:
+	@warning_ignore("unsafe_method_access")
 	return _base.failure_message()
 
 

--- a/addons/gdUnit4/src/asserts/GdUnitObjectAssertImpl.gd
+++ b/addons/gdUnit4/src/asserts/GdUnitObjectAssertImpl.gd
@@ -4,8 +4,8 @@ var _base :GdUnitAssert
 
 
 func _init(current :Variant) -> void:
-	_base = ResourceLoader.load("res://addons/gdUnit4/src/asserts/GdUnitAssertImpl.gd", "GDScript",
-								ResourceLoader.CACHE_MODE_REUSE).new(current)
+	_base = (ResourceLoader.load("res://addons/gdUnit4/src/asserts/GdUnitAssertImpl.gd", "GDScript",
+								ResourceLoader.CACHE_MODE_REUSE) as GDScript).new(current)
 	# save the actual assert instance on the current thread context
 	GdUnitThreadManager.get_current_context().set_assert(self)
 	if (current != null
@@ -25,20 +25,24 @@ func _notification(event :int) -> void:
 
 
 func current_value() -> Variant:
+	@warning_ignore("unsafe_method_access")
 	return _base.current_value()
 
 
 func report_success() -> GdUnitObjectAssert:
+	@warning_ignore("unsafe_method_access")
 	_base.report_success()
 	return self
 
 
 func report_error(error :String) -> GdUnitObjectAssert:
+	@warning_ignore("unsafe_method_access")
 	_base.report_error(error)
 	return self
 
 
 func failure_message() -> String:
+	@warning_ignore("unsafe_method_access")
 	return _base.failure_message()
 
 

--- a/addons/gdUnit4/src/asserts/GdUnitObjectAssertImpl.gd
+++ b/addons/gdUnit4/src/asserts/GdUnitObjectAssertImpl.gd
@@ -106,7 +106,7 @@ func is_not_instanceof(type :Variant) -> GdUnitObjectAssert:
 	if is_instance_of(current, type):
 		var result: = GdObjects.extract_class_name(type)
 		if result.is_success():
-			return report_error("Expected not be a instance of <%s>" % result.value())
+			return report_error("Expected not be a instance of <%s>" % str(result.value()))
 
 		push_error("Internal ERROR: %s" % result.error_message())
 		return self

--- a/addons/gdUnit4/src/asserts/GdUnitObjectAssertImpl.gd
+++ b/addons/gdUnit4/src/asserts/GdUnitObjectAssertImpl.gd
@@ -1,11 +1,10 @@
 extends GdUnitObjectAssert
 
-var _base :GdUnitAssert
+var _base: GdUnitAssertImpl
 
 
 func _init(current :Variant) -> void:
-	_base = (ResourceLoader.load("res://addons/gdUnit4/src/asserts/GdUnitAssertImpl.gd", "GDScript",
-								ResourceLoader.CACHE_MODE_REUSE) as GDScript).new(current)
+	_base = GdUnitAssertImpl.new(current)
 	# save the actual assert instance on the current thread context
 	GdUnitThreadManager.get_current_context().set_assert(self)
 	if (current != null
@@ -25,24 +24,20 @@ func _notification(event :int) -> void:
 
 
 func current_value() -> Variant:
-	@warning_ignore("unsafe_method_access")
 	return _base.current_value()
 
 
 func report_success() -> GdUnitObjectAssert:
-	@warning_ignore("unsafe_method_access")
 	_base.report_success()
 	return self
 
 
 func report_error(error :String) -> GdUnitObjectAssert:
-	@warning_ignore("unsafe_method_access")
 	_base.report_error(error)
 	return self
 
 
 func failure_message() -> String:
-	@warning_ignore("unsafe_method_access")
 	return _base.failure_message()
 
 

--- a/addons/gdUnit4/src/asserts/GdUnitResultAssertImpl.gd
+++ b/addons/gdUnit4/src/asserts/GdUnitResultAssertImpl.gd
@@ -4,8 +4,8 @@ var _base :GdUnitAssert
 
 
 func _init(current :Variant) -> void:
-	_base = ResourceLoader.load("res://addons/gdUnit4/src/asserts/GdUnitAssertImpl.gd", "GDScript",
-								ResourceLoader.CACHE_MODE_REUSE).new(current)
+	_base = (ResourceLoader.load("res://addons/gdUnit4/src/asserts/GdUnitAssertImpl.gd", "GDScript",
+								ResourceLoader.CACHE_MODE_REUSE) as GDScript).new(current)
 	# save the actual assert instance on the current thread context
 	GdUnitThreadManager.get_current_context().set_assert(self)
 	if not validate_value_type(current):
@@ -25,20 +25,24 @@ func validate_value_type(value :Variant) -> bool:
 
 
 func current_value() -> GdUnitResult:
+	@warning_ignore("unsafe_method_access")
 	return _base.current_value() as GdUnitResult
 
 
 func report_success() -> GdUnitResultAssert:
+	@warning_ignore("unsafe_method_access")
 	_base.report_success()
 	return self
 
 
 func report_error(error :String) -> GdUnitResultAssert:
+	@warning_ignore("unsafe_method_access")
 	_base.report_error(error)
 	return self
 
 
 func failure_message() -> String:
+	@warning_ignore("unsafe_method_access")
 	return _base.failure_message()
 
 

--- a/addons/gdUnit4/src/asserts/GdUnitResultAssertImpl.gd
+++ b/addons/gdUnit4/src/asserts/GdUnitResultAssertImpl.gd
@@ -1,11 +1,10 @@
 extends GdUnitResultAssert
 
-var _base :GdUnitAssert
+var _base: GdUnitAssertImpl
 
 
 func _init(current :Variant) -> void:
-	_base = (ResourceLoader.load("res://addons/gdUnit4/src/asserts/GdUnitAssertImpl.gd", "GDScript",
-								ResourceLoader.CACHE_MODE_REUSE) as GDScript).new(current)
+	_base = GdUnitAssertImpl.new(current)
 	# save the actual assert instance on the current thread context
 	GdUnitThreadManager.get_current_context().set_assert(self)
 	if not validate_value_type(current):
@@ -25,24 +24,20 @@ func validate_value_type(value :Variant) -> bool:
 
 
 func current_value() -> GdUnitResult:
-	@warning_ignore("unsafe_method_access")
 	return _base.current_value() as GdUnitResult
 
 
 func report_success() -> GdUnitResultAssert:
-	@warning_ignore("unsafe_method_access")
 	_base.report_success()
 	return self
 
 
 func report_error(error :String) -> GdUnitResultAssert:
-	@warning_ignore("unsafe_method_access")
 	_base.report_error(error)
 	return self
 
 
 func failure_message() -> String:
-	@warning_ignore("unsafe_method_access")
 	return _base.failure_message()
 
 

--- a/addons/gdUnit4/src/asserts/GdUnitStringAssertImpl.gd
+++ b/addons/gdUnit4/src/asserts/GdUnitStringAssertImpl.gd
@@ -4,8 +4,8 @@ var _base :GdUnitAssert
 
 
 func _init(current :Variant) -> void:
-	_base = ResourceLoader.load("res://addons/gdUnit4/src/asserts/GdUnitAssertImpl.gd", "GDScript",
-								ResourceLoader.CACHE_MODE_REUSE).new(current)
+	_base = (ResourceLoader.load("res://addons/gdUnit4/src/asserts/GdUnitAssertImpl.gd", "GDScript",
+								ResourceLoader.CACHE_MODE_REUSE) as GDScript).new(current)
 	# save the actual assert instance on the current thread context
 	GdUnitThreadManager.get_current_context().set_assert(self)
 	if current != null and typeof(current) != TYPE_STRING and typeof(current) != TYPE_STRING_NAME:
@@ -21,19 +21,23 @@ func _notification(event :int) -> void:
 
 
 func failure_message() -> String:
+	@warning_ignore("unsafe_method_access")
 	return _base.failure_message()
 
 
 func current_value() -> Variant:
+	@warning_ignore("unsafe_method_access")
 	return _base.current_value()
 
 
 func report_success() -> GdUnitStringAssert:
+	@warning_ignore("unsafe_method_access")
 	_base.report_success()
 	return self
 
 
 func report_error(error :String) -> GdUnitStringAssert:
+	@warning_ignore("unsafe_method_access")
 	_base.report_error(error)
 	return self
 
@@ -100,49 +104,49 @@ func is_not_equal_ignoring_case(expected :Variant) -> GdUnitStringAssert:
 
 func is_empty() -> GdUnitStringAssert:
 	var current :Variant = current_value()
-	if current == null or not current.is_empty():
+	if current == null or not (current as String).is_empty():
 		return report_error(GdAssertMessages.error_is_empty(current))
 	return report_success()
 
 
 func is_not_empty() -> GdUnitStringAssert:
 	var current :Variant = current_value()
-	if current == null or current.is_empty():
+	if current == null or (current as String).is_empty():
 		return report_error(GdAssertMessages.error_is_not_empty())
 	return report_success()
 
 
 func contains(expected :String) -> GdUnitStringAssert:
 	var current :Variant = current_value()
-	if current == null or current.find(expected) == -1:
+	if current == null or (current as String).find(expected) == -1:
 		return report_error(GdAssertMessages.error_contains(current, expected))
 	return report_success()
 
 
 func not_contains(expected :String) -> GdUnitStringAssert:
 	var current :Variant = current_value()
-	if current != null and current.find(expected) != -1:
+	if current != null and (current as String).find(expected) != -1:
 		return report_error(GdAssertMessages.error_not_contains(current, expected))
 	return report_success()
 
 
 func contains_ignoring_case(expected :String) -> GdUnitStringAssert:
 	var current :Variant = current_value()
-	if current == null or current.findn(expected) == -1:
+	if current == null or (current as String).findn(expected) == -1:
 		return report_error(GdAssertMessages.error_contains_ignoring_case(current, expected))
 	return report_success()
 
 
 func not_contains_ignoring_case(expected :String) -> GdUnitStringAssert:
 	var current :Variant = current_value()
-	if current != null and current.findn(expected) != -1:
+	if current != null and (current as String).findn(expected) != -1:
 		return report_error(GdAssertMessages.error_not_contains_ignoring_case(current, expected))
 	return report_success()
 
 
 func starts_with(expected :String) -> GdUnitStringAssert:
 	var current :Variant = current_value()
-	if current == null or current.find(expected) != 0:
+	if current == null or (current as String).find(expected) != 0:
 		return report_error(GdAssertMessages.error_starts_with(current, expected))
 	return report_success()
 
@@ -151,8 +155,8 @@ func ends_with(expected :String) -> GdUnitStringAssert:
 	var current :Variant = current_value()
 	if current == null:
 		return report_error(GdAssertMessages.error_ends_with(current, expected))
-	var find :int = current.length() - expected.length()
-	if current.rfind(expected) != find:
+	var find :int = (current as String).length() - expected.length()
+	if (current as String).rfind(expected) != find:
 		return report_error(GdAssertMessages.error_ends_with(current, expected))
 	return report_success()
 
@@ -162,22 +166,23 @@ func has_length(expected :int, comparator := Comparator.EQUAL) -> GdUnitStringAs
 	var current :Variant = current_value()
 	if current == null:
 		return report_error(GdAssertMessages.error_has_length(current, expected, comparator))
+	var _current: String = current
 	match comparator:
 		Comparator.EQUAL:
-			if current.length() != expected:
-				return report_error(GdAssertMessages.error_has_length(current, expected, comparator))
+			if _current.length() != expected:
+				return report_error(GdAssertMessages.error_has_length(_current, expected, comparator))
 		Comparator.LESS_THAN:
-			if current.length() >= expected:
-				return report_error(GdAssertMessages.error_has_length(current, expected, comparator))
+			if _current.length() >= expected:
+				return report_error(GdAssertMessages.error_has_length(_current, expected, comparator))
 		Comparator.LESS_EQUAL:
-			if current.length() > expected:
-				return report_error(GdAssertMessages.error_has_length(current, expected, comparator))
+			if _current.length() > expected:
+				return report_error(GdAssertMessages.error_has_length(_current, expected, comparator))
 		Comparator.GREATER_THAN:
-			if current.length() <= expected:
-				return report_error(GdAssertMessages.error_has_length(current, expected, comparator))
+			if _current.length() <= expected:
+				return report_error(GdAssertMessages.error_has_length(_current, expected, comparator))
 		Comparator.GREATER_EQUAL:
-			if current.length() < expected:
-				return report_error(GdAssertMessages.error_has_length(current, expected, comparator))
+			if _current.length() < expected:
+				return report_error(GdAssertMessages.error_has_length(_current, expected, comparator))
 		_:
 			return report_error("Comparator '%d' not implemented!" % comparator)
 	return report_success()

--- a/addons/gdUnit4/src/asserts/GdUnitStringAssertImpl.gd
+++ b/addons/gdUnit4/src/asserts/GdUnitStringAssertImpl.gd
@@ -1,11 +1,10 @@
 extends GdUnitStringAssert
 
-var _base :GdUnitAssert
+var _base: GdUnitAssertImpl
 
 
 func _init(current :Variant) -> void:
-	_base = (ResourceLoader.load("res://addons/gdUnit4/src/asserts/GdUnitAssertImpl.gd", "GDScript",
-								ResourceLoader.CACHE_MODE_REUSE) as GDScript).new(current)
+	_base = GdUnitAssertImpl.new(current)
 	# save the actual assert instance on the current thread context
 	GdUnitThreadManager.get_current_context().set_assert(self)
 	if current != null and typeof(current) != TYPE_STRING and typeof(current) != TYPE_STRING_NAME:
@@ -21,23 +20,19 @@ func _notification(event :int) -> void:
 
 
 func failure_message() -> String:
-	@warning_ignore("unsafe_method_access")
 	return _base.failure_message()
 
 
 func current_value() -> Variant:
-	@warning_ignore("unsafe_method_access")
 	return _base.current_value()
 
 
 func report_success() -> GdUnitStringAssert:
-	@warning_ignore("unsafe_method_access")
 	_base.report_success()
 	return self
 
 
 func report_error(error :String) -> GdUnitStringAssert:
-	@warning_ignore("unsafe_method_access")
 	_base.report_error(error)
 	return self
 

--- a/addons/gdUnit4/src/asserts/GdUnitStringAssertImpl.gd
+++ b/addons/gdUnit4/src/asserts/GdUnitStringAssertImpl.gd
@@ -161,23 +161,23 @@ func has_length(expected :int, comparator := Comparator.EQUAL) -> GdUnitStringAs
 	var current :Variant = current_value()
 	if current == null:
 		return report_error(GdAssertMessages.error_has_length(current, expected, comparator))
-	var _current: String = current
+	var str_current: String = current
 	match comparator:
 		Comparator.EQUAL:
-			if _current.length() != expected:
-				return report_error(GdAssertMessages.error_has_length(_current, expected, comparator))
+			if str_current.length() != expected:
+				return report_error(GdAssertMessages.error_has_length(str_current, expected, comparator))
 		Comparator.LESS_THAN:
-			if _current.length() >= expected:
-				return report_error(GdAssertMessages.error_has_length(_current, expected, comparator))
+			if str_current.length() >= expected:
+				return report_error(GdAssertMessages.error_has_length(str_current, expected, comparator))
 		Comparator.LESS_EQUAL:
-			if _current.length() > expected:
-				return report_error(GdAssertMessages.error_has_length(_current, expected, comparator))
+			if str_current.length() > expected:
+				return report_error(GdAssertMessages.error_has_length(str_current, expected, comparator))
 		Comparator.GREATER_THAN:
-			if _current.length() <= expected:
-				return report_error(GdAssertMessages.error_has_length(_current, expected, comparator))
+			if str_current.length() <= expected:
+				return report_error(GdAssertMessages.error_has_length(str_current, expected, comparator))
 		Comparator.GREATER_EQUAL:
-			if _current.length() < expected:
-				return report_error(GdAssertMessages.error_has_length(_current, expected, comparator))
+			if str_current.length() < expected:
+				return report_error(GdAssertMessages.error_has_length(str_current, expected, comparator))
 		_:
 			return report_error("Comparator '%d' not implemented!" % comparator)
 	return report_success()

--- a/addons/gdUnit4/src/asserts/GdUnitVectorAssertImpl.gd
+++ b/addons/gdUnit4/src/asserts/GdUnitVectorAssertImpl.gd
@@ -6,8 +6,8 @@ var _type_check: bool
 
 func _init(current: Variant, type_check := true) -> void:
 	_type_check = type_check
-	_base = ResourceLoader.load("res://addons/gdUnit4/src/asserts/GdUnitAssertImpl.gd", "GDScript",
-								ResourceLoader.CACHE_MODE_REUSE).new(current)
+	_base = (ResourceLoader.load("res://addons/gdUnit4/src/asserts/GdUnitAssertImpl.gd", "GDScript",
+								ResourceLoader.CACHE_MODE_REUSE) as GDScript).new(current)
 	# save the actual assert instance on the current thread context
 	GdUnitThreadManager.get_current_context().set_assert(self)
 	if not _validate_value_type(current):
@@ -47,20 +47,24 @@ func _validate_is_vector_type(value :Variant) -> bool:
 
 
 func current_value() -> Variant:
+	@warning_ignore("unsafe_method_access")
 	return _base.current_value()
 
 
 func report_success() -> GdUnitVectorAssert:
+	@warning_ignore("unsafe_method_access")
 	_base.report_success()
 	return self
 
 
 func report_error(error :String) -> GdUnitVectorAssert:
+	@warning_ignore("unsafe_method_access")
 	_base.report_error(error)
 	return self
 
 
 func failure_message() -> String:
+	@warning_ignore("unsafe_method_access")
 	return _base.failure_message()
 
 

--- a/addons/gdUnit4/src/asserts/GdUnitVectorAssertImpl.gd
+++ b/addons/gdUnit4/src/asserts/GdUnitVectorAssertImpl.gd
@@ -1,13 +1,12 @@
 extends GdUnitVectorAssert
 
-var _base: GdUnitAssert
+var _base: GdUnitAssertImpl
 var _current_type: int
 var _type_check: bool
 
 func _init(current: Variant, type_check := true) -> void:
 	_type_check = type_check
-	_base = (ResourceLoader.load("res://addons/gdUnit4/src/asserts/GdUnitAssertImpl.gd", "GDScript",
-								ResourceLoader.CACHE_MODE_REUSE) as GDScript).new(current)
+	_base = GdUnitAssertImpl.new(current)
 	# save the actual assert instance on the current thread context
 	GdUnitThreadManager.get_current_context().set_assert(self)
 	if not _validate_value_type(current):
@@ -47,24 +46,20 @@ func _validate_is_vector_type(value :Variant) -> bool:
 
 
 func current_value() -> Variant:
-	@warning_ignore("unsafe_method_access")
 	return _base.current_value()
 
 
 func report_success() -> GdUnitVectorAssert:
-	@warning_ignore("unsafe_method_access")
 	_base.report_success()
 	return self
 
 
 func report_error(error :String) -> GdUnitVectorAssert:
-	@warning_ignore("unsafe_method_access")
 	_base.report_error(error)
 	return self
 
 
 func failure_message() -> String:
-	@warning_ignore("unsafe_method_access")
 	return _base.failure_message()
 
 

--- a/addons/gdUnit4/src/asserts/ValueProvider.gd
+++ b/addons/gdUnit4/src/asserts/ValueProvider.gd
@@ -4,3 +4,7 @@ extends RefCounted
 
 func get_value() -> Variant:
 	return null
+
+
+func dispose() -> void:
+	pass

--- a/addons/gdUnit4/src/cmd/CmdCommandHandler.gd
+++ b/addons/gdUnit4/src/cmd/CmdCommandHandler.gd
@@ -98,7 +98,7 @@ func execute(commands :Array[CmdCommand]) -> GdUnitResult:
 				# we need to find the method and determin the arguments to call the right function
 				for m in cb_m.get_object().get_method_list():
 					if m["name"] == cb_m.get_method():
-						if m["args"].size() > 1:
+						if (m["args"] as Array).size() > 1:
 							cb_m.callv(arguments)
 							break
 						else:

--- a/addons/gdUnit4/src/core/GdArrayTools.gd
+++ b/addons/gdUnit4/src/core/GdArrayTools.gd
@@ -28,10 +28,11 @@ static func is_type_array(type :int) -> bool:
 
 ## Filters an array by given value[br]
 ## If the given value not an array it returns null, will remove all occurence of given value.
-static func filter_value(array: Array[Variant], value: Variant) -> Array[Variant]:
-	#if not is_array_type(array):
-	#	return null
-	var filtered_array: Array[Variant] = array.duplicate()
+@warning_ignore("unsafe_method_access")
+static func filter_value(array: Variant, value: Variant) -> Variant:
+	if not is_array_type(array):
+		return null
+	var filtered_array: Variant = array.duplicate()
 	var index :int = filtered_array.find(value)
 	while index != -1:
 		filtered_array.remove_at(index)
@@ -72,11 +73,11 @@ static func scan_typed(array :Array) -> int:
 ##		# will result in PackedString(["a", "b"])
 ##		GdArrayTools.as_string(PackedColorArray(Color.RED, COLOR.GREEN))
 ## 	[/codeblock]
-static func as_string(elements: Array[Variant], encode_value := true) -> String:
+static func as_string(elements: Variant, encode_value := true) -> String:
 	var delemiter := ", "
 	if elements == null:
 		return "<null>"
-	if elements.is_empty():
+	if (elements as Array).is_empty():
 		return "<empty>"
 	var prefix := _typeof_as_string(elements) if encode_value else ""
 	var formatted := ""

--- a/addons/gdUnit4/src/core/GdArrayTools.gd
+++ b/addons/gdUnit4/src/core/GdArrayTools.gd
@@ -28,10 +28,10 @@ static func is_type_array(type :int) -> bool:
 
 ## Filters an array by given value[br]
 ## If the given value not an array it returns null, will remove all occurence of given value.
-static func filter_value(array :Variant, value :Variant) -> Variant:
-	if not is_array_type(array):
-		return null
-	var filtered_array :Variant = array.duplicate()
+static func filter_value(array: Array[Variant], value: Variant) -> Array[Variant]:
+	#if not is_array_type(array):
+	#	return null
+	var filtered_array: Array[Variant] = array.duplicate()
 	var index :int = filtered_array.find(value)
 	while index != -1:
 		filtered_array.remove_at(index)
@@ -72,9 +72,7 @@ static func scan_typed(array :Array) -> int:
 ##		# will result in PackedString(["a", "b"])
 ##		GdArrayTools.as_string(PackedColorArray(Color.RED, COLOR.GREEN))
 ## 	[/codeblock]
-static func as_string(elements :Variant, encode_value := true) -> String:
-	if not is_array_type(elements):
-		return "ERROR: Not an Array Type!"
+static func as_string(elements: Array[Variant], encode_value := true) -> String:
 	var delemiter := ", "
 	if elements == null:
 		return "<null>"

--- a/addons/gdUnit4/src/core/GdDiffTool.gd
+++ b/addons/gdUnit4/src/core/GdDiffTool.gd
@@ -7,7 +7,7 @@ const DIV_ADD :int = 214
 const DIV_SUB :int = 215
 
 
-static func _diff(lb: PackedByteArray, rb: PackedByteArray, lookup: Array, ldiff: Array, rdiff: Array) -> void:
+static func _diff(lb: PackedByteArray, rb: PackedByteArray, lookup: Array[Array], ldiff: Array, rdiff: Array) -> void:
 	var loffset := lb.size()
 	var roffset := rb.size()
 
@@ -39,8 +39,8 @@ static func _diff(lb: PackedByteArray, rb: PackedByteArray, lookup: Array, ldiff
 
 
 # lookup[i][j] stores the length of LCS of substring X[0..i-1], Y[0..j-1]
-static func _createLookUp(lb: PackedByteArray, rb: PackedByteArray) -> Array:
-	var lookup := Array()
+static func _createLookUp(lb: PackedByteArray, rb: PackedByteArray) -> Array[Array]:
+	var lookup: Array[Array] = []
 	@warning_ignore("return_value_discarded")
 	lookup.resize(lb.size() + 1)
 	for i in lookup.size():
@@ -51,7 +51,7 @@ static func _createLookUp(lb: PackedByteArray, rb: PackedByteArray) -> Array:
 	return lookup
 
 
-static func _buildLookup(lb: PackedByteArray, rb: PackedByteArray) -> Array:
+static func _buildLookup(lb: PackedByteArray, rb: PackedByteArray) -> Array[Array]:
 	var lookup := _createLookUp(lb, rb)
 	# first column of the lookup table will be all 0
 	for i in lookup.size():

--- a/addons/gdUnit4/src/core/GdFunctionDoubler.gd
+++ b/addons/gdUnit4/src/core/GdFunctionDoubler.gd
@@ -84,6 +84,7 @@ static func get_enum_default(value :String) -> Variant:
 	""".dedent() % value
 	@warning_ignore("return_value_discarded")
 	script.reload()
+	@warning_ignore("unsafe_method_access")
 	return script.new().call("get_enum_default")
 
 

--- a/addons/gdUnit4/src/core/GdFunctionDoubler.gd
+++ b/addons/gdUnit4/src/core/GdFunctionDoubler.gd
@@ -136,7 +136,7 @@ func double(func_descriptor: GdFunctionDescriptor, is_callable: bool = false) ->
 		var constructor := "func _init(%s) -> void:\n	super(%s)\n	pass\n" % [constructor_args, ", ".join(arg_names)]
 		return constructor.split("\n")
 
-	var double_src := "@warning_ignore('shadowed_variable', 'untyped_declaration', 'unsafe_call_argument')\n"
+	var double_src := "@warning_ignore('shadowed_variable', 'untyped_declaration', 'unsafe_call_argument', 'unsafe_method_access')\n"
 	if func_descriptor.is_engine():
 		double_src += '@warning_ignore("native_method_override")\n'
 	if func_descriptor.return_type() == GdObjects.TYPE_ENUM:

--- a/addons/gdUnit4/src/core/GdObjects.gd
+++ b/addons/gdUnit4/src/core/GdObjects.gd
@@ -501,7 +501,7 @@ static func create_instance(clazz :Variant) -> GdUnitResult:
 					return GdUnitResult.success(script.new())
 				else:
 					return GdUnitResult.error("Can't create instance for '%s'." % clazz_name)
-	return GdUnitResult.error("Can't create instance for class '%s'." % clazz)
+	return GdUnitResult.error("Can't create instance for class '%s'." % str(clazz))
 
 
 @warning_ignore("return_value_discarded")
@@ -581,7 +581,7 @@ static func extract_class_name(clazz :Variant) -> GdUnitResult:
 	@warning_ignore("unsafe_method_access")
 	var instance :Variant = clazz.new()
 	if instance == null:
-		return GdUnitResult.error("Can't create a instance for class '%s'" % clazz)
+		return GdUnitResult.error("Can't create a instance for class '%s'" % str(clazz))
 	var result := extract_class_name(instance)
 	@warning_ignore("return_value_discarded")
 	GdUnitTools.free_instance(instance)

--- a/addons/gdUnit4/src/core/GdObjects.gd
+++ b/addons/gdUnit4/src/core/GdObjects.gd
@@ -187,8 +187,11 @@ static func obj2dict(obj: Object, hashed_objects := Dictionary()) -> Dictionary:
 				dict[property_name] = obj2dict(property_value as Object, hashed_objects)
 			else:
 				dict[property_name] = property_value
-	if obj.has_method("get_children"):
-		var childrens :Array = obj.get_children()
+	if obj is Node:
+		var childrens :Array = (obj as Node).get_children()
+		dict["childrens"] = childrens.map(func (child :Object) -> Dictionary: return obj2dict(child, hashed_objects))
+	if obj is TreeItem:
+		var childrens :Array = (obj as TreeItem).get_children()
 		dict["childrens"] = childrens.map(func (child :Object) -> Dictionary: return obj2dict(child, hashed_objects))
 
 	return {"%s" % clazz_name : dict}
@@ -198,14 +201,15 @@ static func equals(obj_a :Variant, obj_b :Variant, case_sensitive :bool = false,
 	return _equals(obj_a, obj_b, case_sensitive, compare_mode, [], 0)
 
 
-static func equals_sorted(obj_a :Variant, obj_b :Variant, case_sensitive :bool = false, compare_mode :COMPARE_MODE = COMPARE_MODE.PARAMETER_DEEP_TEST) -> bool:
-	var a: Variant = obj_a.duplicate()
-	var b: Variant = obj_b.duplicate()
+static func equals_sorted(obj_a: Array[Variant], obj_b: Array[Variant], case_sensitive: bool = false, compare_mode: COMPARE_MODE = COMPARE_MODE.PARAMETER_DEEP_TEST) -> bool:
+	var a: Array[Variant] = obj_a.duplicate()
+	var b: Array[Variant] = obj_b.duplicate()
 	a.sort()
 	b.sort()
 	return equals(a, b, case_sensitive, compare_mode)
 
 
+@warning_ignore("unsafe_method_access")
 static func _equals(obj_a :Variant, obj_b :Variant, case_sensitive :bool, compare_mode :COMPARE_MODE, deep_stack :Array, stack_depth :int ) -> bool:
 	var type_a := typeof(obj_a)
 	var type_b := typeof(obj_b)
@@ -389,7 +393,7 @@ static func _is_same(left :Variant, right :Variant) -> bool:
 	if left_type != right_type:
 		return false
 	if left_type == TYPE_OBJECT and right_type == TYPE_OBJECT:
-		return left.get_instance_id() == right.get_instance_id()
+		return (left as Object).get_instance_id() == (right as Object).get_instance_id()
 	return equals(left, right)
 
 
@@ -414,7 +418,7 @@ static func is_scene(value :Variant) -> bool:
 
 
 static func is_scene_resource_path(value :Variant) -> bool:
-	return value is String and value.ends_with(".tscn")
+	return value is String and (value as String).ends_with(".tscn")
 
 
 static func is_gd_script(script :Script) -> bool:
@@ -439,11 +443,11 @@ static func is_gd_testsuite(script :Script) -> bool:
 	return false
 
 
-static func is_singleton(value :Variant) -> bool:
+static func is_singleton(value: Variant) -> bool:
 	if not is_instance_valid(value) or is_native_class(value):
 		return false
 	for name in Engine.get_singleton_list():
-		if value.is_class(name):
+		if (value as Object).is_class(name):
 			return true
 	return false
 
@@ -455,7 +459,7 @@ static func is_instance(value :Variant) -> bool:
 		return true
 	if is_scene(value):
 		return true
-	return not value.has_method('new') and not value.has_method('instance')
+	return not (value as Object).has_method('new') and not (value as Object).has_method('instance')
 
 
 # only object form type Node and attached filename
@@ -469,7 +473,7 @@ static func is_instance_scene(instance :Variant) -> bool:
 static func can_be_instantiate(obj :Variant) -> bool:
 	if not obj or is_engine_type(obj):
 		return false
-	return obj.has_method("new")
+	return (obj as Object).has_method("new")
 
 
 static func create_instance(clazz :Variant) -> GdUnitResult:
@@ -478,6 +482,7 @@ static func create_instance(clazz :Variant) -> GdUnitResult:
 			# test is given clazz already an instance
 			if is_instance(clazz):
 				return GdUnitResult.success(clazz)
+			@warning_ignore("unsafe_method_access")
 			return GdUnitResult.success(clazz.new())
 		TYPE_STRING:
 			var clazz_name := clazz as String
@@ -491,7 +496,7 @@ static func create_instance(clazz :Variant) -> GdUnitResult:
 				var clazz_path :String = extract_class_path(clazz_name)[0]
 				if not FileAccess.file_exists(clazz_path):
 					return GdUnitResult.error("Class '%s' not found." % clazz_name)
-				var script := load(clazz_path)
+				var script: GDScript = load(clazz_path)
 				if script != null:
 					return GdUnitResult.success(script.new())
 				else:
@@ -560,19 +565,20 @@ static func extract_class_name(clazz :Variant) -> GdUnitResult:
 		if ClassDB.class_exists(clazz_name):
 			return GdUnitResult.success(clazz_name)
 		var source_script :GDScript = load(clazz_name)
-		clazz_name = load("res://addons/gdUnit4/src/core/parse/GdScriptParser.gd").new().get_class_name(source_script)
+		clazz_name = GdScriptParser.new().get_class_name(source_script)
 		return GdUnitResult.success(to_pascal_case(clazz_name))
 
 	if is_primitive_type(clazz):
 		return GdUnitResult.error("Can't extract class name for an primitive '%s'" % type_as_string(typeof(clazz)))
 
 	if is_script(clazz):
-		if clazz.resource_path.is_empty():
+		if (clazz as Script).resource_path.is_empty():
 			var class_path := extract_class_name_from_class_path(extract_class_path(clazz))
 			return GdUnitResult.success(class_path);
 		return extract_class_name(clazz.resource_path)
 
 	# need to create an instance for a class typ the extract the class name
+	@warning_ignore("unsafe_method_access")
 	var instance :Variant = clazz.new()
 	if instance == null:
 		return GdUnitResult.error("Can't create a instance for class '%s'" % clazz)

--- a/addons/gdUnit4/src/core/GdUnitClassDoubler.gd
+++ b/addons/gdUnit4/src/core/GdUnitClassDoubler.gd
@@ -43,7 +43,7 @@ static func load_template(template :String, class_info :Dictionary, instance :Ob
 	var lines := GdScriptParser.to_unix_format(source_code).split("\n")
 	# replace template class_name with Doubled<class> name and extends form source class
 	@warning_ignore("return_value_discarded")
-	lines.insert(0, "class_name Doubled%s" % class_info.get("class_name").replace(".", "_"))
+	lines.insert(0, "class_name Doubled%s" % (class_info.get("class_name") as String).replace(".", "_"))
 	@warning_ignore("return_value_discarded")
 	lines.insert(1, extends_clazz(class_info))
 	# append Object interactions stuff

--- a/addons/gdUnit4/src/core/GdUnitObjectInteractions.gd
+++ b/addons/gdUnit4/src/core/GdUnitObjectInteractions.gd
@@ -5,13 +5,15 @@ extends RefCounted
 static func verify(interaction_object :Object, interactions_times :int) -> Variant:
 	if not _is_mock_or_spy(interaction_object, "__verify"):
 		return interaction_object
+	@warning_ignore("unsafe_method_access")
 	return interaction_object.__do_verify_interactions(interactions_times)
 
 
 static func verify_no_interactions(interaction_object :Object) -> GdUnitAssert:
-	var __gd_assert :GdUnitAssert = ResourceLoader.load("res://addons/gdUnit4/src/asserts/GdUnitAssertImpl.gd", "GDScript", ResourceLoader.CACHE_MODE_REUSE).new("")
+	var __gd_assert := GdUnitAssertImpl.new("")
 	if not _is_mock_or_spy(interaction_object, "__verify"):
 		return __gd_assert.report_success()
+	@warning_ignore("unsafe_method_access")
 	var __summary :Dictionary = interaction_object.__verify_no_interactions()
 	if __summary.is_empty():
 		return __gd_assert.report_success()
@@ -19,9 +21,10 @@ static func verify_no_interactions(interaction_object :Object) -> GdUnitAssert:
 
 
 static func verify_no_more_interactions(interaction_object :Object) -> GdUnitAssert:
-	var __gd_assert :GdUnitAssert = ResourceLoader.load("res://addons/gdUnit4/src/asserts/GdUnitAssertImpl.gd", "GDScript", ResourceLoader.CACHE_MODE_REUSE).new("")
+	var __gd_assert := GdUnitAssertImpl.new("")
 	if not _is_mock_or_spy(interaction_object, "__verify_no_more_interactions"):
 		return __gd_assert
+	@warning_ignore("unsafe_method_access")
 	var __summary :Dictionary = interaction_object.__verify_no_more_interactions()
 	if __summary.is_empty():
 		return __gd_assert
@@ -31,12 +34,13 @@ static func verify_no_more_interactions(interaction_object :Object) -> GdUnitAss
 static func reset(interaction_object :Object) -> Object:
 	if not _is_mock_or_spy(interaction_object, "__reset"):
 		return interaction_object
+	@warning_ignore("unsafe_method_access")
 	interaction_object.__reset_interactions()
 	return interaction_object
 
 
 static func _is_mock_or_spy(interaction_object :Object, mock_function_signature :String) -> bool:
-	if interaction_object is GDScript and not interaction_object.get_script().has_script_method(mock_function_signature):
+	if interaction_object is GDScript and not (interaction_object.get_script() as GDScript).has_method(mock_function_signature):
 		push_error("Error: You try to use a non mock or spy!")
 		return false
 	return true

--- a/addons/gdUnit4/src/core/GdUnitObjectInteractionsTemplate.gd
+++ b/addons/gdUnit4/src/core/GdUnitObjectInteractionsTemplate.gd
@@ -1,4 +1,3 @@
-const GdUnitAssertImpl := preload("res://addons/gdUnit4/src/asserts/GdUnitAssertImpl.gd")
 
 var __expected_interactions :int = -1
 var __saved_interactions := Dictionary()

--- a/addons/gdUnit4/src/core/GdUnitRunner.gd
+++ b/addons/gdUnit4/src/core/GdUnitRunner.gd
@@ -77,7 +77,9 @@ func _process(_delta :float) -> void:
 				# process next test suite
 				set_process(false)
 				var test_suite :Node = _test_suites_to_process.pop_front()
+				@warning_ignore("unsafe_method_access")
 				if _cs_executor != null and _cs_executor.IsExecutable(test_suite):
+					@warning_ignore("unsafe_method_access")
 					_cs_executor.Execute(test_suite)
 					@warning_ignore("unsafe_property_access")
 					await _cs_executor.ExecutionCompleted
@@ -136,6 +138,7 @@ func _do_filter_test_case(test_suite :Node, test_case :Node, included_tests :Pac
 			# we have a paremeterized test selection
 			if test_meta.size() > 1:
 				var test_param_index := test_meta[1]
+				@warning_ignore("unsafe_method_access")
 				test_case.set_test_parameter_index(test_param_index.to_int())
 			return
 	# the test is filtered out

--- a/addons/gdUnit4/src/core/GdUnitSceneRunnerImpl.gd
+++ b/addons/gdUnit4/src/core/GdUnitSceneRunnerImpl.gd
@@ -118,6 +118,7 @@ func simulate_action_press(action: String) -> GdUnitSceneRunner:
 	event.pressed = true
 	event.action = action
 	if Engine.get_version_info().hex >= 0x40300:
+		@warning_ignore("unsafe_property_access")
 		event.event_index = InputMap.get_actions().find(action)
 	_action_on_press.append(action)
 	return _handle_input_event(event)
@@ -129,6 +130,7 @@ func simulate_action_release(action: String) -> GdUnitSceneRunner:
 	event.pressed = false
 	event.action = action
 	if Engine.get_version_info().hex >= 0x40300:
+		@warning_ignore("unsafe_property_access")
 		event.event_index = InputMap.get_actions().find(action)
 	_action_on_press.erase(action)
 	return _handle_input_event(event)

--- a/addons/gdUnit4/src/core/GdUnitSceneRunnerImpl.gd
+++ b/addons/gdUnit4/src/core/GdUnitSceneRunnerImpl.gd
@@ -3,7 +3,7 @@ class_name GdUnitSceneRunnerImpl
 extends GdUnitSceneRunner
 
 
-var GdUnitFuncAssertImpl := ResourceLoader.load("res://addons/gdUnit4/src/asserts/GdUnitFuncAssertImpl.gd", "GDScript", ResourceLoader.CACHE_MODE_REUSE)
+var GdUnitFuncAssertImpl: GDScript = ResourceLoader.load("res://addons/gdUnit4/src/asserts/GdUnitFuncAssertImpl.gd", "GDScript", ResourceLoader.CACHE_MODE_REUSE)
 
 
 # mapping of mouse buttons and his masks
@@ -55,7 +55,7 @@ func _init(p_scene: Variant, p_verbose: bool, p_hide_push_errors := false) -> vo
 			if not p_hide_push_errors:
 				push_error("GdUnitSceneRunner: The given resource: '%s'. is not a scene." % p_scene)
 			return
-		_current_scene = load(p_scene as String).instantiate()
+		_current_scene = (load(p_scene as String) as PackedScene).instantiate()
 		_scene_auto_free = true
 	else:
 		# verify we have a node instance
@@ -277,7 +277,7 @@ func simulate_screen_touch_press(index: int, position: Vector2, double_tap := fa
 		simulate_mouse_button_press(MOUSE_BUTTON_LEFT)
 	# push touch press event at position
 	var event := InputEventScreenTouch.new()
-	event.window_id = scene().get_viewport().get_window_id()
+	event.window_id = scene().get_window().get_window_id()
 	event.index = index
 	event.position = position
 	event.double_tap = double_tap
@@ -295,7 +295,7 @@ func simulate_screen_touch_release(index: int, double_tap := false) -> GdUnitSce
 		simulate_mouse_button_release(MOUSE_BUTTON_LEFT)
 	# push touch release event at position
 	var event := InputEventScreenTouch.new()
-	event.window_id = scene().get_viewport().get_window_id()
+	event.window_id = scene().get_window().get_window_id()
 	event.index = index
 	event.position = get_screen_touch_drag_position(index)
 	event.pressed = false
@@ -323,7 +323,7 @@ func simulate_screen_touch_drag(index: int, position: Vector2) -> GdUnitSceneRun
 	if is_emulate_mouse_from_touch():
 		simulate_mouse_move(position)
 	var event := InputEventScreenDrag.new()
-	event.window_id = scene().get_viewport().get_window_id()
+	event.window_id = scene().get_window().get_window_id()
 	event.index = index
 	event.position = position
 	event.relative = _get_screen_touch_drag_position_or_default(index, position) - position
@@ -355,7 +355,7 @@ func _get_screen_touch_drag_position_or_default(index: int, default_position: Ve
 func _do_touch_drag_at(index: int, drag_position: Vector2, time: float, trans_type: Tween.TransitionType) -> GdUnitSceneRunner:
 	# start draging
 	var event := InputEventScreenDrag.new()
-	event.window_id = scene().get_viewport().get_window_id()
+	event.window_id = scene().get_window().get_window_id()
 	event.index = index
 	event.position = get_screen_touch_drag_position(index)
 	event.pressure = 1.0
@@ -587,7 +587,7 @@ func _handle_input_event(event: InputEvent) -> GdUnitSceneRunner:
 			Input.flush_buffered_events()
 		__print("	process event %s (%s) <- %s" % [current_scene, _scene_name(), event.as_text()])
 		if(current_scene.has_method("_gui_input")):
-			current_scene._gui_input(event)
+			(current_scene as Control)._gui_input(event)
 		if(current_scene.has_method("_unhandled_input")):
 			current_scene._unhandled_input(event)
 		current_scene.get_viewport().set_input_as_handled()

--- a/addons/gdUnit4/src/core/GdUnitSignalAwaiter.gd
+++ b/addons/gdUnit4/src/core/GdUnitSignalAwaiter.gd
@@ -69,7 +69,7 @@ func on_signal(source :Object, signal_name :String, expected_signal_args :Array)
 	source.disconnect(signal_name, _on_signal_emmited)
 	_time_left = timer.time_left
 	await scene_tree.process_frame
-	if value is Array and value.size() == 1:
+	if value is Array and (value as Array).size() == 1:
 		return value[0]
 	return value
 

--- a/addons/gdUnit4/src/core/GdUnitSignalCollector.gd
+++ b/addons/gdUnit4/src/core/GdUnitSignalCollector.gd
@@ -78,7 +78,7 @@ func _on_signal_emmited(
 	var emitter :Object = signal_args.pop_back()
 	#prints("_on_signal_emmited:", emitter, signal_name, signal_args)
 	if is_signal_collecting(emitter, signal_name):
-		_collected_signals[emitter][signal_name].append(signal_args)
+		(_collected_signals[emitter][signal_name] as Array).append(signal_args)
 
 
 func reset_received_signals(emitter :Object, signal_name: String, signal_args :Array) -> void:
@@ -86,12 +86,12 @@ func reset_received_signals(emitter :Object, signal_name: String, signal_args :A
 	if _collected_signals.has(emitter):
 		var signals_by_emitter :Dictionary = _collected_signals[emitter]
 		if signals_by_emitter.has(signal_name):
-			_collected_signals[emitter][signal_name].erase(signal_args)
+			(_collected_signals[emitter][signal_name] as Array).erase(signal_args)
 	#_debug_signal_list("after claer");
 
 
 func is_signal_collecting(emitter :Object, signal_name :String) -> bool:
-	return _collected_signals.has(emitter) and _collected_signals[emitter].has(signal_name)
+	return _collected_signals.has(emitter) and (_collected_signals[emitter] as Dictionary).has(signal_name)
 
 
 func match(emitter :Object, signal_name :String, args :Array) -> bool:

--- a/addons/gdUnit4/src/core/GdUnitSignals.gd
+++ b/addons/gdUnit4/src/core/GdUnitSignals.gd
@@ -37,6 +37,8 @@ static func dispose() -> void:
 	# cleanup connected signals
 	for signal_ in signals.get_signal_list():
 		for connection in signals.get_signal_connection_list(signal_["name"] as StringName):
-			connection["signal"].disconnect(connection["callable"])
+			var _signal := connection["signal"] as Signal
+			var _callable := connection["callable"] as Callable
+			_signal.disconnect(_callable)
 	signals = null
 	Engine.remove_meta(META_KEY)

--- a/addons/gdUnit4/src/core/GdUnitSingleton.gd
+++ b/addons/gdUnit4/src/core/GdUnitSingleton.gd
@@ -17,7 +17,7 @@ static func instance(name :String, clazz :Callable) -> Variant:
 		return Engine.get_meta(name)
 	var singleton :Variant = clazz.call()
 	if  is_instance_of(singleton, RefCounted):
-		push_error("Invalid singleton implementation detected for '%s' is `%s`!" % [name, singleton.get_class()])
+		push_error("Invalid singleton implementation detected for '%s' is `%s`!" % [name, (singleton as RefCounted).get_class()])
 		return
 
 	Engine.set_meta(name, singleton)

--- a/addons/gdUnit4/src/core/GdUnitTestSuiteScanner.gd
+++ b/addons/gdUnit4/src/core/GdUnitTestSuiteScanner.gd
@@ -95,7 +95,7 @@ func _parse_is_test_suite(resource_path :String) -> Node:
 		return null
 	# Check in the global class cache whether the GdUnitTestSuite class has been extended.
 	if _included_resources.has(resource_path):
-		return _parse_test_suite(ResourceLoader.load(resource_path) as GDScript)
+		return _parse_test_suite(load_with_disabled_warnings(resource_path))
 
 	# Otherwise we need to scan manual, we need to exclude classes where direct extends form Godot classes
 	# the resource loader can fail to load e.g. plugin classes with do preload other scripts
@@ -104,10 +104,25 @@ func _parse_is_test_suite(resource_path :String) -> Node:
 	if extends_from.is_empty() or ClassDB.class_exists(extends_from):
 		return null
 	# Finally, we need to load the class to determine it is a test suite
-	var script: GDScript = ResourceLoader.load(resource_path)
+	var script := load_with_disabled_warnings(resource_path)
 	if not GdObjects.is_test_suite(script):
 		return null
 	return _parse_test_suite(script)
+
+
+# We load the test suites with disabled unsafe_method_access to avoid spamming loading errors
+# `unsafe_method_access` will happen when using `assert_that`
+func load_with_disabled_warnings(resource_path: String) -> GDScript:
+	# grap current level
+	var unsafe_method_access: Variant = ProjectSettings.get_setting("debug/gdscript/warnings/unsafe_method_access")
+
+	# disable and load the script
+	ProjectSettings.set_setting("debug/gdscript/warnings/unsafe_method_access", 0)
+	var script: GDScript = ResourceLoader.load(resource_path)
+
+	# restore
+	ProjectSettings.set_setting("debug/gdscript/warnings/unsafe_method_access", unsafe_method_access)
+	return script
 
 
 static func _is_script_format_supported(resource_path :String) -> bool:

--- a/addons/gdUnit4/src/core/GdUnitTestSuiteScanner.gd
+++ b/addons/gdUnit4/src/core/GdUnitTestSuiteScanner.gd
@@ -112,7 +112,7 @@ func _parse_is_test_suite(resource_path :String) -> Node:
 
 # We load the test suites with disabled unsafe_method_access to avoid spamming loading errors
 # `unsafe_method_access` will happen when using `assert_that`
-func load_with_disabled_warnings(resource_path: String) -> GDScript:
+static func load_with_disabled_warnings(resource_path: String) -> GDScript:
 	# grap current level
 	var unsafe_method_access: Variant = ProjectSettings.get_setting("debug/gdscript/warnings/unsafe_method_access")
 
@@ -336,7 +336,7 @@ func get_extends_classname(resource_path :String) -> String:
 
 
 static func add_test_case(resource_path :String, func_name :String)  -> GdUnitResult:
-	var script := load(resource_path) as GDScript
+	var script := load_with_disabled_warnings(resource_path)
 	# count all exiting lines and add two as space to add new test case
 	var line_number := count_lines(script) + 2
 	var func_body := TEST_FUNC_TEMPLATE.replace("${func_name}", func_name)
@@ -363,7 +363,7 @@ static func test_suite_exists(test_suite_path :String) -> bool:
 static func test_case_exists(test_suite_path :String, func_name :String) -> bool:
 	if not test_suite_exists(test_suite_path):
 		return false
-	var script := ResourceLoader.load(test_suite_path) as GDScript
+	var script := load_with_disabled_warnings(test_suite_path)
 	for f in script.get_script_method_list():
 		if f["name"] == "test_" + func_name:
 			return true

--- a/addons/gdUnit4/src/core/GdUnitTestSuiteScanner.gd
+++ b/addons/gdUnit4/src/core/GdUnitTestSuiteScanner.gd
@@ -95,7 +95,7 @@ func _parse_is_test_suite(resource_path :String) -> Node:
 		return null
 	# Check in the global class cache whether the GdUnitTestSuite class has been extended.
 	if _included_resources.has(resource_path):
-		return _parse_test_suite(load_with_disabled_warnings(resource_path))
+		return _parse_test_suite(GdUnitTestSuiteScanner.load_with_disabled_warnings(resource_path))
 
 	# Otherwise we need to scan manual, we need to exclude classes where direct extends form Godot classes
 	# the resource loader can fail to load e.g. plugin classes with do preload other scripts
@@ -104,7 +104,7 @@ func _parse_is_test_suite(resource_path :String) -> Node:
 	if extends_from.is_empty() or ClassDB.class_exists(extends_from):
 		return null
 	# Finally, we need to load the class to determine it is a test suite
-	var script := load_with_disabled_warnings(resource_path)
+	var script := GdUnitTestSuiteScanner.load_with_disabled_warnings(resource_path)
 	if not GdObjects.is_test_suite(script):
 		return null
 	return _parse_test_suite(script)

--- a/addons/gdUnit4/src/core/GdUnitTestSuiteScanner.gd
+++ b/addons/gdUnit4/src/core/GdUnitTestSuiteScanner.gd
@@ -126,7 +126,7 @@ func _parse_test_suite(script: Script) -> GdUnitTestSuite:
 		return GdUnit4CSharpApiLoader.parse_test_suite(script.resource_path)
 
 	# Do pares as GDScript
-	var test_suite: GdUnitTestSuite = script.new()
+	var test_suite: GdUnitTestSuite = (script as GDScript).new()
 	test_suite.set_name(GdUnitTestSuiteScanner.parse_test_suite_name(script))
 	# add test cases to test suite and parse test case line nummber
 	var test_case_names := _extract_test_case_names(script as GDScript)

--- a/addons/gdUnit4/src/core/command/GdUnitCommandHandler.gd
+++ b/addons/gdUnit4/src/core/command/GdUnitCommandHandler.gd
@@ -77,7 +77,7 @@ func _init() -> void:
 
 	# schedule discover tests if enabled and running inside the editor
 	if Engine.is_editor_hint() and GdUnitSettings.is_test_discover_enabled():
-		var timer :SceneTreeTimer = Engine.get_main_loop().create_timer(5)
+		var timer :SceneTreeTimer = (Engine.get_main_loop() as SceneTree).create_timer(5)
 		@warning_ignore("return_value_discarded")
 		timer.timeout.connect(cmd_discover_tests)
 
@@ -349,7 +349,7 @@ func _on_settings_changed(property :GdUnitProperty) -> void:
 		prints("Shortcut changed: '%s' to '%s'" % [GdUnitShortcut.ShortCut.keys()[shortcut], input_event.as_text()])
 		register_shortcut(shortcut, input_event)
 	if property.name() == GdUnitSettings.TEST_DISCOVER_ENABLED:
-		var timer :SceneTreeTimer = Engine.get_main_loop().create_timer(3)
+		var timer :SceneTreeTimer = (Engine.get_main_loop() as SceneTree).create_timer(3)
 		@warning_ignore("return_value_discarded")
 		timer.timeout.connect(cmd_discover_tests)
 

--- a/addons/gdUnit4/src/core/discovery/GdUnitTestDiscoverer.gd
+++ b/addons/gdUnit4/src/core/discovery/GdUnitTestDiscoverer.gd
@@ -5,7 +5,7 @@ extends RefCounted
 static func run() -> void:
 	prints("Running test discovery ..")
 	GdUnitSignals.instance().gdunit_event.emit(GdUnitEventTestDiscoverStart.new())
-	await Engine.get_main_loop().create_timer(.5).timeout
+	await (Engine.get_main_loop() as SceneTree).create_timer(.5).timeout
 
 	# We run the test discovery in an extra thread so that the main thread is not blocked
 	var t:= Thread.new()

--- a/addons/gdUnit4/src/core/execution/GdUnitMemoryObserver.gd
+++ b/addons/gdUnit4/src/core/execution/GdUnitMemoryObserver.gd
@@ -41,6 +41,7 @@ static func _is_instance_guard_enabled() -> bool:
 	return false
 
 
+@warning_ignore("unsafe_method_access")
 static func debug_observe(name :String, obj :Object, indent :int = 0) -> void:
 	if not _show_debug:
 		return
@@ -89,7 +90,7 @@ static func gc_guarded_instance(name :String, instance :Object) -> void:
 		#	if base_script:
 		#		base_script.unreference()
 		debug_observe(name, instance)
-		instance.unreference()
+		(instance as RefCounted).unreference()
 		await (Engine.get_main_loop() as SceneTree).process_frame
 
 
@@ -128,4 +129,4 @@ func gc() -> void:
 
 ## Checks whether the specified object is registered for automatic release
 static func is_marked_auto_free(obj: Variant) -> bool:
-	return Engine.get_meta(TAG_AUTO_FREE, []).has(obj)
+	return (Engine.get_meta(TAG_AUTO_FREE, []) as Array).has(obj)

--- a/addons/gdUnit4/src/core/execution/GdUnitTestSuiteExecutor.gd
+++ b/addons/gdUnit4/src/core/execution/GdUnitTestSuiteExecutor.gd
@@ -5,7 +5,7 @@ class_name GdUnitTestSuiteExecutor
 # preload all asserts here
 @warning_ignore("unused_private_class_variable")
 var _assertions := GdUnitAssertions.new()
-var _executeStage :IGdUnitExecutionStage = GdUnitTestSuiteExecutionStage.new()
+var _executeStage := GdUnitTestSuiteExecutionStage.new()
 
 
 func _init(debug_mode :bool = false) -> void:

--- a/addons/gdUnit4/src/core/execution/stages/GdUnitTestSuiteExecutionStage.gd
+++ b/addons/gdUnit4/src/core/execution/stages/GdUnitTestSuiteExecutionStage.gd
@@ -69,7 +69,7 @@ func dispose_timers(test_suite :GdUnitTestSuite) -> void:
 	GdUnitTools.release_timers()
 	for child in test_suite.get_children():
 		if child is Timer:
-			child.stop()
+			(child as Timer).stop()
 			test_suite.remove_child(child)
 			child.free()
 

--- a/addons/gdUnit4/src/core/parse/GdDefaultValueDecoder.gd
+++ b/addons/gdUnit4/src/core/parse/GdDefaultValueDecoder.gd
@@ -247,9 +247,13 @@ func _on_type_Basis(basis :Basis) -> String:
 
 static func decode(value :Variant) -> String:
 	var type := typeof(value)
-	if GdArrayTools.is_type_array(type) and value.is_empty():
+	if GdArrayTools.is_type_array(type) and (value as Array).is_empty():
 		return "<empty>"
-	var decoder :Callable = instance("GdUnitDefaultValueDecoders", func() -> GdDefaultValueDecoder: return GdDefaultValueDecoder.new()).get_decoder(type)
+	var decoder :Callable = (
+			instance("GdUnitDefaultValueDecoders",
+				func() -> GdDefaultValueDecoder: return GdDefaultValueDecoder.new()
+				) as GdDefaultValueDecoder
+		).get_decoder(type)
 	if decoder == null:
 		push_error("No value decoder registered for type '%d'! Please open a Bug issue at 'https://github.com/MikeSchulze/gdUnit4/issues/new/choose'." % type)
 		return "null"
@@ -261,7 +265,11 @@ static func decode(value :Variant) -> String:
 static func decode_typed(type :int, value :Variant) -> String:
 	if value == null:
 		return "null"
-	var decoder: Callable = instance("GdUnitDefaultValueDecoders", func() -> GdDefaultValueDecoder: return GdDefaultValueDecoder.new()).get_decoder(type)
+	var decoder: Callable = (
+			instance("GdUnitDefaultValueDecoders",
+				func() -> GdDefaultValueDecoder: return GdDefaultValueDecoder.new()
+				) as GdDefaultValueDecoder
+			).get_decoder(type)
 	if decoder == null:
 		push_error("No value decoder registered for type '%d'! Please open a Bug issue at 'https://github.com/MikeSchulze/gdUnit4/issues/new/choose'." % type)
 		return "null"

--- a/addons/gdUnit4/src/core/parse/GdFunctionDescriptor.gd
+++ b/addons/gdUnit4/src/core/parse/GdFunctionDescriptor.gd
@@ -106,10 +106,11 @@ func return_type_as_string() -> String:
 	return GdObjects.type_as_string(return_type())
 
 
-func set_argument_value(arg_name: String, value: Variant) -> void:
-	_args.filter(func(arg: GdFunctionArgument) -> bool: return arg.name() == arg_name)\
-		.front()\
-		.set_value(value)
+func set_argument_value(arg_name: String, value: String) -> void:
+	(
+		_args.filter(func(arg: GdFunctionArgument) -> bool: return arg.name() == arg_name)\
+		.front() as GdFunctionArgument
+	).set_value(value)
 
 
 func enrich_file_info(p_source_path: String, p_line_number: int) -> void:

--- a/addons/gdUnit4/src/core/parse/GdUnitExpressionRunner.gd
+++ b/addons/gdUnit4/src/core/parse/GdUnitExpressionRunner.gd
@@ -38,8 +38,7 @@ func execute(src_script: GDScript, value: Variant) -> Variant:
 	@warning_ignore("return_value_discarded")
 	script.reload(true)
 	var runner: Variant = script.new()
-	@warning_ignore("unsafe_method_access")
-	if runner.has_method("queue_free"):
+	if (runner as Object).has_method("queue_free"):
 		(runner as Node).queue_free()
 	@warning_ignore("unsafe_method_access")
 	return runner.__run_expression()

--- a/addons/gdUnit4/src/core/parse/GdUnitExpressionRunner.gd
+++ b/addons/gdUnit4/src/core/parse/GdUnitExpressionRunner.gd
@@ -23,10 +23,11 @@ func execute(src_script: GDScript, value: Variant) -> Variant:
 		# check we need to construct from inner class
 		# we need to use the original class instance from the script_constant_map otherwise we run into a runtime error
 		if expression.begins_with(key + ".new") and parameter_value is GDScript:
+			var object := parameter_value as GDScript
 			var args := build_constructor_arguments(parameter_map, expression.substr(expression.find("new")))
 			if args.is_empty():
-				return parameter_value.new()
-			return parameter_value.callv("new", args)
+				return object.new()
+			return object.callv("new", args)
 
 	var script := GDScript.new()
 	var resource_path := "res://addons/gdUnit4/src/Fuzzers.gd" if src_script.resource_path.is_empty() else src_script.resource_path
@@ -36,9 +37,11 @@ func execute(src_script: GDScript, value: Variant) -> Variant:
 	#script.take_over_path(resource_path)
 	@warning_ignore("return_value_discarded")
 	script.reload(true)
-	var runner :Variant = script.new()
+	var runner: Variant = script.new()
+	@warning_ignore("unsafe_method_access")
 	if runner.has_method("queue_free"):
-		runner.queue_free()
+		(runner as Node).queue_free()
+	@warning_ignore("unsafe_method_access")
 	return runner.__run_expression()
 
 

--- a/addons/gdUnit4/src/core/parse/GdUnitTestParameterSetResolver.gd
+++ b/addons/gdUnit4/src/core/parse/GdUnitTestParameterSetResolver.gd
@@ -45,7 +45,7 @@ func validate(input_value_set: Array) -> String:
 	for input_values :Variant in input_value_set:
 		var parameter_set_index := input_value_set.find(input_values)
 		if input_values is Array:
-			var current_arg_count :int = input_values.size()
+			var current_arg_count :int = (input_values as Array).size()
 			if current_arg_count != expected_arg_count:
 				return "\n	The parameter set at index [%d] does not match the expected input parameters!\n	The test case requires [%d] input parameters, but the set contains [%d]" % [parameter_set_index, expected_arg_count, current_arg_count]
 			var error := GdUnitTestParameterSetResolver.validate_parameter_types(input_arguments, input_values as Array, parameter_set_index)
@@ -153,7 +153,7 @@ func load_parameter_sets(test_case: _TestCase, do_validate := false) -> Array:
 		return []
 	var instance :Object = script.new()
 	GdUnitTestParameterSetResolver.copy_properties(test_case.get_parent(), instance)
-	instance.queue_free()
+	(instance as Node).queue_free()
 	var parameter_sets: Array = instance.call("__extract_test_parameters")
 	if not do_validate:
 		return parameter_sets

--- a/addons/gdUnit4/src/core/templates/test_suite/GdUnitTestSuiteTemplate.gd
+++ b/addons/gdUnit4/src/core/templates/test_suite/GdUnitTestSuiteTemplate.gd
@@ -87,7 +87,7 @@ static func default_CS_template() -> String:
 
 static func build_template(source_path: String) -> String:
 	var clazz_name :String = GdObjects.to_pascal_case(GdObjects.extract_class_name(source_path).value() as String)
-	return GdUnitSettings.get_setting(GdUnitSettings.TEMPLATE_TS_GD, default_GD_template())\
+	return (GdUnitSettings.get_setting(GdUnitSettings.TEMPLATE_TS_GD, default_GD_template()) as String)\
 		.replace(TAG_TEST_SUITE_CLASS, clazz_name+"Test")\
 		.replace(TAG_SOURCE_RESOURCE_PATH, source_path)\
 		.replace(TAG_SOURCE_CLASS_NAME, clazz_name)\

--- a/addons/gdUnit4/src/doubler/CallableDoubler.gd
+++ b/addons/gdUnit4/src/doubler/CallableDoubler.gd
@@ -163,7 +163,7 @@ func rpc(arg0=GdObjects.TYPE_VARARG_PLACEHOLDER_VALUE,
 	arg9=GdObjects.TYPE_VARARG_PLACEHOLDER_VALUE) -> void:
 
 	var args = GdArrayTools.filter_value([arg0,arg1,arg2,arg3,arg4,arg5,arg6,arg7,arg8,arg9], GdObjects.TYPE_VARARG_PLACEHOLDER_VALUE)
-	match args.size():
+	match (args as Array).size():
 		0: _cb.rpc(0)
 		1: _cb.rpc(args[0])
 		2: _cb.rpc(args[0], args[1])
@@ -191,7 +191,7 @@ func rpc_id(peer_id: int,
 	arg9=GdObjects.TYPE_VARARG_PLACEHOLDER_VALUE) -> void:
 
 	var args = GdArrayTools.filter_value([arg0,arg1,arg2,arg3,arg4,arg5,arg6,arg7,arg8,arg9], GdObjects.TYPE_VARARG_PLACEHOLDER_VALUE)
-	match args.size():
+	match (args as Array).size():
 		0: _cb.rpc_id(peer_id)
 		1: _cb.rpc_id(peer_id, args[0])
 		2: _cb.rpc_id(peer_id, args[0], args[1])

--- a/addons/gdUnit4/src/extractors/GdUnitFuncValueExtractor.gd
+++ b/addons/gdUnit4/src/extractors/GdUnitFuncValueExtractor.gd
@@ -1,4 +1,5 @@
 # This class defines a value extractor by given function name and args
+class_name GdUnitFuncValueExtractor
 extends GdUnitValueExtractor
 
 var _func_names :PackedStringArray
@@ -50,17 +51,18 @@ func _call_func(value :Variant, func_name :String) -> Variant:
 	# for array types we need to call explicit by function name, using funcref is only supported for Objects
 	# TODO extend to all array functions
 	if GdArrayTools.is_array_type(value) and func_name == "empty":
-		return value.is_empty()
+		return (value as Array).is_empty()
 
 	if is_instance_valid(value):
 		# extract from function
-		if value.has_method(func_name):
-			var extract := Callable(value as Object, func_name)
+		var obj_value: Object = value
+		if obj_value.has_method(func_name):
+			var extract := Callable(obj_value, func_name)
 			if extract.is_valid():
-				return value.call(func_name) if args().is_empty() else value.callv(func_name, args())
+				return obj_value.call(func_name) if args().is_empty() else obj_value.callv(func_name, args())
 		else:
 			# if no function exists than try to extract form parmeters
-			var parameter :Variant = value.get(func_name)
+			var parameter: Variant = obj_value.get(func_name)
 			if parameter != null:
 				return parameter
 	# nothing found than return 'n.a.'

--- a/addons/gdUnit4/src/matchers/AnyClazzArgumentMatcher.gd
+++ b/addons/gdUnit4/src/matchers/AnyClazzArgumentMatcher.gd
@@ -12,12 +12,13 @@ func is_match(value :Variant) -> bool:
 	if typeof(value) != TYPE_OBJECT:
 		return false
 	if is_instance_valid(value) and GdObjects.is_script(_clazz):
-		return value.get_script() == _clazz
+		return (value as Object).get_script() == _clazz
 	return is_instance_of(value, _clazz)
 
 
 func _to_string() -> String:
 	if (_clazz as Object).is_class("GDScriptNativeClass"):
+		@warning_ignore("unsafe_method_access")
 		var instance :Object = _clazz.new()
 		var clazz_name := instance.get_class()
 		if not instance is RefCounted:

--- a/addons/gdUnit4/src/mocking/GdUnitMock.gd
+++ b/addons/gdUnit4/src/mocking/GdUnitMock.gd
@@ -22,8 +22,9 @@ func _init(value: Variant) -> void:
 ## 		do_return(false).on(myMock).is_selected()
 ## 	[/codeblock]
 func on(obj: Variant) -> Variant:
-	if not GdUnitMock._is_mock_or_spy( obj, "__do_return"):
+	if not GdUnitMock._is_mock_or_spy(obj, "__do_return"):
 		return obj
+	@warning_ignore("unsafe_method_access")
 	return obj.__do_return(_value)
 
 
@@ -34,7 +35,7 @@ func checked(obj :Object) -> Object:
 
 
 static func _is_mock_or_spy(obj: Variant, func_sig: String) -> bool:
-	if obj is GDScript and not obj.get_script().has_script_method(func_sig):
+	if obj is Object and not (obj as Object).has_method(func_sig):
 		push_error("Error: You try to use a non mock or spy!")
 		return false
 	return true

--- a/addons/gdUnit4/src/mocking/GdUnitMockBuilder.gd
+++ b/addons/gdUnit4/src/mocking/GdUnitMockBuilder.gd
@@ -9,6 +9,7 @@ static func is_push_errors() -> bool:
 	return GdUnitSettings.is_report_push_errors()
 
 
+@warning_ignore("unsafe_method_access")
 static func build(clazz :Variant, mock_mode :String, debug_write := false) -> Variant:
 	var push_errors := is_push_errors()
 	if not is_mockable(clazz, push_errors):
@@ -32,6 +33,7 @@ static func build(clazz :Variant, mock_mode :String, debug_write := false) -> Va
 	return register_auto_free(mock_instance)
 
 
+@warning_ignore("unsafe_method_access")
 static func create_instance(clazz: Variant) -> Object:
 	if typeof(clazz) == TYPE_OBJECT and  (clazz as Object).is_class("GDScriptNativeClass"):
 		return clazz.new()
@@ -50,6 +52,7 @@ static func create_instance(clazz: Variant) -> Object:
 	return null
 
 
+@warning_ignore("unsafe_method_access")
 static func mock_on_scene(scene :PackedScene, debug_write :bool) -> Variant:
 	var push_errors := is_push_errors()
 	if not scene.can_instantiate():

--- a/addons/gdUnit4/src/mocking/GdUnitMockImpl.gd
+++ b/addons/gdUnit4/src/mocking/GdUnitMockImpl.gd
@@ -77,6 +77,7 @@ func __save_function_return_value(__fuction_args :Array) -> void:
 	__prepare_return_value = false
 
 
+@warning_ignore("unsafe_method_access")
 func __is_mocked_args_match(__func_args :Array, __mocked_args :Array) -> bool:
 	var __is_matching := false
 	for __index in __mocked_args.size():
@@ -98,6 +99,7 @@ func __is_mocked_args_match(__func_args :Array, __mocked_args :Array) -> bool:
 	return __is_matching
 
 
+@warning_ignore("unsafe_method_access")
 func __get_mocked_return_value_or_default(__fuction_args :Array, __default_return_value :Variant) -> Variant:
 	var __func_name :String = __fuction_args[0]
 	if not __mocked_return_values.has(__func_name):
@@ -120,6 +122,7 @@ func __set_mode(mock_working_mode :String) -> Object:
 	return self
 
 
+@warning_ignore("unsafe_method_access")
 func __do_call_real_func(__func_name :String, __func_args := []) -> bool:
 	var __is_call_real_func := __mock_working_mode == GdUnitMock.CALL_REAL_FUNC  and not __excluded_methods.has(__func_name)
 	# do not call real funcions for mocked functions

--- a/addons/gdUnit4/src/mono/GdUnit4CSharpApiLoader.gd
+++ b/addons/gdUnit4/src/mono/GdUnit4CSharpApiLoader.gd
@@ -6,6 +6,7 @@ static func instance() -> Object:
 	return GdUnitSingleton.instance("GdUnit4CSharpApi", func() -> Object:
 		if not GdUnit4CSharpApiLoader.is_mono_supported():
 			return null
+		@warning_ignore("unsafe_method_access")
 		return load("res://addons/gdUnit4/src/mono/GdUnit4CSharpApi.cs").new()
 	)
 
@@ -22,12 +23,14 @@ static func is_mono_supported() -> bool:
 static func version() -> String:
 	if not GdUnit4CSharpApiLoader.is_mono_supported():
 		return "unknown"
+	@warning_ignore("unsafe_method_access")
 	return instance().Version()
 
 
 static func create_test_suite(source_path :String, line_number :int, test_suite_path :String) -> GdUnitResult:
 	if not GdUnit4CSharpApiLoader.is_mono_supported():
 		return  GdUnitResult.error("Can't create test suite. No C# support found.")
+	@warning_ignore("unsafe_method_access")
 	var result := instance().CreateTestSuite(source_path, line_number, test_suite_path) as Dictionary
 	if result.has("error"):
 		return GdUnitResult.error(result.get("error") as String)
@@ -42,6 +45,7 @@ static func is_test_suite(resource_path :String) -> bool:
 		if GdUnitSettings.is_report_push_errors():
 			push_error("Can't create test suite. Missing resource path.")
 		return  false
+	@warning_ignore("unsafe_method_access")
 	return instance().IsTestSuite(resource_path)
 
 
@@ -50,12 +54,14 @@ static func parse_test_suite(source_path :String) -> Node:
 		if GdUnitSettings.is_report_push_errors():
 			push_error("Can't create test suite. No c# support found.")
 		return null
+	@warning_ignore("unsafe_method_access")
 	return instance().ParseTestSuite(source_path)
 
 
 static func create_executor(listener :Node) -> RefCounted:
 	if not GdUnit4CSharpApiLoader.is_mono_supported():
 		return null
+	@warning_ignore("unsafe_method_access")
 	return instance().Executor(listener)
 
 

--- a/addons/gdUnit4/src/network/GdUnitTcpClient.gd
+++ b/addons/gdUnit4/src/network/GdUnitTcpClient.gd
@@ -72,7 +72,7 @@ func _process(_delta :float) -> void:
 					await get_tree().create_timer(0.500).timeout
 					rpc_ = rpc_receive()
 				set_process(true)
-				_client_id = rpc_.client_id()
+				_client_id = (rpc_ as RPCClientConnect).client_id()
 				console("Connected to Server: %d" % _client_id)
 				connection_succeeded.emit("Connect to TCP Server %s:%d success." % [_host, _port])
 				_connected = true

--- a/addons/gdUnit4/src/network/rpc/dtos/GdUnitResourceDto.gd
+++ b/addons/gdUnit4/src/network/rpc/dtos/GdUnitResourceDto.gd
@@ -8,6 +8,7 @@ var _path :String
 func serialize(resource :Node) -> Dictionary:
 	var serialized := Dictionary()
 	serialized["name"] = resource.get_name()
+	@warning_ignore("unsafe_method_access")
 	serialized["resource_path"] = resource.ResourcePath()
 	return serialized
 

--- a/addons/gdUnit4/src/network/rpc/dtos/GdUnitTestCaseDto.gd
+++ b/addons/gdUnit4/src/network/rpc/dtos/GdUnitTestCaseDto.gd
@@ -6,6 +6,7 @@ var _script_path: String
 var _test_case_names :PackedStringArray = []
 
 
+@warning_ignore("unsafe_method_access")
 func serialize(test_case :Node) -> Dictionary:
 	var serialized := super.serialize(test_case)
 	if test_case.has_method("line_number"):

--- a/addons/gdUnit4/src/report/GdUnitHtmlReport.gd
+++ b/addons/gdUnit4/src/report/GdUnitHtmlReport.gd
@@ -132,9 +132,9 @@ func apply_path_reports(report_dir :String, template :String, report_summaries :
 	return template.replace(GdUnitHtmlPatterns.TABLE_BY_PATHS, "\n".join(table_records))
 
 
-func apply_testsuite_reports(report_dir :String, template :String, test_suite_reports :Array[GdUnitReportSummary]) -> String:
+func apply_testsuite_reports(report_dir: String, template: String, test_suite_reports: Array[GdUnitReportSummary]) -> String:
 	var table_records := PackedStringArray()
-	for report in test_suite_reports:
+	for report: GdUnitTestSuiteReport in test_suite_reports:
 		var report_link :String = report.write(report_dir).replace(report_dir, ".")
 		@warning_ignore("return_value_discarded")
 		table_records.append(report.create_record(report_link) as String)

--- a/addons/gdUnit4/src/report/template/css/logo.png.import
+++ b/addons/gdUnit4/src/report/template/css/logo.png.import
@@ -5,7 +5,6 @@ type="CompressedTexture2D"
 uid="uid://2n0cbwv2t23g"
 path="res://.godot/imported/logo.png-37f10c549c1299049c5a6012ef6f9868.ctex"
 metadata={
-"has_editor_variant": true,
 "vram_texture": false
 }
 

--- a/addons/gdUnit4/src/spy/GdUnitSpyBuilder.gd
+++ b/addons/gdUnit4/src/spy/GdUnitSpyBuilder.gd
@@ -8,7 +8,7 @@ const EXCLUDE_PROPERTIES_TO_COPY = ["script", "type"]
 
 static func build(to_spy: Variant, debug_write := false) -> Variant:
 	if GdObjects.is_singleton(to_spy):
-		push_error("Spy on a Singleton is not allowed! '%s'" % to_spy.get_class())
+		push_error("Spy on a Singleton is not allowed! '%s'" % (to_spy as Object).get_class())
 		return null
 
 	# if resource path load it before
@@ -39,8 +39,10 @@ static func build(to_spy: Variant, debug_write := false) -> Variant:
 	copy_properties(to_spy as Object, spy_instance)
 	@warning_ignore("return_value_discarded")
 	GdUnitObjectInteractions.reset(spy_instance)
+	@warning_ignore("unsafe_method_access")
 	spy_instance.__set_singleton(to_spy)
 	# we do not call the original implementation for _ready and all input function, this is actualy done by the engine
+	@warning_ignore("unsafe_method_access")
 	spy_instance.__exclude_method_call([ "_input", "_gui_input", "_input_event", "_unhandled_input"])
 	return register_auto_free(spy_instance)
 
@@ -57,7 +59,7 @@ static func get_class_info(clazz :Variant) -> Dictionary:
 static func spy_on_script(instance :Variant, function_excludes :PackedStringArray, debug_write :bool) -> GDScript:
 	if GdArrayTools.is_array_type(instance):
 		if GdUnitSettings.is_verbose_assert_errors():
-			push_error("Can't build spy checked type '%s'! Spy checked Container Built-In Type not supported!" % instance.get_class())
+			push_error("Can't build spy checked type '%s'! Spy checked Container Built-In Type not supported!" % type_string(typeof(instance)))
 		return null
 	var class_info := get_class_info(instance)
 	var clazz_name :String = class_info.get("class_name")
@@ -92,7 +94,7 @@ static func spy_on_scene(scene :Node, debug_write :bool) -> Object:
 			push_error("Can't create a spy checked a scene without script '%s'" % scene.get_scene_file_path())
 		return null
 	# buils spy checked original script
-	var scene_script :Object = scene.get_script().new()
+	var scene_script :Object = (scene.get_script() as GDScript).new()
 	var spy := spy_on_script(scene_script, GdUnitClassDoubler.EXLCUDE_SCENE_FUNCTIONS, debug_write)
 	scene_script.free()
 	if spy == null:

--- a/addons/gdUnit4/src/ui/ScriptEditorControls.gd
+++ b/addons/gdUnit4/src/ui/ScriptEditorControls.gd
@@ -87,6 +87,7 @@ static func edit_script(script_path: String, line_number := -1) -> void:
 
 
 static func _menu_popup() -> PopupMenu:
+	@warning_ignore("unsafe_method_access")
 	return EditorInterface.get_script_editor().get_child(0).get_child(0).get_child(0).get_popup()
 
 

--- a/addons/gdUnit4/test/GdUnitScanTestSuitePerformanceTest.gd
+++ b/addons/gdUnit4/test/GdUnitScanTestSuitePerformanceTest.gd
@@ -1,13 +1,14 @@
 extends GdUnitTestSuite
 
 
+@warning_ignore("unsafe_method_access")
 func test_load_performance() -> void:
 	var time := LocalTime.now()
 	prints("Scan for test suites.")
 	var test_suites := GdUnitTestSuiteScanner.new().scan("res://addons/gdUnit4/test/")
 	assert_int(time.elapsed_since_ms())\
-		.override_failure_message("Expecting the loading time overall is less than 10s")\
-		.is_less(10*1000)
+		.override_failure_message("Expecting the loading time overall is less than 5s")\
+		.is_less(5*1000)
 	prints("Scanning of %d test suites took" % test_suites.size(), time.elapsed_since())
 	for ts in test_suites:
 		ts.free()

--- a/addons/gdUnit4/test/GdUnitTestSuiteTest.gd
+++ b/addons/gdUnit4/test/GdUnitTestSuiteTest.gd
@@ -4,7 +4,6 @@ extends GdUnitTestSuite
 
 # TestSuite generated from
 const __source = 'res://addons/gdUnit4/src/GdUnitTestSuite.gd'
-const GdUnitAssertImpl = preload("res://addons/gdUnit4/src/asserts/GdUnitAssertImpl.gd")
 
 var _events :Array[GdUnitEvent] = []
 var _retry_count := 0
@@ -62,9 +61,9 @@ func test_find_child() -> void:
 	node_a.add_child(node_b, true)
 	node_b.add_child(node_c, true)
 
-	assert_that(find_child("node_a", true, false)).is_same(node_a)
-	assert_that(find_child("node_b", true, false)).is_same(node_b)
-	assert_that(find_child("node_c", true, false)).is_same(node_c)
+	assert_object(find_child("node_a", true, false)).is_same(node_a)
+	assert_object(find_child("node_b", true, false)).is_same(node_b)
+	assert_object(find_child("node_c", true, false)).is_same(node_c)
 
 
 func test_find_by_path() -> void:
@@ -78,9 +77,9 @@ func test_find_by_path() -> void:
 	node_a.add_child(node_b, true)
 	node_b.add_child(node_c, true)
 
-	assert_that(get_node(node_a.get_path())).is_same(node_a)
-	assert_that(get_node(node_b.get_path())).is_same(node_b)
-	assert_that(get_node(node_c.get_path())).is_same(node_c)
+	assert_object(get_node(node_a.get_path())).is_same(node_a)
+	assert_object(get_node(node_b.get_path())).is_same(node_b)
+	assert_object(get_node(node_c.get_path())).is_same(node_c)
 
 
 func test_flaky_success() -> void:

--- a/addons/gdUnit4/test/asserts/GdUnitAssertImplTest.gd
+++ b/addons/gdUnit4/test/asserts/GdUnitAssertImplTest.gd
@@ -63,11 +63,12 @@ func test_get_line_number_multiline() -> void:
 		.has_message("Expecting:\n '42'\n but was\n '10'")
 
 
+@warning_ignore("unsafe_method_access")
 func test_get_line_number_verify() -> void:
 	var obj :Variant = mock(RefCounted)
 	assert_failure(func() -> void: verify(obj, 1).get_reference_count()) \
 		.is_failed() \
-		.has_line(68) \
+		.has_line(69) \
 		.has_message("Expecting interaction on:\n	'get_reference_count()'	1 time's\nBut found interactions on:\n")
 
 
@@ -76,7 +77,7 @@ func test_is_null() -> void:
 
 	assert_failure(func() -> void: assert_that(Color.RED).is_null()) \
 		.is_failed() \
-		.has_line(77) \
+		.has_line(78) \
 		.starts_with_message("Expecting: '<null>' but was 'Color(1, 0, 0, 1)'")
 
 
@@ -85,7 +86,7 @@ func test_is_not_null() -> void:
 
 	assert_failure(func() -> void: assert_that(null).is_not_null()) \
 		.is_failed() \
-		.has_line(86) \
+		.has_line(87) \
 		.has_message("Expecting: not to be '<null>'")
 
 
@@ -95,7 +96,7 @@ func test_is_equal() -> void:
 
 	assert_failure(func() -> void: assert_that(Color.RED).is_equal(Color.GREEN)) \
 		.is_failed() \
-		.has_line(96) \
+		.has_line(97) \
 		.has_message("Expecting:\n 'Color(0, 1, 0, 1)'\n but was\n 'Color(1, 0, 0, 1)'")
 
 
@@ -105,28 +106,30 @@ func test_is_not_equal() -> void:
 
 	assert_failure(func() -> void: assert_that(Color.RED).is_not_equal(Color.RED)) \
 		.is_failed() \
-		.has_line(106) \
+		.has_line(107) \
 		.has_message("Expecting:\n 'Color(1, 0, 0, 1)'\n not equal to\n 'Color(1, 0, 0, 1)'")
 
 
 func test_override_failure_message() -> void:
+	@warning_ignore("unsafe_method_access")
 	assert_failure(func() -> void: assert_that(Color.RED) \
 			.override_failure_message("Custom failure message") \
 			.is_null()) \
 		.is_failed() \
-		.has_line(113) \
+		.has_line(115) \
 		.has_message("Custom failure message")
 
 
 func test_assert_not_yet_implemented() -> void:
 	assert_failure(func() -> void: assert_not_yet_implemented()) \
 		.is_failed() \
-		.has_line(122) \
+		.has_line(124) \
 		.has_message("Test not implemented!")
 
 
 func test_append_failure_message() -> void:
 	assert_object(assert_that(null).append_failure_message("error")).is_instanceof(GdUnitObjectAssert)
+	@warning_ignore("unsafe_method_access")
 	assert_failure(func() -> void: assert_that(null) \
 			.append_failure_message("custom failure data") \
 			.is_not_null()) \

--- a/addons/gdUnit4/test/asserts/GdUnitBoolAssertImplTest.gd
+++ b/addons/gdUnit4/test/asserts/GdUnitBoolAssertImplTest.gd
@@ -96,6 +96,7 @@ func test_override_failure_message() -> void:
 
 func test_append_failure_message() -> void:
 	assert_object(assert_bool(true).append_failure_message("error")).is_instanceof(GdUnitBoolAssert)
+	@warning_ignore("unsafe_method_access")
 	assert_failure(func() -> void: assert_bool(true) \
 			.append_failure_message("custom failure data") \
 			.is_false()) \

--- a/addons/gdUnit4/test/asserts/GdUnitDictionaryAssertImplTest.gd
+++ b/addons/gdUnit4/test/asserts/GdUnitDictionaryAssertImplTest.gd
@@ -442,6 +442,7 @@ func test_not_contains_same_keys() -> void:
 
 func test_override_failure_message() -> void:
 	assert_object(assert_dict({1:1}).override_failure_message("error")).is_instanceof(GdUnitDictionaryAssert)
+	@warning_ignore("unsafe_method_access")
 	assert_failure(func() -> void: assert_dict({1:1}) \
 			.override_failure_message("Custom failure message") \
 			.is_null()) \
@@ -451,6 +452,7 @@ func test_override_failure_message() -> void:
 
 func test_append_failure_message() -> void:
 	assert_object(assert_dict({1:1}).append_failure_message("error")).is_instanceof(GdUnitDictionaryAssert)
+	@warning_ignore("unsafe_method_access")
 	assert_failure(func() -> void: assert_dict({1:1}) \
 			.append_failure_message("custom failure data") \
 			.is_empty()) \

--- a/addons/gdUnit4/test/asserts/GdUnitFloatAssertImplTest.gd
+++ b/addons/gdUnit4/test/asserts/GdUnitFloatAssertImplTest.gd
@@ -215,6 +215,7 @@ func test_must_fail_has_invlalid_type() -> void:
 
 func test_override_failure_message() -> void:
 	assert_object(assert_float(3.14).override_failure_message("error")).is_instanceof(GdUnitFloatAssert)
+	@warning_ignore("unsafe_method_access")
 	assert_failure(func() -> void: assert_float(3.14) \
 			.override_failure_message("Custom failure message") \
 			.is_null()) \
@@ -224,6 +225,7 @@ func test_override_failure_message() -> void:
 
 func test_append_failure_message() -> void:
 	assert_object(assert_float(3.14).append_failure_message("error")).is_instanceof(GdUnitFloatAssert)
+	@warning_ignore("unsafe_method_access")
 	assert_failure(func() -> void: assert_float(3.14) \
 			.append_failure_message("custom failure data") \
 			.is_zero()) \

--- a/addons/gdUnit4/test/asserts/GdUnitFuncAssertImplTest.gd
+++ b/addons/gdUnit4/test/asserts/GdUnitFuncAssertImplTest.gd
@@ -331,6 +331,7 @@ func test_override_failure_message() -> void:
 	).has_message("Custom failure message")
 
 
+@warning_ignore("unsafe_method_access")
 func test_append_failure_message() -> void:
 	assert_object(assert_func(RefCounted.new(), "get_reference_count").append_failure_message("error")).is_instanceof(GdUnitFuncAssert)
 	(

--- a/addons/gdUnit4/test/asserts/GdUnitIntAssertImplTest.gd
+++ b/addons/gdUnit4/test/asserts/GdUnitIntAssertImplTest.gd
@@ -211,6 +211,7 @@ func test_must_fail_has_invlalid_type() -> void:
 
 func test_override_failure_message() -> void:
 	assert_object(assert_int(314).override_failure_message("error")).is_instanceof(GdUnitIntAssert)
+	@warning_ignore("unsafe_method_access")
 	assert_failure(func() -> void: assert_int(314)\
 			.override_failure_message("Custom failure message") \
 			.is_null()) \
@@ -220,6 +221,7 @@ func test_override_failure_message() -> void:
 
 func test_append_failure_message() -> void:
 	assert_object(assert_int(314).append_failure_message("error")).is_instanceof(GdUnitIntAssert)
+	@warning_ignore("unsafe_method_access")
 	assert_failure(func() -> void: assert_int(314) \
 			.append_failure_message("custom failure data") \
 			.is_zero()) \

--- a/addons/gdUnit4/test/asserts/GdUnitObjectAssertImplTest.gd
+++ b/addons/gdUnit4/test/asserts/GdUnitObjectAssertImplTest.gd
@@ -76,6 +76,7 @@ func test_is_not_null() -> void:
 		.has_message("Expecting: not to be '<null>'")
 
 
+@warning_ignore("unsafe_method_access")
 func test_is_same() -> void:
 	var obj1 :Variant = auto_free(Node.new())
 	var obj2 :Variant = obj1
@@ -98,6 +99,7 @@ func test_is_same() -> void:
 		.is_failed()
 
 
+@warning_ignore("unsafe_method_access")
 func test_is_not_same() -> void:
 	var obj1 :Variant = auto_free(Node.new())
 	var obj2 :Variant = obj1
@@ -147,6 +149,7 @@ func test_must_fail_has_invlalid_type() -> void:
 
 func test_override_failure_message() -> void:
 	assert_object(assert_object(auto_free(Node.new())).override_failure_message("error")).is_instanceof(GdUnitObjectAssert)
+	@warning_ignore("unsafe_method_access")
 	assert_failure(func() -> void: assert_object(auto_free(Node.new())) \
 			.override_failure_message("Custom failure message") \
 			.is_null()) \
@@ -156,6 +159,7 @@ func test_override_failure_message() -> void:
 
 func test_append_failure_message() -> void:
 	assert_object(assert_object(auto_free(Node.new())).append_failure_message("error")).is_instanceof(GdUnitObjectAssert)
+	@warning_ignore("unsafe_method_access")
 	assert_failure(func() -> void: assert_object(auto_free(Node.new())) \
 			.append_failure_message("custom failure data") \
 			.is_null()) \

--- a/addons/gdUnit4/test/asserts/GdUnitPackedArrayAssertTest.gd
+++ b/addons/gdUnit4/test/asserts/GdUnitPackedArrayAssertTest.gd
@@ -61,7 +61,7 @@ func test_is_not_null(_test :String, array :Variant, test_parameters := [
 		.has_message("Expecting: not to be '<null>'")
 
 
-@warning_ignore("unused_parameter")
+@warning_ignore("unused_parameter", "unsafe_method_access", "unsafe_call_argument")
 func test_is_equal(_test :String, array :Variant, test_parameters := [
 	["Array", Array([1, 2, 3, 4, 5])],
 	["PackedByteArray", PackedByteArray([1, 2, 3, 4, 5])],
@@ -94,7 +94,7 @@ func test_is_equal(_test :String, array :Variant, test_parameters := [
 			.replace("$value", str(array[2]) ) % [GdArrayTools.as_string(other, false), GdArrayTools.as_string(array, false)])
 
 
-@warning_ignore("unused_parameter")
+@warning_ignore("unused_parameter", "unsafe_method_access")
 func test_is_not_equal(_test :String, array :Variant, test_parameters := [
 	["Array", Array([1, 2, 3, 4, 5])],
 	["PackedByteArray", PackedByteArray([1, 2, 3, 4, 5])],
@@ -123,7 +123,7 @@ func test_is_not_equal(_test :String, array :Variant, test_parameters := [
 			.trim_prefix("\n") % [GdDefaultValueDecoder.decode(array), GdDefaultValueDecoder.decode(array)])
 
 
-@warning_ignore("unused_parameter")
+@warning_ignore("unused_parameter", "unsafe_method_access")
 func test_is_empty(_test :String, array :Variant, test_parameters := [
 	["Array", Array([1, 2, 3, 4, 5])],
 	["PackedByteArray", PackedByteArray([1, 2, 3, 4, 5])],
@@ -151,7 +151,7 @@ func test_is_empty(_test :String, array :Variant, test_parameters := [
 			.trim_prefix("\n") % GdDefaultValueDecoder.decode(array))
 
 
-@warning_ignore("unused_parameter")
+@warning_ignore("unused_parameter", "unsafe_method_access")
 func test_is_not_empty(_test :String, array :Variant, test_parameters := [
 	["Array", Array([1, 2, 3, 4, 5])],
 	["PackedByteArray", PackedByteArray([1, 2, 3, 4, 5])],
@@ -174,7 +174,7 @@ func test_is_not_empty(_test :String, array :Variant, test_parameters := [
 		.has_message("Expecting:\n must not be empty")
 
 
-@warning_ignore("unused_parameter")
+@warning_ignore("unused_parameter", "unsafe_method_access")
 func test_is_same(value :Variant, test_parameters := [
 	[[0]],
 	[PackedByteArray([0])],
@@ -201,7 +201,7 @@ func test_is_same(value :Variant, test_parameters := [
 			.trim_prefix("\n") % [v, v])
 
 
-@warning_ignore("unused_parameter")
+@warning_ignore("unused_parameter", "unsafe_method_access")
 func test_is_not_same(value :Variant, test_parameters := [
 	[[0]],
 	[PackedByteArray([0])],
@@ -221,7 +221,7 @@ func test_is_not_same(value :Variant, test_parameters := [
 		.has_message("Expecting not same:\n '%s'" % GdDefaultValueDecoder.decode(value))
 
 
-@warning_ignore("unused_parameter")
+@warning_ignore("unused_parameter", "unsafe_method_access")
 func test_has_size(_test :String, array :Variant, test_parameters := [
 	["Array", Array([1, 2, 3, 4, 5])],
 	["PackedByteArray", PackedByteArray([1, 2, 3, 4, 5])],
@@ -281,7 +281,7 @@ func test_contains(_test :String, array :Variant, test_parameters := [
 		)
 
 
-@warning_ignore("unused_parameter")
+@warning_ignore("unused_parameter", "unsafe_method_access")
 func test_contains_exactly(_test :String, array :Variant, test_parameters := [
 	["Array", Array([1, 2, 3, 4, 5])],
 	["PackedByteArray", PackedByteArray([1, 2, 3, 4, 5])],

--- a/addons/gdUnit4/test/asserts/GdUnitResultAssertImplTest.gd
+++ b/addons/gdUnit4/test/asserts/GdUnitResultAssertImplTest.gd
@@ -118,6 +118,7 @@ func test_is_value() -> void:
 
 func test_override_failure_message() -> void:
 	assert_object(assert_result(GdUnitResult.success("")).override_failure_message("error")).is_instanceof(GdUnitResultAssert)
+	@warning_ignore("unsafe_method_access")
 	assert_failure(func() -> void: assert_result(GdUnitResult.success("")) \
 			.override_failure_message("Custom failure message") \
 			.is_null()) \
@@ -127,6 +128,7 @@ func test_override_failure_message() -> void:
 
 func test_append_failure_message() -> void:
 	assert_object(assert_result(GdUnitResult.success("")).append_failure_message("error")).is_instanceof(GdUnitResultAssert)
+	@warning_ignore("unsafe_method_access")
 	assert_failure(func() -> void: assert_result(GdUnitResult.success("")) \
 			.append_failure_message("custom failure data") \
 			.is_error()) \

--- a/addons/gdUnit4/test/asserts/GdUnitSignalAssertImplTest.gd
+++ b/addons/gdUnit4/test/asserts/GdUnitSignalAssertImplTest.gd
@@ -114,6 +114,7 @@ func test_override_failure_message() -> void:
 	).has_message("Custom failure message")
 
 
+@warning_ignore("unsafe_method_access")
 func test_append_failure_message() -> void:
 	assert_object(assert_signal(signal_emitter).append_failure_message("error")).is_instanceof(GdUnitSignalAssert)
 	(
@@ -175,6 +176,7 @@ class MyEmitter extends Node:
 		my_signal_b.emit("foo")
 
 
+@warning_ignore("unsafe_method_access")
 func test_monitor_signals() -> void:
 	# start to watch on the emitter to collect all emitted signals
 	var emitter_a := monitor_signals(MyEmitter.new())

--- a/addons/gdUnit4/test/asserts/GdUnitStringAssertImplTest.gd
+++ b/addons/gdUnit4/test/asserts/GdUnitStringAssertImplTest.gd
@@ -423,6 +423,7 @@ func test_must_fail_has_invlalid_type() -> void:
 
 func test_override_failure_message() -> void:
 	assert_object(assert_str("").override_failure_message("error")).is_instanceof(GdUnitStringAssert)
+	@warning_ignore("unsafe_method_access")
 	assert_failure(func() -> void: assert_str("") \
 			.override_failure_message("Custom failure message") \
 			.is_null()) \
@@ -432,6 +433,7 @@ func test_override_failure_message() -> void:
 
 func test_append_failure_message() -> void:
 	assert_object(assert_str("").append_failure_message("error")).is_instanceof(GdUnitStringAssert)
+	@warning_ignore("unsafe_method_access")
 	assert_failure(func() -> void: assert_str("") \
 			.append_failure_message("custom failure data") \
 			.is_not_empty()) \

--- a/addons/gdUnit4/test/asserts/GdUnitVectorAssertImplTest.gd
+++ b/addons/gdUnit4/test/asserts/GdUnitVectorAssertImplTest.gd
@@ -341,6 +341,7 @@ func test_is_not_between_over_all_types(value :Variant, from :Variant, to :Varia
 
 func test_override_failure_message() -> void:
 	assert_object(assert_vector(Vector2.ONE).override_failure_message("error")).is_instanceof(GdUnitVectorAssert)
+	@warning_ignore("unsafe_method_access")
 	assert_failure(func() -> void: assert_vector(Vector2.ONE) \
 			.override_failure_message("Custom failure message") \
 			.is_null()) \
@@ -350,6 +351,7 @@ func test_override_failure_message() -> void:
 
 func test_append_failure_message() -> void:
 	assert_object(assert_vector(Vector2.ONE).append_failure_message("error")).is_instanceof(GdUnitVectorAssert)
+	@warning_ignore("unsafe_method_access")
 	assert_failure(func() -> void: assert_vector(Vector2.ONE) \
 			.append_failure_message("custom failure data") \
 			.is_equal(Vector2.ZERO)) \

--- a/addons/gdUnit4/test/asserts/GdUnitVectorAssertImplTest.gd
+++ b/addons/gdUnit4/test/asserts/GdUnitVectorAssertImplTest.gd
@@ -45,7 +45,7 @@ func test_is_null(value :Variant, test_parameters := _test_seta) -> void:
 	else:
 		assert_failure(func() -> void: assert_vector(value).is_null()) \
 			.is_failed() \
-			.starts_with_message("Expecting: '<null>' but was '%s'" % value)
+			.starts_with_message("Expecting: '<null>' but was '%s'" % str(value))
 
 
 @warning_ignore("unused_parameter")

--- a/addons/gdUnit4/test/core/GdArrayToolsTest.gd
+++ b/addons/gdUnit4/test/core/GdArrayToolsTest.gd
@@ -44,7 +44,7 @@ func test_as_string(_test :String, value :Variant, expected :String, test_parame
 
 func test_as_string_simple_format() -> void:
 	var value := PackedStringArray(["a", "b"])
-	prints(GdArrayTools.as_string(value, false))
+
 	assert_that(GdArrayTools.as_string(value, false)).is_equal('[a, b]')
 
 
@@ -88,6 +88,7 @@ func test_is_array_type(_test :String, value :Variant, expected :bool, test_para
 	assert_that(GdArrayTools.is_array_type(value)).is_equal(expected)
 
 
+@warning_ignore("unsafe_method_access")
 func test_is_type_array() -> void:
 	for type :int in [TYPE_NIL, TYPE_MAX]:
 		if type in [TYPE_ARRAY, TYPE_PACKED_COLOR_ARRAY]:

--- a/addons/gdUnit4/test/core/GdUnitTestSuiteScannerTest.gd
+++ b/addons/gdUnit4/test/core/GdUnitTestSuiteScannerTest.gd
@@ -86,14 +86,14 @@ func test_resolve_test_suite_path__path_not_contains_src_folder() -> void:
 func test_test_suite_exists() -> void:
 	var path_exists := "res://addons/gdUnit4/test/resources/core/GeneratedPersonTest.gd"
 	var path_not_exists := "res://addons/gdUnit4/test/resources/core/FamilyTest.gd"
-	assert_that(GdUnitTestSuiteScanner.test_suite_exists(path_exists)).is_true()
-	assert_that(GdUnitTestSuiteScanner.test_suite_exists(path_not_exists)).is_false()
+	assert_bool(GdUnitTestSuiteScanner.test_suite_exists(path_exists)).is_true()
+	assert_bool(GdUnitTestSuiteScanner.test_suite_exists(path_not_exists)).is_false()
 
 
 func test_test_case_exists() -> void:
 	var test_suite_path := "res://addons/gdUnit4/test/resources/core/GeneratedPersonTest.gd"
-	assert_that(GdUnitTestSuiteScanner.test_case_exists(test_suite_path, "name")).is_true()
-	assert_that(GdUnitTestSuiteScanner.test_case_exists(test_suite_path, "last_name")).is_false()
+	assert_bool(GdUnitTestSuiteScanner.test_case_exists(test_suite_path, "name")).is_true()
+	assert_bool(GdUnitTestSuiteScanner.test_case_exists(test_suite_path, "last_name")).is_false()
 
 
 func test_create_test_suite_pascal_case_path() -> void:
@@ -102,7 +102,7 @@ func test_create_test_suite_pascal_case_path() -> void:
 	var source_path := "res://addons/gdUnit4/test/core/resources/naming_conventions/PascalCaseWithClassName.gd"
 	var suite_path := temp_dir + "/test/MyClassTest1.gd"
 	var result := GdUnitTestSuiteScanner.create_test_suite(suite_path, source_path)
-	assert_that(result.is_success()).is_true()
+	assert_bool(result.is_success()).is_true()
 	assert_str(result.value()).is_equal(suite_path)
 	assert_file(result.value()).exists()\
 		.is_file()\
@@ -121,7 +121,7 @@ func test_create_test_suite_pascal_case_path() -> void:
 	source_path = "res://addons/gdUnit4/test/core/resources/naming_conventions/PascalCaseWithoutClassName.gd"
 	suite_path = temp_dir + "/test/MyClassTest2.gd"
 	result = GdUnitTestSuiteScanner.create_test_suite(suite_path, source_path)
-	assert_that(result.is_success()).is_true()
+	assert_bool(result.is_success()).is_true()
 	assert_str(result.value()).is_equal(suite_path)
 	assert_file(result.value()).exists()\
 		.is_file()\
@@ -144,7 +144,7 @@ func test_create_test_suite_snake_case_path() -> void:
 	var source_path :="res://addons/gdUnit4/test/core/resources/naming_conventions/snake_case_with_class_name.gd"
 	var suite_path := temp_dir + "/test/my_class_test1.gd"
 	var result := GdUnitTestSuiteScanner.create_test_suite(suite_path, source_path)
-	assert_that(result.is_success()).is_true()
+	assert_bool(result.is_success()).is_true()
 	assert_str(result.value()).is_equal(suite_path)
 	assert_file(result.value()).exists()\
 		.is_file()\
@@ -163,7 +163,7 @@ func test_create_test_suite_snake_case_path() -> void:
 	source_path ="res://addons/gdUnit4/test/core/resources/naming_conventions/snake_case_without_class_name.gd"
 	suite_path = temp_dir + "/test/my_class_test2.gd"
 	result = GdUnitTestSuiteScanner.create_test_suite(suite_path, source_path)
-	assert_that(result.is_success()).is_true()
+	assert_bool(result.is_success()).is_true()
 	assert_str(result.value()).is_equal(suite_path)
 	assert_file(result.value()).exists()\
 		.is_file()\
@@ -187,7 +187,7 @@ func test_create_test_case() -> void:
 	# generate new test suite with test 'test_last_name()'
 	var test_suite_path := tmp_path + "/test/PersonTest.gd"
 	var result := GdUnitTestSuiteScanner.create_test_case(test_suite_path, "last_name", source_path)
-	assert_that(result.is_success()).is_true()
+	assert_bool(result.is_success()).is_true()
 	var info :Dictionary = result.value()
 	assert_int(info.get("line")).is_equal(11)
 	assert_file(info.get("path")).exists()\
@@ -210,7 +210,7 @@ func test_create_test_case() -> void:
 			""])
 	# try to add again
 	result = GdUnitTestSuiteScanner.create_test_case(test_suite_path, "last_name", source_path)
-	assert_that(result.is_success()).is_true()
+	assert_bool(result.is_success()).is_true()
 	assert_that(result.value()).is_equal({"line" : 16, "path": test_suite_path})
 
 
@@ -373,7 +373,7 @@ func test_scan_test_suite_without_tests() -> void:
 	var scanner :GdUnitTestSuiteScanner = GdUnitTestSuiteScanner.new()
 	var test_suites := scanner.scan("res://addons/gdUnit4/test/core/resources/testsuites/TestSuiteWithoutTests.gd")
 
-	assert_that(test_suites).has_size(1)
+	assert_array(test_suites).has_size(1)
 	assert_that(test_suites[0].get_child_count()).is_equal(0)
 	# finally free all scaned test suites
 	for ts in test_suites:
@@ -384,4 +384,4 @@ func test_scan_test_suite_exclude_non_test_suites() -> void:
 	var test_suites := scanner.scan("res://addons/gdUnit4/test/core/resources/scan_testsuite_inheritance/plugin/")
 
 	# we expect the scanner do not break on scanning plugin classes
-	assert_that(test_suites).is_empty()
+	assert_array(test_suites).is_empty()

--- a/addons/gdUnit4/test/extractors/GdUnitFuncValueExtractorTest.gd
+++ b/addons/gdUnit4/test/extractors/GdUnitFuncValueExtractorTest.gd
@@ -4,7 +4,6 @@ extends GdUnitTestSuite
 
 # TestSuite generated from
 const __source = 'res://addons/gdUnit4/src/extractors/GdUnitFuncValueExtractor.gd'
-const GdUnitFuncValueExtractor = preload("res://addons/gdUnit4/src/extractors/GdUnitFuncValueExtractor.gd")
 
 
 class TestNode extends Resource:

--- a/addons/gdUnit4/test/mocker/GdUnitMockBuilderTest.gd
+++ b/addons/gdUnit4/test/mocker/GdUnitMockBuilderTest.gd
@@ -20,7 +20,7 @@ func test_double_return_typed_function_without_arg() -> void:
 	# String get_class() const
 	var fd := get_function_description("Object", "get_class")
 	var expected := [
-		'@warning_ignore(\'shadowed_variable\', \'untyped_declaration\', \'unsafe_call_argument\')',
+		'@warning_ignore(\'shadowed_variable\', \'untyped_declaration\', \'unsafe_call_argument\', \'unsafe_method_access\')',
 		'@warning_ignore("native_method_override")',
 		'func get_class() -> String:',
 		'	var args__: Array = ["get_class", ]',
@@ -47,7 +47,7 @@ func test_double_return_typed_function_with_args() -> void:
 	# bool is_connected(signal: String, callable_: Callable)) const
 	var fd := get_function_description("Object", "is_connected")
 	var expected := [
-		'@warning_ignore(\'shadowed_variable\', \'untyped_declaration\', \'unsafe_call_argument\')',
+		'@warning_ignore(\'shadowed_variable\', \'untyped_declaration\', \'unsafe_call_argument\', \'unsafe_method_access\')',
 		'@warning_ignore("native_method_override")',
 		'func is_connected(signal_, callable_) -> bool:',
 		'	var args__: Array = ["is_connected", signal_, callable_]',
@@ -75,7 +75,7 @@ func test_double_return_untyped_function_with_args() -> void:
 	# void disconnect(signal: StringName, callable: Callable)
 	var fd := get_function_description("Object", "disconnect")
 	var expected := [
-		'@warning_ignore(\'shadowed_variable\', \'untyped_declaration\', \'unsafe_call_argument\')',
+		'@warning_ignore(\'shadowed_variable\', \'untyped_declaration\', \'unsafe_call_argument\', \'unsafe_method_access\')',
 		'@warning_ignore("native_method_override")',
 		'func disconnect(signal_, callable_) -> void:',
 		'	var args__: Array = ["disconnect", signal_, callable_]',
@@ -102,7 +102,7 @@ func test_double_int_function_with_varargs() -> void:
 	# Error emit_signal(signal: StringName, ...) vararg
 	var fd := get_function_description("Object", "emit_signal")
 	var expected := [
-		'@warning_ignore(\'shadowed_variable\', \'untyped_declaration\', \'unsafe_call_argument\')',
+		'@warning_ignore(\'shadowed_variable\', \'untyped_declaration\', \'unsafe_call_argument\', \'unsafe_method_access\')',
 		'@warning_ignore("native_method_override")',
 		'@warning_ignore("int_as_enum_without_match")',
 		'@warning_ignore("int_as_enum_without_cast")',
@@ -148,7 +148,7 @@ func test_double_untyped_function_with_varargs() -> void:
 		[GdFunctionArgument.new("signal", TYPE_SIGNAL)],
 		GdFunctionDescriptor._build_varargs(true))
 	var expected := [
-		'@warning_ignore(\'shadowed_variable\', \'untyped_declaration\', \'unsafe_call_argument\')',
+		'@warning_ignore(\'shadowed_variable\', \'untyped_declaration\', \'unsafe_call_argument\', \'unsafe_method_access\')',
 		'func emit_custom(signal_, vararg0_="__null__", vararg1_="__null__", vararg2_="__null__", vararg3_="__null__", vararg4_="__null__", vararg5_="__null__", vararg6_="__null__", vararg7_="__null__", vararg8_="__null__", vararg9_="__null__") -> void:',
 		'	var varargs__: Array = __filter_vargs([vararg0_, vararg1_, vararg2_, vararg3_, vararg4_, vararg5_, vararg6_, vararg7_, vararg8_, vararg9_])',
 		'	var args__: Array = ["emit_custom", signal_] + varargs__',
@@ -189,7 +189,7 @@ func test_double_virtual_script_function_without_arg() -> void:
 	# void _ready() virtual
 	var fd := get_function_description("Node", "_ready")
 	var expected := [
-		'@warning_ignore(\'shadowed_variable\', \'untyped_declaration\', \'unsafe_call_argument\')',
+		'@warning_ignore(\'shadowed_variable\', \'untyped_declaration\', \'unsafe_call_argument\', \'unsafe_method_access\')',
 		'@warning_ignore("native_method_override")',
 		'func _ready() -> void:',
 		'	var args__: Array = ["_ready", ]',
@@ -217,7 +217,7 @@ func test_double_virtual_script_function_with_arg() -> void:
 	# void _input(event: InputEvent) virtual
 	var fd := get_function_description("Node", "_input")
 	var expected := [
-		'@warning_ignore(\'shadowed_variable\', \'untyped_declaration\', \'unsafe_call_argument\')',
+		'@warning_ignore(\'shadowed_variable\', \'untyped_declaration\', \'unsafe_call_argument\', \'unsafe_method_access\')',
 		'@warning_ignore("native_method_override")',
 		'func _input(event_) -> void:',
 		'	var args__: Array = ["_input", event_]',
@@ -240,9 +240,9 @@ func test_double_virtual_script_function_with_arg() -> void:
 
 
 func test_mock_on_script_path_without_class_name() -> void:
-	var instance :Object = load("res://addons/gdUnit4/test/mocker/resources/ClassWithoutNameA.gd").new()
+	var instance :Object = (load("res://addons/gdUnit4/test/mocker/resources/ClassWithoutNameA.gd") as GDScript).new()
 	var script := GdUnitMockBuilder.mock_on_script(instance, "res://addons/gdUnit4/test/mocker/resources/ClassWithoutNameA.gd", [], true);
-	assert_that(script.resource_name).starts_with("MockClassWithoutNameA")
+	assert_str(script.resource_name).starts_with("MockClassWithoutNameA")
 	assert_that(script.get_instance_base_type()).is_equal("Resource")
 	# finally check the mocked script is valid
 	assert_int(script.reload()).is_equal(OK)
@@ -250,9 +250,9 @@ func test_mock_on_script_path_without_class_name() -> void:
 
 func test_mock_on_script_path_with_custom_class_name() -> void:
 	# the class contains a class_name definition
-	var instance :Object = load("res://addons/gdUnit4/test/mocker/resources/ClassWithCustomClassName.gd").new()
+	var instance :Object = (load("res://addons/gdUnit4/test/mocker/resources/ClassWithCustomClassName.gd") as GDScript).new()
 	var script := GdUnitMockBuilder.mock_on_script(instance, "res://addons/gdUnit4/test/mocker/resources/ClassWithCustomClassName.gd", [], false);
-	assert_that(script.resource_name).starts_with("MockGdUnitTestCustomClassName")
+	assert_str(script.resource_name).starts_with("MockGdUnitTestCustomClassName")
 	assert_that(script.get_instance_base_type()).is_equal("Resource")
 	# finally check the mocked script is valid
 	assert_int(script.reload()).is_equal(OK)
@@ -260,7 +260,7 @@ func test_mock_on_script_path_with_custom_class_name() -> void:
 
 func test_mock_on_class_with_class_name() -> void:
 	var script := GdUnitMockBuilder.mock_on_script(ClassWithNameA.new(), ClassWithNameA, [], false);
-	assert_that(script.resource_name).starts_with("MockClassWithNameA")
+	assert_str(script.resource_name).starts_with("MockClassWithNameA")
 	assert_that(script.get_instance_base_type()).is_equal("Resource")
 	# finally check the mocked script is valid
 	assert_int(script.reload()).is_equal(OK)
@@ -269,7 +269,7 @@ func test_mock_on_class_with_class_name() -> void:
 func test_mock_on_class_with_custom_class_name() -> void:
 	# the class contains a class_name definition
 	var script := GdUnitMockBuilder.mock_on_script(GdUnit_Test_CustomClassName.new(), GdUnit_Test_CustomClassName, [], false);
-	assert_that(script.resource_name).starts_with("MockGdUnitTestCustomClassName")
+	assert_str(script.resource_name).starts_with("MockGdUnitTestCustomClassName")
 	assert_that(script.get_instance_base_type()).is_equal("Resource")
 	# finally check the mocked script is valid
 	assert_int(script.reload()).is_equal(OK)

--- a/addons/gdUnit4/test/mocker/GdUnitMockerTest.gd
+++ b/addons/gdUnit4/test/mocker/GdUnitMockerTest.gd
@@ -21,6 +21,7 @@ func test_mock_instance_id_is_unique() -> void:
 	var m1: Variant = mock(RefCounted)
 	var m2: Variant = mock(RefCounted)
 	# test the internal instance id is unique
+	@warning_ignore("unsafe_method_access")
 	assert_that(m1.__instance_id()).is_not_equal(m2.__instance_id())
 	assert_object(m1).is_not_same(m2)
 
@@ -33,21 +34,25 @@ func test_is_mockable_godot_classes() -> void:
 		# unregistered classes in ClassDB
 		# protected classes (name starts with underscore)
 		var is_mockable :bool = not Engine.has_singleton(clazz_name) and ClassDB.can_instantiate(clazz_name) and clazz_name.find("_") != 0
+		@warning_ignore("unsafe_method_access")
 		assert_that(GdUnitMockBuilder.is_mockable(clazz_name)) \
 			.override_failure_message("Class '%s' expect mockable %s" % [clazz_name, is_mockable]) \
 			.is_equal(is_mockable)
 
 
+@warning_ignore("unsafe_method_access")
 func test_is_mockable_by_class_type() -> void:
 	assert_that(GdUnitMockBuilder.is_mockable(Node)).is_true()
 	assert_that(GdUnitMockBuilder.is_mockable(CSGBox3D)).is_true()
 
 
+@warning_ignore("unsafe_method_access")
 func test_is_mockable_custom_class_type() -> void:
 	assert_that(GdUnitMockBuilder.is_mockable(CustomResourceTestClass)).is_true()
 	assert_that(GdUnitMockBuilder.is_mockable(CustomNodeTestClass)).is_true()
 
 
+@warning_ignore("unsafe_method_access")
 func test_is_mockable_by_script_path() -> void:
 	assert_that(GdUnitMockBuilder.is_mockable(resource_path + "CustomResourceTestClass.gd")).is_true()
 	assert_that(GdUnitMockBuilder.is_mockable(resource_path + "CustomNodeTestClass.gd")).is_true()
@@ -55,6 +60,7 @@ func test_is_mockable_by_script_path() -> void:
 	assert_that(GdUnitMockBuilder.is_mockable(resource_path + "capsuleshape2d.tres")).is_false()
 
 
+@warning_ignore("unsafe_method_access")
 func test_is_mockable__overriden_func_get_class() -> void:
 	# test with class type
 	assert_that(GdUnitMockBuilder.is_mockable(OverridenGetClassTestClass))\
@@ -72,6 +78,7 @@ func test_mock_godot_class_fullcheck(fuzzer := GodotClassNameFuzzer.new(), fuzze
 	# try to create a mock
 	if GdUnitMockBuilder.is_mockable(clazz_name):
 		var m: Variant = mock(clazz_name, CALL_REAL_FUNC)
+		@warning_ignore("unsafe_method_access")
 		assert_that(m)\
 			.override_failure_message("The class %s should be mockable" % clazz_name)\
 			.is_not_null()
@@ -101,6 +108,7 @@ func test_mock_special_classes() -> void:
 	assert_that(m).is_not_null()
 
 
+@warning_ignore("unsafe_method_access")
 func test_mock_Node() -> void:
 	var mocked_node: Variant = mock(Node)
 	assert_that(mocked_node).is_not_null()
@@ -129,6 +137,7 @@ func test_mock_Node() -> void:
 	assert_that(mocked_node.get_child_count()).is_equal(24)
 
 
+@warning_ignore("unsafe_method_access")
 func test_mock_source_with_class_name_by_resource_path() -> void:
 	var resource_path_ := 'res://addons/gdUnit4/test/mocker/resources/GD-256/world.gd'
 	var m: Variant = mock(resource_path_)
@@ -138,6 +147,7 @@ func test_mock_source_with_class_name_by_resource_path() -> void:
 		.contains("extends '%s'" % resource_path_)
 
 
+@warning_ignore("unsafe_method_access")
 func test_mock_source_with_class_name_by_class() -> void:
 	var resource_path_ := 'res://addons/gdUnit4/test/mocker/resources/GD-256/world.gd'
 	var m: Variant = mock(Munderwood_Pathing_World)
@@ -147,6 +157,7 @@ func test_mock_source_with_class_name_by_class() -> void:
 		.contains("extends '%s'" % resource_path_)
 
 
+@warning_ignore("unsafe_method_access")
 func test_mock_extends_godot_class() -> void:
 	var m: Variant = mock(World3D)
 	var head :String = m.get_script().source_code.substr(0, 200)
@@ -160,6 +171,7 @@ func _emit_ready(a :String, b :String, c :Variant = null) -> void:
 	_test_signal_args = [a, b, c]
 
 
+@warning_ignore("unsafe_method_access")
 func test_mock_Node_func_vararg() -> void:
 	# setup
 	var mocked_node: Variant = mock(Node)
@@ -177,6 +189,7 @@ func test_mock_Node_func_vararg() -> void:
 	assert_that(mocked_node.rpc("test", "arg1", "argX", 42)).is_equal(ERR_CANT_CREATE)
 
 
+@warning_ignore("unsafe_method_access")
 func test_mock_Node_func_vararg_call_real_func() -> void:
 	# setup
 	var mocked_node: Variant = mock(Node, CALL_REAL_FUNC)
@@ -219,6 +232,7 @@ class ClassWithSignal:
 		return true
 
 
+@warning_ignore("unsafe_method_access")
 func _test_mock_verify_emit_signal() -> void:
 	var mocked_node: Variant = mock(ClassWithSignal, CALL_REAL_FUNC)
 	assert_that(mocked_node).is_not_null()
@@ -243,6 +257,7 @@ func _test_mock_verify_emit_signal() -> void:
 	verify(mocked_node, 1).emit_signal("test_signal_b", "bb", true)
 
 
+@warning_ignore("unsafe_method_access")
 func test_mock_custom_class_by_class_name() -> void:
 	var m: Variant = mock(CustomResourceTestClass)
 	assert_that(m).is_not_null()
@@ -265,6 +280,7 @@ func test_mock_custom_class_by_class_name() -> void:
 	assert_that(m.bar(2)).is_equal("arg_2")
 
 
+@warning_ignore("unsafe_method_access")
 func test_mock_custom_class_by_resource_path() -> void:
 	var m: Variant = mock("res://addons/gdUnit4/test/mocker/resources/CustomResourceTestClass.gd")
 	assert_that(m).is_not_null()
@@ -287,6 +303,7 @@ func test_mock_custom_class_by_resource_path() -> void:
 	assert_that(m.bar(2)).is_equal("arg_2")
 
 
+@warning_ignore("unsafe_method_access")
 func test_mock_custom_class_func_foo_use_real_func() -> void:
 	var m: Variant = mock(CustomResourceTestClass, CALL_REAL_FUNC)
 	assert_that(m).is_not_null()
@@ -298,6 +315,7 @@ func test_mock_custom_class_func_foo_use_real_func() -> void:
 	assert_that(m.foo()).is_equal("overridden value")
 
 
+@warning_ignore("unsafe_method_access")
 func test_mock_custom_class_void_func() -> void:
 	var m: Variant = mock(CustomResourceTestClass)
 	assert_that(m).is_not_null()
@@ -309,6 +327,7 @@ func test_mock_custom_class_void_func() -> void:
 	assert_that(m.foo_void()).is_null()
 
 
+@warning_ignore("unsafe_method_access")
 func test_mock_custom_class_void_func_real_func() -> void:
 	var m: Variant = mock(CustomResourceTestClass, CALL_REAL_FUNC)
 	assert_that(m).is_not_null()
@@ -320,6 +339,7 @@ func test_mock_custom_class_void_func_real_func() -> void:
 	assert_that(m.foo_void()).is_null()
 
 
+@warning_ignore("unsafe_method_access")
 func test_mock_custom_class_func_foo_call_times() -> void:
 	var m: Variant = mock(CustomResourceTestClass)
 	assert_that(m).is_not_null()
@@ -333,6 +353,7 @@ func test_mock_custom_class_func_foo_call_times() -> void:
 	verify(m, 4).foo()
 
 
+@warning_ignore("unsafe_method_access")
 func test_mock_custom_class_func_foo_call_times_real_func() -> void:
 	var m: Variant = mock(CustomResourceTestClass, CALL_REAL_FUNC)
 	assert_that(m).is_not_null()
@@ -346,6 +367,7 @@ func test_mock_custom_class_func_foo_call_times_real_func() -> void:
 	verify(m, 4).foo()
 
 
+@warning_ignore("unsafe_method_access")
 func test_mock_custom_class_func_foo_full_test() -> void:
 	var m: Variant = mock(CustomResourceTestClass)
 	assert_that(m).is_not_null()
@@ -358,6 +380,7 @@ func test_mock_custom_class_func_foo_full_test() -> void:
 	verify(m, 2).foo()
 
 
+@warning_ignore("unsafe_method_access")
 func test_mock_custom_class_func_foo_full_test_real_func() -> void:
 	var m: Variant = mock(CustomResourceTestClass, CALL_REAL_FUNC)
 	assert_that(m).is_not_null()
@@ -370,6 +393,7 @@ func test_mock_custom_class_func_foo_full_test_real_func() -> void:
 	verify(m, 2).foo()
 
 
+@warning_ignore("unsafe_method_access")
 func test_mock_custom_class_func_bar() -> void:
 	var m: Variant = mock(CustomResourceTestClass)
 	assert_that(m).is_not_null()
@@ -391,6 +415,7 @@ func test_mock_custom_class_func_bar() -> void:
 	verify(m, 0).bar(23)
 
 
+@warning_ignore("unsafe_method_access")
 func test_mock_custom_class_func_bar_real_func() -> void:
 	var m: Variant = mock(CustomResourceTestClass, CALL_REAL_FUNC)
 	assert_that(m).is_not_null()
@@ -416,6 +441,7 @@ func test_mock_custom_class_func_bar_real_func() -> void:
 	verify(m, 1).bar(10, 20, "other")
 
 
+@warning_ignore("unsafe_method_access")
 func test_mock_custom_class_func_return_type_enum() -> void:
 	var m: Variant = mock(ClassWithEnumReturnTypes)
 	assert_that(m).is_not_null()
@@ -437,6 +463,7 @@ func test_mock_custom_class_func_return_type_enum() -> void:
 	assert_that(m2.get_enum()).is_equal(ClassWithEnumReturnTypes.TEST_ENUM.BAR)
 
 
+@warning_ignore("unsafe_method_access")
 func test_mock_custom_class_func_return_type_internal_class_enum() -> void:
 	var m: Variant = mock(ClassWithEnumReturnTypes)
 	assert_that(m).is_not_null()
@@ -458,6 +485,7 @@ func test_mock_custom_class_func_return_type_internal_class_enum() -> void:
 	assert_that(m2.get_inner_class_enum()).is_equal(ClassWithEnumReturnTypes.InnerClass.TEST_ENUM.BAR)
 
 
+@warning_ignore("unsafe_method_access")
 func test_mock_custom_class_func_return_type_external_class_enum() -> void:
 	var m: Variant = mock(ClassWithEnumReturnTypes)
 	assert_that(m).is_not_null()
@@ -479,6 +507,7 @@ func test_mock_custom_class_func_return_type_external_class_enum() -> void:
 	assert_that(m2.get_external_class_enum()).is_equal(CustomEnums.TEST_ENUM.BAR)
 
 
+@warning_ignore("unsafe_method_access")
 func test_mock_custom_class_extends_Node() -> void:
 	var m: Variant = mock(CustomNodeTestClass)
 	assert_that(m).is_not_null()
@@ -496,6 +525,7 @@ func test_mock_custom_class_extends_Node() -> void:
 	verify(m, 2).get_children()
 
 
+@warning_ignore("unsafe_method_access")
 func test_mock_custom_class_extends_Node_real_func() -> void:
 	var m: Variant = mock(CustomNodeTestClass, CALL_REAL_FUNC)
 	assert_that(m).is_not_null()
@@ -517,6 +547,7 @@ func test_mock_custom_class_extends_Node_real_func() -> void:
 	verify(m, 2).get_children()
 
 
+@warning_ignore("unsafe_method_access")
 func test_mock_custom_class_extends_other_custom_class() -> void:
 	var m: Variant = mock(CustomClassExtendsCustomClass)
 	assert_that(mock).is_not_null()
@@ -546,6 +577,7 @@ func test_mock_custom_class_extends_other_custom_class() -> void:
 	assert_that(m.bar2()).is_equal("abc3")
 
 
+@warning_ignore("unsafe_method_access")
 func test_mock_custom_class_extends_other_custom_class_call_real_func() -> void:
 	var m: Variant = mock(CustomClassExtendsCustomClass, CALL_REAL_FUNC)
 	assert_that(m).is_not_null()
@@ -575,6 +607,7 @@ func test_mock_custom_class_extends_other_custom_class_call_real_func() -> void:
 	assert_that(m.bar2()).is_equal("abc3")
 
 
+@warning_ignore("unsafe_method_access")
 func test_mock_static_func() -> void:
 	var m: Variant = mock(CustomNodeTestClass)
 	assert_that(m).is_not_null()
@@ -594,6 +627,7 @@ func test_mock_static_func() -> void:
 	verify(m, 3).static_test_void()
 
 
+@warning_ignore("unsafe_method_access")
 func test_mock_static_func_real_func() -> void:
 	var m: Variant = mock(CustomNodeTestClass, CALL_REAL_FUNC)
 	assert_that(m).is_not_null()
@@ -613,6 +647,7 @@ func test_mock_static_func_real_func() -> void:
 	verify(m, 3).static_test_void()
 
 
+@warning_ignore("unsafe_method_access")
 func test_mock_custom_class_assert_has_no_side_affect() -> void:
 	var m: Variant = mock(CustomNodeTestClass)
 	assert_that(m).is_not_null()
@@ -632,6 +667,7 @@ func test_mock_custom_class_assert_has_no_side_affect() -> void:
 	node.free()
 
 
+@warning_ignore("unsafe_method_access")
 func test_mock_custom_class_assert_has_no_side_affect_real_func() -> void:
 	var m: Variant = mock(CustomNodeTestClass, CALL_REAL_FUNC)
 	assert_that(m).is_not_null()
@@ -651,6 +687,7 @@ func test_mock_custom_class_assert_has_no_side_affect_real_func() -> void:
 
 # This test verifies a function is calling other internally functions
 # to collect the access times and the override return value is working as expected
+@warning_ignore("unsafe_method_access")
 func test_mock_advanced_func_path() -> void:
 	var m: Variant = mock(AdvancedTestClass, CALL_REAL_FUNC)
 	# initial nothing is called
@@ -690,6 +727,7 @@ func test_mock_advanced_func_path() -> void:
 	verify(m, 1).c()
 
 
+@warning_ignore("unsafe_method_access")
 func _test_mock_godot_class_calls_sub_function() -> void:
 	var m: Variant = mock(MeshInstance3D, CALL_REAL_FUNC)
 	verify(m, 0)._mesh_changed()
@@ -698,6 +736,7 @@ func _test_mock_godot_class_calls_sub_function() -> void:
 	verify(m, 1)._mesh_changed()
 
 
+@warning_ignore("unsafe_method_access")
 func test_mock_class_with_inner_classs() -> void:
 	var mock_advanced: Variant = mock(AdvancedTestClass)
 	assert_that(mock_advanced).is_not_null()
@@ -714,6 +753,7 @@ func test_mock_class_with_inner_classs_() -> void:
 	assert_object(mock_c).is_not_null()
 
 
+@warning_ignore("unsafe_method_access")
 func test_do_return() -> void:
 	var mocked_node: Variant = mock(Node)
 
@@ -741,6 +781,7 @@ func test_do_return() -> void:
 	assert_object(node1).is_instanceof(Area3D)
 
 
+@warning_ignore("unsafe_method_access")
 func test_matching_is_sorted() -> void:
 	var mocked_node: Variant = mock(Node)
 	do_return(null).on(mocked_node).get_child(any(), false)
@@ -762,6 +803,7 @@ func test_matching_is_sorted() -> void:
 	assert_object(first_arguments[4]).is_instanceof(GdUnitArgumentMatcher)
 
 
+@warning_ignore("unsafe_method_access")
 func test_do_return_with_matchers() -> void:
 	var mocked_node: Variant = mock(Node)
 	var childN :Node = auto_free(Node2D.new())
@@ -793,6 +835,7 @@ func test_do_return_with_matchers() -> void:
 	assert_that(mocked_node.get_child(10)).is_same(child10)
 
 
+@warning_ignore("unsafe_method_access")
 func test_example_verify() -> void:
 	var mocked_node: Variant = mock(Node)
 
@@ -812,6 +855,7 @@ func test_example_verify() -> void:
 	verify(mocked_node, 3).set_process(any_bool())
 
 
+@warning_ignore("unsafe_method_access")
 func test_verify_fail() -> void:
 	var mocked_node: Variant = mock(Node)
 
@@ -834,6 +878,7 @@ func test_verify_fail() -> void:
 		.has_message(expected_error)
 
 
+@warning_ignore("unsafe_method_access")
 func test_verify_func_interaction_wiht_PoolStringArray() -> void:
 	var mocked: Variant = mock(ClassWithPoolStringArrayFunc)
 
@@ -843,6 +888,7 @@ func test_verify_func_interaction_wiht_PoolStringArray() -> void:
 	verify_no_more_interactions(mocked)
 
 
+@warning_ignore("unsafe_method_access")
 func test_verify_func_interaction_wiht_PoolStringArray_fail() -> void:
 	var mocked: Variant = mock(ClassWithPoolStringArrayFunc)
 
@@ -877,6 +923,7 @@ func test_verify_func_interaction_wiht_PoolStringArray_fail() -> void:
 		.has_message(expected_error)
 
 
+@warning_ignore("unsafe_method_access")
 func test_reset() -> void:
 	var mocked_node: Variant = mock(Node)
 
@@ -901,6 +948,7 @@ func test_verify_no_interactions() -> void:
 	verify_no_interactions(mocked_node)
 
 
+@warning_ignore("unsafe_method_access")
 func test_verify_no_interactions_fails() -> void:
 	var mocked_node: Variant = mock(Node)
 
@@ -921,6 +969,7 @@ func test_verify_no_interactions_fails() -> void:
 		.has_message(expected_error)
 
 
+@warning_ignore("unsafe_method_access")
 func test_verify_no_more_interactions() -> void:
 	var mocked_node: Variant = mock(Node)
 
@@ -938,6 +987,7 @@ func test_verify_no_more_interactions() -> void:
 	verify_no_more_interactions(mocked_node)
 
 
+@warning_ignore("unsafe_method_access")
 func test_verify_no_more_interactions_but_has() -> void:
 	var mocked_node: Variant = mock(Node)
 
@@ -973,6 +1023,7 @@ func test_verify_no_more_interactions_but_has() -> void:
 		.has_message(expected_error)
 
 
+@warning_ignore("unsafe_method_access")
 func test_mock_snake_case_named_class_by_resource_path() -> void:
 	var mock_a: Variant = mock("res://addons/gdUnit4/test/mocker/resources/snake_case.gd")
 	assert_object(mock_a).is_not_null()
@@ -989,6 +1040,7 @@ func test_mock_snake_case_named_class_by_resource_path() -> void:
 	verify_no_more_interactions(mock_b)
 
 
+@warning_ignore("unsafe_method_access")
 func test_mock_snake_case_named_godot_class_by_name() -> void:
 	# try checked Godot class
 	var mocked_tcp_server: Variant = mock("TCPServer")
@@ -1001,6 +1053,7 @@ func test_mock_snake_case_named_godot_class_by_name() -> void:
 	verify_no_more_interactions(mocked_tcp_server)
 
 
+@warning_ignore("unsafe_method_access")
 func test_mock_snake_case_named_class_by_class() -> void:
 	var m: Variant = mock(snake_case_class_name)
 	assert_object(m).is_not_null()
@@ -1020,6 +1073,7 @@ func test_mock_snake_case_named_class_by_class() -> void:
 	verify_no_more_interactions(mocked_tcp_server)
 
 
+@warning_ignore("unsafe_method_access")
 func test_mock_func_with_default_build_in_type() -> void:
 	var m: Variant = mock(ClassWithDefaultBuildIntTypes)
 	assert_object(m).is_not_null()
@@ -1038,6 +1092,7 @@ func test_mock_func_with_default_build_in_type() -> void:
 	verify_no_more_interactions(m)
 
 
+@warning_ignore("unsafe_method_access")
 func test_mock_virtual_function_is_not_called_twice() -> void:
 	# this test verifies the special handling of virtual functions by Godot
 	# virtual functions are handeld in a special way
@@ -1070,6 +1125,7 @@ func test_mock_virtual_function_is_not_called_twice() -> void:
 	assert_that(m._x).is_equal("ui_accept")
 
 
+@warning_ignore("unsafe_method_access")
 func test_mock_scene_by_path() -> void:
 	var mocked_scene: Variant = mock("res://addons/gdUnit4/test/mocker/resources/scenes/TestScene.tscn")
 	assert_object(mocked_scene).is_not_null()
@@ -1079,6 +1135,7 @@ func test_mock_scene_by_path() -> void:
 	assert_bool(GdUnitMemoryObserver.is_marked_auto_free(mocked_scene)).is_true()
 
 
+@warning_ignore("unsafe_method_access")
 func test_mock_scene_by_resource() -> void:
 	var resource: Object = load("res://addons/gdUnit4/test/mocker/resources/scenes/TestScene.tscn")
 	var mocked_scene: Variant = mock(resource)
@@ -1089,6 +1146,7 @@ func test_mock_scene_by_resource() -> void:
 	assert_bool(GdUnitMemoryObserver.is_marked_auto_free(mocked_scene)).is_true()
 
 
+@warning_ignore("unsafe_method_access")
 func test_mock_scene_by_instance() -> void:
 	var resource := load("res://addons/gdUnit4/test/mocker/resources/scenes/TestScene.tscn")
 	var instance :Control = auto_free(resource.instantiate())
@@ -1102,6 +1160,7 @@ func test_mock_scene_by_path_fail_has_no_script_attached() -> void:
 	assert_object(mocked_scene).is_null()
 
 
+@warning_ignore("unsafe_method_access")
 func test_mock_scene_variables_is_set() -> void:
 	var mocked_scene: Variant = mock("res://addons/gdUnit4/test/mocker/resources/scenes/TestScene.tscn")
 	assert_object(mocked_scene).is_not_null()
@@ -1119,6 +1178,7 @@ func test_mock_scene_variables_is_set() -> void:
 	assert_str(mocked_scene._initial_color.to_html()).is_equal(Color.RED.to_html())
 
 
+@warning_ignore("unsafe_method_access")
 func test_mock_scene_execute_func_yielded() -> void:
 	var mocked_scene: Variant = mock("res://addons/gdUnit4/test/mocker/resources/scenes/TestScene.tscn")
 	assert_object(mocked_scene).is_not_null()

--- a/addons/gdUnit4/test/monitor/GodotGdErrorMonitorTest.gd
+++ b/addons/gdUnit4/test/monitor/GodotGdErrorMonitorTest.gd
@@ -91,11 +91,13 @@ func test_scan_for_push_errors() -> void:
 	monitor._report_enabled = true
 
 	# with disabled push_error reporting
+	@warning_ignore("unsafe_method_access")
 	do_return(false).on(monitor)._is_report_push_errors()
 	await monitor.scan()
 	assert_array(monitor.to_reports()).is_empty()
 
 	# with enabled push_error reporting
+	@warning_ignore("unsafe_method_access")
 	do_return(true).on(monitor)._is_report_push_errors()
 
 	var entry := ErrorLogEntry.new(ErrorLogEntry.TYPE.PUSH_ERROR, -1,
@@ -116,11 +118,13 @@ func test_scan_for_script_errors() -> void:
 	monitor._report_enabled = true
 
 	# with disabled push_error reporting
+	@warning_ignore("unsafe_method_access")
 	do_return(false).on(monitor)._is_report_script_errors()
 	await monitor.scan()
 	assert_array(monitor.to_reports()).is_empty()
 
 	# with enabled push_error reporting
+	@warning_ignore("unsafe_method_access")
 	do_return(true).on(monitor)._is_report_script_errors()
 
 	var entry := ErrorLogEntry.new(ErrorLogEntry.TYPE.PUSH_ERROR, 22,

--- a/addons/gdUnit4/test/spy/GdUnitSpyBuilderTest.gd
+++ b/addons/gdUnit4/test/spy/GdUnitSpyBuilderTest.gd
@@ -32,7 +32,7 @@ func test_double_return_typed_function_without_arg() -> void:
 	# String get_class() const
 	var fd := get_function_description("Object", "get_class")
 	var expected := [
-		'@warning_ignore(\'shadowed_variable\', \'untyped_declaration\', \'unsafe_call_argument\')',
+		'@warning_ignore(\'shadowed_variable\', \'untyped_declaration\', \'unsafe_call_argument\', \'unsafe_method_access\')',
 		'@warning_ignore("native_method_override")',
 		'func get_class() -> String:',
 		'	var args__: Array = ["get_class", ]',
@@ -56,7 +56,7 @@ func test_double_return_typed_function_with_args() -> void:
 	# bool is_connected(signal: String,Callable(target: Object,method: String)) const
 	var fd := get_function_description("Object", "is_connected")
 	var expected := [
-		'@warning_ignore(\'shadowed_variable\', \'untyped_declaration\', \'unsafe_call_argument\')',
+		'@warning_ignore(\'shadowed_variable\', \'untyped_declaration\', \'unsafe_call_argument\', \'unsafe_method_access\')',
 		'@warning_ignore("native_method_override")',
 		'func is_connected(signal_, callable_) -> bool:',
 		'	var args__: Array = ["is_connected", signal_, callable_]',
@@ -80,7 +80,7 @@ func test_double_return_void_function_with_args() -> void:
 	# void disconnect(signal: StringName, callable: Callable)
 	var fd := get_function_description("Object", "disconnect")
 	var expected := [
-		'@warning_ignore(\'shadowed_variable\', \'untyped_declaration\', \'unsafe_call_argument\')',
+		'@warning_ignore(\'shadowed_variable\', \'untyped_declaration\', \'unsafe_call_argument\', \'unsafe_method_access\')',
 		'@warning_ignore("native_method_override")',
 		'func disconnect(signal_, callable_) -> void:',
 		'	var args__: Array = ["disconnect", signal_, callable_]',
@@ -103,7 +103,7 @@ func test_double_return_void_function_without_args() -> void:
 	# void free()
 	var fd := get_function_description("Object", "free")
 	var expected := [
-		'@warning_ignore(\'shadowed_variable\', \'untyped_declaration\', \'unsafe_call_argument\')',
+		'@warning_ignore(\'shadowed_variable\', \'untyped_declaration\', \'unsafe_call_argument\', \'unsafe_method_access\')',
 		'@warning_ignore("native_method_override")',
 		'func free() -> void:',
 		'	var args__: Array = ["free", ]',
@@ -126,7 +126,7 @@ func test_double_return_typed_function_with_args_and_varargs() -> void:
 	# Error emit_signal(signal: StringName, ...) vararg
 	var fd := get_function_description("Object", "emit_signal")
 	var expected := [
-		'@warning_ignore(\'shadowed_variable\', \'untyped_declaration\', \'unsafe_call_argument\')',
+		'@warning_ignore(\'shadowed_variable\', \'untyped_declaration\', \'unsafe_call_argument\', \'unsafe_method_access\')',
 		'@warning_ignore("native_method_override")',
 		'@warning_ignore("int_as_enum_without_match")',
 		'@warning_ignore("int_as_enum_without_cast")',
@@ -151,7 +151,7 @@ func test_double_return_void_function_only_varargs() -> void:
 	# void bar(s...) vararg
 	var fd := GdFunctionDescriptor.new( "bar", 23, false, false, false, TYPE_NIL, "void", [], GdFunctionDescriptor._build_varargs(true))
 	var expected := [
-		'@warning_ignore(\'shadowed_variable\', \'untyped_declaration\', \'unsafe_call_argument\')',
+		'@warning_ignore(\'shadowed_variable\', \'untyped_declaration\', \'unsafe_call_argument\', \'unsafe_method_access\')',
 		'func bar(vararg0_="__null__", vararg1_="__null__", vararg2_="__null__", vararg3_="__null__", vararg4_="__null__", vararg5_="__null__", vararg6_="__null__", vararg7_="__null__", vararg8_="__null__", vararg9_="__null__") -> void:',
 		'	var varargs__: Array = __filter_vargs([vararg0_, vararg1_, vararg2_, vararg3_, vararg4_, vararg5_, vararg6_, vararg7_, vararg8_, vararg9_])',
 		'	var args__: Array = ["bar", ] + varargs__',
@@ -173,7 +173,7 @@ func test_double_return_typed_function_only_varargs() -> void:
 	# String bar(s...) vararg
 	var fd := GdFunctionDescriptor.new( "bar", 23, false, false, false, TYPE_STRING, "String", [], GdFunctionDescriptor._build_varargs(true))
 	var expected := [
-		'@warning_ignore(\'shadowed_variable\', \'untyped_declaration\', \'unsafe_call_argument\')',
+		'@warning_ignore(\'shadowed_variable\', \'untyped_declaration\', \'unsafe_call_argument\', \'unsafe_method_access\')',
 		'func bar(vararg0_="__null__", vararg1_="__null__", vararg2_="__null__", vararg3_="__null__", vararg4_="__null__", vararg5_="__null__", vararg6_="__null__", vararg7_="__null__", vararg8_="__null__", vararg9_="__null__") -> String:',
 		'	var varargs__: Array = __filter_vargs([vararg0_, vararg1_, vararg2_, vararg3_, vararg4_, vararg5_, vararg6_, vararg7_, vararg8_, vararg9_])',
 		'	var args__: Array = ["bar", ] + varargs__',
@@ -195,7 +195,7 @@ func test_double_static_return_void_function_without_args() -> void:
 	# void foo()
 	var fd := GdFunctionDescriptor.new( "foo", 23, false, true, false, TYPE_NIL, "", [])
 	var expected := [
-		'@warning_ignore(\'shadowed_variable\', \'untyped_declaration\', \'unsafe_call_argument\')',
+		'@warning_ignore(\'shadowed_variable\', \'untyped_declaration\', \'unsafe_call_argument\', \'unsafe_method_access\')',
 		'static func foo() -> void:',
 		'	var args__: Array = ["foo", ]',
 		'',
@@ -219,7 +219,7 @@ func test_double_static_return_void_function_with_args() -> void:
 		GdFunctionArgument.new("arg2", TYPE_STRING, "default")
 	])
 	var expected := [
-		'@warning_ignore(\'shadowed_variable\', \'untyped_declaration\', \'unsafe_call_argument\')',
+		'@warning_ignore(\'shadowed_variable\', \'untyped_declaration\', \'unsafe_call_argument\', \'unsafe_method_access\')',
 		'static func foo(arg1_, arg2_="default") -> void:',
 		'	var args__: Array = ["foo", arg1_, arg2_]',
 		'',
@@ -244,7 +244,7 @@ func test_double_static_script_function_with_args_return_bool() -> void:
 		GdFunctionArgument.new("arg2", TYPE_STRING, "default")
 	])
 	var expected := [
-		'@warning_ignore(\'shadowed_variable\', \'untyped_declaration\', \'unsafe_call_argument\')',
+		'@warning_ignore(\'shadowed_variable\', \'untyped_declaration\', \'unsafe_call_argument\', \'unsafe_method_access\')',
 		'static func foo(arg1_, arg2_="default") -> bool:',
 		'	var args__: Array = ["foo", arg1_, arg2_]',
 		'',
@@ -267,7 +267,7 @@ func test_double_virtual_return_void_function_with_arg() -> void:
 	# void _input(event: InputEvent) virtual
 	var fd := get_function_description("Node", "_input")
 	var expected := [
-		'@warning_ignore(\'shadowed_variable\', \'untyped_declaration\', \'unsafe_call_argument\')',
+		'@warning_ignore(\'shadowed_variable\', \'untyped_declaration\', \'unsafe_call_argument\', \'unsafe_method_access\')',
 		'@warning_ignore("native_method_override")',
 		'func _input(event_) -> void:',
 		'	var args__: Array = ["_input", event_]',
@@ -290,7 +290,7 @@ func test_double_virtual_return_void_function_without_arg() -> void:
 	# void _ready() virtual
 	var fd := get_function_description("Node", "_ready")
 	var expected := [
-		'@warning_ignore(\'shadowed_variable\', \'untyped_declaration\', \'unsafe_call_argument\')',
+		'@warning_ignore(\'shadowed_variable\', \'untyped_declaration\', \'unsafe_call_argument\', \'unsafe_method_access\')',
 		'@warning_ignore("native_method_override")',
 		'func _ready() -> void:',
 		'	var args__: Array = ["_ready", ]',
@@ -315,7 +315,8 @@ class NodeWithOutVirtualFunc extends Node:
 	#func _input(event :InputEvent) -> void:
 
 
+@warning_ignore("unsafe_method_access")
 func test_spy_on_script_respect_virtual_functions() -> void:
 	var do_spy :Variant = auto_free(GdUnitSpyBuilder.spy_on_script(auto_free(NodeWithOutVirtualFunc.new()), [], false).new())
-	assert_that(do_spy.has_method("_ready")).is_true()
-	assert_that(do_spy.has_method("_input")).is_false()
+	assert_bool(do_spy.has_method("_ready")).is_true()
+	assert_bool(do_spy.has_method("_input")).is_false()

--- a/addons/gdUnit4/test/spy/GdUnitSpyCallableTest.gd
+++ b/addons/gdUnit4/test/spy/GdUnitSpyCallableTest.gd
@@ -44,6 +44,7 @@ func test_exclude_functions() -> void:
 		.not_contains(CallableDoubler.callable_functions())
 
 
+@warning_ignore("unsafe_method_access")
 func test_call() -> void:
 	var cb := func(x: int) -> String:
 		return "is_called %s" % x
@@ -59,6 +60,7 @@ func test_call() -> void:
 	assert_failure(func() -> void: verify(cb_spy).call(23)).is_failed()
 
 
+@warning_ignore("unsafe_method_access")
 func test_call_with_binded_value() -> void:
 	var cb := func(x: int, y: int) -> String:
 		return "is_called %s.%s" % [x, y]
@@ -77,6 +79,7 @@ func test_call_with_binded_value() -> void:
 # we not able to stub on callv because the original signature of Callabe:callv and Object:callv are different
 # and a spy is a specialized object delegator to the original implementation as object instance
 # a Callable is not inherits form object so it makes it impossible to spy/mock on `callv`
+@warning_ignore("unsafe_method_access")
 func _test_callv() -> void:
 	var cb := func(x: int, y: int) -> String:
 		return "is_called %s.%s" % [x, y]
@@ -90,6 +93,7 @@ func _test_callv() -> void:
 	verify(cb_spy).callv([42, 24])
 
 
+@warning_ignore("unsafe_method_access")
 func test_bind() -> void:
 	var cb := func(x: int, y: int) -> String:
 		return "is_called %s.%s" % [x, y]
@@ -109,6 +113,7 @@ func test_bind() -> void:
 	verify(cb_spy).call(42, 24)
 
 
+@warning_ignore("unsafe_method_access")
 func test_bindv() -> void:
 	var cb := func(a1: int, a2: int, a3: int, a4: int) -> String:
 		return "is_called %s %s %s %s" % [a1, a2, a3, a4]
@@ -123,6 +128,7 @@ func test_bindv() -> void:
 	assert_str(cb_spy.call(42)).is_equal("is_called 42 21 22 23")
 
 
+@warning_ignore("unsafe_method_access")
 func test_unbind() -> void:
 	var cb := func(a1: int, a2: int, a3: int) -> String:
 		return "is_called %s %s %s" % [a1, a2, a3]
@@ -137,6 +143,7 @@ func test_unbind() -> void:
 	assert_str(cb_spy.call(42)).is_equal("is_called 21 22 23")
 
 
+@warning_ignore("unsafe_method_access")
 func test_rpc() -> void:
 	_rpc_called = ""
 	var cb_spy :Variant = spy(do_rpc)
@@ -150,6 +157,7 @@ func test_rpc() -> void:
 	assert_failure(func() -> void: verify(cb_spy).rpc("abc", 43)).is_failed()
 
 
+@warning_ignore("unsafe_method_access")
 func test_rpc_id() -> void:
 	_rpc_called = ""
 	var cb_spy :Variant = spy(do_rpc_on_peer)
@@ -163,6 +171,7 @@ func test_rpc_id() -> void:
 	assert_failure(func() -> void: verify(cb_spy).rpc_id(23, "arg1", "arg2")).is_failed()
 
 
+@warning_ignore("unsafe_method_access")
 func test_get_bound_arguments() -> void:
 	var cb := func() -> void: return
 	var cb_syp :Variant = spy(cb)
@@ -173,6 +182,7 @@ func test_get_bound_arguments() -> void:
 	verify(cb_syp, 1).get_bound_arguments()
 
 
+@warning_ignore("unsafe_method_access")
 func test_get_bound_arguments_count() -> void:
 	var cb := func() -> void: return
 	var cb_syp :Variant = spy(cb)
@@ -183,6 +193,7 @@ func test_get_bound_arguments_count() -> void:
 	verify(cb_syp, 1).get_bound_arguments_count()
 
 
+@warning_ignore("unsafe_method_access")
 func test_get_method() -> void:
 	var cb_syp :Variant = spy(do_rpc)
 
@@ -191,6 +202,7 @@ func test_get_method() -> void:
 	verify(cb_syp, 1).get_method()
 
 
+@warning_ignore("unsafe_method_access")
 func test_get_object() -> void:
 	var cb_syp :Variant = spy(do_rpc)
 
@@ -199,6 +211,7 @@ func test_get_object() -> void:
 	verify(cb_syp, 1).get_object()
 
 
+@warning_ignore("unsafe_method_access")
 func test_get_object_id() -> void:
 	var cb_syp :Variant = spy(do_rpc)
 
@@ -207,6 +220,7 @@ func test_get_object_id() -> void:
 	verify(cb_syp, 1).get_object_id()
 
 
+@warning_ignore("unsafe_method_access")
 func test_hash() -> void:
 	var cb_syp :Variant = spy(do_rpc)
 
@@ -215,6 +229,7 @@ func test_hash() -> void:
 	verify(cb_syp, 1).hash()
 
 
+@warning_ignore("unsafe_method_access")
 func test_is_custom_is_true() -> void:
 	var cb_syp :Variant = spy(do_rpc)
 	assert_that(do_rpc.is_custom()).is_true()
@@ -224,6 +239,7 @@ func test_is_custom_is_true() -> void:
 	verify(cb_syp, 1).is_custom()
 
 
+@warning_ignore("unsafe_method_access")
 func test_is_custom_is_false() -> void:
 	var cb := Callable(self, "do_rpc")
 	assert_that(cb.is_custom()).is_false()
@@ -234,6 +250,7 @@ func test_is_custom_is_false() -> void:
 	verify(cb_syp, 1).is_custom()
 
 
+@warning_ignore("unsafe_method_access")
 func test_is_null() -> void:
 	var cb_syp :Variant = spy(do_rpc)
 
@@ -245,6 +262,7 @@ func test_is_null() -> void:
 	assert_that(cb_syp.is_null()).is_true()
 
 
+@warning_ignore("unsafe_method_access")
 func test_is_standard_is_false() -> void:
 	var cb_syp :Variant = spy(do_rpc)
 	assert_that(do_rpc.is_standard()).is_false()
@@ -254,6 +272,7 @@ func test_is_standard_is_false() -> void:
 	verify(cb_syp, 1).is_standard()
 
 
+@warning_ignore("unsafe_method_access")
 func test_is_standard_is_true() -> void:
 	var cb := Callable(self, "do_rpc")
 	assert_that(cb.is_standard()).is_true()
@@ -264,6 +283,7 @@ func test_is_standard_is_true() -> void:
 	verify(cb_syp, 1).is_standard()
 
 
+@warning_ignore("unsafe_method_access")
 func test_is_valid() -> void:
 	var cb_syp :Variant = spy(do_rpc)
 

--- a/addons/gdUnit4/test/spy/GdUnitSpyTest.gd
+++ b/addons/gdUnit4/test/spy/GdUnitSpyTest.gd
@@ -7,6 +7,7 @@ func before() -> void:
 	ProjectSettings.set_setting(GdUnitSettings.REPORT_ASSERT_ERRORS, false)
 
 
+@warning_ignore("unsafe_method_access")
 func test_spy_instance_id_is_unique() -> void:
 	var m1  :Variant = spy(RefCounted.new())
 	var m2  :Variant = spy(RefCounted.new())
@@ -21,6 +22,7 @@ func test_cant_spy_is_not_a_instance() -> void:
 	assert_object(spy_node).is_null()
 
 
+@warning_ignore("unsafe_method_access")
 func test_spy_on_Node() -> void:
 	var instance :Node = auto_free(Node.new())
 	var spy_node :Variant = spy(instance)
@@ -48,6 +50,7 @@ func test_spy_on_Node() -> void:
 	verify(spy_node, 2).set_process(false)
 
 
+@warning_ignore("unsafe_method_access")
 func test_spy_source_with_class_name_by_resource_path() -> void:
 	var instance :Object = auto_free(load('res://addons/gdUnit4/test/mocker/resources/GD-256/world.gd').new())
 	var m :Variant = spy(instance)
@@ -57,6 +60,7 @@ func test_spy_source_with_class_name_by_resource_path() -> void:
 		.contains("extends 'res://addons/gdUnit4/test/mocker/resources/GD-256/world.gd'")
 
 
+@warning_ignore("unsafe_method_access")
 func test_spy_source_with_class_name_by_class() -> void:
 	var m :Variant = spy(auto_free(Munderwood_Pathing_World.new()))
 	var head :String = m.get_script().source_code.substr(0, 200)
@@ -65,6 +69,7 @@ func test_spy_source_with_class_name_by_class() -> void:
 		.contains("extends 'res://addons/gdUnit4/test/mocker/resources/GD-256/world.gd'")
 
 
+@warning_ignore("unsafe_method_access")
 func test_spy_extends_godot_class() -> void:
 	var m :Variant = spy(auto_free(World3D.new()))
 	var head :String = m.get_script().source_code.substr(0, 200)
@@ -73,6 +78,7 @@ func test_spy_extends_godot_class() -> void:
 		.contains("extends World3D")
 
 
+@warning_ignore("unsafe_method_access")
 func test_spy_on_custom_class() -> void:
 	var instance :AdvancedTestClass = auto_free(AdvancedTestClass.new())
 	var spy_instance :Variant = spy(instance)
@@ -108,6 +114,7 @@ func test_spy_on_custom_class() -> void:
 
 
 # GD-291 https://github.com/MikeSchulze/gdUnit4/issues/291
+@warning_ignore("unsafe_method_access")
 func test_spy_class_with_custom_formattings() -> void:
 	var resource := load("res://addons/gdUnit4/test/mocker/resources/ClassWithCustomFormattings.gd")
 	var do_spy :Variant = spy(auto_free(resource.new("test")))
@@ -116,10 +123,11 @@ func test_spy_class_with_custom_formattings() -> void:
 	verify_no_more_interactions(do_spy)
 	assert_failure(func() -> void: verify_no_interactions(do_spy))\
 		.is_failed() \
-		.has_line(117)
+		.has_line(124)
 
 
 @warning_ignore("unsafe_property_access")
+@warning_ignore("unsafe_method_access")
 func test_spy_copied_class_members() -> void:
 	var instance :Object = auto_free(load("res://addons/gdUnit4/test/mocker/resources/TestPersion.gd").new("user-x", "street", 56616))
 	assert_that(instance._name).is_equal("user-x")
@@ -142,6 +150,7 @@ func test_spy_copied_class_members() -> void:
 	assert_that(spy_instance._value).is_equal(2048)
 
 
+@warning_ignore("unsafe_method_access")
 func test_spy_copied_class_members_on_node() -> void:
 	var node :Node = auto_free(Node.new())
 	# checked a fresh node the name is empty and results into a error when copied at spy
@@ -154,6 +163,7 @@ func test_spy_copied_class_members_on_node() -> void:
 	assert_that(spy(node).name).is_equal("foo")
 
 
+@warning_ignore("unsafe_method_access")
 func test_spy_on_inner_class() -> void:
 	var instance :AdvancedTestClass.AtmosphereData = auto_free(AdvancedTestClass.AtmosphereData.new())
 	var spy_instance :AdvancedTestClass.AtmosphereData = spy(instance)
@@ -172,6 +182,7 @@ func test_spy_on_inner_class() -> void:
 	verify(spy_instance, 1).set_data(AdvancedTestClass.AtmosphereData.SMOKY, 1.3)
 
 
+@warning_ignore("unsafe_method_access")
 func test_spy_on_singleton() -> void:
 	await assert_error(func () -> void:
 							var spy_node_ :Variant = spy(Input)
@@ -179,6 +190,7 @@ func test_spy_on_singleton() -> void:
 							await await_idle_frame()).is_push_error("Spy on a Singleton is not allowed! 'Input'")
 
 
+@warning_ignore("unsafe_method_access")
 func test_example_verify() -> void:
 	var instance :Node = auto_free(Node.new())
 	var spy_node :Variant = spy(instance)
@@ -199,6 +211,7 @@ func test_example_verify() -> void:
 	verify(spy_node, 3).set_process(any_bool())
 
 
+@warning_ignore("unsafe_method_access")
 func test_verify_fail() -> void:
 	var instance :Node = auto_free(Node.new())
 	var spy_node :Variant = spy(instance)
@@ -219,10 +232,11 @@ func test_verify_fail() -> void:
 			.dedent().trim_prefix("\n")
 	assert_failure(func() -> void: verify(spy_node, 1).set_process(true)) \
 		.is_failed() \
-		.has_line(220) \
+		.has_line(233) \
 		.has_message(expected_error)
 
 
+@warning_ignore("unsafe_method_access")
 func test_verify_func_interaction_wiht_PoolStringArray() -> void:
 	var spy_instance :ClassWithPoolStringArrayFunc = spy(ClassWithPoolStringArrayFunc.new())
 
@@ -232,6 +246,7 @@ func test_verify_func_interaction_wiht_PoolStringArray() -> void:
 	verify_no_more_interactions(spy_instance)
 
 
+@warning_ignore("unsafe_method_access")
 func test_verify_func_interaction_wiht_PackedStringArray_fail() -> void:
 	var spy_instance :ClassWithPoolStringArrayFunc = spy(ClassWithPoolStringArrayFunc.new())
 
@@ -246,7 +261,7 @@ func test_verify_func_interaction_wiht_PackedStringArray_fail() -> void:
 			.dedent().trim_prefix("\n")
 	assert_failure(func() -> void: verify(spy_instance, 1).set_values([])) \
 		.is_failed() \
-		.has_line(247) \
+		.has_line(262) \
 		.has_message(expected_error)
 
 	reset(spy_instance)
@@ -264,10 +279,11 @@ func test_verify_func_interaction_wiht_PackedStringArray_fail() -> void:
 			.dedent().trim_prefix("\n")
 	assert_failure(func() -> void: verify(spy_instance, 1).set_values([])) \
 		.is_failed() \
-		.has_line(265) \
+		.has_line(280) \
 		.has_message(expected_error)
 
 
+@warning_ignore("unsafe_method_access")
 func test_reset() -> void:
 	var instance :Node = auto_free(Node.new())
 	var spy_node :Variant = spy(instance)
@@ -286,6 +302,7 @@ func test_reset() -> void:
 	verify_no_interactions(spy_node)
 
 
+@warning_ignore("unsafe_method_access")
 func test_verify_no_interactions() -> void:
 	var instance :Node = auto_free(Node.new())
 	var spy_node :Variant = spy(instance)
@@ -294,6 +311,7 @@ func test_verify_no_interactions() -> void:
 	verify_no_interactions(spy_node)
 
 
+@warning_ignore("unsafe_method_access")
 func test_verify_no_interactions_fails() -> void:
 	var instance :Node = auto_free(Node.new())
 	var spy_node :Variant = spy(instance)
@@ -312,10 +330,11 @@ func test_verify_no_interactions_fails() -> void:
 	# it should fail because we have interactions
 	assert_failure(func() -> void: verify_no_interactions(spy_node)) \
 		.is_failed() \
-		.has_line(313) \
+		.has_line(331) \
 		.has_message(expected_error)
 
 
+@warning_ignore("unsafe_method_access")
 func test_verify_no_more_interactions() -> void:
 	var instance :Node = auto_free(Node.new())
 	var spy_node :Variant = spy(instance)
@@ -334,6 +353,7 @@ func test_verify_no_more_interactions() -> void:
 	verify_no_more_interactions(spy_node)
 
 
+@warning_ignore("unsafe_method_access")
 func test_verify_no_more_interactions_but_has() -> void:
 	var instance :Node = auto_free(Node.new())
 	var spy_node :Variant = spy(instance)
@@ -367,7 +387,7 @@ func test_verify_no_more_interactions_but_has() -> void:
 			.dedent().trim_prefix("\n")
 	assert_failure(func() -> void: verify_no_more_interactions(spy_node)) \
 		.is_failed() \
-		.has_line(368) \
+		.has_line(388) \
 		.has_message(expected_error)
 
 
@@ -385,6 +405,7 @@ func test_create_spy_static_func_untyped() -> void:
 	assert_object(instance).is_not_null()
 
 
+@warning_ignore("unsafe_method_access")
 func test_spy_snake_case_named_class_by_resource_path() -> void:
 	var instance_a :Object = load("res://addons/gdUnit4/test/mocker/resources/snake_case.gd").new()
 	var spy_a :Variant = spy(instance_a)
@@ -403,6 +424,7 @@ func test_spy_snake_case_named_class_by_resource_path() -> void:
 	verify_no_more_interactions(spy_b)
 
 
+@warning_ignore("unsafe_method_access")
 func test_spy_snake_case_named_class_by_class() -> void:
 	var do_spy :Variant = spy(snake_case_class_name.new())
 	assert_object(do_spy).is_not_null()
@@ -426,6 +448,7 @@ const Issue = preload("res://addons/gdUnit4/test/resources/issues/gd-166/issue.g
 const Type = preload("res://addons/gdUnit4/test/resources/issues/gd-166/types.gd")
 
 
+@warning_ignore("unsafe_method_access")
 func test_spy_preload_class_GD_166() -> void:
 	var instance :Object = auto_free(Issue.new())
 	var spy_instance :Variant = spy(instance)
@@ -442,6 +465,7 @@ func _emit_ready(a :String, b :String, c :Variant = null) -> void:
 
 
 # https://github.com/MikeSchulze/gdUnit4/issues/38
+@warning_ignore("unsafe_method_access")
 func test_spy_Node_use_real_func_vararg() -> void:
 	# setup
 	var instance := Node.new()
@@ -484,6 +508,7 @@ class ClassWithSignal:
 
 
 # https://github.com/MikeSchulze/gdUnit4/issues/14
+@warning_ignore("unsafe_method_access")
 func _test_spy_verify_emit_signal() -> void:
 	var spy_instance :Variant = spy(ClassWithSignal.new())
 	assert_that(spy_instance).is_not_null()
@@ -508,6 +533,7 @@ func _test_spy_verify_emit_signal() -> void:
 	verify(spy_instance, 1).emit_signal(spy_instance.test_signal_b.get_name(), "bb", true)
 
 
+@warning_ignore("unsafe_method_access")
 func test_spy_func_with_default_build_in_type() -> void:
 	var spy_instance :ClassWithDefaultBuildIntTypes = spy(ClassWithDefaultBuildIntTypes.new())
 	assert_object(spy_instance).is_not_null()
@@ -526,6 +552,7 @@ func test_spy_func_with_default_build_in_type() -> void:
 	verify_no_more_interactions(spy_instance)
 
 
+@warning_ignore("unsafe_method_access")
 func test_spy_scene_by_resource_path() -> void:
 	var spy_scene :Variant = spy("res://addons/gdUnit4/test/mocker/resources/scenes/TestScene.tscn")
 	assert_object(spy_scene)\
@@ -537,6 +564,7 @@ func test_spy_scene_by_resource_path() -> void:
 	assert_bool(GdUnitMemoryObserver.is_marked_auto_free(spy_scene)).is_true()
 
 
+@warning_ignore("unsafe_method_access")
 func test_spy_on_PackedScene() -> void:
 	var resource := load("res://addons/gdUnit4/test/mocker/resources/scenes/TestScene.tscn")
 	var original_script :Script = resource.get_script()
@@ -557,6 +585,7 @@ func test_spy_on_PackedScene() -> void:
 	assert_bool(GdUnitMemoryObserver.is_marked_auto_free(spy_scene)).is_true()
 
 
+@warning_ignore("unsafe_method_access")
 func test_spy_scene_by_instance() -> void:
 	var resource := load("res://addons/gdUnit4/test/mocker/resources/scenes/TestScene.tscn")
 	var instance :Control = resource.instantiate()
@@ -576,6 +605,7 @@ func test_spy_scene_by_instance() -> void:
 	assert_bool(GdUnitMemoryObserver.is_marked_auto_free(spy_scene)).is_true()
 
 
+@warning_ignore("unsafe_method_access")
 func test_spy_scene_by_path_fail_has_no_script_attached() -> void:
 	var resource := load("res://addons/gdUnit4/test/mocker/resources/scenes/TestSceneWithoutScript.tscn")
 	var instance :Control = auto_free(resource.instantiate())
@@ -585,6 +615,7 @@ func test_spy_scene_by_path_fail_has_no_script_attached() -> void:
 	assert_object(spy_scene).is_null()
 
 
+@warning_ignore("unsafe_method_access")
 func test_spy_scene_initalize() -> void:
 	var spy_scene :Variant = spy("res://addons/gdUnit4/test/mocker/resources/scenes/TestScene.tscn")
 	assert_object(spy_scene).is_not_null()
@@ -616,6 +647,7 @@ class CustomNode extends Node:
 		pass
 
 
+@warning_ignore("unsafe_method_access")
 func test_spy_ready_called_once() -> void:
 	var spy_node :Variant = spy(auto_free(CustomNode.new()))
 
@@ -627,6 +659,7 @@ func test_spy_ready_called_once() -> void:
 	verify(spy_node, 1).only_one_time_call()
 
 
+@warning_ignore("unsafe_method_access")
 func test_spy_with_enum_in_constructor() -> void:
 	# this test uses a class with an enum in the constructor
 	var unit := ClassWithEnumConstructor.new(ClassWithEnumConstructor.MyEnumValue.TWO, [])

--- a/project.godot
+++ b/project.godot
@@ -25,6 +25,7 @@ file_logging/enable_file_logging=true
 gdscript/warnings/exclude_addons=false
 gdscript/warnings/untyped_declaration=2
 gdscript/warnings/unsafe_property_access=1
+gdscript/warnings/unsafe_method_access=1
 gdscript/warnings/unsafe_call_argument=1
 
 [dotnet]

--- a/project.godot
+++ b/project.godot
@@ -38,12 +38,12 @@ enabled=PackedStringArray("res://addons/gdUnit4/plugin.cfg")
 
 [gdunit4]
 
-settings/common/update_notification_enabled=false
 ui/inspector/node_collapse=false
 ui/toolbar/run_overall=true
 ui/inspector/tree_sort_mode=1
 report/godot/script_error=false
 settings/test/flaky_check_enable=true
+settings/common/update_notification_enabled=false
 
 [importer_defaults]
 


### PR DESCRIPTION
# Why
If the default settings for warnings are changed to a more detailed level, many warnings are displayed.

# What
- fix `debug/gdscript/warnings/unsafe_method_access` warnings

