### PR TITLE
GD-594: Fix mock fails on class with parameter getter setter

### DIFF
--- a/addons/gdUnit4/src/core/parse/GdScriptParser.gd
+++ b/addons/gdUnit4/src/core/parse/GdScriptParser.gd
@@ -367,7 +367,7 @@ func get_function_descriptors(script: GDScript, included_functions: PackedString
 		var func_name: String = method_descriptor["name"]
 		if included_functions.is_empty() or func_name in included_functions:
 			# exclude type set/geters
-			if func_name in ["@type_setter", "@type_getter"]:
+			if is_getter_or_setter(func_name):
 				continue
 			if not fds.any(func(fd: GdFunctionDescriptor) -> bool: return fd.name() == func_name):
 				fds.append(GdFunctionDescriptor.extract_from(method_descriptor, false))
@@ -377,6 +377,10 @@ func get_function_descriptors(script: GDScript, included_functions: PackedString
 	_prescan_script(script)
 	_enrich_function_descriptor(script, fds)
 	return fds
+
+
+func is_getter_or_setter(func_name: String) -> bool:
+	return func_name.begins_with("@") and (func_name.ends_with("getter") or func_name.ends_with("setter"))
 
 
 func _parse_function_arguments(input: String) -> Dictionary:

--- a/addons/gdUnit4/test/mocker/GdUnitMockerTest.gd
+++ b/addons/gdUnit4/test/mocker/GdUnitMockerTest.gd
@@ -753,6 +753,26 @@ func test_mock_class_with_inner_classs_() -> void:
 	assert_object(mock_c).is_not_null()
 
 
+func test_mock_class_with_property_getter_and_setter() -> void:
+	var c :Variant = mock(ClassWithParameterGetterSetter)
+
+	# inital value
+	assert_int(c._session_count).is_equal(42)
+
+	# overwrite it by 10
+	c._session_count = 10
+
+	# verify the paramater is set to 10
+	assert_int(c._session_count).is_equal(10)
+	# verify the method still returns the default value
+	assert_int(c.session_count()).is_equal(0)
+
+	# mock the function to return a cutom value
+	do_return(23).on(c).session_count()
+	# verify the method now returns the new value
+	assert_int(c.session_count()).is_equal(23)
+
+
 @warning_ignore("unsafe_method_access")
 func test_do_return() -> void:
 	var mocked_node: Variant = mock(Node)

--- a/addons/gdUnit4/test/mocker/resources/ClassWithParameterGetterSetter.gd
+++ b/addons/gdUnit4/test/mocker/resources/ClassWithParameterGetterSetter.gd
@@ -1,0 +1,13 @@
+class_name ClassWithParameterGetterSetter
+extends RefCounted
+
+
+var _session_count: int = 42:
+	get:
+		return _session_count
+	set(value):
+		_session_count = value
+
+
+func session_count() -> int:
+	return _session_count


### PR DESCRIPTION
# Why
see https://github.com/MikeSchulze/gdUnit4/issues/594

# What
There was a bug in the script parser using hard coded check for getter/setter  parameter named `type`. Fixed by using a pattern to detect a getter/setter matching.

