### PR TITLE
GD-624: Add `is_inheriting` and `is_not_inheriting` to object assert

### DIFF
--- a/addons/gdUnit4/src/GdUnitObjectAssert.gd
+++ b/addons/gdUnit4/src/GdUnitObjectAssert.gd
@@ -47,3 +47,15 @@ func is_instanceof(type: Variant) -> GdUnitObjectAssert:
 @warning_ignore("unused_parameter")
 func is_not_instanceof(type: Variant) -> GdUnitObjectAssert:
 	return self
+
+
+## Checks whether the current object inherits from the specified type.
+@warning_ignore("unused_parameter")
+func is_inheriting(type: Variant) -> GdUnitObjectAssert:
+	return self
+
+
+## Checks whether the current object does NOT inherit from the specified type.
+@warning_ignore("unused_parameter")
+func is_not_inheriting(type: Variant) -> GdUnitObjectAssert:
+	return self

--- a/addons/gdUnit4/src/asserts/GdUnitObjectAssertImpl.gd
+++ b/addons/gdUnit4/src/asserts/GdUnitObjectAssertImpl.gd
@@ -3,7 +3,7 @@ extends GdUnitObjectAssert
 var _base: GdUnitAssertImpl
 
 
-func _init(current :Variant) -> void:
+func _init(current: Variant) -> void:
 	_base = GdUnitAssertImpl.new(current)
 	# save the actual assert instance on the current thread context
 	GdUnitThreadManager.get_current_context().set_assert(self)
@@ -16,7 +16,7 @@ func _init(current :Variant) -> void:
 			report_error("GdUnitObjectAssert inital error, unexpected type <%s>" % GdObjects.typeof_as_string(current))
 
 
-func _notification(event :int) -> void:
+func _notification(event: int) -> void:
 	if event == NOTIFICATION_PREDELETE:
 		if _base != null:
 			_base.notification(event)
@@ -32,7 +32,7 @@ func report_success() -> GdUnitObjectAssert:
 	return self
 
 
-func report_error(error :String) -> GdUnitObjectAssert:
+func report_error(error: String) -> GdUnitObjectAssert:
 	_base.report_error(error)
 	return self
 
@@ -41,25 +41,25 @@ func failure_message() -> String:
 	return _base.failure_message()
 
 
-func override_failure_message(message :String) -> GdUnitObjectAssert:
+func override_failure_message(message: String) -> GdUnitObjectAssert:
 	@warning_ignore("return_value_discarded")
 	_base.override_failure_message(message)
 	return self
 
 
-func append_failure_message(message :String) -> GdUnitObjectAssert:
+func append_failure_message(message: String) -> GdUnitObjectAssert:
 	@warning_ignore("return_value_discarded")
 	_base.append_failure_message(message)
 	return self
 
 
-func is_equal(expected :Variant) -> GdUnitObjectAssert:
+func is_equal(expected: Variant) -> GdUnitObjectAssert:
 	@warning_ignore("return_value_discarded")
 	_base.is_equal(expected)
 	return self
 
 
-func is_not_equal(expected :Variant) -> GdUnitObjectAssert:
+func is_not_equal(expected: Variant) -> GdUnitObjectAssert:
 	@warning_ignore("return_value_discarded")
 	_base.is_not_equal(expected)
 	return self
@@ -78,15 +78,15 @@ func is_not_null() -> GdUnitObjectAssert:
 
 
 @warning_ignore("shadowed_global_identifier")
-func is_same(expected :Variant) -> GdUnitObjectAssert:
-	var current :Variant = current_value()
+func is_same(expected: Variant) -> GdUnitObjectAssert:
+	var current: Variant = current_value()
 	if not is_same(current, expected):
 		return report_error(GdAssertMessages.error_is_same(current, expected))
 	return report_success()
 
 
-func is_not_same(expected :Variant) -> GdUnitObjectAssert:
-	var current :Variant = current_value()
+func is_not_same(expected: Variant) -> GdUnitObjectAssert:
+	var current: Variant = current_value()
 	if is_same(current, expected):
 		return report_error(GdAssertMessages.error_not_same(current, expected))
 	return report_success()
@@ -101,13 +101,64 @@ func is_instanceof(type: Variant) -> GdUnitObjectAssert:
 	return report_success()
 
 
-func is_not_instanceof(type :Variant) -> GdUnitObjectAssert:
-	var current :Variant = current_value()
+func is_not_instanceof(type: Variant) -> GdUnitObjectAssert:
+	var current: Variant = current_value()
 	if is_instance_of(current, type):
-		var result: = GdObjects.extract_class_name(type)
+		var result := GdObjects.extract_class_name(type)
 		if result.is_success():
 			return report_error("Expected not be a instance of <%s>" % str(result.value()))
 
 		push_error("Internal ERROR: %s" % result.error_message())
 		return self
 	return report_success()
+
+
+## Checks whether the current object inherits from the specified type.
+func is_inheriting(type: Variant) -> GdUnitObjectAssert:
+	var current: Variant = current_value()
+	if not is_instance_of(current, TYPE_OBJECT):
+		return report_error("Expected '%s' to inherit from at least Object." % str(current))
+	var result := _inherits(current, type)
+	if result.is_success():
+		return report_success()
+	return report_error(result.error_message())
+
+
+## Checks whether the current object does NOT inherit from the specified type.
+func is_not_inheriting(type: Variant) -> GdUnitObjectAssert:
+	var current: Variant = current_value()
+	if not is_instance_of(current, TYPE_OBJECT):
+		return report_error("Expected '%s' to inherit from at least Object." % str(current))
+	var result := _inherits(current, type)
+	if result.is_success():
+		return report_error("Expected type to not inherit from <%s>" % _extract_class_type(type))
+	return report_success()
+
+
+func _inherits(current: Variant, type: Variant) -> GdUnitResult:
+	var type_as_string := _extract_class_type(type)
+	if type_as_string == "Object":
+		return GdUnitResult.success("")
+
+	var obj: Object = current
+	for p in obj.get_property_list():
+		var clazz_name :String = p["name"]
+		if p["usage"] == PROPERTY_USAGE_CATEGORY and clazz_name == p["hint_string"] and clazz_name == type_as_string:
+			return GdUnitResult.success("")
+	var script: Script = obj.get_script()
+	if script != null:
+		while script != null:
+			var result := GdObjects.extract_class_name(script)
+			if result.is_success() and result.value() == type_as_string:
+				return GdUnitResult.success("")
+			script = script.get_base_script()
+	return GdUnitResult.error("Expected type to inherit from <%s>" % type_as_string)
+
+
+func _extract_class_type(type: Variant) -> String:
+	if type is String:
+		return type
+	var result := GdObjects.extract_class_name(type)
+	if result.is_error():
+		return ""
+	return result.value()

--- a/addons/gdUnit4/test/asserts/GdUnitObjectAssertImplTest.gd
+++ b/addons/gdUnit4/test/asserts/GdUnitObjectAssertImplTest.gd
@@ -60,6 +60,53 @@ func test_is_not_instanceof() -> void:
 		.has_message("Expected not be a instance of <Node>")
 
 
+func test_is_inheriting() -> void:
+	# test on native Godot class
+	assert_object(auto_free(TabContainer.new()))\
+		.is_inheriting(Container)\
+		.is_inheriting(Control)\
+		# we need to specify by string name because is an abstract class
+		.is_inheriting("CanvasItem")\
+		.is_inheriting(Node)\
+		.is_inheriting(Object)
+	assert_failure(func() -> void:
+		assert_object(auto_free(TabContainer.new())).is_inheriting(Node3D)
+	).is_failed().has_message("Expected type to inherit from <Node3D>")
+
+	# test on user custom class
+	assert_object(auto_free(MyNode.new()))\
+		.is_inheriting(Node)\
+		.is_inheriting(Object)
+	assert_object(auto_free(MyExtendedNode.new()))\
+		.is_inheriting(GdUnitObjectAssertImplTest.MyNode)\
+		.is_inheriting(Node)\
+		.is_inheriting(Object)
+	assert_failure(func() -> void:
+		assert_object(auto_free(MyExtendedNode.new())).is_inheriting(Node3D)
+	).is_failed().has_message("Expected type to inherit from <Node3D>")
+
+	# using not Object type
+	assert_failure(func() -> void:
+		assert_object([]).is_inheriting(Node)
+	).is_failed().has_message("Expected '[]' to inherit from at least Object.")
+
+
+func test_is_not_inheriting() -> void:
+	# test on native Godot class
+	assert_object(auto_free(TabContainer.new()))\
+		.is_not_inheriting(Node2D)\
+		.is_not_inheriting(Node3D)
+
+	assert_failure(func() -> void:
+		assert_object(auto_free(TabContainer.new()))\
+			.is_not_inheriting(Node2D)\
+			.is_not_inheriting(Container)
+	).is_failed().has_message("Expected type to not inherit from <Container>")
+	# using not Object type
+	assert_failure(func() -> void:
+		assert_object([]).is_not_inheriting(Node)
+	).is_failed().has_message("Expected '[]' to inherit from at least Object.")
+
 func test_is_null() -> void:
 	assert_object(null).is_null()
 
@@ -76,10 +123,10 @@ func test_is_not_null() -> void:
 		.has_message("Expecting: not to be '<null>'")
 
 
-@warning_ignore("unsafe_method_access")
 func test_is_same() -> void:
 	var obj1 :Variant = auto_free(Node.new())
 	var obj2 :Variant = obj1
+	@warning_ignore("unsafe_method_access")
 	var obj3 :Variant = auto_free(obj1.duplicate())
 	assert_object(obj1).is_same(obj1)
 	assert_object(obj1).is_same(obj2)
@@ -99,10 +146,10 @@ func test_is_same() -> void:
 		.is_failed()
 
 
-@warning_ignore("unsafe_method_access")
 func test_is_not_same() -> void:
 	var obj1 :Variant = auto_free(Node.new())
 	var obj2 :Variant = obj1
+	@warning_ignore("unsafe_method_access")
 	var obj3 :Variant = auto_free(obj1.duplicate())
 	assert_object(null).is_not_same(obj1)
 	assert_object(obj1).is_not_same(obj3)
@@ -193,3 +240,10 @@ func test_is_failure() -> void:
 	if is_failure():
 		return
 	assert_bool(true).override_failure_message("This line shold never be called").is_false()
+
+
+class MyNode extends Node:
+	pass
+
+class MyExtendedNode extends MyNode:
+	pass


### PR DESCRIPTION
# Why
see https://github.com/MikeSchulze/gdUnit4/issues/624

# What
Added `is_inheriting` and `is_not_inheriting` to object assert and covered by tests
