### PR TITLE
GD-731: Fix upgrade warnings for uid's

### DIFF
--- a/addons/gdUnit4/src/core/GdUnitSceneRunnerImpl.gd
+++ b/addons/gdUnit4/src/core/GdUnitSceneRunnerImpl.gd
@@ -502,7 +502,7 @@ func invoke(
 	arg9: Variant = NO_ARG) -> Variant:
 	var args: Array = GdArrayTools.filter_value([arg0,arg1,arg2,arg3,arg4,arg5,arg6,arg7,arg8,arg9], NO_ARG)
 	if scene().has_method(name):
-		return scene().callv(name, args)
+		return await scene().callv(name, args)
 	return "The method '%s' not exist checked loaded scene." % name
 
 

--- a/addons/gdUnit4/src/monitor/GodotGdErrorMonitor.gd
+++ b/addons/gdUnit4/src/monitor/GodotGdErrorMonitor.gd
@@ -52,6 +52,20 @@ func erase_log_entry(entry: ErrorLogEntry) -> void:
 	_entries.erase(entry)
 
 
+func collect_full_logs() -> PackedStringArray:
+	await (Engine.get_main_loop() as SceneTree).process_frame
+	await (Engine.get_main_loop() as SceneTree).physics_frame
+
+	var file := FileAccess.open(_godot_log_file, FileAccess.READ)
+	file.seek(_eof)
+	var records := PackedStringArray()
+	while not file.eof_reached():
+		@warning_ignore("return_value_discarded")
+		records.append(file.get_line())
+
+	return records
+
+
 func _collect_log_entries(force_collect_reports: bool) -> Array[ErrorLogEntry]:
 	var file := FileAccess.open(_godot_log_file, FileAccess.READ)
 	file.seek(_eof)

--- a/addons/gdUnit4/src/ui/parts/InspectorStatusBar.gd
+++ b/addons/gdUnit4/src/ui/parts/InspectorStatusBar.gd
@@ -18,8 +18,8 @@ signal tree_view_mode_changed(flat :bool)
 @onready var _button_failure_up: Button = %btn_failure_up
 @onready var _button_failure_down: Button = %btn_failure_down
 @onready var _button_sync: Button = %btn_tree_sync
-@onready var _button_view_mode: Button = %btn_tree_mode
-@onready var _button_sort_mode: Button = %btn_tree_sort
+@onready var _button_view_mode: MenuButton = %btn_tree_mode
+@onready var _button_sort_mode: MenuButton = %btn_tree_sort
 
 @onready var _icon_errors: TextureRect = %icon_errors
 @onready var _icon_failures: TextureRect = %icon_failures

--- a/addons/gdUnit4/src/ui/settings/GdUnitSettingsDialog.gd
+++ b/addons/gdUnit4/src/ui/settings/GdUnitSettingsDialog.gd
@@ -22,7 +22,7 @@ const GdUnitUpdateClient = preload ("res://addons/gdUnit4/src/update/GdUnitUpdat
 
 var _font_size: float
 
-
+@warning_ignore_start("unsafe_property_access", "unsafe_call_argument", "unsafe_method_access")
 func _ready() -> void:
 	set_name("GdUnitSettingsDialog")
 	# initialize for testing
@@ -315,3 +315,5 @@ func stop_progress() -> void:
 func update_progress(message: String) -> void:
 	_progress_text.text = message
 	_progress_bar.value += 1
+
+@warning_ignore_restore("unsafe_property_access", "unsafe_call_argument", "unsafe_method_access")

--- a/addons/gdUnit4/src/update/GdUnitPatcher.gd
+++ b/addons/gdUnit4/src/update/GdUnitPatcher.gd
@@ -22,6 +22,7 @@ func _scan(scan_path :String, current :GdUnit4Version) -> void:
 func patch_count() -> int:
 	var count := 0
 	for key :String in _patches.keys():
+		@warning_ignore("unsafe_method_access")
 		count += _patches[key].size()
 	return count
 
@@ -29,7 +30,7 @@ func patch_count() -> int:
 func execute() -> void:
 	for key :String in _patches.keys():
 		for path :String in _patches[key]:
-			var patch :GdUnitPatch = load(key + "/" + path).new()
+			var patch :GdUnitPatch = (load(key + "/" + path) as GDScript).new()
 			if patch:
 				prints("execute patch", patch.version(), patch.get_script().resource_path)
 				if not patch.execute():

--- a/addons/gdUnit4/test/update/GdUnitUpdateTest.gd
+++ b/addons/gdUnit4/test/update/GdUnitUpdateTest.gd
@@ -10,9 +10,28 @@ func after_test() -> void:
 	clean_temp_dir()
 
 
-func test__prepare_update_deletes_old_content() -> void:
-	var _update :GdUnitUpdate = auto_free(GdUnitUpdate.new())
+func test_patch_uids() -> void:
+	var update := scene_runner("res://addons/gdUnit4/src/update/GdUnitUpdate.tscn")
+	update.set_property("_debug_mode", true)
 
+	# Us log monitor to catch debug messages
+	var log_monitor := GodotGdErrorMonitor.new()
+	log_monitor.start()
+	# start uid patching
+	await update.invoke("patch_uids")
+	log_monitor.stop()
+	var logs := await log_monitor.collect_full_logs()
 
+	# Verify all scenes are upgrade
+	assert_array(logs).contains([
+		"Upgrade uid for resource 'GdUnitServer.tscn'",
+		"Upgrade uid for resource 'GdUnitConsole.tscn'",
+		"Upgrade uid for resource 'GdUnitUpdate.tscn'",
+		"Upgrade uid for resource 'GdUnitTestRunner.tscn'",
+		"Upgrade uid for resource 'GdUnitInspector.tscn'",
+		"Upgrade uid for resource 'GdUnitUpdateNotify.tscn'"])
 
-
+	# Verify images are reimported
+	assert_array(logs).contains([
+		"Reimport resources 'res://addons/gdUnit4/src/core/assets/touch-button.png'",
+		"Reimport resources 'res://addons/gdUnit4/src/reporters/html/template/css/logo.png'"])


### PR DESCRIPTION
# Why
When the upgrade runs on Godot 4.4.x the uid`s are mismatching and needs to be updated.

# What
- Add patching of all GdUnit4 scenes and images on update

