### PR TITLE
GD-635: Store the test case record on tree item and used as execute argument instead of `resource_path`

### DIFF
--- a/addons/gdUnit4/src/core/command/GdUnitCommandHandler.gd
+++ b/addons/gdUnit4/src/core/command/GdUnitCommandHandler.gd
@@ -224,6 +224,17 @@ func cmd_run_test_case(test_suite_resource_path: String, test_case: String, test
 	cmd_run(debug)
 
 
+func cmd_run_tests(tests_to_execute: Array[GdUnitTestCase], debug: bool) -> void:
+	# Save tests to runner config before execute
+	var result := _runner_config.clear()\
+		.add_test_cases(tests_to_execute)\
+		.save_config()
+	if result.is_error():
+		push_error(result.error_message())
+		return
+	cmd_run(debug)
+
+
 func cmd_run_overall(debug: bool) -> void:
 	var tests_to_execute := await GdUnitTestDiscoverer.run()
 	var result := _runner_config.clear()\

--- a/addons/gdUnit4/src/ui/GdUnitInspector.gd
+++ b/addons/gdUnit4/src/ui/GdUnitInspector.gd
@@ -26,23 +26,6 @@ func _process(_delta: float) -> void:
 	_command_handler._do_process()
 
 
-func _on_MainPanel_run_testsuite(test_suite_paths: PackedStringArray, debug: bool) -> void:
-	var scripts: Array[Script] = []
-	var suite_scaner := GdUnitTestSuiteScanner.new()
-
-	for suite_path in test_suite_paths:
-		var is_dir := DirAccess.dir_exists_absolute(suite_path)
-		if is_dir:
-			scripts.append_array(suite_scaner.scan_directory(suite_path))
-		else:
-			scripts.append(load(suite_path))
-	_command_handler.cmd_run_test_suites(scripts, debug)
-
-
-func _on_MainPanel_run_testcase(resource_path: String, test_case: String, test_param_index: int, debug: bool) -> void:
-	_command_handler.cmd_run_test_case(resource_path, test_case, test_param_index, debug)
-
-
 @warning_ignore("redundant_await")
 func _on_status_bar_request_discover_tests() -> void:
 	await _command_handler.cmd_discover_tests()

--- a/addons/gdUnit4/src/ui/GdUnitInspector.tscn
+++ b/addons/gdUnit4/src/ui/GdUnitInspector.tscn
@@ -64,6 +64,4 @@ layout_mode = 2
 [connection signal="select_flaky_next" from="VBoxContainer/Header/StatusBar" to="VBoxContainer/MainPanel" method="_on_select_next_item_by_state" binds= [4]]
 [connection signal="select_flaky_prevous" from="VBoxContainer/Header/StatusBar" to="VBoxContainer/MainPanel" method="_on_select_previous_item_by_state" binds= [4]]
 [connection signal="tree_view_mode_changed" from="VBoxContainer/Header/StatusBar" to="VBoxContainer/MainPanel" method="_on_status_bar_tree_view_mode_changed"]
-[connection signal="run_testcase" from="VBoxContainer/MainPanel" to="." method="_on_MainPanel_run_testcase"]
-[connection signal="run_testsuite" from="VBoxContainer/MainPanel" to="." method="_on_MainPanel_run_testsuite"]
 [connection signal="jump_to_orphan_nodes" from="VBoxContainer/Monitor" to="VBoxContainer/MainPanel" method="select_first_orphan"]

--- a/addons/gdUnit4/test/ui/parts/InspectorTreeMainPanelTest.gd
+++ b/addons/gdUnit4/test/ui/parts/InspectorTreeMainPanelTest.gd
@@ -239,7 +239,7 @@ func test_suite_text_shows_amount_of_cases() -> void:
 
 
 func test_suite_text_responds_to_test_case_events() -> void:
-	var suite_script_path: String = suite_a_item.get_meta(META_SCRIPT_PATH)
+	var suite_script_path: String = _inspector.get_item_source_file(_inspector.find_tree_item(suite_a_item, "test_aa"))
 	var success_aa := GdUnitEvent.new().test_after(GdUnitGUID.new(), suite_script_path, "ExampleTestSuiteA", "test_aa")
 	_inspector._on_gdunit_event(success_aa)
 	assert_str(suite_a_item.get_text(0)).is_equal("(1/5) ExampleTestSuiteA")
@@ -265,41 +265,44 @@ func test_suite_text_responds_to_test_case_events() -> void:
 func test_update_test_case_on_multiple_test_suite_with_same_name() -> void:
 	# add a second test suite where has same name as suite_a_item
 	var suite_script := GdUnitTestResourceLoader.load_gd_script("res://addons/gdUnit4/test/ui/parts/resources/bar/ExampleTestSuiteA.resource", true)
-	GdUnitTestDiscoverer.discover_tests(suite_script, discover_sink)
+	var discovered_tests := {}
+	GdUnitTestDiscoverer.discover_tests(suite_script, func(discover_test: GdUnitTestCase) -> void:
+		discover_sink(discover_test)
+		discovered_tests[discover_test.test_name] = discover_test
+	)
 	var suite_item := _inspector.get_tree_item(suite_script.resource_path, "ExampleTestSuiteA")
-	var suite_a_script_path: String = suite_a_item.get_meta(META_SCRIPT_PATH)
-
-	assert_object(suite_a_item).is_not_same(suite_item)
-	assert_str(suite_item.get_meta(META_SCRIPT_PATH)).is_equal(suite_script.resource_path)
+	assert_object(suite_item).is_not_same(suite_a_item)
 
 	# verify inital state
-	assert_str(suite_a_item.get_text(0)).is_equal("(0/5) ExampleTestSuiteA")
-	assert_int(get_item_state(suite_a_item, "test_aa")).is_equal(_inspector.STATE.INITIAL)
 	assert_str(suite_item.get_text(0)).is_equal("(0/5) ExampleTestSuiteA")
+	assert_int(get_item_state(suite_item, "test_aa")).is_equal(_inspector.STATE.INITIAL)
+	assert_str(suite_a_item.get_text(0)).is_equal("(0/5) ExampleTestSuiteA")
 
 	# set test starting checked suite_a_item
-	_inspector._on_gdunit_event(GdUnitEvent.new().test_before(GdUnitGUID.new(), suite_a_script_path, "ExampleTestSuiteA", "test_aa"))
-	_inspector._on_gdunit_event(GdUnitEvent.new().test_before(GdUnitGUID.new(), suite_a_script_path, "ExampleTestSuiteA", "test_ab"))
-	assert_str(suite_a_item.get_text(0)).is_equal("(0/5) ExampleTestSuiteA")
-	assert_int(get_item_state(suite_a_item, "test_aa")).is_equal(_inspector.STATE.RUNNING)
-	assert_int(get_item_state(suite_a_item, "test_ab")).is_equal(_inspector.STATE.RUNNING)
-	# test test_suite_aa_path is not affected
+	var test_aa: GdUnitTestCase = discovered_tests["test_aa"]
+	var test_ab: GdUnitTestCase = discovered_tests["test_ab"]
+	_inspector._on_gdunit_event(GdUnitEvent.new().test_before(test_aa.guid, test_aa.source_file, test_aa.suite_name, test_aa.test_name))
+	_inspector._on_gdunit_event(GdUnitEvent.new().test_before(test_ab.guid, test_ab.source_file, test_ab.suite_name, test_ab.test_name))
 	assert_str(suite_item.get_text(0)).is_equal("(0/5) ExampleTestSuiteA")
-	assert_int(get_item_state(suite_item, "test_aa")).is_equal(_inspector.STATE.INITIAL)
-	assert_int(get_item_state(suite_item, "test_ab")).is_equal(_inspector.STATE.INITIAL)
+	assert_int(get_item_state(suite_item, "test_aa")).is_equal(_inspector.STATE.RUNNING)
+	assert_int(get_item_state(suite_item, "test_ab")).is_equal(_inspector.STATE.RUNNING)
+	# test suite_a_item is not affected
+	assert_str(suite_a_item.get_text(0)).is_equal("(0/5) ExampleTestSuiteA")
+	assert_int(get_item_state(suite_a_item, "test_aa")).is_equal(_inspector.STATE.INITIAL)
+	assert_int(get_item_state(suite_a_item, "test_ab")).is_equal(_inspector.STATE.INITIAL)
 
 	# finish the tests with success
-	_inspector._on_gdunit_event(GdUnitEvent.new().test_after(GdUnitGUID.new(), suite_a_script_path, "ExampleTestSuiteA", "test_aa"))
-	_inspector._on_gdunit_event(GdUnitEvent.new().test_after(GdUnitGUID.new(), suite_a_script_path, "ExampleTestSuiteA", "test_ab"))
+	_inspector._on_gdunit_event(GdUnitEvent.new().test_after(test_aa.guid, test_aa.source_file, test_aa.suite_name, test_aa.test_name))
+	_inspector._on_gdunit_event(GdUnitEvent.new().test_after(test_ab.guid, test_ab.source_file, test_ab.suite_name, test_ab.test_name))
 
 	# verify updated state checked suite_a_item
-	assert_str(suite_a_item.get_text(0)).is_equal("(2/5) ExampleTestSuiteA")
-	assert_int(get_item_state(suite_a_item, "test_aa")).is_equal(_inspector.STATE.SUCCESS)
-	assert_int(get_item_state(suite_a_item, "test_ab")).is_equal(_inspector.STATE.SUCCESS)
-	# test test_suite_aa_path is not affected
-	assert_str(suite_item.get_text(0)).is_equal("(0/5) ExampleTestSuiteA")
-	assert_int(get_item_state(suite_item, "test_aa")).is_equal(_inspector.STATE.INITIAL)
-	assert_int(get_item_state(suite_item, "test_ab")).is_equal(_inspector.STATE.INITIAL)
+	assert_str(suite_item.get_text(0)).is_equal("(2/5) ExampleTestSuiteA")
+	assert_int(get_item_state(suite_item, "test_aa")).is_equal(_inspector.STATE.SUCCESS)
+	assert_int(get_item_state(suite_item, "test_ab")).is_equal(_inspector.STATE.SUCCESS)
+	# test suite_a_item is not affected
+	assert_str(suite_a_item.get_text(0)).is_equal("(0/5) ExampleTestSuiteA")
+	assert_int(get_item_state(suite_a_item, "test_aa")).is_equal(_inspector.STATE.INITIAL)
+	assert_int(get_item_state(suite_a_item, "test_ab")).is_equal(_inspector.STATE.INITIAL)
 
 
 # Test coverage for issue GD-278: GdUnit Inspector: Test marks as passed if both warning and error
@@ -312,7 +315,6 @@ func test_update_icon_state() -> void:
 
 	# Verify the inital state
 	assert_str(suite_item.get_text(0)).is_equal("(0/2) " + suite_name)
-	assert_str(suite_item.get_meta(_inspector.META_RESOURCE_PATH)).is_equal(suite_script_path)
 	assert_int(get_item_state(suite_item)).is_equal(_inspector.STATE.INITIAL)
 	assert_int(get_item_state(suite_item, "test_case1")).is_equal(_inspector.STATE.INITIAL)
 	assert_int(get_item_state(suite_item, "test_case2")).is_equal(_inspector.STATE.INITIAL)


### PR DESCRIPTION
# Why
see https://github.com/MikeSchulze/gdUnit4/issues/683

# What
- add test case record as metadata stored by key `gdunit_test_case`
- removed obsolete signals `run_testsuite` and `run_testcase`
- removed obsolete metadata attributes where is covered by new metadata `gdunit_test_case`
- collect test records from selected node and use command handler to execute
