### PR TITLE
GD-678: Update CI to Godot 4.4-rc1

### DIFF
--- a/.github/workflows/ci-pr-publish-report.yml
+++ b/.github/workflows/ci-pr-publish-report.yml
@@ -1,7 +1,7 @@
 name: 'Publish Test Report'
 on:
   workflow_run:
-    workflows: ['ci-pr']  # runs after ci-pr workflow
+    workflows: [ 'ci-pr' ]  # runs after ci-pr workflow
     types:
       - completed
   workflow_dispatch:
@@ -23,12 +23,12 @@ jobs:
       fail-fast: false
       max-parallel: 10
       matrix:
-        godot-version: ['4.3']
-        godot-status: ['stable']
-        godot-net: ['-net', '']
+        godot-version: [ '4.3' ]
+        godot-status: [ 'stable' ]
+        godot-net: [ '-net', '' ]
         include:
           - godot-version: '4.4'
-            godot-status: 'dev7'
+            godot-status: 'rc1'
 
     steps:
       - uses: actions/checkout@v4
@@ -48,7 +48,7 @@ jobs:
         uses: dorny/test-reporter@v1.9.1
         with:
           name: report_gdUnit4_Godot${{ matrix.godot-version }}-${{ matrix.godot-status }}
-          # using artifact to download is broken since download-artifact@v4 see https://github.com/dorny/test-reporter/issues/363 
+          # using artifact to download is broken since download-artifact@v4 see https://github.com/dorny/test-reporter/issues/363
           # We do the download manually on step `Download artifacts`
           #artifact: artifact_gdUnit4_Godot${{ matrix.godot-version }}-${{ matrix.godot-status }}
           path: './home/runner/work/gdUnit4/gdUnit4/reports/**/results.xml'
@@ -61,7 +61,7 @@ jobs:
         uses: dorny/test-reporter@v1.9.1
         with:
           name: report_gdUnit4_Godot${{ matrix.godot-version }}-${{ matrix.godot-status }}-net
-          # using artifact to download is broken since download-artifact@v4 see https://github.com/dorny/test-reporter/issues/363 
+          # using artifact to download is broken since download-artifact@v4 see https://github.com/dorny/test-reporter/issues/363
           # We do the download manually on step `Download artifacts`
           #artifact: artifact_gdUnit4_Godot${{ matrix.godot-version }}-${{ matrix.godot-status }}${{ matrix.godot-net }}
           path: './home/runner/work/gdUnit4/gdUnit4/reports/*.xml'

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -35,7 +35,7 @@ jobs:
         godot-net: [ '.Net', '' ]
         include:
           - godot-version: '4.4'
-            godot-status: 'dev7'
+            godot-status: 'rc1'
 
     permissions:
       actions: write

--- a/addons/gdUnit4/plugin.gd
+++ b/addons/gdUnit4/plugin.gd
@@ -89,7 +89,9 @@ func _remove_context_menus() -> void:
 func _create_context_menu(script_path: String) -> Variant:
 	var context_menu_script := GDScript.new()
 	context_menu_script.source_code = FileAccess.get_file_as_string(script_path)
-	context_menu_script.reload()
+	var err := context_menu_script.reload(true)
+	if err != OK:
+		push_error("Can't create context menu %s, error: %s" % [script_path, error_string(err)])
 	return context_menu_script.new()
 
 

--- a/addons/gdUnit4/src/ui/menu/EditorFileSystemContextMenuHandlerV44.gdx
+++ b/addons/gdUnit4/src/ui/menu/EditorFileSystemContextMenuHandlerV44.gdx
@@ -21,19 +21,20 @@ func _init() -> void:
 
 
 func _popup_menu(paths: PackedStringArray) -> void:
-	var test_suites := PackedStringArray()
+	var test_suites: Array[Script] = []
+	var suite_scaner := GdUnitTestSuiteScanner.new()
 
 	for resource_path in paths:
 		# directories and test-suites are valid to enable the menu
 		if DirAccess.dir_exists_absolute(resource_path):
-			test_suites.append(resource_path)
+			test_suites.append_array(suite_scaner.scan_directory(resource_path))
 			continue
 
 		var file_type := resource_path.get_extension()
 		if file_type == "gd" or file_type == "cs":
-			var resource: Script = ResourceLoader.load(resource_path, "Script", ResourceLoader.CACHE_MODE_REUSE)
-			if GdObjects.is_test_suite(resource):
-				test_suites.append(resource_path)
+			var script: Script = ResourceLoader.load(resource_path, "Script", ResourceLoader.CACHE_MODE_REUSE)
+			if GdObjects.is_test_suite(script):
+				test_suites.append(script)
 
 	# no direcory or test-suites selected?
 	if test_suites.is_empty():


### PR DESCRIPTION
# Why
Godot 4.4-rc1 is out, and we need to update the CI to run on the latest release candidate.

# What
- update `godot-status` version from `dev7` to `rc1`
- improved the context_menu_script load check on plugin.gd
- fixed file system context menu collection now scripts instead of script paths

