### PR TITLE
GD-590: Fix HTML test report footer overlapping in Firefox

### DIFF
--- a/addons/gdUnit4/src/report/template/css/styles.css
+++ b/addons/gdUnit4/src/report/template/css/styles.css
@@ -385,8 +385,7 @@ div.include-footer {
 }
 
 footer {
-	position: fixed;
-	padding-left: 10em;
+	position: static;
 	left: 0;
 	bottom: 0;
 	width: 100%;
@@ -397,6 +396,10 @@ footer {
 	display: flex;
 	justify-content: space-between;
 	align-items: center;
+}
+
+footer p {
+	padding-left: 10em;
 }
 
 footer .status-legend {


### PR DESCRIPTION
# Why
With the report footer's position CSS value set to `fixed`, the bottom test in a long list of tests is able to be viewed, but in Firefox the footer covers most of the bottom test.


# What
Setting its position to `static` fixes this, and it looks correct in both Chrome and Firefox.