### PR TITLE
GD-629: Fix script parser to parse default dictionary function arguments

### DIFF
--- a/addons/gdUnit4/src/core/parse/GdDefaultValueDecoder.gd
+++ b/addons/gdUnit4/src/core/parse/GdDefaultValueDecoder.gd
@@ -160,6 +160,11 @@ func _on_type_Array(value: Variant, type: int) -> String:
 
 
 func _on_type_Vector(value: Variant, type: int) -> String:
+
+	if typeof(value) != type:
+		push_error("Internal Error: type missmatch detected for value '%s', expects type %s" % [value, type_string(type)])
+		return ""
+
 	match type:
 		TYPE_VECTOR2:
 			if value == Vector2():

--- a/addons/gdUnit4/src/core/parse/GdFunctionArgument.gd
+++ b/addons/gdUnit4/src/core/parse/GdFunctionArgument.gd
@@ -57,9 +57,22 @@ func set_value(value: String) -> void:
 
 	if _type == TYPE_NIL or _type == GdObjects.TYPE_VARIANT:
 		_type = _extract_value_type(value)
-		_default_value = value
+		if _type == GdObjects.TYPE_VARIANT:
+			_default_value = value
 	if _default_value == null:
-		_default_value = value
+		match _type:
+			TYPE_DICTIONARY:
+				_default_value = as_dictionary(value)
+			TYPE_ARRAY:
+				_default_value = as_array(value)
+			GdObjects.TYPE_FUZZER:
+				_default_value = value
+			_:
+				_default_value = str_to_var(value)
+				# if converting fails assign the original value without converting
+				if _default_value == null and value != null:
+					_default_value = value
+		#prints("set default_value: ", _default_value, "with type %d" % _type, " from original: '%s'" % value)
 
 
 func _extract_value_type(value: String) -> int:
@@ -170,3 +183,21 @@ func _parse_parameter_set(input :String) -> PackedStringArray:
 			collected_characters.clear()
 			matched = false
 	return output
+
+
+## value converters
+
+func as_array(value: String) -> Array:
+	if value == "Array()":
+		return []
+	if value.begins_with("Array("):
+		value = value.lstrip("Array(").rstrip(")")
+	return str_to_var(value)
+
+
+func as_dictionary(value: String) -> Dictionary:
+	if value == "Dictionary()":
+		return {}
+	if value.begins_with("Dictionary("):
+		value = value.lstrip("Dictionary(").rstrip(")")
+	return str_to_var(value)

--- a/addons/gdUnit4/src/core/parse/GdScriptParser.gd
+++ b/addons/gdUnit4/src/core/parse/GdScriptParser.gd
@@ -478,6 +478,7 @@ func _parse_end_function(input: String, remove_trailing_char := false) -> String
 	var current_index := 0
 	var bracket_count := 0
 	var in_array := 0
+	var in_dict := 0
 	var end_of_func := false
 
 	while current_index < len(input) and not end_of_func:
@@ -504,14 +505,17 @@ func _parse_end_function(input: String, remove_trailing_char := false) -> String
 			# count if inside an array
 			"[": in_array += 1
 			"]": in_array -= 1
+			# count if inside an dictionary
+			"{": in_dict += 1
+			"}": in_dict -= 1
 			# count if inside a function
 			"(": bracket_count += 1
 			")":
 				bracket_count -= 1
-				if bracket_count < 0 and in_array <= 0:
+				if bracket_count < 0 and in_array <= 0 and in_dict <= 0:
 					end_of_func = true
 			",":
-				if bracket_count == 0 and in_array == 0:
+				if bracket_count == 0 and in_array == 0 and in_dict <= 0:
 					end_of_func = true
 		current_index += 1
 	if remove_trailing_char:

--- a/addons/gdUnit4/test/core/parse/GdScriptParsingFunctionDescriptors.gd
+++ b/addons/gdUnit4/test/core/parse/GdScriptParsingFunctionDescriptors.gd
@@ -1,0 +1,486 @@
+extends GdUnitTestSuite
+
+var _parser: GdScriptParser
+
+
+func before() -> void:
+	_parser = GdScriptParser.new()
+
+
+func after() -> void:
+	clean_temp_dir()
+
+
+func test_default_args_dictionary() -> void:
+	var script: GDScript = load("res://addons/gdUnit4/test/core/resources/parsing/functions/container_build_in_types/ClassWithDictionaryDefaultArguments.gd")
+
+	var fds := _parser.get_function_descriptors(script, [])
+	assert_that(fds[0])\
+		.is_equal(GdFunctionDescriptor
+			.create("on_dictionary_case1", script.resource_path, 5, TYPE_ARRAY, [
+				GdFunctionArgument.new("dict", TYPE_DICTIONARY, {}),
+			])
+		)
+	assert_that(fds[1])\
+		.is_equal(GdFunctionDescriptor
+			.create("on_dictionary_case2", script.resource_path, 9, TYPE_ARRAY, [
+				GdFunctionArgument.new("dict", TYPE_DICTIONARY, {}),
+			])
+		)
+	assert_that(fds[2])\
+		.is_equal(GdFunctionDescriptor
+			.create("on_dictionary_case3", script.resource_path, 13, TYPE_ARRAY, [
+				GdFunctionArgument.new("dict", TYPE_DICTIONARY, {}),
+			])
+		)
+	assert_that(fds[3])\
+		.is_equal(GdFunctionDescriptor
+			.create("on_dictionary_case4", script.resource_path, 17, TYPE_ARRAY, [
+				GdFunctionArgument.new("dict", TYPE_DICTIONARY, {"a":"value_a", "b":"value_b"}),
+			])
+		)
+	assert_that(fds[4])\
+		.is_equal(GdFunctionDescriptor
+			.create("on_dictionary_case5", script.resource_path, 21, TYPE_ARRAY, [
+				GdFunctionArgument.new("dict", TYPE_DICTIONARY, {"a":"value_a", "b":"value_b"}),
+			])
+		)
+	assert_that(fds[5])\
+		.is_equal(GdFunctionDescriptor
+			.create("on_dictionary_case6", script.resource_path, 27, TYPE_ARRAY, [
+				GdFunctionArgument.new("dict", TYPE_DICTIONARY, {"a":"value_a", "b":"value_b"}),
+			])
+		)
+
+
+func test_default_args_array() -> void:
+	var script: GDScript = load("res://addons/gdUnit4/test/core/resources/parsing/functions/container_build_in_types/ClassWithArrayDefaultArguments.gd")
+
+	var fds := _parser.get_function_descriptors(script, [])
+	assert_that(fds[0])\
+		.is_equal(GdFunctionDescriptor
+			.create("on_array_case1", script.resource_path, 5, TYPE_ARRAY, [
+				GdFunctionArgument.new("values", TYPE_ARRAY, []),
+			])
+		)
+	assert_that(fds[1])\
+		.is_equal(GdFunctionDescriptor
+			.create("on_array_case2", script.resource_path, 9, TYPE_ARRAY, [
+				GdFunctionArgument.new("values", TYPE_ARRAY, []),
+			])
+		)
+	assert_that(fds[2])\
+		.is_equal(GdFunctionDescriptor
+			.create("on_array_case3", script.resource_path, 13, TYPE_ARRAY, [
+				GdFunctionArgument.new("values", TYPE_ARRAY, []),
+			])
+		)
+	assert_that(fds[3])\
+		.is_equal(GdFunctionDescriptor
+			.create("on_array_case4", script.resource_path, 17, TYPE_ARRAY, [
+				GdFunctionArgument.new("values", TYPE_ARRAY, [1, "3", [], {}]),
+			])
+		)
+	assert_that(fds[4])\
+		.is_equal(GdFunctionDescriptor
+			.create("on_array_case5", script.resource_path, 21, TYPE_ARRAY, [
+				GdFunctionArgument.new("values", TYPE_ARRAY, [1, "3", [], {}]),
+			])
+		)
+	assert_that(fds[5])\
+		.is_equal(GdFunctionDescriptor
+			.create("on_array_case6", script.resource_path, 29, TYPE_ARRAY, [
+				GdFunctionArgument.new("values", TYPE_ARRAY, [1, "3", [], {}]),
+			])
+		)
+
+
+func test_default_args_callable() -> void:
+	var script: GDScript = load("res://addons/gdUnit4/test/core/resources/parsing/functions/container_build_in_types/ClassWithCallableDefaultArguments.gd")
+
+	var fds := _parser.get_function_descriptors(script, [])
+	assert_that(fds[0])\
+		.is_equal(GdFunctionDescriptor
+			.create("on_callable_case1", script.resource_path, 5, TYPE_CALLABLE, [
+				GdFunctionArgument.new("cb", TYPE_CALLABLE),
+			])
+		)
+	assert_that(fds[1])\
+		.is_equal(GdFunctionDescriptor
+			.create("on_callable_case2", script.resource_path, 9, TYPE_CALLABLE, [
+				GdFunctionArgument.new("cb", TYPE_CALLABLE, Callable()),
+			])
+		)
+	assert_that(fds[2])\
+		.is_equal(GdFunctionDescriptor
+			.create("on_callable_case3", script.resource_path, 13, TYPE_CALLABLE, [
+				GdFunctionArgument.new("cb", TYPE_CALLABLE, Callable()),
+			])
+		)
+	assert_that(fds[3])\
+		.is_equal(GdFunctionDescriptor
+			.create("on_callable_case4", script.resource_path, 17, TYPE_CALLABLE, [
+				GdFunctionArgument.new("cb", TYPE_CALLABLE, Callable(null, "method_foo")),
+			])
+		)
+
+
+# Basic build-in-types
+func test_default_args_basic_type_int() -> void:
+	var script: GDScript = load("res://addons/gdUnit4/test/core/resources/parsing/functions/basic_build_in_types/ClassWithBasicTypeIntDefaultArguments.gd")
+
+	var fds := _parser.get_function_descriptors(script, [])
+	assert_that(fds[0])\
+		.is_equal(GdFunctionDescriptor
+			.create("on_int_case1", script.resource_path, 5, TYPE_INT, [
+				GdFunctionArgument.new("value", TYPE_INT),
+			])
+		)
+	assert_that(fds[1])\
+		.is_equal(GdFunctionDescriptor
+			.create("on_int_case2", script.resource_path, 9, TYPE_INT, [
+				GdFunctionArgument.new("value", TYPE_INT, 42),
+			])
+		)
+	assert_that(fds[2])\
+		.is_equal(GdFunctionDescriptor
+			.create("on_int_case3", script.resource_path, 13, TYPE_INT, [
+				GdFunctionArgument.new("value", TYPE_INT, 42),
+			])
+		)
+
+
+func test_default_args_basic_type_float() -> void:
+	var script: GDScript = load("res://addons/gdUnit4/test/core/resources/parsing/functions/basic_build_in_types/ClassWithBasicTypeFloatDefaultArguments.gd")
+
+	var fds := _parser.get_function_descriptors(script, [])
+	assert_that(fds[0])\
+		.is_equal(GdFunctionDescriptor
+			.create("on_float_case1", script.resource_path, 5, TYPE_FLOAT, [
+				GdFunctionArgument.new("value", TYPE_FLOAT),
+			])
+		)
+	assert_that(fds[1])\
+		.is_equal(GdFunctionDescriptor
+			.create("on_float_case2", script.resource_path, 9, TYPE_FLOAT, [
+				GdFunctionArgument.new("value", TYPE_FLOAT, 42.1),
+			])
+		)
+	assert_that(fds[2])\
+		.is_equal(GdFunctionDescriptor
+			.create("on_float_case3", script.resource_path, 13, TYPE_FLOAT, [
+				GdFunctionArgument.new("value", TYPE_FLOAT, 42.1),
+			])
+		)
+
+
+func test_default_args_basic_type_bool() -> void:
+	var script: GDScript = load("res://addons/gdUnit4/test/core/resources/parsing/functions/basic_build_in_types/ClassWithBasicTypeBoolDefaultArguments.gd")
+
+	var fds := _parser.get_function_descriptors(script, [])
+	assert_that(fds[0])\
+		.is_equal(GdFunctionDescriptor
+			.create("on_bool_case1", script.resource_path, 5, TYPE_BOOL, [
+				GdFunctionArgument.new("value", TYPE_BOOL),
+			])
+		)
+	assert_that(fds[1])\
+		.is_equal(GdFunctionDescriptor
+			.create("on_bool_case2", script.resource_path, 9, TYPE_BOOL, [
+				GdFunctionArgument.new("value", TYPE_BOOL, true),
+			])
+		)
+	assert_that(fds[2])\
+		.is_equal(GdFunctionDescriptor
+			.create("on_bool_case3", script.resource_path, 13, TYPE_BOOL, [
+				GdFunctionArgument.new("value", TYPE_BOOL, true),
+			])
+		)
+
+
+func test_default_args_basic_type_string() -> void:
+	var script: GDScript = load("res://addons/gdUnit4/test/core/resources/parsing/functions/basic_build_in_types/ClassWithBasicTypeStringDefaultArguments.gd")
+
+	var fds := _parser.get_function_descriptors(script, [])
+	assert_that(fds[0])\
+		.is_equal(GdFunctionDescriptor
+			.create("on_string_case1", script.resource_path, 5, TYPE_STRING, [
+				GdFunctionArgument.new("value", TYPE_STRING),
+			])
+		)
+	assert_that(fds[1])\
+		.is_equal(GdFunctionDescriptor
+			.create("on_string_case2", script.resource_path, 9, TYPE_STRING, [
+				GdFunctionArgument.new("value", TYPE_STRING, "foo"),
+			])
+		)
+	assert_that(fds[2])\
+		.is_equal(GdFunctionDescriptor
+			.create("on_string_case3", script.resource_path, 13, TYPE_STRING, [
+				GdFunctionArgument.new("value", TYPE_STRING, "foo"),
+			])
+		)
+
+
+func test_default_args_basic_type_string_name() -> void:
+	var script: GDScript = load("res://addons/gdUnit4/test/core/resources/parsing/functions/basic_build_in_types/ClassWithBasicTypeStringNameDefaultArguments.gd")
+
+	var fds := _parser.get_function_descriptors(script, [])
+	assert_that(fds[0])\
+		.is_equal(GdFunctionDescriptor
+			.create("on_string_name_case1", script.resource_path, 5, TYPE_STRING_NAME, [
+				GdFunctionArgument.new("value", TYPE_STRING_NAME),
+			])
+		)
+	assert_that(fds[1])\
+		.is_equal(GdFunctionDescriptor
+			.create("on_string_name_case2", script.resource_path, 9, TYPE_STRING_NAME, [
+				GdFunctionArgument.new("value", TYPE_STRING_NAME, &"foo"),
+			])
+		)
+	assert_that(fds[2])\
+		.is_equal(GdFunctionDescriptor
+			.create("on_string_name_case3", script.resource_path, 13, TYPE_STRING_NAME, [
+				GdFunctionArgument.new("value", TYPE_STRING_NAME, &"foo"),
+			])
+		)
+
+
+func test_default_args_basic_type_node_path() -> void:
+	var script: GDScript = load("res://addons/gdUnit4/test/core/resources/parsing/functions/basic_build_in_types/ClassWithBasicTypeNodePathDefaultArguments.gd")
+
+	var fds := _parser.get_function_descriptors(script, [])
+	assert_that(fds[0])\
+		.is_equal(GdFunctionDescriptor
+			.create("on_node_path_case1", script.resource_path, 5, TYPE_NODE_PATH, [
+				GdFunctionArgument.new("value", TYPE_NODE_PATH),
+			])
+		)
+	assert_that(fds[1])\
+		.is_equal(GdFunctionDescriptor
+			.create("on_node_path_case2", script.resource_path, 9, TYPE_NODE_PATH, [
+				GdFunctionArgument.new("value", TYPE_NODE_PATH, NodePath("foo1")),
+			])
+		)
+	assert_that(fds[2])\
+		.is_equal(GdFunctionDescriptor
+			.create("on_node_path_case3", script.resource_path, 13, TYPE_NODE_PATH, [
+				GdFunctionArgument.new("value", TYPE_NODE_PATH, NodePath("foo2")),
+			])
+		)
+	assert_that(fds[3])\
+		.is_equal(GdFunctionDescriptor
+			.create("on_node_path_case4", script.resource_path, 17, TYPE_NODE_PATH, [
+				GdFunctionArgument.new("value", TYPE_NODE_PATH, NodePath("foo3")),
+			])
+		)
+
+
+func test_default_args_basic_type_vector2() -> void:
+	var script: GDScript = load("res://addons/gdUnit4/test/core/resources/parsing/functions/basic_build_in_types/ClassWithBasicTypeVector2DefaultArguments.gd")
+
+	var fds := _parser.get_function_descriptors(script, [])
+	assert_that(fds[0])\
+		.is_equal(GdFunctionDescriptor
+			.create("on_vector2_case1", script.resource_path, 5, TYPE_VECTOR2, [
+				GdFunctionArgument.new("value", TYPE_VECTOR2),
+			])
+		)
+	assert_that(fds[1])\
+		.is_equal(GdFunctionDescriptor
+			.create("on_vector2_case2", script.resource_path, 9, TYPE_VECTOR2, [
+				GdFunctionArgument.new("value", TYPE_VECTOR2, Vector2.ONE),
+			])
+		)
+	assert_that(fds[2])\
+		.is_equal(GdFunctionDescriptor
+			.create("on_vector2_case3", script.resource_path, 13, TYPE_VECTOR2, [
+				GdFunctionArgument.new("value", TYPE_VECTOR2, Vector2.ONE),
+			])
+		)
+
+
+func test_default_args_basic_type_vector2i() -> void:
+	var script: GDScript = load("res://addons/gdUnit4/test/core/resources/parsing/functions/basic_build_in_types/ClassWithBasicTypeVector2iDefaultArguments.gd")
+
+	var fds := _parser.get_function_descriptors(script, [])
+	assert_that(fds[0])\
+		.is_equal(GdFunctionDescriptor
+			.create("on_vector2i_case1", script.resource_path, 5, TYPE_VECTOR2I, [
+				GdFunctionArgument.new("value", TYPE_VECTOR2I),
+			])
+		)
+	assert_that(fds[1])\
+		.is_equal(GdFunctionDescriptor
+			.create("on_vector2i_case2", script.resource_path, 9, TYPE_VECTOR2I, [
+				GdFunctionArgument.new("value", TYPE_VECTOR2I, Vector2i.ONE),
+			])
+		)
+	assert_that(fds[2])\
+		.is_equal(GdFunctionDescriptor
+			.create("on_vector2i_case3", script.resource_path, 13, TYPE_VECTOR2I, [
+				GdFunctionArgument.new("value", TYPE_VECTOR2I, Vector2i.ONE),
+			])
+		)
+
+
+func test_default_args_basic_type_vector3() -> void:
+	var script: GDScript = load("res://addons/gdUnit4/test/core/resources/parsing/functions/basic_build_in_types/ClassWithBasicTypeVector3DefaultArguments.gd")
+
+	var fds := _parser.get_function_descriptors(script, [])
+	assert_that(fds[0])\
+		.is_equal(GdFunctionDescriptor
+			.create("on_vector3_case1", script.resource_path, 5, TYPE_VECTOR3, [
+				GdFunctionArgument.new("value", TYPE_VECTOR3),
+			])
+		)
+	assert_that(fds[1])\
+		.is_equal(GdFunctionDescriptor
+			.create("on_vector3_case2", script.resource_path, 9, TYPE_VECTOR3, [
+				GdFunctionArgument.new("value", TYPE_VECTOR3, Vector3.ONE),
+			])
+		)
+	assert_that(fds[2])\
+		.is_equal(GdFunctionDescriptor
+			.create("on_vector3_case3", script.resource_path, 13, TYPE_VECTOR3, [
+				GdFunctionArgument.new("value", TYPE_VECTOR3, Vector3.ONE),
+			])
+		)
+
+
+func test_default_args_basic_type_vector3i() -> void:
+	var script: GDScript = load("res://addons/gdUnit4/test/core/resources/parsing/functions/basic_build_in_types/ClassWithBasicTypeVector3iDefaultArguments.gd")
+
+	var fds := _parser.get_function_descriptors(script, [])
+	assert_that(fds[0])\
+		.is_equal(GdFunctionDescriptor
+			.create("on_vector3i_case1", script.resource_path, 5, TYPE_VECTOR3I, [
+				GdFunctionArgument.new("value", TYPE_VECTOR3I),
+			])
+		)
+	assert_that(fds[1])\
+		.is_equal(GdFunctionDescriptor
+			.create("on_vector3i_case2", script.resource_path, 9, TYPE_VECTOR3I, [
+				GdFunctionArgument.new("value", TYPE_VECTOR3I, Vector3i.ONE),
+			])
+		)
+	assert_that(fds[2])\
+		.is_equal(GdFunctionDescriptor
+			.create("on_vector3i_case3", script.resource_path, 13, TYPE_VECTOR3I, [
+				GdFunctionArgument.new("value", TYPE_VECTOR3I, Vector3i.ONE),
+			])
+		)
+
+
+func test_default_args_basic_type_vector4() -> void:
+	var script: GDScript = load("res://addons/gdUnit4/test/core/resources/parsing/functions/basic_build_in_types/ClassWithBasicTypeVector4DefaultArguments.gd")
+
+	var fds := _parser.get_function_descriptors(script, [])
+	assert_that(fds[0])\
+		.is_equal(GdFunctionDescriptor
+			.create("on_vector4_case1", script.resource_path, 5, TYPE_VECTOR4, [
+				GdFunctionArgument.new("value", TYPE_VECTOR4),
+			])
+		)
+	assert_that(fds[1])\
+		.is_equal(GdFunctionDescriptor
+			.create("on_vector4_case2", script.resource_path, 9, TYPE_VECTOR4, [
+				GdFunctionArgument.new("value", TYPE_VECTOR4, Vector4.ONE),
+			])
+		)
+	assert_that(fds[2])\
+		.is_equal(GdFunctionDescriptor
+			.create("on_vector4_case3", script.resource_path, 13, TYPE_VECTOR4, [
+				GdFunctionArgument.new("value", TYPE_VECTOR4, Vector4.ONE),
+			])
+		)
+
+
+func test_default_args_basic_type_vector4i() -> void:
+	var script: GDScript = load("res://addons/gdUnit4/test/core/resources/parsing/functions/basic_build_in_types/ClassWithBasicTypeVector4iDefaultArguments.gd")
+
+	var fds := _parser.get_function_descriptors(script, [])
+	assert_that(fds[0])\
+		.is_equal(GdFunctionDescriptor
+			.create("on_vector4i_case1", script.resource_path, 5, TYPE_VECTOR4I, [
+				GdFunctionArgument.new("value", TYPE_VECTOR4I),
+			])
+		)
+	assert_that(fds[1])\
+		.is_equal(GdFunctionDescriptor
+			.create("on_vector4i_case2", script.resource_path, 9, TYPE_VECTOR4I, [
+				GdFunctionArgument.new("value", TYPE_VECTOR4I, Vector4i.ONE),
+			])
+		)
+	assert_that(fds[2])\
+		.is_equal(GdFunctionDescriptor
+			.create("on_vector4i_case3", script.resource_path, 13, TYPE_VECTOR4I, [
+				GdFunctionArgument.new("value", TYPE_VECTOR4I, Vector4i.ONE),
+			])
+		)
+
+
+func test_default_args_basic_type_rect2() -> void:
+	var script: GDScript = load("res://addons/gdUnit4/test/core/resources/parsing/functions/basic_build_in_types/ClassWithBasicTypeRect2DefaultArguments.gd")
+
+	var fds := _parser.get_function_descriptors(script, [])
+	assert_that(fds[0])\
+		.is_equal(GdFunctionDescriptor
+			.create("on_rect2_case1", script.resource_path, 5, TYPE_RECT2, [
+				GdFunctionArgument.new("value", TYPE_RECT2),
+			])
+		)
+	assert_that(fds[1])\
+		.is_equal(GdFunctionDescriptor
+			.create("on_rect2_case2", script.resource_path, 9, TYPE_RECT2, [
+				GdFunctionArgument.new("value", TYPE_RECT2, Rect2()),
+			])
+		)
+	assert_that(fds[2])\
+		.is_equal(GdFunctionDescriptor
+			.create("on_rect2_case3", script.resource_path, 13, TYPE_RECT2, [
+				GdFunctionArgument.new("value", TYPE_RECT2, Rect2()),
+			])
+		)
+	assert_that(fds[3])\
+		.is_equal(GdFunctionDescriptor
+			.create("on_rect2_case4", script.resource_path, 17, TYPE_RECT2, [
+				GdFunctionArgument.new("value", TYPE_RECT2, Rect2(Vector2.ONE, Vector2.ZERO)),
+			])
+		)
+	assert_that(fds[4])\
+		.is_equal(GdFunctionDescriptor
+			.create("on_rect2_case5", script.resource_path, 21, TYPE_RECT2, [
+				GdFunctionArgument.new("value", TYPE_RECT2, Rect2(Vector2(0, 1), Vector2(2, 3))),
+			])
+		)
+
+
+func test_default_args_basic_type_transform2d() -> void:
+	var script: GDScript = load("res://addons/gdUnit4/test/core/resources/parsing/functions/basic_build_in_types/ClassWithBasicTypeTransform2DDefaultArguments.gd")
+
+	var fds := _parser.get_function_descriptors(script, [])
+	assert_that(fds[0])\
+		.is_equal(GdFunctionDescriptor
+			.create("on_transform2d_case1", script.resource_path, 5, TYPE_TRANSFORM2D, [
+				GdFunctionArgument.new("value", TYPE_TRANSFORM2D),
+			])
+		)
+	assert_that(fds[1])\
+		.is_equal(GdFunctionDescriptor
+			.create("on_transform2d_case2", script.resource_path, 9, TYPE_TRANSFORM2D, [
+				GdFunctionArgument.new("value", TYPE_TRANSFORM2D, Transform2D()),
+			])
+		)
+	assert_that(fds[2])\
+		.is_equal(GdFunctionDescriptor
+			.create("on_transform2d_case3", script.resource_path, 13, TYPE_TRANSFORM2D, [
+				GdFunctionArgument.new("value", TYPE_TRANSFORM2D, Transform2D()),
+			])
+		)
+	assert_that(fds[3])\
+		.is_equal(GdFunctionDescriptor
+			.create("on_transform2d_case4", script.resource_path, 17, TYPE_TRANSFORM2D, [
+				GdFunctionArgument.new("value", TYPE_TRANSFORM2D, Transform2D(1.2, Vector2.ONE)),
+			])
+		)

--- a/addons/gdUnit4/test/core/resources/parsing/functions/basic_build_in_types/ClassWithBasicTypeBoolDefaultArguments.gd
+++ b/addons/gdUnit4/test/core/resources/parsing/functions/basic_build_in_types/ClassWithBasicTypeBoolDefaultArguments.gd
@@ -1,0 +1,14 @@
+class_name  ClassWithBasicTypeBoolDefaultArguments
+extends RefCounted
+
+
+func on_bool_case1(value: bool) -> bool:
+	return value
+
+
+func on_bool_case2(value: bool = true) -> bool:
+	return value
+
+
+func on_bool_case3(value := true) -> bool:
+	return value

--- a/addons/gdUnit4/test/core/resources/parsing/functions/basic_build_in_types/ClassWithBasicTypeFloatDefaultArguments.gd
+++ b/addons/gdUnit4/test/core/resources/parsing/functions/basic_build_in_types/ClassWithBasicTypeFloatDefaultArguments.gd
@@ -1,0 +1,14 @@
+class_name  ClassWithBasicTypeFloatDefaultArguments
+extends RefCounted
+
+
+func on_float_case1(value: float) -> float:
+	return value
+
+
+func on_float_case2(value: float = 42.1) -> float:
+	return value
+
+
+func on_float_case3(value := 42.1) -> float:
+	return value

--- a/addons/gdUnit4/test/core/resources/parsing/functions/basic_build_in_types/ClassWithBasicTypeIntDefaultArguments.gd
+++ b/addons/gdUnit4/test/core/resources/parsing/functions/basic_build_in_types/ClassWithBasicTypeIntDefaultArguments.gd
@@ -1,0 +1,14 @@
+class_name  ClassWithBasicTypeIntDefaultArguments
+extends RefCounted
+
+
+func on_int_case1(value: int) -> int:
+	return value
+
+
+func on_int_case2(value: int = 42) -> int:
+	return value
+
+
+func on_int_case3(value := 42) -> int:
+	return value

--- a/addons/gdUnit4/test/core/resources/parsing/functions/basic_build_in_types/ClassWithBasicTypeNodePathDefaultArguments.gd
+++ b/addons/gdUnit4/test/core/resources/parsing/functions/basic_build_in_types/ClassWithBasicTypeNodePathDefaultArguments.gd
@@ -1,0 +1,18 @@
+class_name ClassWithBasicTypeNodePathDefaultArguments
+extends RefCounted
+
+
+func on_node_path_case1(value: NodePath) -> NodePath:
+	return value
+
+
+func on_node_path_case2(value: NodePath = "foo1") -> NodePath:
+	return value
+
+
+func on_node_path_case3(value: NodePath = NodePath("foo2")) -> NodePath:
+	return value
+
+
+func on_node_path_case4(value := NodePath(NodePath("foo3"))) -> NodePath:
+	return value

--- a/addons/gdUnit4/test/core/resources/parsing/functions/basic_build_in_types/ClassWithBasicTypeRect2DefaultArguments.gd
+++ b/addons/gdUnit4/test/core/resources/parsing/functions/basic_build_in_types/ClassWithBasicTypeRect2DefaultArguments.gd
@@ -1,0 +1,22 @@
+class_name  ClassWithBasicTypeRect2DefaultArguments
+extends RefCounted
+
+
+func on_rect2_case1(value: Rect2) -> Rect2:
+	return value
+
+
+func on_rect2_case2(value: Rect2 = Rect2()) -> Rect2:
+	return value
+
+
+func on_rect2_case3(value := Rect2()) -> Rect2:
+	return value
+
+
+func on_rect2_case4(value := Rect2(Vector2.ONE, Vector2.ZERO)) -> Rect2:
+	return value
+
+
+func on_rect2_case5(value := Rect2(0, 1, 2, 3)) -> Rect2:
+	return value

--- a/addons/gdUnit4/test/core/resources/parsing/functions/basic_build_in_types/ClassWithBasicTypeStringDefaultArguments.gd
+++ b/addons/gdUnit4/test/core/resources/parsing/functions/basic_build_in_types/ClassWithBasicTypeStringDefaultArguments.gd
@@ -1,0 +1,14 @@
+class_name  ClassWithBasicTypeStringDefaultArguments
+extends RefCounted
+
+
+func on_string_case1(value: String) -> String:
+	return value
+
+
+func on_string_case2(value: String = "foo") -> String:
+	return value
+
+
+func on_string_case3(value := "foo") -> String:
+	return value

--- a/addons/gdUnit4/test/core/resources/parsing/functions/basic_build_in_types/ClassWithBasicTypeStringNameDefaultArguments.gd
+++ b/addons/gdUnit4/test/core/resources/parsing/functions/basic_build_in_types/ClassWithBasicTypeStringNameDefaultArguments.gd
@@ -1,0 +1,14 @@
+class_name  ClassWithBasicTypeStringNameDefaultArguments
+extends RefCounted
+
+
+func on_string_name_case1(value: StringName) -> StringName:
+	return value
+
+
+func on_string_name_case2(value: StringName = &"foo") -> StringName:
+	return value
+
+
+func on_string_name_case3(value := &"foo") -> StringName:
+	return value

--- a/addons/gdUnit4/test/core/resources/parsing/functions/basic_build_in_types/ClassWithBasicTypeTransform2DDefaultArguments.gd
+++ b/addons/gdUnit4/test/core/resources/parsing/functions/basic_build_in_types/ClassWithBasicTypeTransform2DDefaultArguments.gd
@@ -1,0 +1,18 @@
+class_name  ClassWithBasicTypeTransform2DDefaultArguments
+extends RefCounted
+
+
+func on_transform2d_case1(value: Transform2D) -> Transform2D:
+	return value
+
+
+func on_transform2d_case2(value: Transform2D = Transform2D()) -> Transform2D:
+	return value
+
+
+func on_transform2d_case3(value := Transform2D()) -> Transform2D:
+	return value
+
+
+func on_transform2d_case4(value := Transform2D(1.2, Vector2.ONE)) -> Transform2D:
+	return value

--- a/addons/gdUnit4/test/core/resources/parsing/functions/basic_build_in_types/ClassWithBasicTypeVector2DefaultArguments.gd
+++ b/addons/gdUnit4/test/core/resources/parsing/functions/basic_build_in_types/ClassWithBasicTypeVector2DefaultArguments.gd
@@ -1,0 +1,14 @@
+class_name  ClassWithBasicTypeVector2DefaultArguments
+extends RefCounted
+
+
+func on_vector2_case1(value: Vector2) -> Vector2:
+	return value
+
+
+func on_vector2_case2(value: Vector2 = Vector2.ONE) -> Vector2:
+	return value
+
+
+func on_vector2_case3(value := Vector2.ONE) -> Vector2:
+	return value

--- a/addons/gdUnit4/test/core/resources/parsing/functions/basic_build_in_types/ClassWithBasicTypeVector2iDefaultArguments.gd
+++ b/addons/gdUnit4/test/core/resources/parsing/functions/basic_build_in_types/ClassWithBasicTypeVector2iDefaultArguments.gd
@@ -1,0 +1,14 @@
+class_name  ClassWithBasicTypeVector2iDefaultArguments
+extends RefCounted
+
+
+func on_vector2i_case1(value: Vector2i) -> Vector2i:
+	return value
+
+
+func on_vector2i_case2(value: Vector2i = Vector2i.ONE) -> Vector2i:
+	return value
+
+
+func on_vector2i_case3(value := Vector2i.ONE) -> Vector2i:
+	return value

--- a/addons/gdUnit4/test/core/resources/parsing/functions/basic_build_in_types/ClassWithBasicTypeVector3DefaultArguments.gd
+++ b/addons/gdUnit4/test/core/resources/parsing/functions/basic_build_in_types/ClassWithBasicTypeVector3DefaultArguments.gd
@@ -1,0 +1,14 @@
+class_name  ClassWithBasicTypeVector3DefaultArguments
+extends RefCounted
+
+
+func on_vector3_case1(value: Vector3) -> Vector3:
+	return value
+
+
+func on_vector3_case2(value: Vector3 = Vector3.ONE) -> Vector3:
+	return value
+
+
+func on_vector3_case3(value := Vector3.ONE) -> Vector3:
+	return value

--- a/addons/gdUnit4/test/core/resources/parsing/functions/basic_build_in_types/ClassWithBasicTypeVector3iDefaultArguments.gd
+++ b/addons/gdUnit4/test/core/resources/parsing/functions/basic_build_in_types/ClassWithBasicTypeVector3iDefaultArguments.gd
@@ -1,0 +1,14 @@
+class_name  ClassWithBasicTypeVector3iDefaultArguments
+extends RefCounted
+
+
+func on_vector3i_case1(value: Vector3i) -> Vector3i:
+	return value
+
+
+func on_vector3i_case2(value: Vector3i = Vector3i.ONE) -> Vector3i:
+	return value
+
+
+func on_vector3i_case3(value := Vector3i.ONE) -> Vector3i:
+	return value

--- a/addons/gdUnit4/test/core/resources/parsing/functions/basic_build_in_types/ClassWithBasicTypeVector4DefaultArguments.gd
+++ b/addons/gdUnit4/test/core/resources/parsing/functions/basic_build_in_types/ClassWithBasicTypeVector4DefaultArguments.gd
@@ -1,0 +1,14 @@
+class_name  ClassWithBasicTypeVector4DefaultArguments
+extends RefCounted
+
+
+func on_vector4_case1(value: Vector4) -> Vector4:
+	return value
+
+
+func on_vector4_case2(value: Vector4 = Vector4.ONE) -> Vector4:
+	return value
+
+
+func on_vector4_case3(value := Vector4.ONE) -> Vector4:
+	return value

--- a/addons/gdUnit4/test/core/resources/parsing/functions/basic_build_in_types/ClassWithBasicTypeVector4iDefaultArguments.gd
+++ b/addons/gdUnit4/test/core/resources/parsing/functions/basic_build_in_types/ClassWithBasicTypeVector4iDefaultArguments.gd
@@ -1,0 +1,14 @@
+class_name  ClassWithBasicTypeVector4iDefaultArguments
+extends RefCounted
+
+
+func on_vector4i_case1(value: Vector4i) -> Vector4i:
+	return value
+
+
+func on_vector4i_case2(value: Vector4i = Vector4i.ONE) -> Vector4i:
+	return value
+
+
+func on_vector4i_case3(value := Vector4i.ONE) -> Vector4i:
+	return value

--- a/addons/gdUnit4/test/core/resources/parsing/functions/container_build_in_types/ClassWithArrayDefaultArguments.gd
+++ b/addons/gdUnit4/test/core/resources/parsing/functions/container_build_in_types/ClassWithArrayDefaultArguments.gd
@@ -1,0 +1,70 @@
+class_name ClassWithArrayDefaultArguments
+extends RefCounted
+
+
+func on_array_case1(values: Array = []) -> Array:
+	return values
+
+
+func on_array_case2(values := Array()) -> Array:
+	return values
+
+
+func on_array_case3(values := []) -> Array:
+	return values
+
+
+func on_array_case4(values := [1, "3", [], {}]) -> Array:
+	return values
+
+
+func on_array_case5(values := [
+	1,
+	"3",
+	[],
+	{}]) -> Array:
+	return values
+
+
+func on_array_case6(values := Array([1, "3", [], {}])) -> Array:
+	return values
+
+
+func on_packed_byte_array(values := PackedByteArray()) -> Array:
+	return values
+
+
+func on_packed_color_array(values := PackedColorArray()) -> Array:
+	return values
+
+
+func on_packed_float32_array(values := PackedFloat32Array()) -> Array:
+	return values
+
+
+func on_packed_float64_array(values := PackedFloat64Array()) -> Array:
+	return values
+
+
+func on_packed_int32_array(values := PackedInt32Array()) -> Array:
+	return values
+
+
+func on_packed_int64_array(values := PackedInt64Array()) -> Array:
+	return values
+
+
+func on_packed_string_array(values := PackedStringArray()) -> Array:
+	return values
+
+
+func on_packed_vector2_array(values := PackedVector2Array()) -> Array:
+	return values
+
+
+func on_packed_vector3_array(values := PackedVector3Array()) -> Array:
+	return values
+
+
+func on_packed_vector4_array(values := PackedVector4Array()) -> Array:
+	return values

--- a/addons/gdUnit4/test/core/resources/parsing/functions/container_build_in_types/ClassWithCallableDefaultArguments.gd
+++ b/addons/gdUnit4/test/core/resources/parsing/functions/container_build_in_types/ClassWithCallableDefaultArguments.gd
@@ -1,0 +1,18 @@
+class_name ClassWithCallableDefaultArguments
+extends RefCounted
+
+
+func on_callable_case1(cb: Callable) -> Callable:
+	return cb
+
+
+func on_callable_case2(cb: Callable = Callable()) -> Callable:
+	return cb
+
+
+func on_callable_case3(cb := Callable()) -> Callable:
+	return cb
+
+
+func on_callable_case4(cb := Callable(null, "method_foo")) -> Callable:
+	return cb

--- a/addons/gdUnit4/test/core/resources/parsing/functions/container_build_in_types/ClassWithDictionaryDefaultArguments.gd
+++ b/addons/gdUnit4/test/core/resources/parsing/functions/container_build_in_types/ClassWithDictionaryDefaultArguments.gd
@@ -1,0 +1,28 @@
+class_name ClassWithDictionaryDefaultArguments
+extends RefCounted
+
+
+func on_dictionary_case1(dict: Dictionary = {}) -> Array:
+	return dict.keys()
+
+
+func on_dictionary_case2(dict := Dictionary()) -> Array:
+	return dict.keys()
+
+
+func on_dictionary_case3(dict := {}) -> Array:
+	return dict.keys()
+
+
+func on_dictionary_case4(dict := {"a":"value_a", "b":"value_b"}) -> Array:
+	return dict.keys()
+
+
+func on_dictionary_case5(dict := {
+	"a":"value_a",
+	"b":"value_b"}) -> Array:
+	return dict.keys()
+
+
+func on_dictionary_case6(dict := Dictionary({"a":"value_a", "b":"value_b"})) -> Array:
+	return dict.keys()

--- a/addons/gdUnit4/test/mocker/GdUnitMockerTest.gd
+++ b/addons/gdUnit4/test/mocker/GdUnitMockerTest.gd
@@ -1229,3 +1229,13 @@ class Foo extends Base:
 func test_mock_with_inheritance_method() -> void:
 	var foo: Variant = mock(Foo)
 	assert_object(foo).is_not_null()
+
+
+func test_mock_func_default_arg_dict() -> void:
+	var mock_obj :ClassWithDictionaryDefaultArguments = mock(ClassWithDictionaryDefaultArguments)
+
+	do_return(["a", "b"]).on(mock_obj).on_dictionary_case1(any_dictionary())
+	verify_no_interactions(mock_obj)
+
+	assert_array(mock_obj.on_dictionary_case1({})).contains_exactly(["a", "b"])
+	verify(mock_obj).on_dictionary_case1({})


### PR DESCRIPTION
# Why
The mock of an class containing a function with default dictionary argument was failing at runtime. The parse was not handling well the default argument parsing for dictionaries

# What
- Fixed the script parser to handle dictionary as function arguments.
- Added more test coverage of parsing functions with default values.
- Added test with mocks a class containing a function with default dictionary argument


