### PR TITLE
GD-616: fix file type check on filesystem context menu checks

### DIFF
--- a/addons/gdUnit4/src/ui/menu/EditorFileSystemContextMenuHandlerV44.gdx
+++ b/addons/gdUnit4/src/ui/menu/EditorFileSystemContextMenuHandlerV44.gdx
@@ -24,7 +24,7 @@ func _popup_menu(paths: PackedStringArray) -> void:
 			continue
 
 		var file_type := resource_path.get_extension()
-		if file_type == "GDScript" or file_type == "CSharpScript":
+		if file_type == "gd" or file_type == "cs":
 			var resource: Script = ResourceLoader.load(resource_path, "Script", ResourceLoader.CACHE_MODE_REUSE)
 			if GdObjects.is_test_suite(resource):
 				test_suites.append(resource_path)


### PR DESCRIPTION
# Why
With https://github.com/MikeSchulze/gdUnit4/issues/616 introduced change has a little bug to evaluate the file type

# What
use `gd` and `cs` for file type check (it was before script type check)


