### PR TITLE
GD-635: Fix test case counting.

### DIFF
--- a/addons/gdUnit4/src/reporters/GdUnitTestReporter.gd
+++ b/addons/gdUnit4/src/reporters/GdUnitTestReporter.gd
@@ -26,7 +26,7 @@ func init_statistics() -> void:
 
 
 func update_statistics(event: GdUnitEvent) -> void:
-	var test_statisitics: Dictionary = _statistics.get_or_add(event.test_name(), {
+	var test_statisitics: Dictionary = _statistics.get_or_add(event.guid(), {
 		"error_count" : 0,
 		"failed_count" : 0,
 		"skipped_count" : event.is_skipped() as int,

--- a/addons/gdUnit4/test/reporters/GdUnitConsoleTestReporterTest.gd
+++ b/addons/gdUnit4/test/reporters/GdUnitConsoleTestReporterTest.gd
@@ -1,0 +1,58 @@
+# GdUnit generated TestSuite
+class_name GdUnitConsoleTestReporterTest
+extends GdUnitTestSuite
+
+
+var reporter :=  GdUnitConsoleTestReporter.new(GdUnitMessageWritter.new())
+
+
+func before_test() -> void:
+	reporter.on_gdunit_event(GdUnitInit.new())
+
+
+func test_on_gdunit_event_init() -> void:
+	assert_int(reporter.processed_suite_count()).is_equal(0)
+	assert_int(reporter.total_test_count()).is_equal(0)
+	assert_int(reporter.total_flaky_count()).is_equal(0)
+	assert_int(reporter.total_error_count()).is_equal(0)
+	assert_int(reporter.total_failure_count()).is_equal(0)
+	assert_int(reporter.total_skipped_count()).is_equal(0)
+	assert_int(reporter.total_orphan_count()).is_equal(0)
+	assert_int(reporter.elapsed_time()).is_equal(0)
+
+
+func test_on_gdunit_event_empty_test_suite() -> void:
+	reporter.on_gdunit_event(GdUnitEvent.new().suite_before("res://tests/suite_a.gd", "suide_a", 0))
+	reporter.on_gdunit_event(GdUnitEvent.new().suite_after("res://tests/suite_a.gd", "suide_a"))
+
+	assert_int(reporter.processed_suite_count()).is_equal(1)
+	assert_int(reporter.total_test_count()).is_equal(0)
+	assert_int(reporter.total_flaky_count()).is_equal(0)
+	assert_int(reporter.total_error_count()).is_equal(0)
+	assert_int(reporter.total_failure_count()).is_equal(0)
+	assert_int(reporter.total_skipped_count()).is_equal(0)
+	assert_int(reporter.total_orphan_count()).is_equal(0)
+	assert_int(reporter.elapsed_time()).is_equal(0)
+
+
+func test_on_gdunit_event_full_test_suite() -> void:
+	var test_id_a := GdUnitGUID.new()
+	var test_id_b := GdUnitGUID.new()
+	var test_id_c := GdUnitGUID.new()
+	reporter.on_gdunit_event(GdUnitEvent.new().suite_before("res://tests/suite_a.gd", "suide_a", 0))
+	reporter.on_gdunit_event(GdUnitEvent.new().test_before(test_id_a))
+	reporter.on_gdunit_event(GdUnitEvent.new().test_after(test_id_a))
+	reporter.on_gdunit_event(GdUnitEvent.new().test_before(test_id_b))
+	reporter.on_gdunit_event(GdUnitEvent.new().test_after(test_id_b))
+	reporter.on_gdunit_event(GdUnitEvent.new().test_before(test_id_c))
+	reporter.on_gdunit_event(GdUnitEvent.new().test_after(test_id_c))
+	reporter.on_gdunit_event(GdUnitEvent.new().suite_after("res://tests/suite_a.gd", "suide_a"))
+
+	assert_int(reporter.processed_suite_count()).is_equal(1)
+	assert_int(reporter.total_test_count()).is_equal(3)
+	assert_int(reporter.total_flaky_count()).is_equal(0)
+	assert_int(reporter.total_error_count()).is_equal(0)
+	assert_int(reporter.total_failure_count()).is_equal(0)
+	assert_int(reporter.total_skipped_count()).is_equal(0)
+	assert_int(reporter.total_orphan_count()).is_equal(0)
+	assert_int(reporter.elapsed_time()).is_equal(0)


### PR DESCRIPTION
# Why
see https://github.com/MikeSchulze/gdUnit4/issues/724

# What
- Use event `guid` to update the test statistics, (we address all tests by his unique id)


