### PR TITLE
Replace references to GdUnit3 with GdUnit4

### DIFF
--- a/addons/gdUnit4/src/core/templates/test_suite/GdUnitTestSuiteDefaultTemplate.gd
+++ b/addons/gdUnit4/src/core/templates/test_suite/GdUnitTestSuiteDefaultTemplate.gd
@@ -18,7 +18,7 @@ const DEFAULT_TEMP_TS_CS = """
 	// GdUnit generated TestSuite
 
 	using Godot;
-	using GdUnit3;
+	using GdUnit4;
 
 	namespace ${name_space}
 	{

--- a/addons/gdUnit4/src/network/GdUnitTcpClient.gd
+++ b/addons/gdUnit4/src/network/GdUnitTcpClient.gd
@@ -38,8 +38,8 @@ func start(host :String, port :int) -> GdUnitResult:
 		var err := _stream.connect_to_host(host, port)
 		#prints("connect_to_host", host, port, err)
 		if err != OK:
-			return GdUnitResult.error("GdUnit3: Can't establish client, error code: %s" % err)
-	return GdUnitResult.success("GdUnit3: Client connected checked port %d" % port)
+			return GdUnitResult.error("GdUnit4: Can't establish client, error code: %s" % err)
+	return GdUnitResult.success("GdUnit4: Client connected checked port %d" % port)
 
 
 func _process(_delta :float) -> void:

--- a/addons/gdUnit4/src/network/GdUnitTcpServer.gd
+++ b/addons/gdUnit4/src/network/GdUnitTcpServer.gd
@@ -126,8 +126,8 @@ func start() -> GdUnitResult:
 			break
 	if err != OK:
 		if err == ERR_ALREADY_IN_USE:
-			return GdUnitResult.error("GdUnit3: Can't establish server, the server is already in use. Error: %s, " % error_string(err))
-		return GdUnitResult.error("GdUnit3: Can't establish server. Error: %s." % error_string(err))
+			return GdUnitResult.error("GdUnit4: Can't establish server, the server is already in use. Error: %s, " % error_string(err))
+		return GdUnitResult.error("GdUnit4: Can't establish server. Error: %s." % error_string(err))
 	prints("GdUnit4: Test server successfully started checked port: %d" % server_port)
 	return GdUnitResult.success(server_port)
 


### PR DESCRIPTION
# Why
<!-- Enter a clean description why we need this changeset -->
The default C# template still had `using GdUnit3`. It's easy to change the default template (thank you!) from project settings, but this should be a little nicer on everyone.


# What
<!-- Describe exactly what you have changed and what the effects are -->
This changes the template to have `using GdUnit4`. This also changes error messages in `GdUnitTcp{Client,Server}.gd` to be attributed to `GdUnit4` instead of `GdUnit3`.

Some references still remain, left untouched here:
 - One in FUNDING.yml, which appears to be an account name unlikely to have changed, and I wouldn't feel comfortable touching this one anyway.
 - One each in bbcode_example.txt and markdown_example.txt. As these are examples taken from that era, I think these are fine to leave?
 - gdUnit3-examples and all of its references. Given there are `res://` links to here, I'm not sure what migration would look like. I'm at least not confident in this being as simple a set of changes as the ones provided in this PR.