### PR TITLE
GD-686: Add `--godot_bin` argument and Godot .NET detection to test-runners scripts

### DIFF
--- a/addons/gdUnit4/runtest.cmd
+++ b/addons/gdUnit4/runtest.cmd
@@ -1,25 +1,62 @@
-@ECHO OFF
-CLS
+@echo off
+setlocal enabledelayedexpansion
 
-IF NOT DEFINED GODOT_BIN (
-	ECHO "GODOT_BIN is not set."
-	ECHO "Please set the environment variable 'setx GODOT_BIN <path to godot.exe>'"
-	EXIT /b -1
+:: Initialize variables
+set "godot_bin="
+set "filtered_args="
+
+:: Process all arguments
+set "i=0"
+:parse_args
+if "%~1"=="" goto end_parse_args
+
+if "%~1"=="--godot_bin" (
+    set "godot_bin=%~2"
+    shift
+    shift
+) else (
+    set "filtered_args=!filtered_args! %~1"
+    shift
+)
+goto parse_args
+:end_parse_args
+
+:: If --godot_bin wasn't provided, fallback to environment variable
+if "!godot_bin!"=="" (
+    set "godot_bin=%GODOT_BIN%"
 )
 
-REM scan if Godot mono used and compile c# classes
-for /f "tokens=5 delims=. " %%i in ('%GODOT_BIN% --version') do set GODOT_TYPE=%%i
-IF "%GODOT_TYPE%" == "mono" (
-	ECHO "Godot mono detected"
-	ECHO Compiling c# classes ... Please Wait
-	dotnet build --debug
-	ECHO done %errorlevel%
+:: Check if we have a godot_bin value from any source
+if "!godot_bin!"=="" (
+    echo Godot binary path is not specified.
+    echo Please either:
+    echo   - Set the environment variable: set GODOT_BIN=C:\path\to\godot.exe
+    echo   - Or use the --godot_bin argument: --godot_bin C:\path\to\godot.exe
+    exit /b 1
 )
 
-%GODOT_BIN% -s -d res://addons/gdUnit4/bin/GdUnitCmdTool.gd %*
-SET exit_code=%errorlevel%
-%GODOT_BIN% --headless --quiet -s -d res://addons/gdUnit4/bin/GdUnitCopyLog.gd %*
+:: Check if the Godot binary exists
+if not exist "!godot_bin!" (
+    echo Error: The specified Godot binary '!godot_bin!' does not exist.
+    exit /b 1
+)
 
-ECHO %exit_code%
+:: Get Godot version and check if it's a mono build
+for /f "tokens=*" %%i in ('"!godot_bin!" --version') do set GODOT_VERSION=%%i
+echo !GODOT_VERSION! | findstr /I "mono" >nul
+if !errorlevel! equ 0 (
+    echo Godot .NET detected
+    echo Compiling c# classes ... Please Wait
+    dotnet build --debug
+    echo done !errorlevel!
+)
 
-EXIT /B %exit_code%
+:: Run the tests with the filtered arguments
+"!godot_bin!" --path . -s -d res://addons/gdUnit4/bin/GdUnitCmdTool.gd !filtered_args!
+set exit_code=%ERRORLEVEL%
+echo Run tests ends with %exit_code%
+
+:: Run the copy log command
+"!godot_bin!" --headless --path . --quiet -s res://addons/gdUnit4/bin/GdUnitCopyLog.gd !filtered_args! > nul
+set exit_code2=%ERRORLEVEL%
+exit /b %exit_code%

--- a/addons/gdUnit4/runtest.sh
+++ b/addons/gdUnit4/runtest.sh
@@ -1,15 +1,62 @@
-#!/bin/sh
+#!/bin/bash
 
-if [ -z "$GODOT_BIN" ]; then
-    echo "'GODOT_BIN' is not set."
-    echo "Please set the environment variable  'export GODOT_BIN=/Applications/Godot.app/Contents/MacOS/Godot'"
+# Check for command-line argument
+godot_bin=""
+filtered_args=""
+
+# Process all arguments with a more compatible approach
+while [ $# -gt 0 ]; do
+    if [ "$1" = "--godot_bin" ] && [ $# -gt 1 ]; then
+        # Get the next argument as the value
+        godot_bin="$2"
+        shift 2
+    else
+        # Keep non-godot_bin arguments for passing to Godot
+        filtered_args="$filtered_args $1"
+        shift
+    fi
+done
+
+# If --godot_bin wasn't provided, fallback to environment variable
+if [ -z "$godot_bin" ]; then
+    godot_bin="$GODOT_BIN"
+fi
+
+# Check if we have a godot_bin value from any source
+if [ -z "$godot_bin" ]; then
+    echo "Godot binary path is not specified."
+    echo "Please either:"
+    echo "  - Set the environment variable: export GODOT_BIN=/path/to/godot"
+    echo "  - Or use the --godot_bin argument: --godot_bin /path/to/godot"
     exit 1
 fi
 
-"$GODOT_BIN" --path . -s -d res://addons/gdUnit4/bin/GdUnitCmdTool.gd $*
+# Check if the Godot binary exists and is executable
+if [ ! -f "$godot_bin" ]; then
+    echo "Error: The specified Godot binary '$godot_bin' does not exist."
+    exit 1
+fi
+
+if [ ! -x "$godot_bin" ]; then
+    echo "Error: The specified Godot binary '$godot_bin' is not executable."
+    exit 1
+fi
+
+# Get Godot version and check if it's a .NET build
+GODOT_VERSION=$("$godot_bin" --version)
+if echo "$GODOT_VERSION" | grep -i "mono" > /dev/null; then
+    echo "Godot .NET detected"
+    echo "Compiling c# classes ... Please Wait"
+    dotnet build --debug
+    echo "done $?"
+fi
+
+# Run the tests with the filtered arguments
+"$godot_bin" --path . -s -d res://addons/gdUnit4/bin/GdUnitCmdTool.gd $filtered_args
 exit_code=$?
 echo "Run tests ends with $exit_code"
 
-"$GODOT_BIN" --headless --path . --quiet -s -d res://addons/gdUnit4/bin/GdUnitCopyLog.gd $* > /dev/null
+# Run the copy log command
+"$godot_bin" --headless --path . --quiet -s res://addons/gdUnit4/bin/GdUnitCopyLog.gd $filtered_args > /dev/null
 exit_code2=$?
 exit $exit_code


### PR DESCRIPTION
# Why
Users needed a way to override Godot binary path without changing environment variables. Godot .NET projects require C# code to be compiled before tests can run

# What
- Add optional --godot_bin argument to specify Godot executable path
  - Maintained fallback to GODOT_BIN environment variable if argument not provided
- Add version detection to automatically identify Godot .NET by checking for "mono"
  - Run "dotnet build --debug" automatically when .NET is detected
- Added file existence and executable checks for better error handling
- Made both Windows and Unix runners consistent in behavior

