### PR TITLE
GD-635: Comand line tool returns 0 on failed tests

### DIFF
--- a/addons/gdUnit4/src/core/GdUnitTestSuiteScanner.gd
+++ b/addons/gdUnit4/src/core/GdUnitTestSuiteScanner.gd
@@ -150,7 +150,9 @@ func load_suite(script: GDScript, tests: Array[GdUnitTestCase]) -> GdUnitTestSui
 		# Create test from descriptor and given attributes
 		var test_group: Array = grouped_by_test[fd.name()]
 		for test: GdUnitTestCase in test_group:
-			test_suite.add_child(_TestCase.new(test, test_attribute, fd))
+			# We need a copy, because of mutable state
+			var attribute: TestCaseAttribute = test_attribute.duplicate(true)
+			test_suite.add_child(_TestCase.new(test, attribute, fd))
 	return test_suite
 
 

--- a/addons/gdUnit4/src/core/GdUnitTestSuiteScanner.gd
+++ b/addons/gdUnit4/src/core/GdUnitTestSuiteScanner.gd
@@ -151,7 +151,7 @@ func load_suite(script: GDScript, tests: Array[GdUnitTestCase]) -> GdUnitTestSui
 		var test_group: Array = grouped_by_test[fd.name()]
 		for test: GdUnitTestCase in test_group:
 			# We need a copy, because of mutable state
-			var attribute: TestCaseAttribute = test_attribute.duplicate(true)
+			var attribute: TestCaseAttribute = test_attribute.clone()
 			test_suite.add_child(_TestCase.new(test, attribute, fd))
 	return test_suite
 

--- a/addons/gdUnit4/src/core/GdUnitTools.gd
+++ b/addons/gdUnit4/src/core/GdUnitTools.gd
@@ -128,9 +128,12 @@ static func release_double(instance :Object) -> void:
 
 
 
-static func find_test_case(test_suite: Node, test_case_name: String) -> _TestCase:
+static func find_test_case(test_suite: Node, test_case_name: String, index := -1) -> _TestCase:
 	for test_case: _TestCase in test_suite.get_children():
 		if test_case.test_name() == test_case_name:
+			if index != -1:
+				if test_case._test_case.attribute_index != index:
+					continue
 			return test_case
 	return null
 

--- a/addons/gdUnit4/src/core/attributes/TestCaseAttribute.gd
+++ b/addons/gdUnit4/src/core/attributes/TestCaseAttribute.gd
@@ -60,3 +60,17 @@ var fuzzer_iterations: int = Fuzzer.ITERATION_DEFAULT_COUNT
 ## Each [GdFunctionArgument] defines how random test data[br]
 ## should be generated for a particular parameter.
 var fuzzers: Array[GdFunctionArgument] = []
+
+
+# There is a bug in `duplicate` see https://github.com/godotengine/godot/issues/98644
+# we need in addition to overwrite default values with the source values
+@warning_ignore("native_method_override")
+func clone() -> Resource:
+	var copy: TestCaseAttribute = TestCaseAttribute.new()
+	copy.timeout = timeout
+	copy.test_seed = test_seed
+	copy.is_skipped = is_skipped
+	copy.skip_reason = skip_reason
+	copy.fuzzer_iterations = fuzzer_iterations
+	copy.fuzzers = fuzzers.duplicate()
+	return copy

--- a/addons/gdUnit4/src/core/runners/GdUnitTestCIRunner.gd
+++ b/addons/gdUnit4/src/core/runners/GdUnitTestCIRunner.gd
@@ -496,10 +496,10 @@ func _on_gdunit_event(event: GdUnitEvent) -> void:
 
 
 func report_exit_code(report: GdUnitHtmlReport) -> int:
-	if report.error_count() + report.failure_count() > 0:
+	if _test_reporter.total_error_count() + _test_reporter.total_failure_count() > 0:
 		console_info("Exit code: %d" % RETURN_ERROR, Color.FIREBRICK)
 		return RETURN_ERROR
-	if report.orphan_count() > 0:
+	if _test_reporter.total_orphan_count() > 0:
 		console_info("Exit code: %d" % RETURN_WARNING, Color.GOLDENROD)
 		return RETURN_WARNING
 	console_info("Exit code: %d" % RETURN_SUCCESS, Color.DARK_SALMON)

--- a/addons/gdUnit4/src/core/runners/GdUnitTestResultReporter.gd
+++ b/addons/gdUnit4/src/core/runners/GdUnitTestResultReporter.gd
@@ -96,6 +96,22 @@ func total_flaky_count() -> int:
 	return _summary["flaky_count"]
 
 
+func total_error_count() -> int:
+	return _summary["error_count"]
+
+
+func total_failure_count() -> int:
+	return _summary["failed_count"]
+
+
+func total_skipped_count() -> int:
+	return _summary["skipped_count"]
+
+
+func total_orphan_count() -> int:
+	return _summary["orphan_nodes"]
+
+
 func elapsed_time() -> int:
 	return _summary["elapsed_time"]
 

--- a/addons/gdUnit4/test/cmd/runtestDebug.tscn
+++ b/addons/gdUnit4/test/cmd/runtestDebug.tscn
@@ -12,7 +12,7 @@ func _ready() -> void:
 	#var tool := CmdTool.new()
 
 	var runner := GdUnitTestCIRunner.new()
-	runner._debug_cmd_args = [\"GdUnitCmdTool.gd\", \"--add\", \"res://addons/gdUnit4/test/core/GdUnitTestSuiteBuilderTest.gd\", \"--continue\", \"-rc\", \"1\"]
+	runner._debug_cmd_args = [\"GdUnitCmdTool.gd\", \"--add\", \"res://addons/gdUnit4/test/core/parse/GdUnitTestParameterSetResolverTest.gd\", \"--continue\", \"-rc\", \"1\"]
 
 	add_child(runner)
 

--- a/addons/gdUnit4/test/core/GdUnitTestSuiteScannerTest.gd
+++ b/addons/gdUnit4/test/core/GdUnitTestSuiteScannerTest.gd
@@ -246,7 +246,7 @@ func test_scan_by_inheritance_class_name() -> void:
 	assert_array(test_suites).has_size(3)
 	# sort by names
 	assert_array(test_suites).extract("resource_path")\
-		.contains_exactly([
+		.contains_exactly_in_any_order([
 			"res://addons/gdUnit4/test/core/resources/scan_testsuite_inheritance/by_class_name/BaseTest.gd",
 			"res://addons/gdUnit4/test/core/resources/scan_testsuite_inheritance/by_class_name/ExtendedTest.gd",
 			"res://addons/gdUnit4/test/core/resources/scan_testsuite_inheritance/by_class_name/ExtendsExtendedTest.gd"])

--- a/addons/gdUnit4/test/core/parse/GdUnitTestParameterSetResolverTest.gd
+++ b/addons/gdUnit4/test/core/parse/GdUnitTestParameterSetResolverTest.gd
@@ -166,7 +166,7 @@ func assert_is_not_skipped(test_suite :GdUnitTestSuite, test_case :String) -> vo
 	if test.is_parameterized():
 		# to load parameter set and force validate
 		test._resolve_test_parameters(0)
-	assert_that(test.is_skipped()).is_false()
+	assert_bool(test.is_skipped()).is_false()
 
 
 func assert_is_skipped(test_suite :GdUnitTestSuite, test_case :String) -> GdUnitStringAssert:
@@ -174,12 +174,13 @@ func assert_is_skipped(test_suite :GdUnitTestSuite, test_case :String) -> GdUnit
 	if test.is_parameterized():
 		# to load parameter set and force validate
 		test._resolve_test_parameters(0)
-	assert_that(test.is_skipped()).is_true()
+	assert_bool(test.is_skipped()).is_true()
 	return assert_str(test.skip_info())
 
 
 func load_parameter_sets(child_name: String) -> Array:
-	var function_descriptors := GdScriptParser.new().get_function_descriptors(self.get_script(), [child_name])
+	var script: GDScript = self.get_script()
+	var function_descriptors := GdScriptParser.new().get_function_descriptors(script, [child_name])
 	var fd: GdFunctionDescriptor = function_descriptors.front()
 	var result := GdUnitTestParameterSetResolver.new(fd).load_parameter_sets(self)
 	if result.is_success():


### PR DESCRIPTION
# Why
see https://github.com/MikeSchulze/gdUnit4/issues/675

# What
using the new `gdUnitTestResultReporter` to finally evaluate the exit status based on the tracked failure count

