### PR TITLE
Fixed typo in "scanned" in code and in prints

### DIFF
--- a/addons/gdUnit4/bin/GdUnitCmdTool.gd
+++ b/addons/gdUnit4/bin/GdUnitCmdTool.gd
@@ -376,9 +376,9 @@ class CLIRunner:
 		var ts_scanner := GdUnitTestSuiteScanner.new()
 		for as_resource_path in to_execute.keys() as Array[String]:
 			var selected_tests: PackedStringArray = to_execute.get(as_resource_path)
-			var scaned_suites := ts_scanner.scan(as_resource_path)
-			skip_test_case(scaned_suites, selected_tests)
-			test_suites_to_process.append_array(scaned_suites)
+			var scanned_suites := ts_scanner.scan(as_resource_path)
+			skip_test_case(scanned_suites, selected_tests)
+			test_suites_to_process.append_array(scanned_suites)
 		skip_suites(test_suites_to_process, config)
 		return test_suites_to_process
 

--- a/addons/gdUnit4/src/core/GdUnitRunner.gd
+++ b/addons/gdUnit4/src/core/GdUnitRunner.gd
@@ -106,15 +106,15 @@ func load_test_suits() -> Array[Node]:
 	var _scanner := GdUnitTestSuiteScanner.new()
 	for resource_path :String in to_execute.keys():
 		var selected_tests :PackedStringArray = to_execute.get(resource_path)
-		var scaned_suites := _scanner.scan(resource_path)
-		_filter_test_case(scaned_suites, selected_tests)
-		test_suites += scaned_suites
+		var scanned_suites := _scanner.scan(resource_path)
+		_filter_test_case(scanned_suites, selected_tests)
+		test_suites += scanned_suites
 	return test_suites
 
 
 func gdUnitInit() -> void:
 	#enable_manuall_polling()
-	send_message("Scaned %d test suites" % _test_suites_to_process.size())
+	send_message("Scanned %d test suites" % _test_suites_to_process.size())
 	var total_count := _collect_test_case_count(_test_suites_to_process)
 	_on_gdunit_event(GdUnitInit.new(_test_suites_to_process.size(), total_count))
 	if not GdUnitSettings.is_test_discover_enabled():

--- a/addons/gdUnit4/test/core/GdUnitTestSuiteScannerTest.gd
+++ b/addons/gdUnit4/test/core/GdUnitTestSuiteScannerTest.gd
@@ -298,7 +298,7 @@ func test_scan_by_inheritance_class_name() -> void:
 		.contains_same_exactly_in_any_order([&"test_foo2", &"test_foo1"])
 	assert_array(test_suites[2].get_children()).extract("name")\
 		.contains_same_exactly_in_any_order([&"test_foo3", &"test_foo2", &"test_foo1"])
-	# finally free all scaned test suites
+	# finally free all scanned test suites
 	for ts in test_suites:
 		ts.free()
 
@@ -313,7 +313,7 @@ func test_scan_by_inheritance_class_path() -> void:
 			tuple("ExtendedTest","res://addons/gdUnit4/test/core/resources/scan_testsuite_inheritance/by_class_path/ExtendedTest.gd", [&"test_foo2", &"test_foo1"]),
 			tuple("ExtendsExtendedTest", "res://addons/gdUnit4/test/core/resources/scan_testsuite_inheritance/by_class_path/ExtendsExtendedTest.gd", [&"test_foo3", &"test_foo2", &"test_foo1"])
 		])
-	# finally free all scaned test suites
+	# finally free all scanned test suites
 	for ts in test_suites:
 		ts.free()
 
@@ -375,7 +375,7 @@ func test_scan_test_suite_without_tests() -> void:
 
 	assert_array(test_suites).has_size(1)
 	assert_that(test_suites[0].get_child_count()).is_equal(0)
-	# finally free all scaned test suites
+	# finally free all scanned test suites
 	for ts in test_suites:
 		ts.free()
 


### PR DESCRIPTION
# Why
<!-- Enter a clean description why we need this changeset -->
I noticed a typo in the message printed to the gdUnit console after pressing the button to scan for unit tests. So I thought I'd help out by fixing this slight problem.

I hope it's fine that I'm not opening a separate issue as I didn't want to appear to be nitpicking so hard that I'd open an issue rather than just directly fixing this.

# What
<!-- Describe exactly what you have changed and what the effects are -->
I looked for all instances of "scaned" in the repo and changed them all to "scanned"