### PR TITLE
GD-635: Fix GdUnit console test counters

### DIFF
--- a/addons/gdUnit4/bin/GdUnitCmdTool.gd
+++ b/addons/gdUnit4/bin/GdUnitCmdTool.gd
@@ -504,9 +504,6 @@ class CLIRunner:
 					event.is_flaky(),
 					event.elapsed_time())
 				_report.add_testcase_reports(event.resource_path(), event.test_name(), event.reports())
-			GdUnitEvent.TESTCASE_STATISTICS:
-				_report.update_testsuite_counters(event.resource_path(), event.is_error(), event.failed_count(), event.orphan_nodes(),\
-					event.is_skipped(), event.is_flaky(), event.elapsed_time())
 		print_status(event)
 
 

--- a/addons/gdUnit4/src/core/event/GdUnitEvent.gd
+++ b/addons/gdUnit4/src/core/event/GdUnitEvent.gd
@@ -20,7 +20,6 @@ enum {
 	TESTSUITE_AFTER,
 	TESTCASE_BEFORE,
 	TESTCASE_AFTER,
-	TESTCASE_STATISTICS,
 	DISCOVER_START,
 	DISCOVER_END,
 	DISCOVER_SUITE_ADDED,
@@ -71,15 +70,6 @@ func test_after(p_resource_path :String, p_suite_name :String, p_test_name :Stri
 	_test_name = p_test_name
 	_statistics = p_statistics
 	_reports = p_reports
-	return self
-
-
-func test_statistics(p_resource_path :String, p_suite_name :String, p_test_name :String, p_statistics :Dictionary = {}) -> GdUnitEvent:
-	_event_type = TESTCASE_STATISTICS
-	_resource_path = p_resource_path
-	_suite_name  = p_suite_name
-	_test_name = p_test_name
-	_statistics = p_statistics
 	return self
 
 

--- a/addons/gdUnit4/src/core/execution/stages/GdUnitTestCaseExecutionStage.gd
+++ b/addons/gdUnit4/src/core/execution/stages/GdUnitTestCaseExecutionStage.gd
@@ -29,13 +29,6 @@ func _execute(context :GdUnitExecutionContext) -> void:
 	await context.gc()
 	await context.error_monitor_stop()
 
-	# finally fire test statistics report
-	fire_event(GdUnitEvent.new()\
-		.test_statistics(context.get_test_suite_path(),
-			context.get_test_suite_name(),
-			context.get_test_case_name(),
-			context.get_execution_statistics()))
-
 	# finally free the test instance
 	if is_instance_valid(context.test_case):
 		context.test_case.dispose()

--- a/addons/gdUnit4/src/core/execution/stages/GdUnitTestSuiteExecutionStage.gd
+++ b/addons/gdUnit4/src/core/execution/stages/GdUnitTestSuiteExecutionStage.gd
@@ -99,7 +99,12 @@ func fire_test_suite_skipped(context :GdUnitExecutionContext) -> void:
 			var test_case_context := GdUnitExecutionContext.of_test_case(context, test_case)
 			fire_event(GdUnitEvent.new()\
 				.test_before(test_case_context.get_test_suite_path(), test_case_context.get_test_suite_name(), test_case_context.get_test_case_name()))
-			fire_test_skipped(test_case_context)
+
+			if test_case.is_parameterized():
+				for test_name in test_case.test_case_names():
+					fire_test_skipped(GdUnitExecutionContext.of_parameterized_test(test_case_context, test_name, []))
+			else:
+				fire_test_skipped(test_case_context)
 
 
 	var statistics := {
@@ -139,12 +144,6 @@ func fire_test_skipped(context: GdUnitExecutionContext) -> void:
 			context.get_test_case_name(),
 			statistics,
 			[report]))
-	# finally fire test statistics report
-	fire_event(GdUnitEvent.new()\
-		.test_statistics(context.get_test_suite_path(),
-			context.get_test_suite_name(),
-			context.get_test_case_name(),
-			statistics))
 
 
 func set_debug_mode(debug_mode :bool = false) -> void:

--- a/addons/gdUnit4/src/core/parse/GdUnitTestParameterSetResolver.gd
+++ b/addons/gdUnit4/src/core/parse/GdUnitTestParameterSetResolver.gd
@@ -199,7 +199,6 @@ func fixure_typed_parameters(parameter_sets: Array, arg_descriptors: Array[GdFun
 	return parameter_sets
 
 
-
 static func copy_properties(source: Object, dest: Object) -> void:
 	for property in source.get_property_list():
 		var property_name :String = property["name"]

--- a/addons/gdUnit4/src/ui/parts/InspectorStatusBar.gd
+++ b/addons/gdUnit4/src/ui/parts/InspectorStatusBar.gd
@@ -133,20 +133,12 @@ func _on_gdunit_event(event: GdUnitEvent) -> void:
 			total_errors = 0
 			total_flaky = 0
 			status_changed(0, 0, 0)
-		GdUnitEvent.TESTCASE_BEFORE:
-			pass
-		GdUnitEvent.TESTCASE_STATISTICS:
-			if event.is_error():
-				status_changed(event.error_count(), 0, event.is_flaky())
-			else:
-				status_changed(0, event.failed_count(), event.is_flaky())
-		GdUnitEvent.TESTSUITE_BEFORE:
-			pass
-		GdUnitEvent.TESTSUITE_AFTER:
-			if event.is_error():
-				status_changed(event.error_count(), 0, 0)
-			else:
-				status_changed(0, event.failed_count(), 0)
+
+		GdUnitEvent.TESTCASE_AFTER:
+			status_changed(event.error_count(), event.failed_count(),  event.is_flaky())
+
+		#GdUnitEvent.TESTSUITE_AFTER:
+		#	status_changed(event.error_count(), event.failed_count(),  event.is_flaky())
 
 
 func _on_btn_error_up_pressed() -> void:

--- a/addons/gdUnit4/src/ui/parts/InspectorTreeMainPanel.gd
+++ b/addons/gdUnit4/src/ui/parts/InspectorTreeMainPanel.gd
@@ -312,6 +312,7 @@ func reset_tree_state(parent: TreeItem) -> void:
 	if parent == _tree_root:
 		_tree_root.set_meta(META_GDUNIT_TEST_INDEX, 0)
 		_tree_root.set_meta(META_GDUNIT_STATE, STATE.INITIAL)
+		test_counters_changed.emit(0, 0, STATE.INITIAL)
 
 	for item in parent.get_children():
 		set_state_initial(item)

--- a/addons/gdUnit4/test/GdUnitTestSuiteTest.gd
+++ b/addons/gdUnit4/test/GdUnitTestSuiteTest.gd
@@ -17,7 +17,7 @@ func collect_report(event :GdUnitEvent) -> void:
 func before() -> void:
 	# register to receive test reports
 	GdUnitSignals.instance().gdunit_event.connect(collect_report)
-	_flaky_settings = ProjectSettings.get_setting(GdUnitSettings.TEST_FLAKY_CHECK)
+	_flaky_settings = ProjectSettings.get_setting(GdUnitSettings.TEST_FLAKY_CHECK, false)
 	ProjectSettings.set_setting(GdUnitSettings.TEST_FLAKY_CHECK, true)
 
 

--- a/addons/gdUnit4/test/asserts/GdUnitGodotErrorWithAssertTest.gd
+++ b/addons/gdUnit4/test/asserts/GdUnitGodotErrorWithAssertTest.gd
@@ -32,9 +32,7 @@ func do_a_fail() -> void:
 
 
 func catch_test_events(event :GdUnitEvent) -> void:
-	# we not catch the statistics
-	if event.type() != GdUnitEvent.TESTCASE_STATISTICS:
-		_catched_events.append(event)
+	_catched_events.append(event)
 
 
 func before() -> void:


### PR DESCRIPTION
# What
- removed obsolete TESTCASE_STATISTICS event
- fix test counter on the console
- fix counting based on TESTCASE_AFTER because we removed TESTCASE_STATISTICS
- fix initial progress counter
- fix skipped test reporting for parameterized tests

