### PR TITLE
GD-616: Use `EditorContextMenuPlugin` for Godot4.4.x

### DIFF
--- a/addons/gdUnit4/plugin.gd
+++ b/addons/gdUnit4/plugin.gd
@@ -68,7 +68,7 @@ func _add_context_menus() -> void:
 		# With Godot 4.4 we have to use the 'add_context_menu_plugin' to register editor context menus
 		_gd_filesystem_context_menu = _create_context_menu("res://addons/gdUnit4/src/ui/menu/EditorFileSystemContextMenuHandlerV44.gdx")
 		call_deferred("add_context_menu_plugin", CONTEXT_SLOT_FILESYSTEM, _gd_filesystem_context_menu)
-		# the CONTEXT_SLOT_SCRIPT_EDITOR is adding to the script panel instead of script editor
+		# the CONTEXT_SLOT_SCRIPT_EDITOR is adding to the script panel instead of script editor see https://github.com/godotengine/godot/pull/100556
 		#_gd_scripteditor_context_menu = _preload("res://addons/gdUnit4/src/ui/menu/ScriptEditorContextMenuHandlerV44.gdx")
 		#call_deferred("add_context_menu_plugin", CONTEXT_SLOT_SCRIPT_EDITOR, _gd_scripteditor_context_menu)
 		# so we use the old hacky way to add the context menu

--- a/addons/gdUnit4/plugin.gd
+++ b/addons/gdUnit4/plugin.gd
@@ -1,6 +1,10 @@
 @tool
 extends EditorPlugin
 
+# We need to define manually the slot id's, to be downwards compatible
+const CONTEXT_SLOT_FILESYSTEM = 1 # EditorContextMenuPlugin.CONTEXT_SLOT_FILESYSTEM
+const CONTEXT_SLOT_SCRIPT_EDITOR = 2 # EditorContextMenuPlugin.CONTEXT_SLOT_SCRIPT_EDITOR
+
 const GdUnitTools := preload("res://addons/gdUnit4/src/core/GdUnitTools.gd")
 const GdUnitTestDiscoverGuard := preload("res://addons/gdUnit4/src/core/discovery/GdUnitTestDiscoverGuard.gd")
 const GdUnitConsole := preload("res://addons/gdUnit4/src/ui/GdUnitConsole.gd")
@@ -8,6 +12,8 @@ const GdUnitConsole := preload("res://addons/gdUnit4/src/ui/GdUnitConsole.gd")
 
 var _gd_inspector: Control
 var _gd_console: GdUnitConsole
+var _gd_filesystem_context_menu: Variant
+var _gd_scripteditor_context_menu: Variant
 var _guard: GdUnitTestDiscoverGuard
 
 
@@ -22,6 +28,7 @@ func _enter_tree() -> void:
 	GdUnitSettings.setup()
 	# Install the GdUnit Inspector
 	_gd_inspector = (load("res://addons/gdUnit4/src/ui/GdUnitInspector.tscn") as PackedScene).instantiate()
+	_add_context_menus()
 	add_control_to_dock(EditorPlugin.DOCK_SLOT_LEFT_UR, _gd_inspector)
 	# Install the GdUnit Console
 	_gd_console = (load("res://addons/gdUnit4/src/ui/GdUnitConsole.tscn") as PackedScene).instantiate()
@@ -42,6 +49,7 @@ func _exit_tree() -> void:
 	if is_instance_valid(_gd_inspector):
 		remove_control_from_docks(_gd_inspector)
 		_gd_inspector.free()
+	_remove_context_menus()
 	if is_instance_valid(_gd_console):
 		remove_control_from_bottom_panel(_gd_console)
 		_gd_console.free()
@@ -53,6 +61,36 @@ func check_running_in_test_env() -> bool:
 	var args := OS.get_cmdline_args()
 	args.append_array(OS.get_cmdline_user_args())
 	return DisplayServer.get_name() == "headless" or args.has("--selftest") or args.has("--add") or args.has("-a") or args.has("--quit-after") or args.has("--import")
+
+
+func _add_context_menus() -> void:
+	if Engine.get_version_info().hex >= 0x40400:
+		# With Godot 4.4 we have to use the 'add_context_menu_plugin' to register editor context menus
+		_gd_filesystem_context_menu = _create_context_menu("res://addons/gdUnit4/src/ui/menu/EditorFileSystemContextMenuHandlerV44.gdx")
+		call_deferred("add_context_menu_plugin", CONTEXT_SLOT_FILESYSTEM, _gd_filesystem_context_menu)
+		# the CONTEXT_SLOT_SCRIPT_EDITOR is adding to the script panel instead of script editor
+		#_gd_scripteditor_context_menu = _preload("res://addons/gdUnit4/src/ui/menu/ScriptEditorContextMenuHandlerV44.gdx")
+		#call_deferred("add_context_menu_plugin", CONTEXT_SLOT_SCRIPT_EDITOR, _gd_scripteditor_context_menu)
+		# so we use the old hacky way to add the context menu
+		_gd_inspector.add_child(preload("res://addons/gdUnit4/src/ui/menu/ScriptEditorContextMenuHandler.gd").new())
+	else:
+		# TODO Delete it if the minimum requirement for the plugin is set to Godot 4.4.
+		_gd_inspector.add_child(preload("res://addons/gdUnit4/src/ui/menu/EditorFileSystemContextMenuHandler.gd").new())
+		_gd_inspector.add_child(preload("res://addons/gdUnit4/src/ui/menu/ScriptEditorContextMenuHandler.gd").new())
+
+
+func _remove_context_menus() -> void:
+	if is_instance_valid(_gd_filesystem_context_menu):
+		call_deferred("remove_context_menu_plugin", _gd_filesystem_context_menu)
+	if is_instance_valid(_gd_scripteditor_context_menu):
+		call_deferred("remove_context_menu_plugin", _gd_scripteditor_context_menu)
+
+
+func _create_context_menu(script_path: String) -> Variant:
+	var context_menu_script := GDScript.new()
+	context_menu_script.source_code = FileAccess.get_file_as_string(script_path)
+	context_menu_script.reload()
+	return context_menu_script.new()
 
 
 func _on_resource_saved(resource: Resource) -> void:

--- a/addons/gdUnit4/src/ui/GdUnitInspector.gd
+++ b/addons/gdUnit4/src/ui/GdUnitInspector.gd
@@ -2,15 +2,11 @@
 class_name GdUnitInspecor
 extends Panel
 
-const ScriptEditorContextMenuHandler = preload("res://addons/gdUnit4/src/ui/menu/ScriptEditorContextMenuHandler.gd")
-const EditorFileSystemContextMenuHandler = preload("res://addons/gdUnit4/src/ui/menu/EditorFileSystemContextMenuHandler.gd")
 
 var _command_handler := GdUnitCommandHandler.instance()
 
 
 func _ready() -> void:
-	if Engine.is_editor_hint():
-		_getEditorThemes()
 	@warning_ignore("return_value_discarded")
 	GdUnitCommandHandler.instance().gdunit_runner_start.connect(func() -> void:
 		var control :Control = get_parent_control()
@@ -21,55 +17,10 @@ func _ready() -> void:
 				if tab_container.get_tab_title(tab_index) == "GdUnit":
 					tab_container.set_current_tab(tab_index)
 	)
-	if Engine.is_editor_hint():
-		add_script_editor_context_menu()
-		add_file_system_dock_context_menu()
 
 
 func _process(_delta: float) -> void:
 	_command_handler._do_process()
-
-
-func _getEditorThemes() -> void:
-	# example to access current theme
-	#var editiorTheme := interface.get_base_control().theme
-	# setup inspector button icons
-	#var stylebox_types :PackedStringArray = editiorTheme.get_stylebox_type_list()
-	#for stylebox_type in stylebox_types:
-		#prints("stylebox_type", stylebox_type)
-	#	if "Tree" == stylebox_type:
-	#		prints(editiorTheme.get_stylebox_list(stylebox_type))
-	#var style:StyleBoxFlat = editiorTheme.get_stylebox("panel", "Tree")
-	#style.bg_color = Color.RED
-	#var locale = interface.get_editor_settings().get_setting("interface/editor/editor_language")
-	#sessions_label.add_theme_color_override("font_color", get_color("contrast_color_2", "Editor"))
-	#status_label.add_theme_color_override("font_color", get_color("contrast_color_2", "Editor"))
-	#no_sessions_label.add_theme_color_override("font_color", get_color("contrast_color_2", "Editor"))
-	pass
-
-
-# Context menu registrations ----------------------------------------------------------------------
-func add_file_system_dock_context_menu() -> void:
-	var is_test_suite := func is_visible(script: Script, is_ts: bool) -> bool:
-		if script == null:
-			return false
-		return GdObjects.is_test_suite(script) == is_ts
-	var menu :Array[GdUnitContextMenuItem] = [
-		GdUnitContextMenuItem.new(GdUnitContextMenuItem.MENU_ID.TEST_RUN, "Run Testsuites", "Play", is_test_suite.bind(true), _command_handler.command(GdUnitCommandHandler.CMD_RUN_TESTSUITE)),
-		GdUnitContextMenuItem.new(GdUnitContextMenuItem.MENU_ID.TEST_DEBUG, "Debug Testsuites", "PlayStart", is_test_suite.bind(true), _command_handler.command(GdUnitCommandHandler.CMD_RUN_TESTSUITE_DEBUG)),
-	]
-	add_child(EditorFileSystemContextMenuHandler.new(menu))
-
-
-func add_script_editor_context_menu() -> void:
-	var is_test_suite := func is_visible(script: Script, is_ts: bool) -> bool:
-		return GdObjects.is_test_suite(script) == is_ts
-	var menu :Array[GdUnitContextMenuItem] = [
-		GdUnitContextMenuItem.new(GdUnitContextMenuItem.MENU_ID.TEST_RUN, "Run Tests", "Play", is_test_suite.bind(true), _command_handler.command(GdUnitCommandHandler.CMD_RUN_TESTCASE)),
-		GdUnitContextMenuItem.new(GdUnitContextMenuItem.MENU_ID.TEST_DEBUG, "Debug Tests", "PlayStart", is_test_suite.bind(true),_command_handler.command(GdUnitCommandHandler.CMD_RUN_TESTCASE_DEBUG)),
-		GdUnitContextMenuItem.new(GdUnitContextMenuItem.MENU_ID.CREATE_TEST, "Create Test", "New", is_test_suite.bind(false), _command_handler.command(GdUnitCommandHandler.CMD_CREATE_TESTCASE))
-	]
-	add_child(ScriptEditorContextMenuHandler.new(menu))
 
 
 func _on_MainPanel_run_testsuite(test_suite_paths: Array, debug: bool) -> void:

--- a/addons/gdUnit4/src/ui/menu/EditorFileSystemContextMenuHandler.gd
+++ b/addons/gdUnit4/src/ui/menu/EditorFileSystemContextMenuHandler.gd
@@ -2,10 +2,20 @@
 extends Control
 
 var _context_menus := Dictionary()
+var _command_handler := GdUnitCommandHandler.instance()
 
 
-func _init(context_menus: Array[GdUnitContextMenuItem]) -> void:
+func _init() -> void:
 	set_name("EditorFileSystemContextMenuHandler")
+
+	var is_test_suite := func is_visible(script: Script, is_ts: bool) -> bool:
+		if script == null:
+			return false
+		return GdObjects.is_test_suite(script) == is_ts
+	var context_menus :Array[GdUnitContextMenuItem] = [
+		GdUnitContextMenuItem.new(GdUnitContextMenuItem.MENU_ID.TEST_RUN, "Run Testsuites", "Play", is_test_suite.bind(true), _command_handler.command(GdUnitCommandHandler.CMD_RUN_TESTSUITE)),
+		GdUnitContextMenuItem.new(GdUnitContextMenuItem.MENU_ID.TEST_DEBUG, "Debug Testsuites", "PlayStart", is_test_suite.bind(true), _command_handler.command(GdUnitCommandHandler.CMD_RUN_TESTSUITE_DEBUG)),
+	]
 	for menu in context_menus:
 		_context_menus[menu.id] = menu
 	var popup := _menu_popup()

--- a/addons/gdUnit4/src/ui/menu/EditorFileSystemContextMenuHandlerV44.gdx
+++ b/addons/gdUnit4/src/ui/menu/EditorFileSystemContextMenuHandlerV44.gdx
@@ -1,0 +1,41 @@
+@tool
+extends EditorContextMenuPlugin
+
+var _context_menus := Dictionary()
+var _command_handler := GdUnitCommandHandler.instance()
+
+
+func _init() -> void:
+	var is_test_suite := func is_visible(script: Script, is_ts: bool) -> bool:
+		if script == null:
+			return false
+		return GdObjects.is_test_suite(script) == is_ts
+	_context_menus[GdUnitContextMenuItem.MENU_ID.TEST_RUN] = GdUnitContextMenuItem.new(GdUnitContextMenuItem.MENU_ID.TEST_RUN, "Run Testsuites", "Play", is_test_suite.bind(true), _command_handler.command(GdUnitCommandHandler.CMD_RUN_TESTSUITE))
+	_context_menus[GdUnitContextMenuItem.MENU_ID.TEST_DEBUG] = GdUnitContextMenuItem.new(GdUnitContextMenuItem.MENU_ID.TEST_DEBUG, "Debug Testsuites", "PlayStart", is_test_suite.bind(true), _command_handler.command(GdUnitCommandHandler.CMD_RUN_TESTSUITE_DEBUG))
+
+
+func _popup_menu(paths: PackedStringArray) -> void:
+	var test_suites := PackedStringArray()
+
+	for resource_path in paths:
+		# directories and test-suites are valid to enable the menu
+		if DirAccess.dir_exists_absolute(resource_path):
+			test_suites.append(resource_path)
+			continue
+
+		var file_type := resource_path.get_extension()
+		if file_type == "GDScript" or file_type == "CSharpScript":
+			var resource: Script = ResourceLoader.load(resource_path, "Script", ResourceLoader.CACHE_MODE_REUSE)
+			if GdObjects.is_test_suite(resource):
+				test_suites.append(resource_path)
+
+	# no direcory or test-suites selected?
+	if test_suites.is_empty():
+		return
+
+	for menu_item: GdUnitContextMenuItem  in _context_menus.values():
+		@warning_ignore("unused_parameter")
+		add_context_menu_item(menu_item.name,
+			func call(files: Array) -> void:
+				menu_item.execute([test_suites]),
+			GdUnitUiTools.get_icon(menu_item.icon))

--- a/addons/gdUnit4/src/ui/menu/ScriptEditorContextMenuHandler.gd
+++ b/addons/gdUnit4/src/ui/menu/ScriptEditorContextMenuHandler.gd
@@ -3,10 +3,19 @@ extends Control
 
 var _context_menus := Dictionary()
 var _editor: ScriptEditor
+var _command_handler := GdUnitCommandHandler.instance()
 
 
-func _init(context_menus: Array[GdUnitContextMenuItem]) -> void:
+func _init() -> void:
 	set_name("ScriptEditorContextMenuHandler")
+
+	var is_test_suite := func is_visible(script: Script, is_ts: bool) -> bool:
+		return GdObjects.is_test_suite(script) == is_ts
+	var context_menus :Array[GdUnitContextMenuItem] = [
+		GdUnitContextMenuItem.new(GdUnitContextMenuItem.MENU_ID.TEST_RUN, "Run Tests", "Play", is_test_suite.bind(true), _command_handler.command(GdUnitCommandHandler.CMD_RUN_TESTCASE)),
+		GdUnitContextMenuItem.new(GdUnitContextMenuItem.MENU_ID.TEST_DEBUG, "Debug Tests", "PlayStart", is_test_suite.bind(true), _command_handler.command(GdUnitCommandHandler.CMD_RUN_TESTCASE_DEBUG)),
+		GdUnitContextMenuItem.new(GdUnitContextMenuItem.MENU_ID.CREATE_TEST, "Create Test", "New", is_test_suite.bind(false), _command_handler.command(GdUnitCommandHandler.CMD_CREATE_TESTCASE))
+	]
 	for menu in context_menus:
 		_context_menus[menu.id] = menu
 	_editor = EditorInterface.get_script_editor()

--- a/addons/gdUnit4/src/ui/menu/ScriptEditorContextMenuHandlerV44.gdx
+++ b/addons/gdUnit4/src/ui/menu/ScriptEditorContextMenuHandlerV44.gdx
@@ -1,0 +1,33 @@
+@tool
+extends EditorContextMenuPlugin
+
+var _context_menus := Dictionary()
+var _editor: ScriptEditor
+var _command_handler := GdUnitCommandHandler.instance()
+
+
+func _init() -> void:
+	var is_test_suite := func is_visible(script: Script, is_ts: bool) -> bool:
+		return GdObjects.is_test_suite(script) == is_ts
+	var context_menus :Array[GdUnitContextMenuItem] = [
+		GdUnitContextMenuItem.new(GdUnitContextMenuItem.MENU_ID.TEST_RUN, "Run Tests", "Play", is_test_suite.bind(true), _command_handler.command(GdUnitCommandHandler.CMD_RUN_TESTCASE)),
+		GdUnitContextMenuItem.new(GdUnitContextMenuItem.MENU_ID.TEST_DEBUG, "Debug Tests", "PlayStart", is_test_suite.bind(true), _command_handler.command(GdUnitCommandHandler.CMD_RUN_TESTCASE_DEBUG)),
+		GdUnitContextMenuItem.new(GdUnitContextMenuItem.MENU_ID.CREATE_TEST, "Create Test", "New", is_test_suite.bind(false), _command_handler.command(GdUnitCommandHandler.CMD_CREATE_TESTCASE))
+	]
+	for menu in context_menus:
+		_context_menus[menu.id] = menu
+	_editor = EditorInterface.get_script_editor()
+	@warning_ignore("return_value_discarded")
+
+
+func _popup_menu(paths: PackedStringArray) -> void:
+	var script_path := paths[0]
+	var script: Script = ResourceLoader.load(script_path, "Script", ResourceLoader.CACHE_MODE_REUSE)
+
+	for menu_id: int in _context_menus.keys():
+		var menu_item: GdUnitContextMenuItem = _context_menus[menu_id]
+		if menu_item.is_visible(script):
+			add_context_menu_item(menu_item.name,
+				func call(files: Array) -> void:
+					menu_item.execute([script_path]),
+				GdUnitUiTools.get_icon(menu_item.icon))


### PR DESCRIPTION
# Why
see https://github.com/MikeSchulze/gdUnit4/issues/616

# What
- Removed the context menu creation form, the `GdUnitInspector` into the context menu classes.
- Provide different implementations for Godot 4.4 and lower to implement version specific solutions
  - use for Godot4.4+ the new provided `EditorContextMenuPlugin` interfaces to add the context menus
  - use for Godot4.3- the classic hacky way to add the context menus
- for script editor context menus we need to use the old way until https://github.com/godotengine/godot/pull/100556 is merged
