### PR TITLE
GD-635: Using `GdUnit4Net` test engine to execute C# tests

### DIFF
--- a/addons/gdUnit4/src/core/discovery/GdUnitTestCase.gd
+++ b/addons/gdUnit4/src/core/discovery/GdUnitTestCase.gd
@@ -34,6 +34,9 @@ var require_godot_runtime: bool = true
 ## Used for test discovery and execution.
 var source_file: String
 
+## Optional holds the assembly location for C# tests
+var assembly_location: String = ""
+
 ## The line number where the test case is defined in the source file.
 ## Used for navigation and error reporting.
 var line_number: int = -1
@@ -48,7 +51,7 @@ var metadata: Dictionary = {}
 
 static func from_dict(dict: Dictionary) -> GdUnitTestCase:
 	var test := GdUnitTestCase.new()
-	test.guid = GdUnitGUID.new(str(dict["Guid"]))
+	test.guid = GdUnitGUID.new(str(dict["guid"]))
 	test.suite_name = dict["managed_type"]
 	test.test_name = dict["test_name"]
 	test.display_name = dict["simple_name"]
@@ -57,7 +60,23 @@ static func from_dict(dict: Dictionary) -> GdUnitTestCase:
 	test.source_file = dict["source_file"]
 	test.line_number = dict["line_number"]
 	test.require_godot_runtime = dict["require_godot_runtime"]
+	test.assembly_location = dict["assembly_location"]
 	return test
+
+
+static func to_dict(test: GdUnitTestCase) -> Dictionary:
+	return {
+		"guid": test.guid._guid,
+		"managed_type": test.suite_name,
+		"test_name" : test.test_name,
+		"simple_name" : test.display_name,
+		"fully_qualified_name" : test.fully_qualified_name,
+		"attribute_index" : test.attribute_index,
+		"source_file" : test.source_file,
+		"line_number" : test.line_number,
+		"require_godot_runtime" : test.require_godot_runtime,
+		"assembly_location" : test.assembly_location
+	}
 
 
 static func from(_source_file: String, _line_number: int, _test_name: String, _attribute_index := -1, _test_parameters := "") -> GdUnitTestCase:

--- a/addons/gdUnit4/src/core/runners/GdUnitTestCIRunner.gd
+++ b/addons/gdUnit4/src/core/runners/GdUnitTestCIRunner.gd
@@ -405,17 +405,12 @@ func discover_tests() -> Array[GdUnitTestCase]:
 	for path in _included_tests:
 		var scripts := scanner.scan(path)
 		for script in scripts:
-			if script is GDScript:
-				var gd_script: GDScript = script
-				GdUnitTestDiscoverer.discover_tests(gd_script, func(test: GdUnitTestCase) -> void:
-					if not is_skipped(test):
-						#_console.println_message("discoverd %s" % test.display_name)
-						_test_cases.append(test)
-						gdunit_test_discover_added.emit(test)
-				)
-			else:
-				## TODO implement c# test discovery here
-				pass
+			GdUnitTestDiscoverer.discover_tests(script, func(test: GdUnitTestCase) -> void:
+				if not is_skipped(test):
+					#_console.println_message("discoverd %s" % test.display_name)
+					_test_cases.append(test)
+					gdunit_test_discover_added.emit(test)
+			)
 
 	return _test_cases
 

--- a/gdUnit4.csproj
+++ b/gdUnit4.csproj
@@ -10,9 +10,9 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0"/>
-    <!-- ProjectReference Include="..\gdUnit4Net\api\gdUnit4Api.csproj" / -->
-    <PackageReference Include="gdUnit4.api" Version="4.4.0-rc11"/>
-    <PackageReference Include="gdUnit4.test.adapter" Version="2.1.0-rc3"/>
+    <!-- ProjectReference Include="..\gdUnit4Net\api\gdUnit4Api.csproj" /-->
+    <PackageReference Include="gdUnit4.api" Version="4.4.0-rc12"/>
+    <PackageReference Include="gdUnit4.test.adapter" Version="2.1.0-rc4"/>
     <PackageReference Include="gdUnit4.analyzers" Version="1.0.0-rc5">
       <PrivateAssets>none</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
# Why
We want to execute C# test inside the Godot GdUnit4 inspector.

# What
- Delegate the C# test execution to `GdUnit4NetApiGodotBridge`

