### PR TITLE
GD-653: Simplify GdUnitEvent by using the GdUnitGUID

### DIFF
--- a/addons/gdUnit4/plugin.gd
+++ b/addons/gdUnit4/plugin.gd
@@ -9,7 +9,7 @@ var _gd_inspector: Control
 var _gd_console: Control
 var _gd_filesystem_context_menu: Variant
 var _gd_scripteditor_context_menu: Variant
-var _guard: RefCounted
+var _guard: GdUnitTestDiscoverGuard
 
 
 func _enter_tree() -> void:
@@ -34,8 +34,7 @@ func _enter_tree() -> void:
 	if GdUnit4CSharpApiLoader.is_mono_supported():
 		prints("GdUnit4Net version '%s' loaded." % GdUnit4CSharpApiLoader.version())
 	# Connect to be notified for script changes to be able to discover new tests
-	@warning_ignore("unsafe_method_access")
-	_guard = load("res://addons/gdUnit4/src/core/discovery/GdUnitTestDiscoverGuard.gd").new()
+	_guard = GdUnitTestDiscoverGuard.new()
 	@warning_ignore("return_value_discarded")
 	resource_saved.connect(_on_resource_saved)
 	prints("Loading GdUnit4 Plugin success")
@@ -97,5 +96,4 @@ func _create_context_menu(script_path: String) -> Variant:
 
 func _on_resource_saved(resource: Resource) -> void:
 	if resource is Script:
-		@warning_ignore("unsafe_method_access")
 		await _guard.discover(resource as Script)

--- a/addons/gdUnit4/src/core/GdUnitTestSuiteScanner.gd
+++ b/addons/gdUnit4/src/core/GdUnitTestSuiteScanner.gd
@@ -202,7 +202,10 @@ static func load_with_disabled_warnings(resource_path: String) -> GDScript:
 
 	# disable and load the script
 	ProjectSettings.set_setting("debug/gdscript/warnings/unsafe_method_access", 0)
-	var script: GDScript = ResourceLoader.load(resource_path)
+
+	var script: GDScript = (
+		GdUnitTestResourceLoader.load_gd_script(resource_path) if resource_path.ends_with("resource")
+		else ResourceLoader.load(resource_path))
 
 	# restore
 	ProjectSettings.set_setting("debug/gdscript/warnings/unsafe_method_access", unsafe_method_access)

--- a/addons/gdUnit4/src/core/discovery/GdUnitTestDiscoverGuard.gd
+++ b/addons/gdUnit4/src/core/discovery/GdUnitTestDiscoverGuard.gd
@@ -34,6 +34,7 @@
 ## # Discover tests and track changes
 ## await guard.discover(test_script)
 ## [/codeblock]
+class_name GdUnitTestDiscoverGuard
 extends RefCounted
 
 
@@ -117,6 +118,22 @@ func handle_discover_events(event: GdUnitEvent) -> void:
 ## Default sink writes to [class GdUnitTestDiscoverSink].
 static func default_discover_sink(test_case: GdUnitTestCase) -> void:
 	GdUnitTestDiscoverSink.discover(test_case)
+
+
+## Finds a test case by its unique identifier.[br]
+## [br]
+## Searches through all cached test cases across all test suites[br]
+## to find a test with the matching GUID.[br]
+## [br]
+## [param id] The GUID of the test to find[br]
+## Returns the matching test case or null if not found.
+func find_test_by_id(id: GdUnitGUID) -> GdUnitTestCase:
+	for test_sets: Array[GdUnitTestCase] in _discover_cache.values():
+		for test in test_sets:
+			if test.guid.equals(id):
+				return test
+
+	return null
 
 
 ## Discovers tests in a script and tracks changes.[br]

--- a/addons/gdUnit4/src/core/event/GdUnitEvent.gd
+++ b/addons/gdUnit4/src/core/event/GdUnitEvent.gd
@@ -55,21 +55,15 @@ func suite_after(p_resource_path: String, p_suite_name: String, p_statistics: Di
 	return self
 
 
-func test_before(p_guid: GdUnitGUID, p_resource_path: String, p_suite_name: String, p_test_name: String) -> GdUnitEvent:
+func test_before(p_guid: GdUnitGUID) -> GdUnitEvent:
 	_event_type = TESTCASE_BEFORE
 	_guid = p_guid
-	_resource_path = p_resource_path
-	_suite_name  = p_suite_name
-	_test_name = p_test_name
 	return self
 
 
-func test_after(p_guid: GdUnitGUID, p_resource_path: String, p_suite_name: String, p_test_name: String, p_statistics: Dictionary = {}, p_reports :Array[GdUnitReport] = []) -> GdUnitEvent:
+func test_after(p_guid: GdUnitGUID, p_statistics: Dictionary = {}, p_reports :Array[GdUnitReport] = []) -> GdUnitEvent:
 	_event_type = TESTCASE_AFTER
 	_guid = p_guid
-	_resource_path = p_resource_path
-	_suite_name  = p_suite_name
-	_test_name = p_test_name
 	_statistics = p_statistics
 	_reports = p_reports
 	return self

--- a/addons/gdUnit4/src/core/execution/stages/GdUnitTestCaseAfterStage.gd
+++ b/addons/gdUnit4/src/core/execution/stages/GdUnitTestCaseAfterStage.gd
@@ -26,12 +26,7 @@ func _execute(context: GdUnitExecutionContext) -> void:
 	if context.is_skipped():
 		fire_test_skipped(context)
 	else:
-		fire_event(GdUnitEvent.new() \
-			.test_after(context.test_case.id(), context.get_test_suite_path(),
-				context.get_test_suite_name(),
-				context.get_test_case_name(),
-				context.get_execution_statistics(),
-				reports))
+		fire_event(GdUnitEvent.new().test_after(context.test_case.id(), context.get_execution_statistics(), reports))
 
 
 func fire_test_skipped(context: GdUnitExecutionContext) -> void:
@@ -49,9 +44,4 @@ func fire_test_skipped(context: GdUnitExecutionContext) -> void:
 	}
 	var report := GdUnitReport.new() \
 		.create(GdUnitReport.SKIPPED, test_case.line_number(), GdAssertMessages.test_skipped(test_case.skip_info()))
-	fire_event(GdUnitEvent.new() \
-		.test_after(test_case.id(), context.get_test_suite_path(),
-			context.get_test_suite_name(),
-			context.get_test_case_name(),
-			statistics,
-			[report]))
+	fire_event(GdUnitEvent.new().test_after(test_case.id(), statistics, [report]))

--- a/addons/gdUnit4/src/core/execution/stages/GdUnitTestCaseBeforeStage.gd
+++ b/addons/gdUnit4/src/core/execution/stages/GdUnitTestCaseBeforeStage.gd
@@ -13,8 +13,7 @@ func _init(call_stage := true) -> void:
 func _execute(context :GdUnitExecutionContext) -> void:
 	var test_suite := context.test_suite
 
-	fire_event(GdUnitEvent.new()\
-		.test_before(context.test_case.id(), context.get_test_suite_path(), context.get_test_suite_name(), context.get_test_case_name()))
+	fire_event(GdUnitEvent.new().test_before(context.test_case.id()))
 	if _call_stage:
 		@warning_ignore("redundant_await")
 		await test_suite.before_test()

--- a/addons/gdUnit4/src/core/execution/stages/GdUnitTestSuiteExecutionStage.gd
+++ b/addons/gdUnit4/src/core/execution/stages/GdUnitTestSuiteExecutionStage.gd
@@ -97,8 +97,7 @@ func fire_test_suite_skipped(context :GdUnitExecutionContext) -> void:
 			if not is_instance_valid(test_case):
 				continue
 			var test_case_context := GdUnitExecutionContext.of_test_case(context, test_case)
-			fire_event(GdUnitEvent.new()\
-				.test_before(test_case.id(), test_case_context.get_test_suite_path(), test_case_context.get_test_suite_name(), test_case_context.get_test_case_name()))
+			fire_event(GdUnitEvent.new().test_before(test_case.id()))
 			fire_test_skipped(test_case_context)
 
 
@@ -133,12 +132,7 @@ func fire_test_skipped(context: GdUnitExecutionContext) -> void:
 	}
 	var report := GdUnitReport.new() \
 		.create(GdUnitReport.SKIPPED, test_case.line_number(), GdAssertMessages.test_skipped("Skipped from the entire test suite"))
-	fire_event(GdUnitEvent.new() \
-		.test_after(test_case.id(), context.get_test_suite_path(),
-			context.get_test_suite_name(),
-			context.get_test_case_name(),
-			statistics,
-			[report]))
+	fire_event(GdUnitEvent.new().test_after(test_case.id(), statistics, [report]))
 
 
 func set_debug_mode(debug_mode :bool = false) -> void:

--- a/addons/gdUnit4/src/core/runners/GdUnitTestCIRunner.gd
+++ b/addons/gdUnit4/src/core/runners/GdUnitTestCIRunner.gd
@@ -398,8 +398,9 @@ func init_gd_unit() -> void:
 	_state = RUN
 
 
-
 func discover_tests() -> Array[GdUnitTestCase]:
+	var gdunit_test_discover_added := GdUnitSignals.instance().gdunit_test_discover_added
+
 	_test_cases = _runner_config.test_cases()
 	var scanner := GdUnitTestSuiteScanner.new()
 	for path in _included_tests:
@@ -411,6 +412,7 @@ func discover_tests() -> Array[GdUnitTestCase]:
 					if not is_skipped(test):
 						#_console.println_message("discoverd %s" % test.display_name)
 						_test_cases.append(test)
+						gdunit_test_discover_added.emit(test)
 				)
 			else:
 				## TODO implement c# test discovery here

--- a/addons/gdUnit4/src/ui/parts/InspectorTreeMainPanel.gd
+++ b/addons/gdUnit4/src/ui/parts/InspectorTreeMainPanel.gd
@@ -640,14 +640,12 @@ func create_item(parent: TreeItem, test: GdUnitTestCase, item_name: String, type
 	match type:
 		GdUnitType.TEST_CASE:
 			item.set_meta(META_TEST_CASE, test)
-		GdUnitType.FOLDER:
-			pass
-		GdUnitType.TEST_SUITE:
-			# we need to create a copy of GdUnitTestCase with a new guid
-			item.set_meta(META_TEST_CASE, GdUnitTestCase.from(test.source_file, test.line_number, test.suite_name))
-		_:
-			# we need to create a copy of GdUnitTestCase with a new guid
+		GdUnitType.TEST_GROUP:
+			# We need to create a copy of the test record meta with a new uniqe guid
 			item.set_meta(META_TEST_CASE, GdUnitTestCase.from(test.source_file, test.line_number, test.test_name))
+		GdUnitType.TEST_SUITE:
+			# We need to create a copy of the test record meta with a new uniqe guid
+			item.set_meta(META_TEST_CASE, GdUnitTestCase.from(test.source_file, test.line_number, test.suite_name))
 
 	item.set_meta(META_GDUNIT_NAME, item_name)
 	item.set_meta(META_GDUNIT_TYPE, type)

--- a/addons/gdUnit4/test/GdUnitTestResourceLoader.gd
+++ b/addons/gdUnit4/test/GdUnitTestResourceLoader.gd
@@ -9,7 +9,7 @@ enum {
 }
 
 
-static func load_test_suite(resource_path :String, script_type := GD_SUITE) -> Node:
+static func load_test_suite(resource_path: String, script_type := GD_SUITE) -> Node:
 	match script_type:
 		GD_SUITE:
 			return load_test_suite_gd(resource_path)
@@ -19,7 +19,17 @@ static func load_test_suite(resource_path :String, script_type := GD_SUITE) -> N
 	return null
 
 
-static func load_test_suite_gd(resource_path :String) -> GdUnitTestSuite:
+static func load_tests(resource_path: String) -> Dictionary:
+	var script := load_gd_script(resource_path)
+	var discovered_tests := {}
+	GdUnitTestDiscoverer.discover_tests(script, func(test: GdUnitTestCase) -> void:
+		discovered_tests[test.display_name] = test
+	)
+
+	return discovered_tests
+
+
+static func load_test_suite_gd(resource_path: String) -> GdUnitTestSuite:
 	var script := load_gd_script(resource_path)
 	var discovered_tests: Array[GdUnitTestCase] = []
 	GdUnitTestDiscoverer.discover_tests(script, func(test: GdUnitTestCase) -> void:
@@ -29,7 +39,7 @@ static func load_test_suite_gd(resource_path :String) -> GdUnitTestSuite:
 	return GdUnitTestSuiteScanner.new().load_suite(script, discovered_tests)
 
 
-static func load_test_suite_cs(resource_path :String) -> Node:
+static func load_test_suite_cs(resource_path: String) -> Node:
 	if not GdUnit4CSharpApiLoader.is_mono_supported():
 		return null
 	var script :Script = ClassDB.instantiate("CSharpScript")
@@ -39,7 +49,7 @@ static func load_test_suite_cs(resource_path :String) -> Node:
 	return null
 
 
-static func load_cs_script(resource_path :String, debug_write := false) -> Script:
+static func load_cs_script(resource_path: String, debug_write := false) -> Script:
 	if not GdUnit4CSharpApiLoader.is_mono_supported():
 		return null
 	var script :Script = ClassDB.instantiate("CSharpScript")
@@ -59,7 +69,7 @@ static func load_cs_script(resource_path :String, debug_write := false) -> Scrip
 	return script
 
 
-static func load_gd_script(resource_path :String, debug_write := false) -> GDScript:
+static func load_gd_script(resource_path: String, debug_write := false) -> GDScript:
 		# grap current level
 	var unsafe_method_access: Variant = ProjectSettings.get_setting("debug/gdscript/warnings/unsafe_method_access")
 	# disable and load the script

--- a/addons/gdUnit4/test/core/discovery/GdUnitTestDiscoverGuardTest.gd
+++ b/addons/gdUnit4/test/core/discovery/GdUnitTestDiscoverGuardTest.gd
@@ -4,8 +4,6 @@ extends GdUnitTestSuite
 @warning_ignore('unused_parameter')
 @warning_ignore('return_value_discarded')
 
-# TestSuite generated from
-const GdUnitTestDiscoverGuard = preload("res://addons/gdUnit4/src/core/discovery/GdUnitTestDiscoverGuard.gd")
 
 
 func test_inital() -> void:

--- a/addons/gdUnit4/test/core/event/GdUnitTestEventSerdeTest.gd
+++ b/addons/gdUnit4/test/core/event/GdUnitTestEventSerdeTest.gd
@@ -19,14 +19,14 @@ func test_serde_suite_after() -> void:
 
 
 func test_serde_test_before() -> void:
-	var event := GdUnitEvent.new().test_before(GdUnitGUID.new(), "path", "test_suite_a", "test_foo")
+	var event := GdUnitEvent.new().test_before(GdUnitGUID.new())
 	var serialized := event.serialize()
 	var deserialized := GdUnitEvent.new().deserialize(serialized)
 	assert_that(deserialized).is_equal(event)
 
 
 func test_serde_test_after_no_report() -> void:
-	var event := GdUnitEvent.new().test_after(GdUnitGUID.new(), "path", "test_suite_a", "test_foo")
+	var event := GdUnitEvent.new().test_after(GdUnitGUID.new())
 	var serialized := event.serialize()
 	var deserialized := GdUnitEvent.new().deserialize(serialized)
 	assert_that(deserialized).is_equal(event)
@@ -36,7 +36,7 @@ func test_serde_test_after_with_report() -> void:
 	var reports :Array[GdUnitReport] = [\
 		GdUnitReport.new().create(GdUnitReport.FAILURE, 24, "this is a error a"), \
 		GdUnitReport.new().create(GdUnitReport.FAILURE, 26, "this is a error b")]
-	var event := GdUnitEvent.new().test_after(GdUnitGUID.new(), "path", "test_suite_a", "test_foo", {}, reports)
+	var event := GdUnitEvent.new().test_after(GdUnitGUID.new(), {}, reports)
 
 	var serialized := event.serialize()
 	var deserialized := GdUnitEvent.new().deserialize(serialized)

--- a/addons/gdUnit4/test/core/execution/GdUnitTestSuiteExecutorTest.gd
+++ b/addons/gdUnit4/test/core/execution/GdUnitTestSuiteExecutorTest.gd
@@ -41,28 +41,39 @@ func _on_gdunit_event_debug(event :GdUnitEvent) -> void:
 	_collected_events.append(event)
 
 
-func _load(resource_path :String) -> GdUnitTestSuite:
-	return GdUnitTestResourceLoader.load_test_suite_gd(resource_path)
-
-
 func flating_message(message :String) -> String:
 	return GdUnitTools.richtext_normalize(message)
 
 
-func execute(test_suite :GdUnitTestSuite) -> Array[GdUnitEvent]:
-	await GdUnitThreadManager.run("test_executor", func() -> void:
+func run_tests(tests :Array[GdUnitTestCase], settings := {}) -> Array[GdUnitEvent]:
+	# run in a separate context to not affect the current test run
+	await GdUnitThreadManager.run("test_executor_%d" % randi(), func() -> void:
 		var executor := GdUnitTestSuiteExecutor.new(true)
-		await executor.execute(test_suite))
+
+		# apply custom run settints
+		var saves_settings := {}
+		for key: String in settings.keys():
+			saves_settings[key] =  ProjectSettings.get_setting(key)
+			ProjectSettings.set_setting(key, settings[key])
+
+		# execute all tests
+		await executor.run_and_wait(tests)
+
+		# restore settings
+		for key: String in saves_settings.keys():
+			ProjectSettings.set_setting(key, saves_settings[key])
+
+	)
 	return _collected_events
 
 
 func assert_event_list(events :Array[GdUnitEvent], suite_name :String, test_case_names :Array[String]) -> void:
 	var expected_events := Array()
-	expected_events.append(tuple(GdUnitEvent.TESTSUITE_BEFORE, suite_name, "before", test_case_names.size()))
+	expected_events.append(tuple(GdUnitEvent.TESTSUITE_BEFORE, suite_name, any_class(GdUnitGUID), test_case_names.size()))
 	for test_case in test_case_names:
 		expected_events.append(tuple(GdUnitEvent.TESTCASE_BEFORE, suite_name, test_case, 0))
 		expected_events.append(tuple(GdUnitEvent.TESTCASE_AFTER, suite_name, test_case, 0))
-	expected_events.append(tuple(GdUnitEvent.TESTSUITE_AFTER, suite_name, "after", 0))
+	expected_events.append(tuple(GdUnitEvent.TESTSUITE_AFTER, suite_name, any_class(GdUnitGUID), 0))
 
 	# the suite hooks 2 + (test hocks 2 * test count)
 	var expected_event_count := 2 + test_case_names.size() * 2
@@ -79,14 +90,14 @@ func assert_test_counters(events :Array[GdUnitEvent]) -> GdUnitArrayAssert:
 	var _events := events.filter(func(event: GdUnitEvent) -> bool:
 		return event.type() in [GdUnitEvent.TESTSUITE_BEFORE, GdUnitEvent.TESTSUITE_AFTER, GdUnitEvent.TESTCASE_BEFORE, GdUnitEvent.TESTCASE_AFTER]
 	)
-	return assert_array(_events).extractv(extr("test_name"), extr("type"), extr("error_count"), extr("failed_count"), extr("orphan_nodes"))
+	return assert_array(_events).extractv(extr("guid"), extr("type"), extr("error_count"), extr("failed_count"), extr("orphan_nodes"))
 
 
 func assert_event_states(events :Array[GdUnitEvent]) -> GdUnitArrayAssert:
 	var _events := events.filter(func(event: GdUnitEvent) -> bool:
 		return event.type() in [GdUnitEvent.TESTSUITE_BEFORE, GdUnitEvent.TESTSUITE_AFTER, GdUnitEvent.TESTCASE_BEFORE, GdUnitEvent.TESTCASE_AFTER]
 	)
-	return assert_array(_events).extractv(extr("test_name"), extr("is_success"), extr("is_skipped"), extr("is_warning"), extr("is_failed"), extr("is_error"))
+	return assert_array(_events).extractv(extr("guid"), extr("is_success"), extr("is_skipped"), extr("is_warning"), extr("is_failed"), extr("is_error"))
 
 
 @warning_ignore("unsafe_method_access", "unsafe_cast")
@@ -107,28 +118,35 @@ func assert_event_reports(events: Array[GdUnitEvent], expected_reports: Array) -
 
 
 func test_execute_success() -> void:
-	var test_suite := _load("res://addons/gdUnit4/test/core/resources/testsuites/TestSuiteAllStagesSuccess.resource")
+	var tests := GdUnitTestResourceLoader.load_tests("res://addons/gdUnit4/test/core/resources/testsuites/TestSuiteAllStagesSuccess.resource")
+	var all_tests: Array[GdUnitTestCase] = Array(tests.values(), TYPE_OBJECT, "RefCounted", GdUnitTestCase)
+	var test_case1: GdUnitTestCase = tests["test_case1"]
+	var test_case2: GdUnitTestCase = tests["test_case2"]
 	# simulate test suite execution
-	var events := await execute(test_suite)
-	assert_event_list(events,\
-		"TestSuiteAllStagesSuccess",\
-		["test_case1", "test_case2"])
+	var events := await run_tests(all_tests)
+
+	# (before_test+after_test) * test count + before+after hooks
+	var expected_event_count := tests.size() * 2 + 2
+	assert_array(events)\
+		.override_failure_message("Expecting be %d events emitted, but counts %d." % [expected_event_count, events.size()])\
+		.has_size(expected_event_count)
+
 	# verify all counters are zero / no errors, failures, orphans
 	assert_test_counters(events).contains_exactly([
-		tuple("before", GdUnitEvent.TESTSUITE_BEFORE, 0, 0, 0),
-		tuple("test_case1", GdUnitEvent.TESTCASE_BEFORE, 0, 0, 0),
-		tuple("test_case1", GdUnitEvent.TESTCASE_AFTER, 0, 0, 0),
-		tuple("test_case2", GdUnitEvent.TESTCASE_BEFORE, 0, 0, 0),
-		tuple("test_case2", GdUnitEvent.TESTCASE_AFTER, 0, 0, 0),
-		tuple("after", GdUnitEvent.TESTSUITE_AFTER, 0, 0, 0),
+		tuple(any_class(GdUnitGUID), GdUnitEvent.TESTSUITE_BEFORE, 0, 0, 0),
+		tuple(test_case1.guid, GdUnitEvent.TESTCASE_BEFORE, 0, 0, 0),
+		tuple(test_case1.guid, GdUnitEvent.TESTCASE_AFTER, 0, 0, 0),
+		tuple(test_case2.guid, GdUnitEvent.TESTCASE_BEFORE, 0, 0, 0),
+		tuple(test_case2.guid, GdUnitEvent.TESTCASE_AFTER, 0, 0, 0),
+		tuple(any_class(GdUnitGUID), GdUnitEvent.TESTSUITE_AFTER, 0, 0, 0),
 	])
 	assert_event_states(events).contains_exactly([
-		tuple("before", SUCCEEDED, NOT_SKIPPED, false, false, false),
-		tuple("test_case1", SUCCEEDED, NOT_SKIPPED, false, false, false),
-		tuple("test_case1", SUCCEEDED, NOT_SKIPPED, false, false, false),
-		tuple("test_case2", SUCCEEDED, NOT_SKIPPED, false, false, false),
-		tuple("test_case2", SUCCEEDED, NOT_SKIPPED, false, false, false),
-		tuple("after", SUCCEEDED, NOT_SKIPPED, false, false, false),
+		tuple(any_class(GdUnitGUID), SUCCEEDED, NOT_SKIPPED, false, false, false),
+		tuple(test_case1.guid, SUCCEEDED, NOT_SKIPPED, false, false, false),
+		tuple(test_case1.guid, SUCCEEDED, NOT_SKIPPED, false, false, false),
+		tuple(test_case2.guid, SUCCEEDED, NOT_SKIPPED, false, false, false),
+		tuple(test_case2.guid, SUCCEEDED, NOT_SKIPPED, false, false, false),
+		tuple(any_class(GdUnitGUID), SUCCEEDED, NOT_SKIPPED, false, false, false),
 	])
 	# all success no reports expected
 	assert_event_reports(events, [
@@ -137,32 +155,38 @@ func test_execute_success() -> void:
 
 
 func test_execute_failure_on_stage_before() -> void:
-	var test_suite := _load("res://addons/gdUnit4/test/core/resources/testsuites/TestSuiteFailOnStageBefore.resource")
+	var tests := GdUnitTestResourceLoader.load_tests("res://addons/gdUnit4/test/core/resources/testsuites/TestSuiteFailOnStageBefore.resource")
+	var all_tests: Array[GdUnitTestCase] = Array(tests.values(), TYPE_OBJECT, "RefCounted", GdUnitTestCase)
+	var test_case1: GdUnitTestCase = tests["test_case1"]
+	var test_case2: GdUnitTestCase = tests["test_case2"]
 	# simulate test suite execution
-	var events := await execute(test_suite)
-	# verify basis infos
-	assert_event_list(events,\
-		"TestSuiteFailOnStageBefore",\
-		["test_case1", "test_case2"])
+	var events := await run_tests(all_tests)
+
+	# (before_test+after_test) * test count + before+after hooks
+	var expected_event_count := tests.size() * 2 + 2
+	assert_array(events)\
+		.override_failure_message("Expecting be %d events emitted, but counts %d." % [expected_event_count, events.size()])\
+		.has_size(expected_event_count)
+
 	# we expect the testsuite is failing on stage 'before()' and commits one failure
 	# reported finally at TESTSUITE_AFTER event
 	assert_test_counters(events).contains_exactly([
-		tuple("before", GdUnitEvent.TESTSUITE_BEFORE, 0, 0, 0),
-		tuple("test_case1", GdUnitEvent.TESTCASE_BEFORE, 0, 0, 0),
-		tuple("test_case1", GdUnitEvent.TESTCASE_AFTER, 0, 0, 0),
-		tuple("test_case2", GdUnitEvent.TESTCASE_BEFORE, 0, 0, 0),
-		tuple("test_case2", GdUnitEvent.TESTCASE_AFTER, 0, 0, 0),
+		tuple(any_class(GdUnitGUID), GdUnitEvent.TESTSUITE_BEFORE, 0, 0, 0),
+		tuple(test_case1.guid, GdUnitEvent.TESTCASE_BEFORE, 0, 0, 0),
+		tuple(test_case1.guid, GdUnitEvent.TESTCASE_AFTER, 0, 0, 0),
+		tuple(test_case2.guid, GdUnitEvent.TESTCASE_BEFORE, 0, 0, 0),
+		tuple(test_case2.guid, GdUnitEvent.TESTCASE_AFTER, 0, 0, 0),
 		# report failure failed_count = 1
-		tuple("after", GdUnitEvent.TESTSUITE_AFTER, 0, 1, 0),
+		tuple(any_class(GdUnitGUID), GdUnitEvent.TESTSUITE_AFTER, 0, 1, 0),
 	])
 	assert_event_states(events).contains_exactly([
-		tuple("before", SUCCEEDED, NOT_SKIPPED, false, false, false),
-		tuple("test_case1", SUCCEEDED, NOT_SKIPPED, false, false, false),
-		tuple("test_case1", SUCCEEDED, NOT_SKIPPED, false, false, false),
-		tuple("test_case2", SUCCEEDED, NOT_SKIPPED, false, false, false),
-		tuple("test_case2", SUCCEEDED, NOT_SKIPPED, false, false, false),
+		tuple(any_class(GdUnitGUID), SUCCEEDED, NOT_SKIPPED, false, false, false),
+		tuple(test_case1.guid, SUCCEEDED, NOT_SKIPPED, false, false, false),
+		tuple(test_case1.guid, SUCCEEDED, NOT_SKIPPED, false, false, false),
+		tuple(test_case2.guid, SUCCEEDED, NOT_SKIPPED, false, false, false),
+		tuple(test_case2.guid, SUCCEEDED, NOT_SKIPPED, false, false, false),
 		# report suite is not success, is failed
-		tuple("after", FAILED, NOT_SKIPPED, false, true, false),
+		tuple(any_class(GdUnitGUID), FAILED, NOT_SKIPPED, false, true, false),
 	])
 	# one failure at before()
 	assert_event_reports(events, [
@@ -176,32 +200,38 @@ func test_execute_failure_on_stage_before() -> void:
 
 
 func test_execute_failure_on_stage_after() -> void:
-	var test_suite := _load("res://addons/gdUnit4/test/core/resources/testsuites/TestSuiteFailOnStageAfter.resource")
+	var tests := GdUnitTestResourceLoader.load_tests("res://addons/gdUnit4/test/core/resources/testsuites/TestSuiteFailOnStageAfter.resource")
+	var all_tests: Array[GdUnitTestCase] = Array(tests.values(), TYPE_OBJECT, "RefCounted", GdUnitTestCase)
+	var test_case1: GdUnitTestCase = tests["test_case1"]
+	var test_case2: GdUnitTestCase = tests["test_case2"]
 	# simulate test suite execution
-	var events := await execute(test_suite)
-	# verify basis infos
-	assert_event_list(events,\
-		"TestSuiteFailOnStageAfter",\
-		["test_case1", "test_case2"])
+	var events := await run_tests(all_tests)
+
+	# (before_test+after_test) * test count + before+after hooks
+	var expected_event_count := tests.size() * 2 + 2
+	assert_array(events)\
+		.override_failure_message("Expecting be %d events emitted, but counts %d." % [expected_event_count, events.size()])\
+		.has_size(expected_event_count)
+
 	# we expect the testsuite is failing on stage 'after()' and commits one failure
 	# reported finally at TESTSUITE_AFTER event
 	assert_test_counters(events).contains_exactly([
-		tuple("before", GdUnitEvent.TESTSUITE_BEFORE, 0, 0, 0),
-		tuple("test_case1", GdUnitEvent.TESTCASE_BEFORE, 0, 0, 0),
-		tuple("test_case1", GdUnitEvent.TESTCASE_AFTER, 0, 0, 0),
-		tuple("test_case2", GdUnitEvent.TESTCASE_BEFORE, 0, 0, 0),
-		tuple("test_case2", GdUnitEvent.TESTCASE_AFTER, 0, 0, 0),
+		tuple(any_class(GdUnitGUID), GdUnitEvent.TESTSUITE_BEFORE, 0, 0, 0),
+		tuple(test_case1.guid, GdUnitEvent.TESTCASE_BEFORE, 0, 0, 0),
+		tuple(test_case1.guid, GdUnitEvent.TESTCASE_AFTER, 0, 0, 0),
+		tuple(test_case2.guid, GdUnitEvent.TESTCASE_BEFORE, 0, 0, 0),
+		tuple(test_case2.guid, GdUnitEvent.TESTCASE_AFTER, 0, 0, 0),
 		# report failure failed_count = 1
-		tuple("after", GdUnitEvent.TESTSUITE_AFTER, 0, 1, 0),
+		tuple(any_class(GdUnitGUID), GdUnitEvent.TESTSUITE_AFTER, 0, 1, 0),
 	])
 	assert_event_states(events).contains_exactly([
-		tuple("before", SUCCEEDED, NOT_SKIPPED, false, false, false),
-		tuple("test_case1", SUCCEEDED, NOT_SKIPPED, false, false, false),
-		tuple("test_case1", SUCCEEDED, NOT_SKIPPED, false, false, false),
-		tuple("test_case2", SUCCEEDED, NOT_SKIPPED, false, false, false),
-		tuple("test_case2", SUCCEEDED, NOT_SKIPPED, false, false, false),
+		tuple(any_class(GdUnitGUID), SUCCEEDED, NOT_SKIPPED, false, false, false),
+		tuple(test_case1.guid, SUCCEEDED, NOT_SKIPPED, false, false, false),
+		tuple(test_case1.guid, SUCCEEDED, NOT_SKIPPED, false, false, false),
+		tuple(test_case2.guid, SUCCEEDED, NOT_SKIPPED, false, false, false),
+		tuple(test_case2.guid, SUCCEEDED, NOT_SKIPPED, false, false, false),
 		# report suite is not success, is failed
-		tuple("after", FAILED, NOT_SKIPPED, false, true, false),
+		tuple(any_class(GdUnitGUID), FAILED, NOT_SKIPPED, false, true, false),
 	])
 	# one failure at after()
 	assert_event_reports(events, [
@@ -215,33 +245,39 @@ func test_execute_failure_on_stage_after() -> void:
 
 
 func test_execute_failure_on_stage_before_test() -> void:
-	var test_suite := _load("res://addons/gdUnit4/test/core/resources/testsuites/TestSuiteFailOnStageBeforeTest.resource")
+	var tests := GdUnitTestResourceLoader.load_tests("res://addons/gdUnit4/test/core/resources/testsuites/TestSuiteFailOnStageBeforeTest.resource")
+	var all_tests: Array[GdUnitTestCase] = Array(tests.values(), TYPE_OBJECT, "RefCounted", GdUnitTestCase)
+	var test_case1: GdUnitTestCase = tests["test_case1"]
+	var test_case2: GdUnitTestCase = tests["test_case2"]
 	# simulate test suite execution
-	var events := await execute(test_suite)
-	# verify basis infos
-	assert_event_list(events,\
-		"TestSuiteFailOnStageBeforeTest",\
-		["test_case1", "test_case2"])
+	var events := await run_tests(all_tests)
+
+	# (before_test+after_test) * test count + before+after hooks
+	var expected_event_count := tests.size() * 2 + 2
+	assert_array(events)\
+		.override_failure_message("Expecting be %d events emitted, but counts %d." % [expected_event_count, events.size()])\
+		.has_size(expected_event_count)
+
 	# we expect the testsuite is failing on stage 'before_test()' and commits one failure on each test case
 	# because is in scope of test execution
 	assert_test_counters(events).contains_exactly([
-		tuple("before", GdUnitEvent.TESTSUITE_BEFORE, 0, 0, 0),
-		tuple("test_case1", GdUnitEvent.TESTCASE_BEFORE, 0, 0, 0),
+		tuple(any_class(GdUnitGUID), GdUnitEvent.TESTSUITE_BEFORE, 0, 0, 0),
+		tuple(test_case1.guid, GdUnitEvent.TESTCASE_BEFORE, 0, 0, 0),
 		# failure is count to the test
-		tuple("test_case1", GdUnitEvent.TESTCASE_AFTER, 0, 1, 0),
+		tuple(test_case1.guid, GdUnitEvent.TESTCASE_AFTER, 0, 1, 0),
 		# failure is count to the test
-		tuple("test_case2", GdUnitEvent.TESTCASE_BEFORE, 0, 0, 0),
-		tuple("test_case2", GdUnitEvent.TESTCASE_AFTER, 0, 1, 0),
-		tuple("after", GdUnitEvent.TESTSUITE_AFTER, 0, 0, 0),
+		tuple(test_case2.guid, GdUnitEvent.TESTCASE_BEFORE, 0, 0, 0),
+		tuple(test_case2.guid, GdUnitEvent.TESTCASE_AFTER, 0, 1, 0),
+		tuple(any_class(GdUnitGUID), GdUnitEvent.TESTSUITE_AFTER, 0, 0, 0),
 	])
 	assert_event_states(events).contains_exactly([
-		tuple("before", SUCCEEDED, NOT_SKIPPED, false, false, false),
-		tuple("test_case1", SUCCEEDED, NOT_SKIPPED, false, false, false),
-		tuple("test_case1", FAILED, NOT_SKIPPED, false, true, false),
-		tuple("test_case2", SUCCEEDED, NOT_SKIPPED, false, false, false),
-		tuple("test_case2", FAILED, NOT_SKIPPED, false, true, false),
+		tuple(any_class(GdUnitGUID), SUCCEEDED, NOT_SKIPPED, false, false, false),
+		tuple(test_case1.guid, SUCCEEDED, NOT_SKIPPED, false, false, false),
+		tuple(test_case1.guid, FAILED, NOT_SKIPPED, false, true, false),
+		tuple(test_case2.guid, SUCCEEDED, NOT_SKIPPED, false, false, false),
+		tuple(test_case2.guid, FAILED, NOT_SKIPPED, false, true, false),
 		# report suite is not success, is failed
-		tuple("after", FAILED, NOT_SKIPPED, false, true, false),
+		tuple(any_class(GdUnitGUID), FAILED, NOT_SKIPPED, false, true, false),
 	])
 	# before_test() failure report is append to each test
 	assert_event_reports(events, [
@@ -257,33 +293,39 @@ func test_execute_failure_on_stage_before_test() -> void:
 
 
 func test_execute_failure_on_stage_after_test() -> void:
-	var test_suite := _load("res://addons/gdUnit4/test/core/resources/testsuites/TestSuiteFailOnStageAfterTest.resource")
+	var tests := GdUnitTestResourceLoader.load_tests("res://addons/gdUnit4/test/core/resources/testsuites/TestSuiteFailOnStageAfterTest.resource")
+	var all_tests: Array[GdUnitTestCase] = Array(tests.values(), TYPE_OBJECT, "RefCounted", GdUnitTestCase)
+	var test_case1: GdUnitTestCase = tests["test_case1"]
+	var test_case2: GdUnitTestCase = tests["test_case2"]
 	# simulate test suite execution
-	var events := await execute(test_suite)
-	# verify basis infos
-	assert_event_list(events,\
-		"TestSuiteFailOnStageAfterTest",\
-		["test_case1", "test_case2"])
+	var events := await run_tests(all_tests)
+
+	# (before_test+after_test) * test count + before+after hooks
+	var expected_event_count := tests.size() * 2 + 2
+	assert_array(events)\
+		.override_failure_message("Expecting be %d events emitted, but counts %d." % [expected_event_count, events.size()])\
+		.has_size(expected_event_count)
+
 	# we expect the testsuite is failing on stage 'after_test()' and commits one failure on each test case
 	# because is in scope of test execution
 	assert_test_counters(events).contains_exactly([
-		tuple("before", GdUnitEvent.TESTSUITE_BEFORE, 0, 0, 0),
-		tuple("test_case1", GdUnitEvent.TESTCASE_BEFORE, 0, 0, 0),
+		tuple(any_class(GdUnitGUID), GdUnitEvent.TESTSUITE_BEFORE, 0, 0, 0),
+		tuple(test_case1.guid, GdUnitEvent.TESTCASE_BEFORE, 0, 0, 0),
 		# failure is count to the test
-		tuple("test_case1", GdUnitEvent.TESTCASE_AFTER, 0, 1, 0),
-		tuple("test_case2", GdUnitEvent.TESTCASE_BEFORE, 0, 0, 0),
+		tuple(test_case1.guid, GdUnitEvent.TESTCASE_AFTER, 0, 1, 0),
+		tuple(test_case2.guid, GdUnitEvent.TESTCASE_BEFORE, 0, 0, 0),
 		# failure is count to the test
-		tuple("test_case2", GdUnitEvent.TESTCASE_AFTER, 0, 1, 0),
-		tuple("after", GdUnitEvent.TESTSUITE_AFTER, 0, 0, 0),
+		tuple(test_case2.guid, GdUnitEvent.TESTCASE_AFTER, 0, 1, 0),
+		tuple(any_class(GdUnitGUID), GdUnitEvent.TESTSUITE_AFTER, 0, 0, 0),
 	])
 	assert_event_states(events).contains_exactly([
-		tuple("before", SUCCEEDED, NOT_SKIPPED, false, false, false),
-		tuple("test_case1", SUCCEEDED, NOT_SKIPPED, false, false, false),
-		tuple("test_case1", FAILED, NOT_SKIPPED, false, true, false),
-		tuple("test_case2", SUCCEEDED, NOT_SKIPPED, false, false, false),
-		tuple("test_case2", FAILED, NOT_SKIPPED, false, true, false),
+		tuple(any_class(GdUnitGUID), SUCCEEDED, NOT_SKIPPED, false, false, false),
+		tuple(test_case1.guid, SUCCEEDED, NOT_SKIPPED, false, false, false),
+		tuple(test_case1.guid, FAILED, NOT_SKIPPED, false, true, false),
+		tuple(test_case2.guid, SUCCEEDED, NOT_SKIPPED, false, false, false),
+		tuple(test_case2.guid, FAILED, NOT_SKIPPED, false, true, false),
 		# report suite is not success, is failed
-		tuple("after", FAILED, NOT_SKIPPED, false, true, false),
+		tuple(any_class(GdUnitGUID), FAILED, NOT_SKIPPED, false, true, false),
 	])
 	# 'after_test' failure report is append to each test
 	assert_event_reports(events, [
@@ -299,31 +341,37 @@ func test_execute_failure_on_stage_after_test() -> void:
 
 
 func test_execute_failure_on_stage_test_case1() -> void:
-	var test_suite := _load("res://addons/gdUnit4/test/core/resources/testsuites/TestSuiteFailOnStageTestCase1.resource")
+	var tests := GdUnitTestResourceLoader.load_tests("res://addons/gdUnit4/test/core/resources/testsuites/TestSuiteFailOnStageTestCase1.resource")
+	var all_tests: Array[GdUnitTestCase] = Array(tests.values(), TYPE_OBJECT, "RefCounted", GdUnitTestCase)
+	var test_case1: GdUnitTestCase = tests["test_case1"]
+	var test_case2: GdUnitTestCase = tests["test_case2"]
 	# simulate test suite execution
-	var events := await execute(test_suite)
-	# verify basis infos
-	assert_event_list(events,\
-		"TestSuiteFailOnStageTestCase1",\
-		["test_case1", "test_case2"])
+	var events := await run_tests(all_tests)
+
+	# (before_test+after_test) * test count + before+after hooks
+	var expected_event_count := tests.size() * 2 + 2
+	assert_array(events)\
+		.override_failure_message("Expecting be %d events emitted, but counts %d." % [expected_event_count, events.size()])\
+		.has_size(expected_event_count)
+
 	# we expect the test case 'test_case1' is failing and commits one failure
 	assert_test_counters(events).contains_exactly([
-		tuple("before", GdUnitEvent.TESTSUITE_BEFORE, 0, 0, 0),
-		tuple("test_case1", GdUnitEvent.TESTCASE_BEFORE, 0, 0, 0),
+		tuple(any_class(GdUnitGUID), GdUnitEvent.TESTSUITE_BEFORE, 0, 0, 0),
+		tuple(test_case1.guid, GdUnitEvent.TESTCASE_BEFORE, 0, 0, 0),
 		# test has one failure
-		tuple("test_case1", GdUnitEvent.TESTCASE_AFTER, 0, 1, 0),
-		tuple("test_case2", GdUnitEvent.TESTCASE_BEFORE, 0, 0, 0),
-		tuple("test_case2", GdUnitEvent.TESTCASE_AFTER, 0, 0, 0),
-		tuple("after", GdUnitEvent.TESTSUITE_AFTER, 0, 0, 0),
+		tuple(test_case1.guid, GdUnitEvent.TESTCASE_AFTER, 0, 1, 0),
+		tuple(test_case2.guid, GdUnitEvent.TESTCASE_BEFORE, 0, 0, 0),
+		tuple(test_case2.guid, GdUnitEvent.TESTCASE_AFTER, 0, 0, 0),
+		tuple(any_class(GdUnitGUID), GdUnitEvent.TESTSUITE_AFTER, 0, 0, 0),
 	])
 	assert_event_states(events).contains_exactly([
-		tuple("before", SUCCEEDED, NOT_SKIPPED, false, false, false),
-		tuple("test_case1", SUCCEEDED, NOT_SKIPPED, false, false, false),
-		tuple("test_case1", FAILED, NOT_SKIPPED, false, true, false),
-		tuple("test_case2", SUCCEEDED, NOT_SKIPPED, false, false, false),
-		tuple("test_case2", SUCCEEDED, NOT_SKIPPED, false, false, false),
+		tuple(any_class(GdUnitGUID), SUCCEEDED, NOT_SKIPPED, false, false, false),
+		tuple(test_case1.guid, SUCCEEDED, NOT_SKIPPED, false, false, false),
+		tuple(test_case1.guid, FAILED, NOT_SKIPPED, false, true, false),
+		tuple(test_case2.guid, SUCCEEDED, NOT_SKIPPED, false, false, false),
+		tuple(test_case2.guid, SUCCEEDED, NOT_SKIPPED, false, false, false),
 		# report suite is not success, is failed
-		tuple("after", FAILED, NOT_SKIPPED, false, true, false),
+		tuple(any_class(GdUnitGUID), FAILED, NOT_SKIPPED, false, true, false),
 	])
 	# only 'test_case1' reports a failure
 	assert_event_reports(events, [
@@ -339,33 +387,39 @@ func test_execute_failure_on_stage_test_case1() -> void:
 
 func test_execute_failure_on_multiple_stages() -> void:
 	# this is a more complex failure state, we expect to find multipe failures on different stages
-	var test_suite := _load("res://addons/gdUnit4/test/core/resources/testsuites/TestSuiteFailOnMultipeStages.resource")
+	var tests := GdUnitTestResourceLoader.load_tests("res://addons/gdUnit4/test/core/resources/testsuites/TestSuiteFailOnMultipeStages.resource")
+	var all_tests: Array[GdUnitTestCase] = Array(tests.values(), TYPE_OBJECT, "RefCounted", GdUnitTestCase)
+	var test_case1: GdUnitTestCase = tests["test_case1"]
+	var test_case2: GdUnitTestCase = tests["test_case2"]
 	# simulate test suite execution
-	var events := await execute(test_suite)
-	# verify basis infos
-	assert_event_list(events,\
-		"TestSuiteFailOnMultipeStages",\
-		["test_case1", "test_case2"])
+	var events := await run_tests(all_tests)
+
+	# (before_test+after_test) * test count + before+after hooks
+	var expected_event_count := tests.size() * 2 + 2
+	assert_array(events)\
+		.override_failure_message("Expecting be %d events emitted, but counts %d." % [expected_event_count, events.size()])\
+		.has_size(expected_event_count)
+
 	# we expect failing on multiple stages
 	assert_test_counters(events).contains_exactly([
-		tuple("before", GdUnitEvent.TESTSUITE_BEFORE, 0, 0, 0),
-		tuple("test_case1", GdUnitEvent.TESTCASE_BEFORE, 0, 0, 0),
+		tuple(any_class(GdUnitGUID), GdUnitEvent.TESTSUITE_BEFORE, 0, 0, 0),
+		tuple(test_case1.guid, GdUnitEvent.TESTCASE_BEFORE, 0, 0, 0),
 		# the first test has two failures plus one from 'before_test'
-		tuple("test_case1", GdUnitEvent.TESTCASE_AFTER, 0, 3, 0),
-		tuple("test_case2", GdUnitEvent.TESTCASE_BEFORE, 0, 0, 0),
+		tuple(test_case1.guid, GdUnitEvent.TESTCASE_AFTER, 0, 3, 0),
+		tuple(test_case2.guid, GdUnitEvent.TESTCASE_BEFORE, 0, 0, 0),
 		# the second test has no failures but one from 'before_test'
-		tuple("test_case2", GdUnitEvent.TESTCASE_AFTER, 0, 1, 0),
+		tuple(test_case2.guid, GdUnitEvent.TESTCASE_AFTER, 0, 1, 0),
 		# and one failure is on stage 'after' found
-		tuple("after", GdUnitEvent.TESTSUITE_AFTER, 0, 1, 0),
+		tuple(any_class(GdUnitGUID), GdUnitEvent.TESTSUITE_AFTER, 0, 1, 0),
 	])
 	assert_event_states(events).contains_exactly([
-		tuple("before", SUCCEEDED, NOT_SKIPPED, false, false, false),
-		tuple("test_case1", SUCCEEDED, NOT_SKIPPED, false, false, false),
-		tuple("test_case1", FAILED, NOT_SKIPPED, false, true, false),
-		tuple("test_case2", SUCCEEDED, NOT_SKIPPED, false, false, false),
-		tuple("test_case2", FAILED, NOT_SKIPPED, false, true, false),
+		tuple(any_class(GdUnitGUID), SUCCEEDED, NOT_SKIPPED, false, false, false),
+		tuple(test_case1.guid, SUCCEEDED, NOT_SKIPPED, false, false, false),
+		tuple(test_case1.guid, FAILED, NOT_SKIPPED, false, true, false),
+		tuple(test_case2.guid, SUCCEEDED, NOT_SKIPPED, false, false, false),
+		tuple(test_case2.guid, FAILED, NOT_SKIPPED, false, true, false),
 		# report suite is not success, is failed
-		tuple("after", FAILED, NOT_SKIPPED, false, true, false),
+		tuple(any_class(GdUnitGUID), FAILED, NOT_SKIPPED, false, true, false),
 	])
 	# only 'test_case1' reports a 'real' failures plus test setup stage failures
 	assert_event_reports(events, [
@@ -384,38 +438,44 @@ func test_execute_failure_on_multiple_stages() -> void:
 # GD-63
 func test_execute_failure_and_orphans() -> void:
 	# this is a more complex failure state, we expect to find multipe orphans on different stages
-	var test_suite := _load("res://addons/gdUnit4/test/core/resources/testsuites/TestSuiteFailAndOrpahnsDetected.resource")
+	var tests := GdUnitTestResourceLoader.load_tests("res://addons/gdUnit4/test/core/resources/testsuites/TestSuiteFailAndOrpahnsDetected.resource")
+	var all_tests: Array[GdUnitTestCase] = Array(tests.values(), TYPE_OBJECT, "RefCounted", GdUnitTestCase)
+	var test_case1: GdUnitTestCase = tests["test_case1"]
+	var test_case2: GdUnitTestCase = tests["test_case2"]
 	# simulate test suite execution
-	var events := await execute(test_suite)
-	# verify basis infos
-	assert_event_list(events,\
-		"TestSuiteFailAndOrpahnsDetected",\
-		["test_case1", "test_case2"])
+	var events := await run_tests(all_tests)
+
+	# (before_test+after_test) * test count + before+after hooks
+	var expected_event_count := tests.size() * 2 + 2
+	assert_array(events)\
+		.override_failure_message("Expecting be %d events emitted, but counts %d." % [expected_event_count, events.size()])\
+		.has_size(expected_event_count)
+
 	# we expect failing on multiple stages
 	assert_test_counters(events).contains_exactly([
-		tuple("before", GdUnitEvent.TESTSUITE_BEFORE, 0, 0, 0),
-		tuple("test_case1", GdUnitEvent.TESTCASE_BEFORE, 0, 0, 0),
+		tuple(any_class(GdUnitGUID), GdUnitEvent.TESTSUITE_BEFORE, 0, 0, 0),
+		tuple(test_case1.guid, GdUnitEvent.TESTCASE_BEFORE, 0, 0, 0),
 		# the first test ends with a warning and in summ 5 orphans detected
 		# 2 from stage 'before_test' + 3 from test itself
-		tuple("test_case1", GdUnitEvent.TESTCASE_AFTER, 0, 0, 5),
-		tuple("test_case2", GdUnitEvent.TESTCASE_BEFORE, 0, 0, 0),
+		tuple(test_case1.guid, GdUnitEvent.TESTCASE_AFTER, 0, 0, 5),
+		tuple(test_case2.guid, GdUnitEvent.TESTCASE_BEFORE, 0, 0, 0),
 		# the second test ends with a one failure and in summ 6 orphans detected
 		# 2 from stage 'before_test' + 4 from test itself
-		tuple("test_case2", GdUnitEvent.TESTCASE_AFTER, 0, 1, 6),
+		tuple(test_case2.guid, GdUnitEvent.TESTCASE_AFTER, 0, 1, 6),
 		# and one orphan detected from stage 'before'
-		tuple("after", GdUnitEvent.TESTSUITE_AFTER, 0, 0, 1),
+		tuple(any_class(GdUnitGUID), GdUnitEvent.TESTSUITE_AFTER, 0, 0, 1),
 	])
 	# is_success, is_warning, is_failed, is_error
 	assert_event_states(events).contains_exactly([
-		tuple("before", SUCCEEDED, NOT_SKIPPED, !IS_WARNING, !IS_FAILED, !IS_ERROR),
-		tuple("test_case1", SUCCEEDED, NOT_SKIPPED, !IS_WARNING, !IS_FAILED, !IS_ERROR),
+		tuple(any_class(GdUnitGUID), SUCCEEDED, NOT_SKIPPED, !IS_WARNING, !IS_FAILED, !IS_ERROR),
+		tuple(test_case1.guid, SUCCEEDED, NOT_SKIPPED, !IS_WARNING, !IS_FAILED, !IS_ERROR),
 		# test case has only warnings
-		tuple("test_case1", FAILED, NOT_SKIPPED, IS_WARNING, !IS_FAILED, !IS_ERROR),
-		tuple("test_case2", SUCCEEDED, NOT_SKIPPED, !IS_WARNING, !IS_FAILED, !IS_ERROR),
+		tuple(test_case1.guid, FAILED, NOT_SKIPPED, IS_WARNING, !IS_FAILED, !IS_ERROR),
+		tuple(test_case2.guid, SUCCEEDED, NOT_SKIPPED, !IS_WARNING, !IS_FAILED, !IS_ERROR),
 		# test case has failures and warnings
-		tuple("test_case2", FAILED, NOT_SKIPPED, IS_WARNING, IS_FAILED, !IS_ERROR),
+		tuple(test_case2.guid, FAILED, NOT_SKIPPED, IS_WARNING, IS_FAILED, !IS_ERROR),
 		# report suite is not success, has warnings and failures
-		tuple("after", FAILED, NOT_SKIPPED, IS_WARNING, IS_FAILED, !IS_ERROR),
+		tuple(any_class(GdUnitGUID), FAILED, NOT_SKIPPED, IS_WARNING, IS_FAILED, !IS_ERROR),
 	])
 	# only 'test_case1' reports a 'real' failures plus test setup stage failures
 	assert_event_reports(events, [
@@ -436,38 +496,43 @@ func test_execute_failure_and_orphans() -> void:
 
 func test_execute_failure_and_orphans_report_orphan_disabled() -> void:
 	# this is a more complex failure state, we expect to find multipe orphans on different stages
-	var test_suite := _load("res://addons/gdUnit4/test/core/resources/testsuites/TestSuiteFailAndOrpahnsDetected.resource")
+	var tests := GdUnitTestResourceLoader.load_tests("res://addons/gdUnit4/test/core/resources/testsuites/TestSuiteFailAndOrpahnsDetected.resource")
+	var all_tests: Array[GdUnitTestCase] = Array(tests.values(), TYPE_OBJECT, "RefCounted", GdUnitTestCase)
+	var test_case1: GdUnitTestCase = tests["test_case1"]
+	var test_case2: GdUnitTestCase = tests["test_case2"]
+
 	# simulate test suite execution whit disabled orphan detection
+	var events := await run_tests(all_tests, {
+		GdUnitSettings.REPORT_ORPHANS: false
+	})
 
-	ProjectSettings.set_setting(GdUnitSettings.REPORT_ORPHANS, false)
-	var events := await execute(test_suite)
-	ProjectSettings.set_setting(GdUnitSettings.REPORT_ORPHANS, true)
+	# (before_test+after_test) * test count + before+after hooks
+	var expected_event_count := tests.size() * 2 + 2
+	assert_array(events)\
+		.override_failure_message("Expecting be %d events emitted, but counts %d." % [expected_event_count, events.size()])\
+		.has_size(expected_event_count)
 
-	# verify basis infos
-	assert_event_list(events,\
-		"TestSuiteFailAndOrpahnsDetected",\
-		["test_case1", "test_case2"])
 	# we expect failing on multiple stages, no orphans reported
 	assert_test_counters(events).contains_exactly([
-		tuple("before", GdUnitEvent.TESTSUITE_BEFORE, 0, 0, 0),
-		tuple("test_case1", GdUnitEvent.TESTCASE_BEFORE, 0, 0, 0),
-		tuple("test_case1", GdUnitEvent.TESTCASE_AFTER, 0, 0, 0),
-		tuple("test_case2", GdUnitEvent.TESTCASE_BEFORE, 0, 0, 0),
+		tuple(any_class(GdUnitGUID), GdUnitEvent.TESTSUITE_BEFORE, 0, 0, 0),
+		tuple(test_case1.guid, GdUnitEvent.TESTCASE_BEFORE, 0, 0, 0),
+		tuple(test_case1.guid, GdUnitEvent.TESTCASE_AFTER, 0, 0, 0),
+		tuple(test_case2.guid, GdUnitEvent.TESTCASE_BEFORE, 0, 0, 0),
 		# one failure
-		tuple("test_case2", GdUnitEvent.TESTCASE_AFTER, 0, 1, 0),
-		tuple("after", GdUnitEvent.TESTSUITE_AFTER, 0, 0, 0),
+		tuple(test_case2.guid, GdUnitEvent.TESTCASE_AFTER, 0, 1, 0),
+		tuple(any_class(GdUnitGUID), GdUnitEvent.TESTSUITE_AFTER, 0, 0, 0),
 	])
 	# is_success, is_warning, is_failed, is_error
 	assert_event_states(events).contains_exactly([
-		tuple("before", SUCCEEDED, NOT_SKIPPED, false, false, false),
-		tuple("test_case1", SUCCEEDED, NOT_SKIPPED, false, false, false),
+		tuple(any_class(GdUnitGUID), SUCCEEDED, NOT_SKIPPED, false, false, false),
+		tuple(test_case1.guid, SUCCEEDED, NOT_SKIPPED, false, false, false),
 		# test case has success
-		tuple("test_case1", SUCCEEDED, NOT_SKIPPED, false, false, false),
-		tuple("test_case2", SUCCEEDED, NOT_SKIPPED, false, false, false),
+		tuple(test_case1.guid, SUCCEEDED, NOT_SKIPPED, false, false, false),
+		tuple(test_case2.guid, SUCCEEDED, NOT_SKIPPED, false, false, false),
 		# test case has a failure
-		tuple("test_case2", FAILED, NOT_SKIPPED, false, true, false),
+		tuple(test_case2.guid, FAILED, NOT_SKIPPED, false, true, false),
 		# report suite is not success, has warnings and failures
-		tuple("after", FAILED, NOT_SKIPPED, false, true, false),
+		tuple(any_class(GdUnitGUID), FAILED, NOT_SKIPPED, false, true, false),
 	])
 	# only 'test_case1' reports a failure, orphans are not reported
 	assert_event_reports(events, [
@@ -483,32 +548,38 @@ func test_execute_failure_and_orphans_report_orphan_disabled() -> void:
 
 func test_execute_error_on_test_timeout() -> void:
 	# this tests a timeout on a test case reported as error
-	var test_suite := _load("res://addons/gdUnit4/test/core/resources/testsuites/TestSuiteErrorOnTestTimeout.resource")
+	var tests := GdUnitTestResourceLoader.load_tests("res://addons/gdUnit4/test/core/resources/testsuites/TestSuiteErrorOnTestTimeout.resource")
+	var all_tests: Array[GdUnitTestCase] = Array(tests.values(), TYPE_OBJECT, "RefCounted", GdUnitTestCase)
+	var test_case1: GdUnitTestCase = tests["test_case1"]
+	var test_case2: GdUnitTestCase = tests["test_case2"]
 	# simulate test suite execution
-	var events := await execute(test_suite)
-	# verify basis infos
-	assert_event_list(events,\
-		"TestSuiteErrorOnTestTimeout",\
-		["test_case1", "test_case2"])
+	var events := await run_tests(all_tests)
+
+	# (before_test+after_test) * test count + before+after hooks
+	var expected_event_count := tests.size() * 2 + 2
+	assert_array(events)\
+		.override_failure_message("Expecting be %d events emitted, but counts %d." % [expected_event_count, events.size()])\
+		.has_size(expected_event_count)
+
 	# we expect test_case1 fails by a timeout
 	assert_test_counters(events).contains_exactly([
-		tuple("before", GdUnitEvent.TESTSUITE_BEFORE, 0, 0, 0),
+		tuple(any_class(GdUnitGUID), GdUnitEvent.TESTSUITE_BEFORE, 0, 0, 0),
 		# the first test timed out after 2s
-		tuple("test_case1", GdUnitEvent.TESTCASE_BEFORE, 0, 0, 0),
-		tuple("test_case1", GdUnitEvent.TESTCASE_AFTER, 1, 0, 0),
-		tuple("test_case2", GdUnitEvent.TESTCASE_BEFORE, 0, 0, 0),
-		tuple("test_case2", GdUnitEvent.TESTCASE_AFTER, 0, 0, 0),
-		tuple("after", GdUnitEvent.TESTSUITE_AFTER, 0, 0, 0),
+		tuple(test_case1.guid, GdUnitEvent.TESTCASE_BEFORE, 0, 0, 0),
+		tuple(test_case1.guid, GdUnitEvent.TESTCASE_AFTER, 1, 0, 0),
+		tuple(test_case2.guid, GdUnitEvent.TESTCASE_BEFORE, 0, 0, 0),
+		tuple(test_case2.guid, GdUnitEvent.TESTCASE_AFTER, 0, 0, 0),
+		tuple(any_class(GdUnitGUID), GdUnitEvent.TESTSUITE_AFTER, 0, 0, 0),
 	])
 	assert_event_states(events).contains_exactly([
-		tuple("before", SUCCEEDED, NOT_SKIPPED, false, false, false),
-		tuple("test_case1", SUCCEEDED, NOT_SKIPPED, false, false, false),
+		tuple(any_class(GdUnitGUID), SUCCEEDED, NOT_SKIPPED, false, false, false),
+		tuple(test_case1.guid, SUCCEEDED, NOT_SKIPPED, false, false, false),
 		# testcase ends with a timeout error
-		tuple("test_case1", FAILED, NOT_SKIPPED, false, false, true),
-		tuple("test_case2", SUCCEEDED, NOT_SKIPPED, false, false, false),
-		tuple("test_case2", SUCCEEDED, NOT_SKIPPED, false, false, false),
+		tuple(test_case1.guid, FAILED, NOT_SKIPPED, false, false, true),
+		tuple(test_case2.guid, SUCCEEDED, NOT_SKIPPED, false, false, false),
+		tuple(test_case2.guid, SUCCEEDED, NOT_SKIPPED, false, false, false),
 		# report suite is not success, is error
-		tuple("after", FAILED, NOT_SKIPPED, false, false, true),
+		tuple(any_class(GdUnitGUID), FAILED, NOT_SKIPPED, false, false, true),
 	])
 	# 'test_case1' reports a error triggered by test timeout
 	assert_event_reports(events, [
@@ -524,12 +595,14 @@ func test_execute_error_on_test_timeout() -> void:
 
 # This test checks if all test stages are called at each test iteration.
 func test_execute_fuzzed_metrics() -> void:
-	var test_suite := _load("res://addons/gdUnit4/test/core/resources/testsuites/TestSuiteFuzzedMetricsTest.resource")
+	var tests := GdUnitTestResourceLoader.load_tests("res://addons/gdUnit4/test/core/resources/testsuites/TestSuiteFuzzedMetricsTest.resource")
+	var all_tests: Array[GdUnitTestCase] = Array(tests.values(), TYPE_OBJECT, "RefCounted", GdUnitTestCase)
 
-	var events := await execute(test_suite)
+	# simulate test suite execution
+	var events := await run_tests(all_tests)
 	assert_event_states(events).contains([
-		tuple("before", SUCCEEDED, NOT_SKIPPED, false, false, false),
-		tuple("after", SUCCEEDED, NOT_SKIPPED, false, false, false),
+		tuple(any_class(GdUnitGUID), SUCCEEDED, NOT_SKIPPED, false, false, false),
+		tuple(any_class(GdUnitGUID), SUCCEEDED, NOT_SKIPPED, false, false, false),
 	])
 	assert_event_reports(events, [
 			[],
@@ -543,12 +616,14 @@ func test_execute_fuzzed_metrics() -> void:
 
 # This test checks if all test stages are called at each test iteration.
 func test_execute_parameterized_metrics() -> void:
-	var test_suite := _load("res://addons/gdUnit4/test/core/resources/testsuites/TestSuiteParameterizedMetricsTest.resource")
+	var tests := GdUnitTestResourceLoader.load_tests("res://addons/gdUnit4/test/core/resources/testsuites/TestSuiteParameterizedMetricsTest.resource")
+	var all_tests: Array[GdUnitTestCase] = Array(tests.values(), TYPE_OBJECT, "RefCounted", GdUnitTestCase)
 
-	var events := await execute(test_suite)
+	# simulate test suite execution
+	var events := await run_tests(all_tests)
 	assert_event_states(events).contains([
-		tuple("before", SUCCEEDED, NOT_SKIPPED, false, false, false),
-		tuple("after", SUCCEEDED, NOT_SKIPPED, false, false, false),
+		tuple(any_class(GdUnitGUID), SUCCEEDED, NOT_SKIPPED, false, false, false),
+		tuple(any_class(GdUnitGUID), SUCCEEDED, NOT_SKIPPED, false, false, false),
 	])
 	assert_event_reports(events, [
 			[],
@@ -562,33 +637,37 @@ func test_execute_parameterized_metrics() -> void:
 
 func test_execute_failure_fuzzer_iteration() -> void:
 	# this tests a timeout on a test case reported as error
-	var test_suite := _load("res://addons/gdUnit4/test/core/resources/testsuites/GdUnitFuzzerTest.resource")
-
+	var tests := GdUnitTestResourceLoader.load_tests("res://addons/gdUnit4/test/core/resources/testsuites/GdUnitFuzzerTest.resource")
+	var all_tests: Array[GdUnitTestCase] = Array(tests.values(), TYPE_OBJECT, "RefCounted", GdUnitTestCase)
+	var test_multi_yielding_with_fuzzer: GdUnitTestCase = tests["test_multi_yielding_with_fuzzer"]
+	var test_multi_yielding_with_fuzzer_fail_after_3_iterations: GdUnitTestCase = tests["test_multi_yielding_with_fuzzer_fail_after_3_iterations"]
 	# simulate test suite execution
-	var events := await execute(test_suite)
+	var events := await run_tests(all_tests)
 
-	# verify basis infos
-	assert_event_list(events, "GdUnitFuzzerTest", [
-		"test_multi_yielding_with_fuzzer",
-		"test_multi_yielding_with_fuzzer_fail_after_3_iterations"])
+	# (before_test+after_test) * test count + before+after hooks
+	var expected_event_count := tests.size() * 2 + 2
+	assert_array(events)\
+		.override_failure_message("Expecting be %d events emitted, but counts %d." % [expected_event_count, events.size()])\
+		.has_size(expected_event_count)
+
 	# we expect failing at 'test_multi_yielding_with_fuzzer_fail_after_3_iterations' after three iterations
 	assert_test_counters(events).contains_exactly([
-		tuple("before", GdUnitEvent.TESTSUITE_BEFORE, 0, 0, 0),
-		tuple("test_multi_yielding_with_fuzzer", GdUnitEvent.TESTCASE_BEFORE, 0, 0, 0),
-		tuple("test_multi_yielding_with_fuzzer", GdUnitEvent.TESTCASE_AFTER, 0, 0, 0),
-		tuple("test_multi_yielding_with_fuzzer_fail_after_3_iterations", GdUnitEvent.TESTCASE_BEFORE, 0, 0, 0),
+		tuple(any_class(GdUnitGUID), GdUnitEvent.TESTSUITE_BEFORE, 0, 0, 0),
+		tuple(test_multi_yielding_with_fuzzer.guid, GdUnitEvent.TESTCASE_BEFORE, 0, 0, 0),
+		tuple(test_multi_yielding_with_fuzzer.guid, GdUnitEvent.TESTCASE_AFTER, 0, 0, 0),
+		tuple(test_multi_yielding_with_fuzzer_fail_after_3_iterations.guid, GdUnitEvent.TESTCASE_BEFORE, 0, 0, 0),
 		# test failed after 3 iterations
-		tuple("test_multi_yielding_with_fuzzer_fail_after_3_iterations", GdUnitEvent.TESTCASE_AFTER, 0, 1, 0),
-		tuple("after", GdUnitEvent.TESTSUITE_AFTER, 0, 0, 0),
+		tuple(test_multi_yielding_with_fuzzer_fail_after_3_iterations.guid, GdUnitEvent.TESTCASE_AFTER, 0, 1, 0),
+		tuple(any_class(GdUnitGUID), GdUnitEvent.TESTSUITE_AFTER, 0, 0, 0),
 	])
 	# is_success, is_warning, is_failed, is_error
 	assert_event_states(events).contains_exactly([
-		tuple("before", SUCCEEDED, NOT_SKIPPED, false, false, false),
-		tuple("test_multi_yielding_with_fuzzer", SUCCEEDED, NOT_SKIPPED, false, false, false),
-		tuple("test_multi_yielding_with_fuzzer", SUCCEEDED, NOT_SKIPPED, false, false, false),
-		tuple("test_multi_yielding_with_fuzzer_fail_after_3_iterations", SUCCEEDED, NOT_SKIPPED, false, false, false),
-		tuple("test_multi_yielding_with_fuzzer_fail_after_3_iterations", FAILED, NOT_SKIPPED, false, true, false),
-		tuple("after", FAILED, NOT_SKIPPED, false, true, false),
+		tuple(any_class(GdUnitGUID), SUCCEEDED, NOT_SKIPPED, false, false, false),
+		tuple(test_multi_yielding_with_fuzzer.guid, SUCCEEDED, NOT_SKIPPED, false, false, false),
+		tuple(test_multi_yielding_with_fuzzer.guid, SUCCEEDED, NOT_SKIPPED, false, false, false),
+		tuple(test_multi_yielding_with_fuzzer_fail_after_3_iterations.guid, SUCCEEDED, NOT_SKIPPED, false, false, false),
+		tuple(test_multi_yielding_with_fuzzer_fail_after_3_iterations.guid, FAILED, NOT_SKIPPED, false, true, false),
+		tuple(any_class(GdUnitGUID), FAILED, NOT_SKIPPED, false, true, false),
 	])
 	# 'test_case1' reports a error triggered by test timeout
 	assert_event_reports(events, [
@@ -603,29 +682,35 @@ func test_execute_failure_fuzzer_iteration() -> void:
 
 
 func test_execute_add_child_on_before_GD_106() -> void:
-	var test_suite := _load("res://addons/gdUnit4/test/core/resources/testsuites/TestSuiteFailAddChildStageBefore.resource")
+	var tests := GdUnitTestResourceLoader.load_tests("res://addons/gdUnit4/test/core/resources/testsuites/TestSuiteFailAddChildStageBefore.resource")
+	var all_tests: Array[GdUnitTestCase] = Array(tests.values(), TYPE_OBJECT, "RefCounted", GdUnitTestCase)
+	var test_case1: GdUnitTestCase = tests["test_case1"]
+	var test_case2: GdUnitTestCase = tests["test_case2"]
 	# simulate test suite execution
-	var events := await execute(test_suite)
-	# verify basis infos
-	assert_event_list(events,\
-		"TestSuiteFailAddChildStageBefore",\
-		["test_case1", "test_case2"])
+	var events := await run_tests(all_tests)
+
+	# (before_test+after_test) * test count + before+after hooks
+	var expected_event_count := tests.size() * 2 + 2
+	assert_array(events)\
+		.override_failure_message("Expecting be %d events emitted, but counts %d." % [expected_event_count, events.size()])\
+		.has_size(expected_event_count)
+
 	# verify all counters are zero / no errors, failures, orphans
 	assert_test_counters(events).contains_exactly([
-		tuple("before", GdUnitEvent.TESTSUITE_BEFORE, 0, 0, 0),
-		tuple("test_case1", GdUnitEvent.TESTCASE_BEFORE, 0, 0, 0),
-		tuple("test_case1", GdUnitEvent.TESTCASE_AFTER, 0, 0, 0),
-		tuple("test_case2", GdUnitEvent.TESTCASE_BEFORE, 0, 0, 0),
-		tuple("test_case2", GdUnitEvent.TESTCASE_AFTER, 0, 0, 0),
-		tuple("after", GdUnitEvent.TESTSUITE_AFTER, 0, 0, 0),
+		tuple(any_class(GdUnitGUID), GdUnitEvent.TESTSUITE_BEFORE, 0, 0, 0),
+		tuple(test_case1.guid, GdUnitEvent.TESTCASE_BEFORE, 0, 0, 0),
+		tuple(test_case1.guid, GdUnitEvent.TESTCASE_AFTER, 0, 0, 0),
+		tuple(test_case2.guid, GdUnitEvent.TESTCASE_BEFORE, 0, 0, 0),
+		tuple(test_case2.guid, GdUnitEvent.TESTCASE_AFTER, 0, 0, 0),
+		tuple(any_class(GdUnitGUID), GdUnitEvent.TESTSUITE_AFTER, 0, 0, 0),
 	])
 	assert_event_states(events).contains_exactly([
-		tuple("before", SUCCEEDED, NOT_SKIPPED, false, false, false),
-		tuple("test_case1", SUCCEEDED, NOT_SKIPPED, false, false, false),
-		tuple("test_case1", SUCCEEDED, NOT_SKIPPED, false, false, false),
-		tuple("test_case2", SUCCEEDED, NOT_SKIPPED, false, false, false),
-		tuple("test_case2", SUCCEEDED, NOT_SKIPPED, false, false, false),
-		tuple("after", SUCCEEDED, NOT_SKIPPED, false, false, false),
+		tuple(any_class(GdUnitGUID), SUCCEEDED, NOT_SKIPPED, false, false, false),
+		tuple(test_case1.guid, SUCCEEDED, NOT_SKIPPED, false, false, false),
+		tuple(test_case1.guid, SUCCEEDED, NOT_SKIPPED, false, false, false),
+		tuple(test_case2.guid, SUCCEEDED, NOT_SKIPPED, false, false, false),
+		tuple(test_case2.guid, SUCCEEDED, NOT_SKIPPED, false, false, false),
+		tuple(any_class(GdUnitGUID), SUCCEEDED, NOT_SKIPPED, false, false, false),
 	])
 	# all success no reports expected
 	assert_event_reports(events, [
@@ -635,53 +720,69 @@ func test_execute_add_child_on_before_GD_106() -> void:
 
 func test_execute_parameterizied_tests() -> void:
 	# this is a more complex failure state, we expect to find multipe failures on different stages
-	var test_suite := _load("res://addons/gdUnit4/test/core/resources/testsuites/TestSuiteParameterizedTests.resource")
+	var tests := GdUnitTestResourceLoader.load_tests("res://addons/gdUnit4/test/core/resources/testsuites/TestSuiteParameterizedTests.resource")
+	var all_tests: Array[GdUnitTestCase] = Array(tests.values(), TYPE_OBJECT, "RefCounted", GdUnitTestCase)
+	var test_0: GdUnitTestCase = find_test(tests, "test_dictionary_div_number_types:0")
+	var test_1: GdUnitTestCase = find_test(tests, "test_dictionary_div_number_types:1")
+	var test_2: GdUnitTestCase = find_test(tests, "test_dictionary_div_number_types:2")
+	var test_3: GdUnitTestCase = find_test(tests, "test_dictionary_div_number_types:3")
+
 	# simulate test suite execution
 	# run the tests with to compare type save
 	var original_mode :Variant = ProjectSettings.get_setting(GdUnitSettings.REPORT_ASSERT_STRICT_NUMBER_TYPE_COMPARE)
 	ProjectSettings.set_setting(GdUnitSettings.REPORT_ASSERT_STRICT_NUMBER_TYPE_COMPARE, true)
-	var events := await execute(test_suite)
-	var suite_name := "TestSuiteParameterizedTests"
+	var events := await run_tests(all_tests, {
+		GdUnitSettings.REPORT_ASSERT_STRICT_NUMBER_TYPE_COMPARE : true
+	})
 	# the test is partial failing because of diverent type in the dictionary
 	assert_array(events).extractv(
-		extr("type"), extr("suite_name"), TestCaseNameExtractor.new(), extr("is_error"), extr("is_failed"), extr("orphan_nodes"))\
+		extr("type"), extr("guid"), extr("is_error"), extr("is_failed"), extr("orphan_nodes"))\
 		.contains([
-			tuple(GdUnitEvent.TESTCASE_AFTER, suite_name, "test_dictionary_div_number_types:0", false, true, 0),
-			tuple(GdUnitEvent.TESTCASE_AFTER, suite_name, "test_dictionary_div_number_types:1", false, false, 0),
-			tuple(GdUnitEvent.TESTCASE_AFTER, suite_name, "test_dictionary_div_number_types:2", false, true, 0),
-			tuple(GdUnitEvent.TESTCASE_AFTER, suite_name, "test_dictionary_div_number_types:3", false, false, 0)
+			tuple(GdUnitEvent.TESTCASE_AFTER, test_0.guid, false, true, 0),
+			tuple(GdUnitEvent.TESTCASE_AFTER, test_1.guid, false, false, 0),
+			tuple(GdUnitEvent.TESTCASE_AFTER, test_2.guid, false, true, 0),
+			tuple(GdUnitEvent.TESTCASE_AFTER, test_3.guid, false, false, 0)
 		])
 
 	# rerun the same tests again with allow to compare type unsave
 	ProjectSettings.set_setting(GdUnitSettings.REPORT_ASSERT_STRICT_NUMBER_TYPE_COMPARE, false)
 	# simulate test suite execution
-	test_suite = _load("res://addons/gdUnit4/test/core/resources/testsuites/TestSuiteParameterizedTests.resource")
-	events = await execute(test_suite)
+	events = await run_tests(all_tests)
 	ProjectSettings.set_setting(GdUnitSettings.REPORT_ASSERT_STRICT_NUMBER_TYPE_COMPARE, original_mode)
 
 	# the test should now be successful
 	assert_array(events).extractv(
-		extr("type"), extr("suite_name"), TestCaseNameExtractor.new(), extr("is_error"), extr("is_failed"), extr("orphan_nodes"))\
+		extr("type"), extr("guid"), extr("is_error"), extr("is_failed"), extr("orphan_nodes"))\
 		.contains([
-			tuple(GdUnitEvent.TESTCASE_AFTER, suite_name, "test_dictionary_div_number_types:0", false, false, 0),
-			tuple(GdUnitEvent.TESTCASE_AFTER, suite_name, "test_dictionary_div_number_types:1", false, false, 0),
-			tuple(GdUnitEvent.TESTCASE_AFTER, suite_name, "test_dictionary_div_number_types:2", false, false, 0),
-			tuple(GdUnitEvent.TESTCASE_AFTER, suite_name, "test_dictionary_div_number_types:3", false, false, 0)
+			tuple(GdUnitEvent.TESTCASE_AFTER, test_0.guid, false, false, 0),
+			tuple(GdUnitEvent.TESTCASE_AFTER, test_1.guid, false, false, 0),
+			tuple(GdUnitEvent.TESTCASE_AFTER, test_2.guid, false, false, 0),
+			tuple(GdUnitEvent.TESTCASE_AFTER, test_3.guid, false, false, 0)
 		])
 
 
 func test_execute_test_suite_is_skipped() -> void:
-	var test_suite := _load("res://addons/gdUnit4/test/core/resources/testsuites/TestSuiteSkipped.resource")
+	var tests := GdUnitTestResourceLoader.load_tests("res://addons/gdUnit4/test/core/resources/testsuites/TestSuiteSkipped.resource")
+	var all_tests: Array[GdUnitTestCase] = Array(tests.values(), TYPE_OBJECT, "RefCounted", GdUnitTestCase)
+	var test_case1: GdUnitTestCase = tests["test_case1"]
+	var test_case2: GdUnitTestCase = tests["test_case2"]
 	# simulate test suite execution
-	var events := await execute(test_suite)
+	var events := await run_tests(all_tests)
+
+	# (before_test+after_test) * test count + before+after hooks
+	var expected_event_count := tests.size() * 2 + 2
+	assert_array(events)\
+		.override_failure_message("Expecting be %d events emitted, but counts %d." % [expected_event_count, events.size()])\
+		.has_size(expected_event_count)
+
 	# the entire test-suite is skipped
 	assert_event_states(events).contains_exactly([
-		tuple("before", SUCCEEDED, NOT_SKIPPED, false, false, false),
-		tuple("test_case1", SUCCEEDED, NOT_SKIPPED, false, false, false),
-		tuple("test_case1", false, SKIPPED, false, false, false),
-		tuple("test_case2", SUCCEEDED, NOT_SKIPPED, false, false, false),
-		tuple("test_case2", false, SKIPPED, false, false, false),
-		tuple("after", FAILED, SKIPPED, false, false, false),
+		tuple(any_class(GdUnitGUID), SUCCEEDED, NOT_SKIPPED, false, false, false),
+		tuple(test_case1.guid, SUCCEEDED, NOT_SKIPPED, false, false, false),
+		tuple(test_case1.guid, false, SKIPPED, false, false, false),
+		tuple(test_case2.guid, SUCCEEDED, NOT_SKIPPED, false, false, false),
+		tuple(test_case2.guid, false, SKIPPED, false, false, false),
+		tuple(any_class(GdUnitGUID), FAILED, SKIPPED, false, false, false),
 	])
 	assert_event_reports(events, [
 			[],
@@ -705,17 +806,27 @@ func test_execute_test_suite_is_skipped() -> void:
 
 
 func test_execute_test_case_is_skipped() -> void:
-	var test_suite := _load("res://addons/gdUnit4/test/core/resources/testsuites/TestCaseSkipped.resource")
+	var tests := GdUnitTestResourceLoader.load_tests("res://addons/gdUnit4/test/core/resources/testsuites/TestCaseSkipped.resource")
+	var all_tests: Array[GdUnitTestCase] = Array(tests.values(), TYPE_OBJECT, "RefCounted", GdUnitTestCase)
+	var test_case1: GdUnitTestCase = tests["test_case1"]
+	var test_case2: GdUnitTestCase = tests["test_case2"]
 	# simulate test suite execution
-	var events := await execute(test_suite)
+	var events := await run_tests(all_tests)
+
+	# (before_test+after_test) * test count + before+after hooks
+	var expected_event_count := tests.size() * 2 + 2
+	assert_array(events)\
+		.override_failure_message("Expecting be %d events emitted, but counts %d." % [expected_event_count, events.size()])\
+		.has_size(expected_event_count)
+
 	# the test_case1 is skipped
 	assert_event_states(events).contains_exactly([
-		tuple("before", SUCCEEDED, NOT_SKIPPED, false, false, false),
-		tuple("test_case1", SUCCEEDED, NOT_SKIPPED, false, false, false),
-		tuple("test_case1", FAILED, SKIPPED, false, false, false),
-		tuple("test_case2", SUCCEEDED, NOT_SKIPPED, false, false, false),
-		tuple("test_case2", SUCCEEDED, NOT_SKIPPED, false, false, false),
-		tuple("after", SUCCEEDED, NOT_SKIPPED, false, false, false),
+		tuple(any_class(GdUnitGUID), SUCCEEDED, NOT_SKIPPED, false, false, false),
+		tuple(test_case1.guid, SUCCEEDED, NOT_SKIPPED, false, false, false),
+		tuple(test_case1.guid, FAILED, SKIPPED, false, false, false),
+		tuple(test_case2.guid, SUCCEEDED, NOT_SKIPPED, false, false, false),
+		tuple(test_case2.guid, SUCCEEDED, NOT_SKIPPED, false, false, false),
+		tuple(any_class(GdUnitGUID), SUCCEEDED, NOT_SKIPPED, false, false, false),
 	])
 
 	assert_event_reports(events, [
@@ -732,241 +843,262 @@ func test_execute_test_case_is_skipped() -> void:
 
 
 func test_execute_test_case_is_flaky_and_failed() -> void:
-	var test_suite := _load("res://addons/gdUnit4/test/core/resources/testsuites/TestCaseFlaky.resource")
-	@warning_ignore("unsafe_property_access")
-	test_suite._run_with_reries = 5
-	# simulate flaky test suite execution
-	var events := await execute(test_suite)
+	var tests := GdUnitTestResourceLoader.load_tests("res://addons/gdUnit4/test/core/resources/testsuites/TestCaseFlaky.resource")
+	var all_tests: Array[GdUnitTestCase] = Array(tests.values(), TYPE_OBJECT, "RefCounted", GdUnitTestCase)
+	var test_success := find_test(tests, "test_success")
+	var test_flaky_success := find_test(tests, "test_flaky_success")
+	var test_flaky_fail := find_test(tests, "test_flaky_fail")
+	var test_parameterized_flaky0 := find_test(tests, "test_parameterized_flaky:0")
+	var test_parameterized_flaky1 := find_test(tests, "test_parameterized_flaky:1")
+	var test_parameterized_flaky2 := find_test(tests, "test_parameterized_flaky:2")
+	var test_parameterized_flaky3 := find_test(tests, "test_parameterized_flaky:3")
+	var test_parameterized_flaky4 := find_test(tests, "test_parameterized_flaky:4")
+	var test_fuzzed_flaky_success := find_test(tests, "test_fuzzed_flaky_success")
+	var test_fuzzed_flaky_fail := find_test(tests, "test_fuzzed_flaky_fail")
 
-	assert_array(events).extractv(extr("test_name"), extr("is_flaky"))\
+	# simulate flaky test suite execution
+	var events := await run_tests(all_tests, {
+		GdUnitSettings.TEST_FLAKY_CHECK : true,
+		GdUnitSettings.TEST_FLAKY_MAX_RETRIES : 5
+	})
+
+	assert_array(events).extractv(extr("guid"), extr("is_flaky"))\
 		.contains([
-		tuple("before", false),
-		tuple("test_success", false),
-		tuple("test_flaky_success", true),
-		tuple("test_flaky_fail", true),
-		tuple("test_parameterized_flaky:0 (0, 1)", false),
-		tuple("test_parameterized_flaky:1 (1, 1)", false),
-		tuple("test_parameterized_flaky:2 (2, 6)", true),
-		tuple("test_parameterized_flaky:3 (3, 1)", false),
-		tuple("test_parameterized_flaky:4 (4, 3)", true),
-		tuple("test_fuzzed_flaky_success", true),
-		tuple("test_fuzzed_flaky_fail", true),
-		tuple("after", true),
+		tuple(any_class(GdUnitGUID), false),
+		tuple(test_success.guid, false),
+		tuple(test_flaky_success.guid, true),
+		tuple(test_flaky_fail.guid, true),
+		tuple(test_parameterized_flaky0.guid, false),
+		tuple(test_parameterized_flaky1.guid, false),
+		tuple(test_parameterized_flaky2.guid, true),
+		tuple(test_parameterized_flaky3.guid, false),
+		tuple(test_parameterized_flaky4.guid, true),
+		tuple(test_fuzzed_flaky_success.guid, true),
+		tuple(test_fuzzed_flaky_fail.guid, true),
+		tuple(any_class(GdUnitGUID), true),
 	])
 
 	# verify test execution results
 	assert_array(events)\
-		.extractv(extr("type"), extr("test_name"), extr("is_success"), extr("is_flaky"), extr("is_failed"))\
+		.extractv(extr("type"), extr("guid"), extr("is_success"), extr("is_flaky"), extr("is_failed"))\
 		.contains([
-		tuple(GdUnitEvent.TESTSUITE_BEFORE, "before", true, false, false),
+		tuple(GdUnitEvent.TESTSUITE_BEFORE, any_class(GdUnitGUID), true, false, false),
 		# expect finaly state failed and flaky
-		tuple(GdUnitEvent.TESTSUITE_AFTER, "after", false, true, true)
+		tuple(GdUnitEvent.TESTSUITE_AFTER, any_class(GdUnitGUID), false, true, true)
 	])
 
-	assert_array(filter_by_test_case(events, "test_flaky_success"))\
-		.extractv(extr("type"), extr("test_name"), extr("is_success"), extr("is_flaky"), extr("is_failed"))\
+	assert_array(filter_by_test_case(events, test_flaky_success))\
+		.extractv(extr("type"), extr("guid"), extr("is_success"), extr("is_flaky"), extr("is_failed"))\
 		.contains_exactly([
 		# expect be success after 3 retries and marked as flaky
-		tuple(GdUnitEvent.TESTCASE_AFTER, "test_flaky_success", false, false, true),
-		tuple(GdUnitEvent.TESTCASE_AFTER, "test_flaky_success", false, true, true),
-		tuple(GdUnitEvent.TESTCASE_AFTER, "test_flaky_success", true, true, false),
+		tuple(GdUnitEvent.TESTCASE_AFTER, test_flaky_success.guid, false, false, true),
+		tuple(GdUnitEvent.TESTCASE_AFTER, test_flaky_success.guid, false, true, true),
+		tuple(GdUnitEvent.TESTCASE_AFTER, test_flaky_success.guid, true, true, false),
 	])
 
-	assert_array(filter_by_test_case(events, "test_flaky_fail"))\
-		.extractv(extr("type"), extr("test_name"), extr("is_success"), extr("is_flaky"), extr("is_failed"))\
+	assert_array(filter_by_test_case(events, test_flaky_fail))\
+		.extractv(extr("type"), extr("guid"), extr("is_success"), extr("is_flaky"), extr("is_failed"))\
 		.contains_exactly([
 		# expect be fail 5 times and marked as flaky
-		tuple(GdUnitEvent.TESTCASE_AFTER, "test_flaky_fail", false, false, true),
-		tuple(GdUnitEvent.TESTCASE_AFTER, "test_flaky_fail", false, true, true),
-		tuple(GdUnitEvent.TESTCASE_AFTER, "test_flaky_fail", false, true, true),
-		tuple(GdUnitEvent.TESTCASE_AFTER, "test_flaky_fail", false, true, true),
-		tuple(GdUnitEvent.TESTCASE_AFTER, "test_flaky_fail", false, true, true),
+		tuple(GdUnitEvent.TESTCASE_AFTER, test_flaky_fail.guid, false, false, true),
+		tuple(GdUnitEvent.TESTCASE_AFTER, test_flaky_fail.guid, false, true, true),
+		tuple(GdUnitEvent.TESTCASE_AFTER, test_flaky_fail.guid, false, true, true),
+		tuple(GdUnitEvent.TESTCASE_AFTER, test_flaky_fail.guid, false, true, true),
+		tuple(GdUnitEvent.TESTCASE_AFTER, test_flaky_fail.guid, false, true, true),
 	])
 
-	assert_array(filter_by_test_case(events, "test_success"))\
-		.extractv(extr("type"), extr("test_name"), extr("is_success"), extr("is_flaky"), extr("is_failed"))\
+	assert_array(filter_by_test_case(events, test_success))\
+		.extractv(extr("type"), extr("guid"), extr("is_success"), extr("is_flaky"), extr("is_failed"))\
 		.contains_exactly([
 		# expect be success on first run and not flaky
-		tuple(GdUnitEvent.TESTCASE_AFTER, "test_success", true, false, false),
+		tuple(GdUnitEvent.TESTCASE_AFTER, test_success.guid, true, false, false),
 	])
 
 	# --test_parameterized_flaky---------------------------------------------------------------
-	assert_array(filter_by_test_case(events, "test_parameterized_flaky:0 (0, 1)"))\
-		.extractv(extr("type"), extr("test_name"), extr("is_success"), extr("is_flaky"), extr("is_failed"))\
+	assert_array(filter_by_test_case(events, test_parameterized_flaky0))\
+		.extractv(extr("type"), extr("guid"), extr("is_success"), extr("is_flaky"), extr("is_failed"))\
 		.contains_exactly([
 		# expect be success on first run and not flaky
-		tuple(GdUnitEvent.TESTCASE_AFTER, "test_parameterized_flaky:0 (0, 1)", true, false, false),
+		tuple(GdUnitEvent.TESTCASE_AFTER, test_parameterized_flaky0.guid, true, false, false),
 	])
-	assert_array(filter_by_test_case(events, "test_parameterized_flaky:1 (1, 1)"))\
-		.extractv(extr("type"), extr("test_name"), extr("is_success"), extr("is_flaky"), extr("is_failed"))\
+	assert_array(filter_by_test_case(events, test_parameterized_flaky1))\
+		.extractv(extr("type"), extr("guid"), extr("is_success"), extr("is_flaky"), extr("is_failed"))\
 		.contains_exactly([
 		# expect be success on first run and not flaky
-		tuple(GdUnitEvent.TESTCASE_AFTER, "test_parameterized_flaky:1 (1, 1)", true, false, false),
+		tuple(GdUnitEvent.TESTCASE_AFTER, test_parameterized_flaky1.guid, true, false, false),
 	])
-	assert_array(filter_by_test_case(events, "test_parameterized_flaky:2 (2, 6)"))\
-		.extractv(extr("type"), extr("test_name"), extr("is_success"), extr("is_flaky"), extr("is_failed"))\
+	assert_array(filter_by_test_case(events, test_parameterized_flaky2))\
+		.extractv(extr("type"), extr("guid"), extr("is_success"), extr("is_flaky"), extr("is_failed"))\
 		.contains_exactly([
 		# expect be fail after 5 retries and marked as flaky
-		tuple(GdUnitEvent.TESTCASE_AFTER, "test_parameterized_flaky:2 (2, 6)", false, false, true),
-		tuple(GdUnitEvent.TESTCASE_AFTER, "test_parameterized_flaky:2 (2, 6)", false, true, true),
-		tuple(GdUnitEvent.TESTCASE_AFTER, "test_parameterized_flaky:2 (2, 6)", false, true, true),
-		tuple(GdUnitEvent.TESTCASE_AFTER, "test_parameterized_flaky:2 (2, 6)", false, true, true),
-		tuple(GdUnitEvent.TESTCASE_AFTER, "test_parameterized_flaky:2 (2, 6)", false, true, true),
+		tuple(GdUnitEvent.TESTCASE_AFTER, test_parameterized_flaky2.guid, false, false, true),
+		tuple(GdUnitEvent.TESTCASE_AFTER, test_parameterized_flaky2.guid, false, true, true),
+		tuple(GdUnitEvent.TESTCASE_AFTER, test_parameterized_flaky2.guid, false, true, true),
+		tuple(GdUnitEvent.TESTCASE_AFTER, test_parameterized_flaky2.guid, false, true, true),
+		tuple(GdUnitEvent.TESTCASE_AFTER, test_parameterized_flaky2.guid, false, true, true),
 	])
-	assert_array(filter_by_test_case(events, "test_parameterized_flaky:3 (3, 1)"))\
-		.extractv(extr("type"), extr("test_name"), extr("is_success"), extr("is_flaky"), extr("is_failed"))\
+	assert_array(filter_by_test_case(events, test_parameterized_flaky3))\
+		.extractv(extr("type"), extr("guid"), extr("is_success"), extr("is_flaky"), extr("is_failed"))\
 		.contains_exactly([
 		# expect be success on first run and not flaky
-		tuple(GdUnitEvent.TESTCASE_AFTER, "test_parameterized_flaky:3 (3, 1)", true, false, false),
+		tuple(GdUnitEvent.TESTCASE_AFTER, test_parameterized_flaky3.guid, true, false, false),
 	])
-	assert_array(filter_by_test_case(events, "test_parameterized_flaky:4 (4, 3)"))\
-		.extractv(extr("type"), extr("test_name"), extr("is_success"), extr("is_flaky"), extr("is_failed"))\
+	assert_array(filter_by_test_case(events, test_parameterized_flaky4))\
+		.extractv(extr("type"), extr("guid"), extr("is_success"), extr("is_flaky"), extr("is_failed"))\
 		.contains_exactly([
 		# expect be success after 3 retries and marked as flaky
-		tuple(GdUnitEvent.TESTCASE_AFTER, "test_parameterized_flaky:4 (4, 3)", false, false, true),
-		tuple(GdUnitEvent.TESTCASE_AFTER, "test_parameterized_flaky:4 (4, 3)", false, true, true),
-		tuple(GdUnitEvent.TESTCASE_AFTER, "test_parameterized_flaky:4 (4, 3)", true, true, false),
+		tuple(GdUnitEvent.TESTCASE_AFTER, test_parameterized_flaky4.guid, false, false, true),
+		tuple(GdUnitEvent.TESTCASE_AFTER, test_parameterized_flaky4.guid, false, true, true),
+		tuple(GdUnitEvent.TESTCASE_AFTER, test_parameterized_flaky4.guid, true, true, false),
 	])
 
-	assert_array(filter_by_test_case(events, "test_fuzzed_flaky_success"))\
-		.extractv(extr("type"), extr("test_name"), extr("is_success"), extr("is_flaky"), extr("is_failed"))\
+	assert_array(filter_by_test_case(events, test_fuzzed_flaky_success))\
+		.extractv(extr("type"), extr("guid"), extr("is_success"), extr("is_flaky"), extr("is_failed"))\
 		.contains_exactly([
 		# expect be success after 3 retries and marked as flaky
-		tuple(GdUnitEvent.TESTCASE_AFTER, "test_fuzzed_flaky_success", false, false, true),
-		tuple(GdUnitEvent.TESTCASE_AFTER, "test_fuzzed_flaky_success", false, true, true),
-		tuple(GdUnitEvent.TESTCASE_AFTER, "test_fuzzed_flaky_success", true, true, false)
+		tuple(GdUnitEvent.TESTCASE_AFTER, test_fuzzed_flaky_success.guid, false, false, true),
+		tuple(GdUnitEvent.TESTCASE_AFTER, test_fuzzed_flaky_success.guid, false, true, true),
+		tuple(GdUnitEvent.TESTCASE_AFTER, test_fuzzed_flaky_success.guid, true, true, false)
 	])
 
-	assert_array(filter_by_test_case(events, "test_fuzzed_flaky_fail"))\
-		.extractv(extr("type"), extr("test_name"), extr("is_success"), extr("is_flaky"), extr("is_failed"))\
+	assert_array(filter_by_test_case(events, test_fuzzed_flaky_fail))\
+		.extractv(extr("type"), extr("guid"), extr("is_success"), extr("is_flaky"), extr("is_failed"))\
 		.contains_exactly([
 		# expect be fail after 5 retries and marked as flaky
-		tuple(GdUnitEvent.TESTCASE_AFTER, "test_fuzzed_flaky_fail", false, false, true),
-		tuple(GdUnitEvent.TESTCASE_AFTER, "test_fuzzed_flaky_fail", false, true, true),
-		tuple(GdUnitEvent.TESTCASE_AFTER, "test_fuzzed_flaky_fail", false, true, true),
-		tuple(GdUnitEvent.TESTCASE_AFTER, "test_fuzzed_flaky_fail", false, true, true),
-		tuple(GdUnitEvent.TESTCASE_AFTER, "test_fuzzed_flaky_fail", false, true, true),
+		tuple(GdUnitEvent.TESTCASE_AFTER, test_fuzzed_flaky_fail.guid, false, false, true),
+		tuple(GdUnitEvent.TESTCASE_AFTER, test_fuzzed_flaky_fail.guid, false, true, true),
+		tuple(GdUnitEvent.TESTCASE_AFTER, test_fuzzed_flaky_fail.guid, false, true, true),
+		tuple(GdUnitEvent.TESTCASE_AFTER, test_fuzzed_flaky_fail.guid, false, true, true),
+		tuple(GdUnitEvent.TESTCASE_AFTER, test_fuzzed_flaky_fail.guid, false, true, true),
 	])
 
 
 func test_execute_test_case_is_flaky_and_success() -> void:
-	var test_suite := _load("res://addons/gdUnit4/test/core/resources/testsuites/TestCaseFlaky.resource")
-	@warning_ignore("unsafe_property_access")
-	test_suite._run_with_reries = 6
+	var tests := GdUnitTestResourceLoader.load_tests("res://addons/gdUnit4/test/core/resources/testsuites/TestCaseFlaky.resource")
+	var all_tests: Array[GdUnitTestCase] = Array(tests.values(), TYPE_OBJECT, "RefCounted", GdUnitTestCase)
+	var test_success := find_test(tests, "test_success")
+	var test_flaky_success := find_test(tests, "test_flaky_success")
+	var test_flaky_fail := find_test(tests, "test_flaky_fail")
+	var test_parameterized_flaky0 := find_test(tests, "test_parameterized_flaky:0")
+	var test_parameterized_flaky1 := find_test(tests, "test_parameterized_flaky:1")
+	var test_parameterized_flaky2 := find_test(tests, "test_parameterized_flaky:2")
+	var test_parameterized_flaky3 := find_test(tests, "test_parameterized_flaky:3")
+	var test_parameterized_flaky4 := find_test(tests, "test_parameterized_flaky:4")
+	var test_fuzzed_flaky_success := find_test(tests, "test_fuzzed_flaky_success")
+	var test_fuzzed_flaky_fail := find_test(tests, "test_fuzzed_flaky_fail")
+
 	# simulate flaky test suite execution
-	var events := await execute(test_suite)
+	var events := await run_tests(all_tests, {
+		GdUnitSettings.TEST_FLAKY_CHECK : true,
+		GdUnitSettings.TEST_FLAKY_MAX_RETRIES : 6
+	})
 
 	# verify test execution results
 	assert_array(events)\
-		.extractv(extr("type"), extr("test_name"), extr("is_success"), extr("is_flaky"), extr("is_failed"))\
+		.extractv(extr("type"), extr("guid"), extr("is_success"), extr("is_flaky"), extr("is_failed"))\
 		.contains([
-		tuple(GdUnitEvent.TESTSUITE_BEFORE, "before", SUCCEEDED, !FLAKY, !IS_FAILED),
+		tuple(GdUnitEvent.TESTSUITE_BEFORE, any_class(GdUnitGUID), SUCCEEDED, !FLAKY, !IS_FAILED),
 		# expect finaly state failed and flaky
-		tuple(GdUnitEvent.TESTSUITE_AFTER, "after", SUCCEEDED, FLAKY, !IS_FAILED)
+		tuple(GdUnitEvent.TESTSUITE_AFTER, any_class(GdUnitGUID), SUCCEEDED, FLAKY, !IS_FAILED)
 	])
 
-	assert_array(filter_by_test_case(events, "test_flaky_success"))\
-		.extractv(extr("type"), extr("test_name"), extr("is_success"), extr("is_flaky"), extr("is_failed"))\
+	assert_array(filter_by_test_case(events, test_flaky_success))\
+		.extractv(extr("type"), extr("guid"), extr("is_success"), extr("is_flaky"), extr("is_failed"))\
 		.contains_exactly([
 		# expect be success after 3 retries and marked as flaky
-		tuple(GdUnitEvent.TESTCASE_AFTER, "test_flaky_success", false, false, true),
-		tuple(GdUnitEvent.TESTCASE_AFTER, "test_flaky_success", false, true, true),
-		tuple(GdUnitEvent.TESTCASE_AFTER, "test_flaky_success", true, true, false),
+		tuple(GdUnitEvent.TESTCASE_AFTER, test_flaky_success.guid, false, false, true),
+		tuple(GdUnitEvent.TESTCASE_AFTER, test_flaky_success.guid, false, true, true),
+		tuple(GdUnitEvent.TESTCASE_AFTER, test_flaky_success.guid, true, true, false),
 	])
 
-	assert_array(filter_by_test_case(events, "test_flaky_fail"))\
-		.extractv(extr("type"), extr("test_name"), extr("is_success"), extr("is_flaky"), extr("is_failed"))\
+	assert_array(filter_by_test_case(events, test_flaky_fail))\
+		.extractv(extr("type"), extr("guid"), extr("is_success"), extr("is_flaky"), extr("is_failed"))\
 		.contains_exactly([
 		# expect be fail 5 times and on 6't to be success and marked as flaky
-		tuple(GdUnitEvent.TESTCASE_AFTER, "test_flaky_fail", false, false, true),
-		tuple(GdUnitEvent.TESTCASE_AFTER, "test_flaky_fail", false, true, true),
-		tuple(GdUnitEvent.TESTCASE_AFTER, "test_flaky_fail", false, true, true),
-		tuple(GdUnitEvent.TESTCASE_AFTER, "test_flaky_fail", false, true, true),
-		tuple(GdUnitEvent.TESTCASE_AFTER, "test_flaky_fail", false, true, true),
-		tuple(GdUnitEvent.TESTCASE_AFTER, "test_flaky_fail", true, true, false),
+		tuple(GdUnitEvent.TESTCASE_AFTER, test_flaky_fail.guid, false, false, true),
+		tuple(GdUnitEvent.TESTCASE_AFTER, test_flaky_fail.guid, false, true, true),
+		tuple(GdUnitEvent.TESTCASE_AFTER, test_flaky_fail.guid, false, true, true),
+		tuple(GdUnitEvent.TESTCASE_AFTER, test_flaky_fail.guid, false, true, true),
+		tuple(GdUnitEvent.TESTCASE_AFTER, test_flaky_fail.guid, false, true, true),
+		tuple(GdUnitEvent.TESTCASE_AFTER, test_flaky_fail.guid, true, true, false),
 	])
 
-	assert_array(filter_by_test_case(events, "test_success"))\
-		.extractv(extr("type"), extr("test_name"), extr("is_success"), extr("is_flaky"), extr("is_failed"))\
+	assert_array(filter_by_test_case(events, test_success))\
+		.extractv(extr("type"), extr("guid"), extr("is_success"), extr("is_flaky"), extr("is_failed"))\
 		.contains_exactly([
 		# expect be success on first run and not flaky
-		tuple(GdUnitEvent.TESTCASE_AFTER, "test_success", true, false, false),
+		tuple(GdUnitEvent.TESTCASE_AFTER, test_success.guid, true, false, false),
 	])
 
 	# --test_parameterized_flaky---------------------------------------------------------------
-	assert_array(filter_by_test_case(events, "test_parameterized_flaky:0 (0, 1)"))\
-		.extractv(extr("type"), extr("test_name"), extr("is_success"), extr("is_flaky"), extr("is_failed"))\
+	assert_array(filter_by_test_case(events, test_parameterized_flaky0))\
+		.extractv(extr("type"), extr("guid"), extr("is_success"), extr("is_flaky"), extr("is_failed"))\
 		.contains_exactly([
 		# expect be success on first run and not flaky
-		tuple(GdUnitEvent.TESTCASE_AFTER, "test_parameterized_flaky:0 (0, 1)", true, false, false),
+		tuple(GdUnitEvent.TESTCASE_AFTER, test_parameterized_flaky0.guid, true, false, false),
 	])
-	assert_array(filter_by_test_case(events, "test_parameterized_flaky:1 (1, 1)"))\
-		.extractv(extr("type"), extr("test_name"), extr("is_success"), extr("is_flaky"), extr("is_failed"))\
+	assert_array(filter_by_test_case(events, test_parameterized_flaky1))\
+		.extractv(extr("type"), extr("guid"), extr("is_success"), extr("is_flaky"), extr("is_failed"))\
 		.contains_exactly([
 		# expect be success on first run and not flaky
-		tuple(GdUnitEvent.TESTCASE_AFTER, "test_parameterized_flaky:1 (1, 1)", true, false, false),
+		tuple(GdUnitEvent.TESTCASE_AFTER, test_parameterized_flaky1.guid, true, false, false),
 	])
-	assert_array(filter_by_test_case(events, "test_parameterized_flaky:2 (2, 6)"))\
-		.extractv(extr("type"), extr("test_name"), extr("is_success"), extr("is_flaky"), extr("is_failed"))\
+	assert_array(filter_by_test_case(events, test_parameterized_flaky2))\
+		.extractv(extr("type"), extr("guid"), extr("is_success"), extr("is_flaky"), extr("is_failed"))\
 		.contains_exactly([
 		# expect be fail 5 times and on 6't to be success and marked as flaky
-		tuple(GdUnitEvent.TESTCASE_AFTER, "test_parameterized_flaky:2 (2, 6)", false, false, true),
-		tuple(GdUnitEvent.TESTCASE_AFTER, "test_parameterized_flaky:2 (2, 6)", false, true, true),
-		tuple(GdUnitEvent.TESTCASE_AFTER, "test_parameterized_flaky:2 (2, 6)", false, true, true),
-		tuple(GdUnitEvent.TESTCASE_AFTER, "test_parameterized_flaky:2 (2, 6)", false, true, true),
-		tuple(GdUnitEvent.TESTCASE_AFTER, "test_parameterized_flaky:2 (2, 6)", false, true, true),
-		tuple(GdUnitEvent.TESTCASE_AFTER, "test_parameterized_flaky:2 (2, 6)", true, true, false),
+		tuple(GdUnitEvent.TESTCASE_AFTER, test_parameterized_flaky2.guid, false, false, true),
+		tuple(GdUnitEvent.TESTCASE_AFTER, test_parameterized_flaky2.guid, false, true, true),
+		tuple(GdUnitEvent.TESTCASE_AFTER, test_parameterized_flaky2.guid, false, true, true),
+		tuple(GdUnitEvent.TESTCASE_AFTER, test_parameterized_flaky2.guid, false, true, true),
+		tuple(GdUnitEvent.TESTCASE_AFTER, test_parameterized_flaky2.guid, false, true, true),
+		tuple(GdUnitEvent.TESTCASE_AFTER, test_parameterized_flaky2.guid, true, true, false),
 	])
-	assert_array(filter_by_test_case(events, "test_parameterized_flaky:3 (3, 1)"))\
-		.extractv(extr("type"), extr("test_name"), extr("is_success"), extr("is_flaky"), extr("is_failed"))\
+	assert_array(filter_by_test_case(events, test_parameterized_flaky3))\
+		.extractv(extr("type"), extr("guid"), extr("is_success"), extr("is_flaky"), extr("is_failed"))\
 		.contains_exactly([
 		# expect be success on first run and not flaky
-		tuple(GdUnitEvent.TESTCASE_AFTER, "test_parameterized_flaky:3 (3, 1)", true, false, false),
+		tuple(GdUnitEvent.TESTCASE_AFTER, test_parameterized_flaky3.guid, true, false, false),
 	])
-	assert_array(filter_by_test_case(events, "test_parameterized_flaky:4 (4, 3)"))\
-		.extractv(extr("type"), extr("test_name"), extr("is_success"), extr("is_flaky"), extr("is_failed"))\
+	assert_array(filter_by_test_case(events, test_parameterized_flaky4))\
+		.extractv(extr("type"), extr("guid"), extr("is_success"), extr("is_flaky"), extr("is_failed"))\
 		.contains_exactly([
 		# expect be success after 3 retries and marked as flaky
-		tuple(GdUnitEvent.TESTCASE_AFTER, "test_parameterized_flaky:4 (4, 3)", false, false, true),
-		tuple(GdUnitEvent.TESTCASE_AFTER, "test_parameterized_flaky:4 (4, 3)", false, true, true),
-		tuple(GdUnitEvent.TESTCASE_AFTER, "test_parameterized_flaky:4 (4, 3)", true, true, false),
+		tuple(GdUnitEvent.TESTCASE_AFTER, test_parameterized_flaky4.guid, false, false, true),
+		tuple(GdUnitEvent.TESTCASE_AFTER, test_parameterized_flaky4.guid, false, true, true),
+		tuple(GdUnitEvent.TESTCASE_AFTER, test_parameterized_flaky4.guid, true, true, false),
 	])
 
 	# -- fuzzed tests ------------------------------------------------------------------------------------------
-	assert_array(filter_by_test_case(events, "test_fuzzed_flaky_success"))\
-		.extractv(extr("type"), extr("test_name"), extr("is_success"), extr("is_flaky"), extr("is_failed"))\
+	assert_array(filter_by_test_case(events, test_fuzzed_flaky_success))\
+		.extractv(extr("type"), extr("guid"), extr("is_success"), extr("is_flaky"), extr("is_failed"))\
 		.contains_exactly([
 		# expect be success after 3 retries and marked as flaky
-		tuple(GdUnitEvent.TESTCASE_AFTER, "test_fuzzed_flaky_success", false, false, true),
-		tuple(GdUnitEvent.TESTCASE_AFTER, "test_fuzzed_flaky_success", false, true, true),
-		tuple(GdUnitEvent.TESTCASE_AFTER, "test_fuzzed_flaky_success", true, true, false)
+		tuple(GdUnitEvent.TESTCASE_AFTER, test_fuzzed_flaky_success.guid, false, false, true),
+		tuple(GdUnitEvent.TESTCASE_AFTER, test_fuzzed_flaky_success.guid, false, true, true),
+		tuple(GdUnitEvent.TESTCASE_AFTER, test_fuzzed_flaky_success.guid, true, true, false)
 	])
 
-	assert_array(filter_by_test_case(events, "test_fuzzed_flaky_fail"))\
-		.extractv(extr("type"), extr("test_name"), extr("is_success"), extr("is_flaky"), extr("is_failed"))\
+	assert_array(filter_by_test_case(events, test_fuzzed_flaky_fail))\
+		.extractv(extr("type"), extr("guid"), extr("is_success"), extr("is_flaky"), extr("is_failed"))\
 		.contains_exactly([
 		# expect be fail 5 times and on 6't to be success and marked as flaky
-		tuple(GdUnitEvent.TESTCASE_AFTER, "test_fuzzed_flaky_fail", false, false, true),
-		tuple(GdUnitEvent.TESTCASE_AFTER, "test_fuzzed_flaky_fail", false, true, true),
-		tuple(GdUnitEvent.TESTCASE_AFTER, "test_fuzzed_flaky_fail", false, true, true),
-		tuple(GdUnitEvent.TESTCASE_AFTER, "test_fuzzed_flaky_fail", false, true, true),
-		tuple(GdUnitEvent.TESTCASE_AFTER, "test_fuzzed_flaky_fail", false, true, true),
-		tuple(GdUnitEvent.TESTCASE_AFTER, "test_fuzzed_flaky_fail", true, true, false),
+		tuple(GdUnitEvent.TESTCASE_AFTER, test_fuzzed_flaky_fail.guid, false, false, true),
+		tuple(GdUnitEvent.TESTCASE_AFTER, test_fuzzed_flaky_fail.guid, false, true, true),
+		tuple(GdUnitEvent.TESTCASE_AFTER, test_fuzzed_flaky_fail.guid, false, true, true),
+		tuple(GdUnitEvent.TESTCASE_AFTER, test_fuzzed_flaky_fail.guid, false, true, true),
+		tuple(GdUnitEvent.TESTCASE_AFTER, test_fuzzed_flaky_fail.guid, false, true, true),
+		tuple(GdUnitEvent.TESTCASE_AFTER, test_fuzzed_flaky_fail.guid, true, true, false),
 	])
 
 
-func filter_by_test_case(events:  Array[GdUnitEvent], test_case_name: String) -> Array[GdUnitEvent]:
+func filter_by_test_case(events:  Array[GdUnitEvent], test: GdUnitTestCase) -> Array[GdUnitEvent]:
 	return events.filter(func (event: GdUnitEvent) -> bool:
-		return event.test_name() == test_case_name and event.type() == GdUnitEvent.TESTCASE_AFTER
+		return event.guid().equals(test.guid) and event.type() == GdUnitEvent.TESTCASE_AFTER
 	)
 
-
-class TestCaseNameExtractor extends GdUnitValueExtractor:
-	var r := RegEx.create_from_string("^.*:\\d")
-
-	@warning_ignore("unsafe_method_access", "unsafe_cast")
-	func extract_value(value: Variant) -> String:
-		@warning_ignore("unsafe_method_access")
-		var test_name := str(value.test_name())
-		var m := r.search(test_name)
-		return m.get_string(0) if m != null else test_name
+func find_test(tests: Dictionary, test_name: String) -> GdUnitTestCase:
+	for key: String in tests.keys():
+		if key.begins_with(test_name):
+			return tests[key]
+	return null

--- a/addons/gdUnit4/test/core/resources/testsuites/TestCaseFlaky.resource
+++ b/addons/gdUnit4/test/core/resources/testsuites/TestCaseFlaky.resource
@@ -15,9 +15,7 @@ var test_retries := {
 	"test_fuzzed_flaky_fail" = 0
 }
 
-var _max_retries := 0
-var _flaky_check_enabled :bool
-var _run_with_reries := 5
+var _run_with_retries: int = GdUnitSettings.get_flaky_max_retries()
 
 
 class ValueSetFuzzer extends Fuzzer:
@@ -28,24 +26,18 @@ class ValueSetFuzzer extends Fuzzer:
 
 
 func before() -> void:
-	_max_retries = GdUnitSettings.get_flaky_max_retries()
-	_flaky_check_enabled = GdUnitSettings.is_test_flaky_check_enabled()
-	ProjectSettings.set_setting(GdUnitSettings.TEST_FLAKY_CHECK, true)
-	ProjectSettings.set_setting(GdUnitSettings.TEST_FLAKY_MAX_RETRIES, _run_with_reries)
+	prints("run with max retries", _run_with_retries)
 
 
 func after() -> void:
-	ProjectSettings.set_setting(GdUnitSettings.TEST_FLAKY_CHECK, _flaky_check_enabled)
-	ProjectSettings.set_setting(GdUnitSettings.TEST_FLAKY_MAX_RETRIES, _max_retries)
-
 	var retry_count :int = test_retries["test_flaky_success"]
 	assert_int(retry_count)\
 		.override_failure_message("Expecting 3 retries to succeed for test 'test_flaky_success'\n but was %d" % retry_count)\
 		.is_equal(3)
 	retry_count = test_retries["test_flaky_fail"]
 	assert_int(retry_count)\
-		.override_failure_message("Expecting %d retries for test 'test_flaky_fail'\n but was %d" % [_run_with_reries, retry_count])\
-		.is_equal(_run_with_reries)
+		.override_failure_message("Expecting %d retries for test 'test_flaky_fail'\n but was %d" % [_run_with_retries, retry_count])\
+		.is_equal(_run_with_retries)
 	retry_count = test_retries["test_success"]
 	assert_int(retry_count)\
 		.override_failure_message("Expecting one test iteration to succeed 'test_success'\n but was %d" % retry_count)\
@@ -61,8 +53,8 @@ func after() -> void:
 		.is_equal(1)
 	retry_count = test_retries["test_parameterized_flaky:2"]
 	assert_int(retry_count)\
-		.override_failure_message("Expecting %d test iteration to fail 'test_parameterized_flaky:2'\n but was %d" % [_run_with_reries, retry_count])\
-		.is_equal(_run_with_reries)
+		.override_failure_message("Expecting %d test iteration to fail 'test_parameterized_flaky:2'\n but was %d" % [_run_with_retries, retry_count])\
+		.is_equal(_run_with_retries)
 	retry_count = test_retries["test_parameterized_flaky:3"]
 	assert_int(retry_count)\
 		.override_failure_message("Expecting one test iteration to succeed 'test_parameterized_flaky:3'\n but was %d" % retry_count)\
@@ -78,8 +70,8 @@ func after() -> void:
 		.is_equal(3)
 	retry_count = test_retries["test_fuzzed_flaky_fail"]
 	assert_int(retry_count)\
-		.override_failure_message("Expecting %d retries for test 'test_fuzzed_flaky_fail'\n but was %d" % [_run_with_reries, retry_count])\
-		.is_equal(_run_with_reries)
+		.override_failure_message("Expecting %d retries for test 'test_fuzzed_flaky_fail'\n but was %d" % [_run_with_retries, retry_count])\
+		.is_equal(_run_with_retries)
 
 
 func test_flaky_success() -> void:

--- a/addons/gdUnit4/test/ui/parts/InspectorTreeMainPanelTest.gd
+++ b/addons/gdUnit4/test/ui/parts/InspectorTreeMainPanelTest.gd
@@ -69,9 +69,9 @@ func setup_test_env() -> void:
 		discovered_tests_suite_c[discover_test.test_name] = discover_test
 	)
 
-	suite_a_item = _inspector.get_tree_item(suite_a.resource_path, "ExampleTestSuiteA")
-	suite_b_item = _inspector.get_tree_item(suite_b.resource_path, "ExampleTestSuiteB")
-	suite_c_item = _inspector.get_tree_item(suite_c.resource_path, "ExampleTestSuiteC")
+	suite_a_item = _inspector._find_tree_item_by_path(suite_a.resource_path, "ExampleTestSuiteA")
+	suite_b_item = _inspector._find_tree_item_by_path(suite_b.resource_path, "ExampleTestSuiteB")
+	suite_c_item = _inspector._find_tree_item_by_path(suite_c.resource_path, "ExampleTestSuiteC")
 
 
 func find_test_case(resource_path :String, test_case :String) -> TreeItem:
@@ -80,7 +80,7 @@ func find_test_case(resource_path :String, test_case :String) -> TreeItem:
 
 func set_test_state(test_cases: Array[GdUnitTestCase], state: InspectorTreeMainPanel.STATE) -> void:
 	for test in test_cases:
-		var item := _inspector.find_tree_item_by_id(_inspector._tree_root, test.guid)
+		var item := _inspector._find_tree_item_by_id(_inspector._tree_root, test.guid)
 		var parent := item.get_parent()
 		var test_event := GdUnitEvent.new().test_after(test.guid)
 		match state:
@@ -113,7 +113,7 @@ func test_find_item_by_id() -> void:
 		discovered_tests[discover_test.test_name] = discover_test
 	)
 	var test_aa: GdUnitTestCase = discovered_tests["test_aa"]
-	var item := _inspector.find_tree_item_by_id(_inspector._tree_root, test_aa.guid)
+	var item := _inspector._find_tree_item_by_id(_inspector._tree_root, test_aa.guid)
 	assert_object(item).is_not_null()
 
 
@@ -330,7 +330,7 @@ func test_update_test_case_on_multiple_test_suite_with_same_name() -> void:
 		discover_sink(discover_test)
 		discovered_tests[discover_test.test_name] = discover_test
 	)
-	var suite_item := _inspector.get_tree_item(suite_script.resource_path, "ExampleTestSuiteA")
+	var suite_item := _inspector._find_tree_item_by_path(suite_script.resource_path, "ExampleTestSuiteA")
 	assert_object(suite_item).is_not_same(suite_a_item)
 
 	# verify inital state
@@ -375,7 +375,7 @@ func test_update_icon_state() -> void:
 	)
 	var suite_script_path := suite_script.resource_path
 	var suite_name := "TestSuiteFailAndOrpahnsDetected"
-	var suite_item := _inspector.get_tree_item(suite_script_path, suite_name)
+	var suite_item := _inspector._find_tree_item_by_path(suite_script_path, suite_name)
 
 	# Verify the inital state
 	assert_str(suite_item.get_text(0)).is_equal("(0/2) " + suite_name)
@@ -500,21 +500,21 @@ func test_collect_test_cases() -> void:
 
 	# Test select a single suite
 	# Collect all test cases from the suite node (parent of test_case1)
-	var test := _inspector.find_tree_item_by_id(_inspector._tree_root, test_case1.guid)
+	var test := _inspector._find_tree_item_by_id(_inspector._tree_root, test_case1.guid)
 	var collected_tests := _inspector.collect_test_cases(test.get_parent())
 	# Do verify all tests are collected, ignoring the order could be different according to selected sort mode
 	assert_array(collected_tests).contains_exactly_in_any_order(tests_by_id.values())
 
 	# Test select a single test
 	# Find tree node by test id
-	test = _inspector.find_tree_item_by_id(_inspector._tree_root, test_case1.guid)
+	test = _inspector._find_tree_item_by_id(_inspector._tree_root, test_case1.guid)
 	# Collect all test cases by given tree node
 	collected_tests = _inspector.collect_test_cases(test)
 	assert_array(collected_tests).contains_exactly([test_case1])
 
 	# Test select on paramaterized
 	var paramaterized_test: GdUnitTestCase = tests_by_id["test_parameterized_static:0 (1, 1)"]
-	test = _inspector.find_tree_item_by_id(_inspector._tree_root, paramaterized_test.guid)
+	test = _inspector._find_tree_item_by_id(_inspector._tree_root, paramaterized_test.guid)
 	# Collect all paramaterized tests (by parent of paramaterized_test)
 	collected_tests = _inspector.collect_test_cases(test.get_parent())
 	# Do verify all tests are collected, ignoring the order could be different according to selected sort mode

--- a/addons/gdUnit4/test/ui/parts/InspectorTreeMainPanelTest.gd
+++ b/addons/gdUnit4/test/ui/parts/InspectorTreeMainPanelTest.gd
@@ -16,6 +16,11 @@ var suite_a_item: TreeItem
 var suite_b_item: TreeItem
 var suite_c_item: TreeItem
 
+var discovered_tests_suite_a := {}
+var discovered_tests_suite_b := {}
+var discovered_tests_suite_c := {}
+
+
 var _inspector: InspectorTreeMainPanel
 
 
@@ -49,9 +54,20 @@ func setup_test_env() -> void:
 	var suite_a := GdUnitTestResourceLoader.load_gd_script("res://addons/gdUnit4/test/ui/parts/resources/foo/ExampleTestSuiteA.resource", true)
 	var suite_b := GdUnitTestResourceLoader.load_gd_script("res://addons/gdUnit4/test/ui/parts/resources/foo/ExampleTestSuiteB.resource", true)
 	var suite_c := GdUnitTestResourceLoader.load_gd_script("res://addons/gdUnit4/test/ui/parts/resources/foo/ExampleTestSuiteC.resource", true)
-	GdUnitTestDiscoverer.discover_tests(suite_a, discover_sink)
-	GdUnitTestDiscoverer.discover_tests(suite_b, discover_sink)
-	GdUnitTestDiscoverer.discover_tests(suite_c, discover_sink)
+
+
+	GdUnitTestDiscoverer.discover_tests(suite_a, func(discover_test: GdUnitTestCase) -> void:
+		discover_sink(discover_test)
+		discovered_tests_suite_a[discover_test.test_name] = discover_test
+	)
+	GdUnitTestDiscoverer.discover_tests(suite_b, func(discover_test: GdUnitTestCase) -> void:
+		discover_sink(discover_test)
+		discovered_tests_suite_b[discover_test.test_name] = discover_test
+	)
+	GdUnitTestDiscoverer.discover_tests(suite_c, func(discover_test: GdUnitTestCase) -> void:
+		discover_sink(discover_test)
+		discovered_tests_suite_c[discover_test.test_name] = discover_test
+	)
 
 	suite_a_item = _inspector.get_tree_item(suite_a.resource_path, "ExampleTestSuiteA")
 	suite_b_item = _inspector.get_tree_item(suite_b.resource_path, "ExampleTestSuiteB")
@@ -62,29 +78,24 @@ func find_test_case(resource_path :String, test_case :String) -> TreeItem:
 	return _inspector.get_tree_item(resource_path, test_case)
 
 
-func set_test_state(test_cases: PackedStringArray, state: InspectorTreeMainPanel.STATE, parent:TreeItem = _inspector._tree_root) -> void:
-	assert_object(parent).is_not_null()
-	# mark all test as failed
-	if parent != _inspector._tree_root:
-		_inspector.set_state_succeded(parent)
+func set_test_state(test_cases: Array[GdUnitTestCase], state: InspectorTreeMainPanel.STATE) -> void:
+	for test in test_cases:
+		var item := _inspector.find_tree_item_by_id(_inspector._tree_root, test.guid)
+		var parent := item.get_parent()
+		var test_event := GdUnitEvent.new().test_after(test.guid)
+		match state:
+			ERROR:
+				_inspector.set_state_error(parent)
+				_inspector.set_state_error(item)
+			FAILED:
+				_inspector.set_state_failed(parent, test_event)
+				_inspector.set_state_failed(item, test_event)
+			FLAKY:
+				_inspector.set_state_flaky(parent, test_event)
+				_inspector.set_state_flaky(item, test_event)
 
-	var test_event := GdUnitEvent.new().test_after(GdUnitGUID.new(), "res://foo.gd", "test_suite", "test_name")
 
-	for item in parent.get_children():
-		set_test_state(test_cases, state, item)
-		if test_cases.has(item.get_text(0)):
-			match state:
-				ERROR:
-					_inspector.set_state_error(parent)
-					_inspector.set_state_error(item)
-				FAILED:
-					_inspector.set_state_failed(parent, test_event)
-					_inspector.set_state_failed(item, test_event)
-				FLAKY:
-					_inspector.set_state_flaky(parent, test_event)
-					_inspector.set_state_flaky(item, test_event)
-		else:
-			_inspector.set_state_succeded(item)
+	#		_inspector.set_state_succeded(item)
 
 
 func get_item_state(parent :TreeItem, item_name :String = "") -> int:
@@ -92,6 +103,18 @@ func get_item_state(parent :TreeItem, item_name :String = "") -> int:
 		if item.get_text(0) == item_name:
 			return item.get_meta(_inspector.META_GDUNIT_STATE)
 	return parent.get_meta(_inspector.META_GDUNIT_STATE)
+
+
+func test_find_item_by_id() -> void:
+	var suite_script := GdUnitTestResourceLoader.load_gd_script("res://addons/gdUnit4/test/ui/parts/resources/bar/ExampleTestSuiteA.resource", true)
+	var discovered_tests := {}
+	GdUnitTestDiscoverer.discover_tests(suite_script, func(discover_test: GdUnitTestCase) -> void:
+		discover_sink(discover_test)
+		discovered_tests[discover_test.test_name] = discover_test
+	)
+	var test_aa: GdUnitTestCase = discovered_tests["test_aa"]
+	var item := _inspector.find_tree_item_by_id(_inspector._tree_root, test_aa.guid)
+	assert_object(item).is_not_null()
 
 
 func test_select_first_failure() -> void:
@@ -103,7 +126,13 @@ func test_select_first_failure() -> void:
 	assert_object(_inspector._tree.get_selected()).is_null()
 
 	# add failures
-	set_test_state(["test_aa", "test_ad", "test_cb", "test_cc", "test_ce"], FAILED)
+	set_test_state([
+		discovered_tests_suite_a["test_aa"],
+		discovered_tests_suite_a["test_ad"],
+		discovered_tests_suite_c["test_cb"],
+		discovered_tests_suite_c["test_cc"],
+		discovered_tests_suite_c["test_ce"]]
+		, FAILED)
 
 	# select first failure
 	_inspector._on_select_next_item_by_state(FAILED)
@@ -119,7 +148,13 @@ func test_select_last_failure() -> void:
 	assert_object(_inspector._tree.get_selected()).is_null()
 
 	# add failures
-	set_test_state(["test_aa", "test_ad", "test_cb", "test_cc", "test_ce"], FAILED)
+	set_test_state([
+		discovered_tests_suite_a["test_aa"],
+		discovered_tests_suite_a["test_ad"],
+		discovered_tests_suite_c["test_cb"],
+		discovered_tests_suite_c["test_cc"],
+		discovered_tests_suite_c["test_ce"]]
+		, FAILED)
 	# select last failure
 	_inspector._on_select_previous_item_by_state(FAILED)
 	assert_str(_inspector._tree.get_selected().get_text(0)).is_equal("test_ce")
@@ -134,7 +169,13 @@ func test_select_next_failure() -> void:
 	assert_str(_inspector._tree.get_selected()).is_null()
 
 	# add failures
-	set_test_state(["test_aa", "test_ad", "test_cb", "test_cc", "test_ce"], FAILED)
+	set_test_state([
+		discovered_tests_suite_a["test_aa"],
+		discovered_tests_suite_a["test_ad"],
+		discovered_tests_suite_c["test_cb"],
+		discovered_tests_suite_c["test_cc"],
+		discovered_tests_suite_c["test_ce"]]
+		, FAILED)
 
 	# first time select next than select first failure
 	_inspector._on_select_next_item_by_state(FAILED)
@@ -163,7 +204,13 @@ func test_select_previous_failure() -> void:
 	assert_str(_inspector._tree.get_selected()).is_null()
 
 	# add failures
-	set_test_state(["test_aa", "test_ad", "test_cb", "test_cc", "test_ce"], FAILED)
+	set_test_state([
+		discovered_tests_suite_a["test_aa"],
+		discovered_tests_suite_a["test_ad"],
+		discovered_tests_suite_c["test_cb"],
+		discovered_tests_suite_c["test_cc"],
+		discovered_tests_suite_c["test_ce"]]
+		, FAILED)
 
 	# first time select previous than select last failure
 	_inspector._on_select_previous_item_by_state(FAILED)
@@ -192,7 +239,11 @@ func test_select_next_flaky() -> void:
 	assert_str(_inspector._tree.get_selected()).is_null()
 
 	# add flaky tests
-	set_test_state(["test_cb", "test_cc", "test_ce"], FLAKY)
+	set_test_state([
+		discovered_tests_suite_c["test_cb"],
+		discovered_tests_suite_c["test_cc"],
+		discovered_tests_suite_c["test_ce"]]
+		, FLAKY)
 
 	# first time select next than select first failure
 	_inspector._on_select_next_item_by_state(FLAKY)
@@ -217,7 +268,11 @@ func test_select_previous_flaky() -> void:
 	assert_str(_inspector._tree.get_selected()).is_null()
 
 	# add failures
-	set_test_state(["test_cb", "test_cc", "test_ce"], FLAKY)
+	set_test_state([
+		discovered_tests_suite_c["test_cb"],
+		discovered_tests_suite_c["test_cc"],
+		discovered_tests_suite_c["test_ce"]]
+		, FLAKY)
 
 	# first time select previous than select last failure
 	_inspector._on_select_previous_item_by_state(FLAKY)
@@ -239,24 +294,29 @@ func test_suite_text_shows_amount_of_cases() -> void:
 
 
 func test_suite_text_responds_to_test_case_events() -> void:
-	var suite_script_path: String = _inspector.get_item_source_file(_inspector.find_tree_item(suite_a_item, "test_aa"))
-	var success_aa := GdUnitEvent.new().test_after(GdUnitGUID.new(), suite_script_path, "ExampleTestSuiteA", "test_aa")
+
+	var test_aa: GdUnitTestCase = discovered_tests_suite_a["test_aa"]
+	var test_ab: GdUnitTestCase = discovered_tests_suite_a["test_ab"]
+	var test_ac: GdUnitTestCase = discovered_tests_suite_a["test_ac"]
+	var test_ad: GdUnitTestCase = discovered_tests_suite_a["test_ad"]
+	var test_ae: GdUnitTestCase = discovered_tests_suite_a["test_ae"]
+	var success_aa := GdUnitEvent.new().test_after(test_aa.guid)
 	_inspector._on_gdunit_event(success_aa)
 	assert_str(suite_a_item.get_text(0)).is_equal("(1/5) ExampleTestSuiteA")
 
-	var error_ad := GdUnitEvent.new().test_after(GdUnitGUID.new(), suite_script_path, "ExampleTestSuiteA", "test_ad", {GdUnitEvent.ERRORS: true})
+	var error_ad := GdUnitEvent.new().test_after(test_ad.guid, {GdUnitEvent.ERRORS: true})
 	_inspector._on_gdunit_event(error_ad)
 	assert_str(suite_a_item.get_text(0)).is_equal("(1/5) ExampleTestSuiteA")
 
-	var failure_ab := GdUnitEvent.new().test_after(GdUnitGUID.new(), suite_script_path, "ExampleTestSuiteA", "test_ab", {GdUnitEvent.FAILED: true})
+	var failure_ab := GdUnitEvent.new().test_after(test_ab.guid, {GdUnitEvent.FAILED: true})
 	_inspector._on_gdunit_event(failure_ab)
 	assert_str(suite_a_item.get_text(0)).is_equal("(1/5) ExampleTestSuiteA")
 
-	var skipped_ac := GdUnitEvent.new().test_after(GdUnitGUID.new(), suite_script_path, "ExampleTestSuiteA", "test_ac", {GdUnitEvent.SKIPPED: true})
+	var skipped_ac := GdUnitEvent.new().test_after(test_ac.guid, {GdUnitEvent.SKIPPED: true})
 	_inspector._on_gdunit_event(skipped_ac)
 	assert_str(suite_a_item.get_text(0)).is_equal("(1/5) ExampleTestSuiteA")
 
-	var success_ae := GdUnitEvent.new().test_after(GdUnitGUID.new(), suite_script_path, "ExampleTestSuiteA", "test_ae")
+	var success_ae := GdUnitEvent.new().test_after(test_ae.guid)
 	_inspector._on_gdunit_event(success_ae)
 	assert_str(suite_a_item.get_text(0)).is_equal("(2/5) ExampleTestSuiteA")
 
@@ -281,8 +341,8 @@ func test_update_test_case_on_multiple_test_suite_with_same_name() -> void:
 	# set test starting checked suite_a_item
 	var test_aa: GdUnitTestCase = discovered_tests["test_aa"]
 	var test_ab: GdUnitTestCase = discovered_tests["test_ab"]
-	_inspector._on_gdunit_event(GdUnitEvent.new().test_before(test_aa.guid, test_aa.source_file, test_aa.suite_name, test_aa.test_name))
-	_inspector._on_gdunit_event(GdUnitEvent.new().test_before(test_ab.guid, test_ab.source_file, test_ab.suite_name, test_ab.test_name))
+	_inspector._on_gdunit_event(GdUnitEvent.new().test_before(test_aa.guid))
+	_inspector._on_gdunit_event(GdUnitEvent.new().test_before(test_ab.guid))
 	assert_str(suite_item.get_text(0)).is_equal("(0/5) ExampleTestSuiteA")
 	assert_int(get_item_state(suite_item, "test_aa")).is_equal(_inspector.STATE.RUNNING)
 	assert_int(get_item_state(suite_item, "test_ab")).is_equal(_inspector.STATE.RUNNING)
@@ -292,8 +352,8 @@ func test_update_test_case_on_multiple_test_suite_with_same_name() -> void:
 	assert_int(get_item_state(suite_a_item, "test_ab")).is_equal(_inspector.STATE.INITIAL)
 
 	# finish the tests with success
-	_inspector._on_gdunit_event(GdUnitEvent.new().test_after(test_aa.guid, test_aa.source_file, test_aa.suite_name, test_aa.test_name))
-	_inspector._on_gdunit_event(GdUnitEvent.new().test_after(test_ab.guid, test_ab.source_file, test_ab.suite_name, test_ab.test_name))
+	_inspector._on_gdunit_event(GdUnitEvent.new().test_after(test_aa.guid))
+	_inspector._on_gdunit_event(GdUnitEvent.new().test_after(test_ab.guid))
 
 	# verify updated state checked suite_a_item
 	assert_str(suite_item.get_text(0)).is_equal("(2/5) ExampleTestSuiteA")
@@ -308,7 +368,11 @@ func test_update_test_case_on_multiple_test_suite_with_same_name() -> void:
 # Test coverage for issue GD-278: GdUnit Inspector: Test marks as passed if both warning and error
 func test_update_icon_state() -> void:
 	var suite_script := GdUnitTestResourceLoader.load_gd_script("res://addons/gdUnit4/test/core/resources/testsuites/TestSuiteFailAndOrpahnsDetected.resource", true)
-	GdUnitTestDiscoverer.discover_tests(suite_script, discover_sink)
+	var discovered_tests := {}
+	GdUnitTestDiscoverer.discover_tests(suite_script, func(discover_test: GdUnitTestCase) -> void:
+		discover_sink(discover_test)
+		discovered_tests[discover_test.test_name] = discover_test
+	)
 	var suite_script_path := suite_script.resource_path
 	var suite_name := "TestSuiteFailAndOrpahnsDetected"
 	var suite_item := _inspector.get_tree_item(suite_script_path, suite_name)
@@ -320,8 +384,10 @@ func test_update_icon_state() -> void:
 	assert_int(get_item_state(suite_item, "test_case2")).is_equal(_inspector.STATE.INITIAL)
 
 	# Set tests to running
-	_inspector._on_gdunit_event(GdUnitEvent.new().test_before(GdUnitGUID.new(), suite_script_path, suite_name, "test_case1"))
-	_inspector._on_gdunit_event(GdUnitEvent.new().test_before(GdUnitGUID.new(), suite_script_path, suite_name, "test_case2"))
+	var test_case1: GdUnitTestCase = discovered_tests["test_case1"]
+	var test_case2: GdUnitTestCase = discovered_tests["test_case2"]
+	_inspector._on_gdunit_event(GdUnitEvent.new().test_before(test_case1.guid))
+	_inspector._on_gdunit_event(GdUnitEvent.new().test_before(test_case2.guid))
 	# Verify all items on state running.
 	assert_str(suite_item.get_text(0)).is_equal("(0/2) " + suite_name)
 	assert_int(get_item_state(suite_item, "test_case1")).is_equal(_inspector.STATE.RUNNING)
@@ -329,13 +395,11 @@ func test_update_icon_state() -> void:
 
 	# Simulate test processed and fails on test_case2
 	# test_case1 succeeded
-	_inspector._on_gdunit_event(GdUnitEvent.new().test_after(GdUnitGUID.new(), suite_script_path, suite_name, "test_case1"))
+	_inspector._on_gdunit_event(GdUnitEvent.new().test_after(test_case1.guid))
 	# test_case2 is failing by an orphan warning and an failure
-	_inspector._on_gdunit_event(GdUnitEvent.new()\
-		.test_after(GdUnitGUID.new(), suite_script_path, suite_name, "test_case2", {GdUnitEvent.FAILED: true}))
+	_inspector._on_gdunit_event(GdUnitEvent.new().test_after(test_case2.guid, {GdUnitEvent.FAILED: true}))
 	# We check whether a test event with a warning does not overwrite a higher object status, e.g. an error.
-	_inspector._on_gdunit_event(GdUnitEvent.new()\
-		.test_after(GdUnitGUID.new(), suite_script_path, suite_name, "test_case2", {GdUnitEvent.WARNINGS: true}))
+	_inspector._on_gdunit_event(GdUnitEvent.new().test_after(test_case2.guid, {GdUnitEvent.WARNINGS: true}))
 
 	# Verify the final state
 	assert_str(suite_item.get_text(0)).is_equal("(2/2) " + suite_name)
@@ -432,19 +496,27 @@ func test_collect_test_cases() -> void:
 		tests_by_id[test_to_discover.display_name] = test_to_discover
 	)
 
+	var test_case1: GdUnitTestCase = tests_by_id["test_case1"]
+
+	# Test select a single suite
+	# Collect all test cases from the suite node (parent of test_case1)
+	var test := _inspector.find_tree_item_by_id(_inspector._tree_root, test_case1.guid)
+	var collected_tests := _inspector.collect_test_cases(test.get_parent())
+	# Do verify all tests are collected, ignoring the order could be different according to selected sort mode
+	assert_array(collected_tests).contains_exactly_in_any_order(tests_by_id.values())
+
 	# Test select a single test
-	var expected_test: GdUnitTestCase = tests_by_id["test_case1"]
 	# Find tree node by test id
-	var test := _inspector.find_tree_item_by_id(_inspector._tree_root, expected_test.guid)
+	test = _inspector.find_tree_item_by_id(_inspector._tree_root, test_case1.guid)
 	# Collect all test cases by given tree node
-	var collected_tests := _inspector.collect_test_cases(test)
-	assert_array(collected_tests).contains_exactly([expected_test])
+	collected_tests = _inspector.collect_test_cases(test)
+	assert_array(collected_tests).contains_exactly([test_case1])
 
 	# Test select on paramaterized
 	var paramaterized_test: GdUnitTestCase = tests_by_id["test_parameterized_static:0 (1, 1)"]
 	test = _inspector.find_tree_item_by_id(_inspector._tree_root, paramaterized_test.guid)
-	# Collect all paramaterized tests
-	collected_tests = _inspector.collect_test_cases(test)
+	# Collect all paramaterized tests (by parent of paramaterized_test)
+	collected_tests = _inspector.collect_test_cases(test.get_parent())
 	# Do verify all tests are collected, ignoring the order could be different according to selected sort mode
 	var expected_tests: Array = tests_by_id.values().filter(func(test_to_filter: GdUnitTestCase) -> bool:
 		return test_to_filter.test_name == "test_parameterized_static"
@@ -452,12 +524,6 @@ func test_collect_test_cases() -> void:
 	assert_array(collected_tests)\
 		.has_size(3)\
 		.contains_exactly_in_any_order(expected_tests)
-
-	# Test select a single suite
-	# Collect all test cases from the suite node (parent)
-	collected_tests = _inspector.collect_test_cases(test.get_parent())
-	# Do verify all tests are collected, ignoring the order could be different according to selected sort mode
-	assert_array(collected_tests).contains_exactly_in_any_order(tests_by_id.values())
 
 
 ## test helpers to validate two trees


### PR DESCRIPTION
# Why
see https://github.com/MikeSchulze/gdUnit4/issues/688

# What
- simplify `test_before` and `test_after`
- do find tree items by guid on explorer instead of using path + name
- use guid to find test record on discovery guard to build test output messages
- fix item creation by add test case record based on time type
- fix bug in `is_test_id` by using `equals` of `GdUnitGUID`