### PR TITLE
Update ci-pr-publish-report.yml to work with `dorny/test-reporter@v2`

### DIFF
--- a/.github/workflows/ci-pr-publish-report.yml
+++ b/.github/workflows/ci-pr-publish-report.yml
@@ -18,7 +18,7 @@ permissions:
 
 jobs:
   publish-reports:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       max-parallel: 10
@@ -31,13 +31,27 @@ jobs:
         #     godot-status: 'rc3'
 
     steps:
-      - name: 'Publish Test Results'
-        if: ${{ matrix.godot-net == '' }}
-        uses: dorny/test-reporter@v2.0.0
+      - uses: actions/checkout@v4
         with:
+          sparse-checkout: .github
+
+      - name: 'Download artifacts'
+        uses: actions/download-artifact@v4
+        with:
+          name: artifact_gdUnit4_Godot${{ matrix.godot-version }}-${{ matrix.godot-status }}${{ matrix.godot-net }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          repository: MikeSchulze/gdUnit4
+          run-id: ${{ github.event.inputs.workflow_run_id || github.event.workflow_run.id }}
+
+      - name: 'Publish Test Results'
+        uses: dorny/test-reporter@v2
+        with:
+          # using artifact to download is broken since download-artifact@v4 see https://github.com/dorny/test-reporter/issues/363
+          # We do the download manually on step `Download artifacts`
+          #artifact: artifact_gdUnit4_Godot${{ matrix.godot-version }}-${{ matrix.godot-status }}${{ matrix.godot-net }}
           name: report_gdUnit4_Godot${{ matrix.godot-version }}-${{ matrix.godot-status }}${{ matrix.godot-net }}
-          artifact: artifact_gdUnit4_Godot${{ matrix.godot-version }}-${{ matrix.godot-status }}${{ matrix.godot-net }}
-          path: './home/runner/work/gdUnit4/gdUnit4/reports/**/results.xml,./home/runner/work/gdUnit4/gdUnit4/reports/*.xml'
-          reporter: java-junit
+          path: './home/runner/work/gdUnit4/gdUnit4/reports/**/*.xml'
+          reporter: ${{ matrix.godot-net == '-net' && 'dotnet-trx' || 'java-junit' }}
           fail-on-error: 'false'
           fail-on-empty: 'false'
+          use-actions-summary: 'false'

--- a/.github/workflows/ci-pr-publish-report.yml
+++ b/.github/workflows/ci-pr-publish-report.yml
@@ -31,40 +31,13 @@ jobs:
         #     godot-status: 'rc3'
 
     steps:
-      - uses: actions/checkout@v4
-        with:
-          sparse-checkout: .github
-
-      - name: Download artifacts
-        uses: actions/download-artifact@v4.2.1
-        with:
-          name: artifact_gdUnit4_Godot${{ matrix.godot-version }}-${{ matrix.godot-status }}${{ matrix.godot-net }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          repository: MikeSchulze/gdUnit4
-          run-id: ${{ github.event.inputs.workflow_run_id || github.event.workflow_run.id }}
-
       - name: 'Publish Test Results'
         if: ${{ matrix.godot-net == '' }}
         uses: dorny/test-reporter@v2.0.0
         with:
-          name: report_gdUnit4_Godot${{ matrix.godot-version }}-${{ matrix.godot-status }}
-          # using artifact to download is broken since download-artifact@v4 see https://github.com/dorny/test-reporter/issues/363
-          # We do the download manually on step `Download artifacts`
-          #artifact: artifact_gdUnit4_Godot${{ matrix.godot-version }}-${{ matrix.godot-status }}
-          path: './home/runner/work/gdUnit4/gdUnit4/reports/**/results.xml'
+          name: report_gdUnit4_Godot${{ matrix.godot-version }}-${{ matrix.godot-status }}${{ matrix.godot-net }}
+          artifact: artifact_gdUnit4_Godot${{ matrix.godot-version }}-${{ matrix.godot-status }}${{ matrix.godot-net }}
+          path: './home/runner/work/gdUnit4/gdUnit4/reports/**/results.xml,./home/runner/work/gdUnit4/gdUnit4/reports/*.xml'
           reporter: java-junit
-          fail-on-error: 'false'
-          fail-on-empty: 'false'
-
-      - name: 'Publish Test Adapter Results'
-        if: ${{ matrix.godot-net == '-net' }}
-        uses: dorny/test-reporter@v2.0.0
-        with:
-          name: report_gdUnit4_Godot${{ matrix.godot-version }}-${{ matrix.godot-status }}-net
-          # using artifact to download is broken since download-artifact@v4 see https://github.com/dorny/test-reporter/issues/363
-          # We do the download manually on step `Download artifacts`
-          #artifact: artifact_gdUnit4_Godot${{ matrix.godot-version }}-${{ matrix.godot-status }}${{ matrix.godot-net }}
-          path: './home/runner/work/gdUnit4/gdUnit4/reports/*.xml'
-          reporter: dotnet-trx
           fail-on-error: 'false'
           fail-on-empty: 'false'

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -65,7 +65,7 @@ jobs:
           godot-status: ${{ matrix.godot-status }}
           version: installed
           paths: |
-            res://addons/gdUnit4/test/
+            res://addons/gdUnit4/test/extractors
           arguments: |
             --verbose
           timeout: 10
@@ -82,7 +82,7 @@ jobs:
           godot-net: true
           version: installed
           paths: |
-            res://addons/gdUnit4/test/mono
+            res://addons/gdUnit4/test/dotnet
           timeout: 5
           warnings-as-errors: true
           retries: 3 # We have set the number of repetitions to 3 because Godot mono randomly crashes during C# tests

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -65,7 +65,7 @@ jobs:
           godot-status: ${{ matrix.godot-status }}
           version: installed
           paths: |
-            res://addons/gdUnit4/test/extractors
+            res://addons/gdUnit4/test/
           arguments: |
             --verbose
           timeout: 10


### PR DESCRIPTION
# Why
Since update the dorny/test-reporter to v2 the reports are no longer linked to the trigger CI PR

# What
- Fix `ci-pr-publish-report.yml` by using parameter `use-actions-summary: 'false'`
- Simplify the reporter selection by evaluate the `matrix.godot-net` value
- Fix `cr-pr` .net test running on directory `res://addons/gdUnit4/test/dotnet`  (was changed from mono to dotner)
