### PR TITLE
GD-614: Fixed using un-type test parameters

### DIFF
--- a/addons/gdUnit4/src/core/GdUnitTestSuiteScanner.gd
+++ b/addons/gdUnit4/src/core/GdUnitTestSuiteScanner.gd
@@ -191,9 +191,9 @@ func _handle_test_case_arguments(test_suite: GdUnitTestSuite, script: GDScript, 
 		elif arg.has_default():
 			match arg.name():
 				_TestCase.ARGUMENT_TIMEOUT:
-					timeout = arg.default()
+					timeout =  convert(arg.default(), TYPE_INT)
 				_TestCase.ARGUMENT_SKIP:
-					var result :Variant = _expression_runner.execute(script, arg.plain_value())
+					var result: Variant = _expression_runner.execute(script, arg.plain_value())
 					if result is bool:
 						is_skipped = result
 					else:
@@ -201,9 +201,9 @@ func _handle_test_case_arguments(test_suite: GdUnitTestSuite, script: GDScript, 
 				_TestCase.ARGUMENT_SKIP_REASON:
 					skip_reason = arg.plain_value()
 				Fuzzer.ARGUMENT_ITERATIONS:
-					iterations = arg.default()
+					iterations = convert(arg.default(), TYPE_INT)
 				Fuzzer.ARGUMENT_SEED:
-					seed_value = arg.default()
+					seed_value = convert(arg.default(), TYPE_INT)
 	# create new test
 	@warning_ignore("return_value_discarded")
 	test.configure(fd.name(), fd.line_number(), fd.source_path(), timeout, fuzzers, iterations, seed_value)

--- a/addons/gdUnit4/test/fuzzers/GdUnitFuzzerValueInjectionTest.gd
+++ b/addons/gdUnit4/test/fuzzers/GdUnitFuzzerValueInjectionTest.gd
@@ -159,3 +159,8 @@ func test_multiline_fuzzer_args(
 		assert_object(fuzzer_a).is_not_null()
 		assert_object(fuzzer_b).is_not_null()
 		_current_iterations["test_multiline_fuzzer_args"] += 1
+
+
+@warning_ignore("untyped_declaration", "unused_parameter")
+func test_fuzzing_with_untyped_parameters(float_fuzzer = Fuzzers.rangef(-100.0, 100.0), fuzzer_iterations = 10):
+	assert_float(float_fuzzer.next_value()).is_between(-100.0, 100.0)


### PR DESCRIPTION
# Why
Using untyped test parameters, e.g. `fuzzer_iterations = 10` ends up in a runtime error of invalid type assignment.

# What
Enforce test parameter to convert to expected type to avoid invalid type assignment.

