### PR TITLE
GD-645: Spying on a scene with `@onready` properties loses the property values

### DIFF
--- a/addons/gdUnit4/src/spy/GdUnitSpyBuilder.gd
+++ b/addons/gdUnit4/src/spy/GdUnitSpyBuilder.gd
@@ -104,8 +104,21 @@ static func spy_on_scene(scene :Node, debug_write :bool) -> Object:
 	scene_script.free()
 	if spy == null:
 		return null
-	# replace original script whit spy
+
+	# we need to restore the original script properties to apply after script exchange
+	var original_properties := {}
+	for p in scene.get_property_list():
+		var property_name: String = p["name"]
+		var usage: int = p["usage"]
+		if (usage & PROPERTY_USAGE_SCRIPT_VARIABLE) == PROPERTY_USAGE_SCRIPT_VARIABLE:
+			original_properties[property_name] = scene.get(property_name)
+
+	# exchage with spy
 	scene.set_script(spy)
+	# apply original script properties to the spy
+	for property_name: String in original_properties.keys():
+		scene.set(property_name, original_properties[property_name])
+
 	@warning_ignore("unsafe_method_access")
 	scene.__init(scene, [])
 	return register_auto_free(scene)

--- a/addons/gdUnit4/test/spy/GdUnitSpyBuilderTest.gd
+++ b/addons/gdUnit4/test/spy/GdUnitSpyBuilderTest.gd
@@ -25,7 +25,7 @@ func test_double__init() -> void:
 			@warning_ignore("unsafe_call_argument")
 			super()
 
-	""".dedent()
+		""".dedent()
 	assert_str("\n".join(doubler.double(fd))).is_equal(expected)
 
 
@@ -366,3 +366,27 @@ func test_spy_on_script_respect_virtual_functions() -> void:
 	do_spy.__init(do_spy)
 	assert_bool(do_spy.has_method("_ready")).is_true()
 	assert_bool(do_spy.has_method("_input")).is_false()
+
+
+func test_spy_on_scene_with_onready_parameters() -> void:
+	# setup a scene with holding parameters
+	@warning_ignore("unsafe_method_access")
+	var scene: TestSceneWithProperties = load("res://addons/gdUnit4/test/spy/resources/TestSceneWithProperties.tscn").instantiate()
+	add_child(scene)
+
+	# precheck the parameters are original set
+	var original_progress_value: Variant = scene.progress
+	assert_object(original_progress_value).is_not_null()
+	assert_object(scene._parameter_obj).is_not_null()
+	assert_dict(scene._parameter_dict).is_equal({"key" : "value"})
+
+	# create spy on scene
+	var spy_scene :Variant = spy(scene)
+
+	# verify the @onready property is set
+	assert_object(spy_scene.progress).is_same(original_progress_value)
+	# verify all properties are set
+	assert_object(spy_scene._parameter_obj).is_not_null().is_same(scene._parameter_obj)
+	assert_dict(spy_scene._parameter_dict).is_not_null().is_same(scene._parameter_dict)
+
+	scene.free()

--- a/addons/gdUnit4/test/spy/resources/TestSceneWithProperties.tscn
+++ b/addons/gdUnit4/test/spy/resources/TestSceneWithProperties.tscn
@@ -1,0 +1,11 @@
+[gd_scene load_steps=2 format=3 uid="uid://bm5kdwn5suu1t"]
+
+[ext_resource type="Script" path="res://addons/gdUnit4/test/spy/resources/test_scene_with_parmeters.gd" id="1_0ll7j"]
+
+[node name="TestSceneWithParmeters" type="Node2D"]
+script = ExtResource("1_0ll7j")
+
+[node name="ProgressBar" type="ProgressBar" parent="."]
+unique_name_in_owner = true
+offset_right = 4.0
+offset_bottom = 27.0

--- a/addons/gdUnit4/test/spy/resources/test_scene_with_parmeters.gd
+++ b/addons/gdUnit4/test/spy/resources/test_scene_with_parmeters.gd
@@ -1,0 +1,15 @@
+class_name TestSceneWithProperties
+extends Node2D
+
+
+@onready var progress := %ProgressBar
+
+@warning_ignore("unused_private_class_variable")
+var _parameter_obj := RefCounted.new()
+@warning_ignore("unused_private_class_variable")
+var _parameter_dict := {"key" : "value"}
+
+# Called when the node enters the scene tree for the first time.
+func _ready() -> void:
+	#prints(progress, _parameter_obj, _parameter_dict)
+	pass


### PR DESCRIPTION

# Why
see https://github.com/MikeSchulze/gdUnit4/issues/645 
The spying scene loses the properties after assign the new spy script to the scene.

# What

We copy all script properties from source to the spy after exchanging the script


