### PR TITLE
GD-635:  Fix test run statistics counters

### DIFF
--- a/addons/gdUnit4/bin/GdUnitCmdTool.gd
+++ b/addons/gdUnit4/bin/GdUnitCmdTool.gd
@@ -371,8 +371,7 @@ class CLIRunner:
 			_console.prints_color("Exit code: %d" % RETURN_SUCCESS, Color.DARK_SALMON)
 			_state = STOP
 			quit(RETURN_SUCCESS)
-		var total_test_count := _collect_test_case_count(_test_suites_to_process)
-		_on_gdunit_event(GdUnitInit.new(_test_suites_to_process.size(), total_test_count))
+		_on_gdunit_event(GdUnitInit.new())
 
 
 	func load_testsuites(config: GdUnitRunnerConfig) -> Array[Node]:

--- a/addons/gdUnit4/src/core/command/GdUnitCommandHandler.gd
+++ b/addons/gdUnit4/src/core/command/GdUnitCommandHandler.gd
@@ -195,15 +195,14 @@ func cmd_run_test_suites(scripts: Array[Script], debug: bool, rerun := false) ->
 func cmd_run_test_case(test_suite_resource_path: String, test_case: String, test_param_index: int, debug: bool, rerun := false) -> void:
 	# Update test discovery
 	var script := load(test_suite_resource_path)
-
+	GdUnitSignals.instance().gdunit_event.emit(GdUnitEventTestDiscoverStart.new())
 	if script is GDScript:
-		GdUnitSignals.instance().gdunit_event.emit(GdUnitEventTestDiscoverStart.new())
 		GdUnitTestDiscoverer.discover_test(script as GDScript, [test_case])
-		GdUnitSignals.instance().gdunit_event.emit(GdUnitEventTestDiscoverEnd.new(0, 0))
 	else:
 		# todo call gdunit4Net discovery
 		print_debug("CSharpScript discovery not implemented!")
 		return
+	GdUnitSignals.instance().gdunit_event.emit(GdUnitEventTestDiscoverEnd.new(0, 0))
 
 	# create new runner config for fresh run otherwise use saved one
 	if not rerun:
@@ -231,6 +230,7 @@ func cmd_run(debug: bool) -> void:
 	# don't start is already running
 	if _is_running:
 		return
+	GdUnitSignals.instance().gdunit_event.emit(GdUnitInit.new(0, 0))
 	# save current selected excution config
 	var server_port: int = Engine.get_meta("gdunit_server_port")
 	var result := _runner_config.set_server_port(server_port).save_config()

--- a/addons/gdUnit4/src/core/command/GdUnitCommandHandler.gd
+++ b/addons/gdUnit4/src/core/command/GdUnitCommandHandler.gd
@@ -230,7 +230,7 @@ func cmd_run(debug: bool) -> void:
 	# don't start is already running
 	if _is_running:
 		return
-	GdUnitSignals.instance().gdunit_event.emit(GdUnitInit.new(0, 0))
+	GdUnitSignals.instance().gdunit_event.emit(GdUnitInit.new())
 	# save current selected excution config
 	var server_port: int = Engine.get_meta("gdunit_server_port")
 	var result := _runner_config.set_server_port(server_port).save_config()

--- a/addons/gdUnit4/src/core/event/GdUnitEvent.gd
+++ b/addons/gdUnit4/src/core/event/GdUnitEvent.gd
@@ -127,6 +127,10 @@ func skipped_count() -> int:
 	return _statistics.get(SKIPPED_COUNT, 0)
 
 
+func retry_count() -> int:
+	return _statistics.get(RETRY_COUNT, 0)
+
+
 func resource_path() -> String:
 	return _resource_path
 

--- a/addons/gdUnit4/src/core/event/GdUnitEventInit.gd
+++ b/addons/gdUnit4/src/core/event/GdUnitEventInit.gd
@@ -2,18 +2,5 @@ class_name GdUnitInit
 extends GdUnitEvent
 
 
-var _total_testsuites :int
-
-
-func _init(p_total_testsuites :int, p_total_count :int) -> void:
+func _init() -> void:
 	_event_type = INIT
-	_total_testsuites = p_total_testsuites
-	_total_count = p_total_count
-
-
-func total_test_suites() -> int:
-	return _total_testsuites
-
-
-func total_tests() -> int:
-	return _total_count

--- a/addons/gdUnit4/src/ui/parts/InspectorProgressBar.gd
+++ b/addons/gdUnit4/src/ui/parts/InspectorProgressBar.gd
@@ -22,6 +22,8 @@ func _on_test_counter_changed(index: int, total: int, state: GdUnitInspectorTree
 	# inital state
 	if index == 0:
 		style.bg_color = Color.DARK_GREEN
+	if is_flaky(state):
+		style.bg_color = Color.WEB_GREEN
 	if is_failed(state):
 		style.bg_color = Color.DARK_RED
 	update_text()
@@ -32,3 +34,7 @@ func is_failed(state: GdUnitInspectorTreeConstants.STATE) -> bool:
 		GdUnitInspectorTreeConstants.STATE.FAILED,
 		GdUnitInspectorTreeConstants.STATE.ERROR,
 		GdUnitInspectorTreeConstants.STATE.ABORDED]
+
+
+func is_flaky(state: GdUnitInspectorTreeConstants.STATE) -> bool:
+	return state == GdUnitInspectorTreeConstants.STATE.FLAKY

--- a/addons/gdUnit4/test/GdUnitTestSuiteTest.gd
+++ b/addons/gdUnit4/test/GdUnitTestSuiteTest.gd
@@ -7,6 +7,7 @@ const __source = 'res://addons/gdUnit4/src/GdUnitTestSuite.gd'
 
 var _events :Array[GdUnitEvent] = []
 var _retry_count := 0
+var _flaky_settings: bool
 
 
 func collect_report(event :GdUnitEvent) -> void:
@@ -16,6 +17,7 @@ func collect_report(event :GdUnitEvent) -> void:
 func before() -> void:
 	# register to receive test reports
 	GdUnitSignals.instance().gdunit_event.connect(collect_report)
+	_flaky_settings = ProjectSettings.get_setting(GdUnitSettings.TEST_FLAKY_CHECK)
 	ProjectSettings.set_setting(GdUnitSettings.TEST_FLAKY_CHECK, true)
 
 
@@ -24,7 +26,8 @@ func after() -> void:
 	assert_array(_events).extractv(extr("type"), extr("is_skipped"), extr("test_name"))\
 		.contains([tuple(GdUnitEvent.TESTCASE_AFTER, true, "test_unknown_argument_in_test_case")])
 	GdUnitSignals.instance().gdunit_event.disconnect(collect_report)
-	ProjectSettings.set_setting(GdUnitSettings.TEST_FLAKY_CHECK, false)
+	# Restore original project settings
+	ProjectSettings.set_setting(GdUnitSettings.TEST_FLAKY_CHECK, _flaky_settings)
 
 
 func test_assert_that_types() -> void:


### PR DESCRIPTION
# Why
https://github.com/MikeSchulze/gdUnit4/issues/659

# What
- emit `GdUnitInit` to reset the statistics before every new test run
- fix progress counter issues on flaky test execution
- fix UI glitches on counter representation in the tree
- remove unused counters from GdUnitEvent