### PR TITLE
GD-616: Fix update shortcuts

### DIFF
--- a/addons/gdUnit4/src/core/command/GdUnitCommandHandler.gd
+++ b/addons/gdUnit4/src/core/command/GdUnitCommandHandler.gd
@@ -364,7 +364,11 @@ func _on_settings_changed(property: GdUnitProperty) -> void:
 		var value: PackedInt32Array = property.value()
 		var input_event := create_shortcut_input_even(value)
 		prints("Shortcut changed: '%s' to '%s'" % [GdUnitShortcut.ShortCut.keys()[shortcut], input_event.as_text()])
-		register_shortcut(shortcut, input_event)
+		var action := get_shortcut_action(shortcut)
+		if action != null:
+			action.update_shortcut(input_event)
+		else:
+			register_shortcut(shortcut, input_event)
 	if property.name() == GdUnitSettings.TEST_DISCOVER_ENABLED:
 		var timer :SceneTreeTimer = (Engine.get_main_loop() as SceneTree).create_timer(3)
 		@warning_ignore("return_value_discarded")

--- a/addons/gdUnit4/src/core/command/GdUnitShortcutAction.gd
+++ b/addons/gdUnit4/src/core/command/GdUnitShortcutAction.gd
@@ -32,5 +32,9 @@ var command: String:
 		return command
 
 
+func update_shortcut(input_event: InputEventKey) -> void:
+	shortcut.set_events([input_event])
+
+
 func _to_string() -> String:
 	return "GdUnitShortcutAction: %s (%s) -> %s" % [GdUnitShortcut.ShortCut.keys()[type], shortcut.get_as_text(), command]

--- a/addons/gdUnit4/src/ui/menu/EditorFileSystemContextMenuHandlerV44.gdx
+++ b/addons/gdUnit4/src/ui/menu/EditorFileSystemContextMenuHandlerV44.gdx
@@ -15,9 +15,9 @@ func _init() -> void:
 
 	# setup shortcuts
 	for menu_item: GdUnitContextMenuItem  in _context_menus.values():
-		_set_menu_shortcut(menu_item)
-	# register for shortcut changes
-	GdUnitSignals.instance().gdunit_settings_changed.connect(_on_settings_changed)
+		var cb := func call(files: Array) -> void:
+			menu_item.execute([files])
+		add_menu_shortcut(menu_item.shortcut(), cb)
 
 
 func _popup_menu(paths: PackedStringArray) -> void:
@@ -44,20 +44,3 @@ func _popup_menu(paths: PackedStringArray) -> void:
 		var cb := func call(files: Array) -> void:
 			menu_item.execute([test_suites])
 		add_context_menu_item(menu_item.name, cb, GdUnitUiTools.get_icon(menu_item.icon))
-
-
-func _on_settings_changed(property: GdUnitProperty) -> void:
-	if GdUnitCommandHandler.SETTINGS_SHORTCUT_MAPPING.has(property.name()):
-		var shortcut :GdUnitShortcut.ShortCut = GdUnitCommandHandler.SETTINGS_SHORTCUT_MAPPING.get(property.name())
-		for menu_item: GdUnitContextMenuItem in _context_menus.values():
-			if menu_item.command.shortcut != shortcut:
-				continue
-			_set_menu_shortcut(menu_item)
-
-
-func _set_menu_shortcut(menu_item: GdUnitContextMenuItem) -> void:
-	var cb := func call(files: Array) -> void:
-		menu_item.execute([files])
-	# From the documentaion it should be called only ones, but we need to reset/overwrite the settings
-	# see https://github.com/godotengine/godot/pull/100556
-	add_menu_shortcut(menu_item.shortcut(), cb)


### PR DESCRIPTION
# Why
We do a mistake on `EditorFileSystemContextMenuHandlerV44` by act on `gdunit_settings_changed` signal to add a new shortcut. Instead, we have to update the shortcut object to exchange the input event

# What
- removed the invalid handling of settings, changed to update/add the shortcut
- fix on `CommandHandler` to update the input event for existing shortcuts

