### PR TITLE
GD-728: Fix mocking of functions with Variant dafaults

### DIFF
--- a/addons/gdUnit4/src/core/parse/GdDefaultValueDecoder.gd
+++ b/addons/gdUnit4/src/core/parse/GdDefaultValueDecoder.gd
@@ -255,6 +255,9 @@ static func decode(value: Variant) -> String:
 	@warning_ignore("unsafe_cast")
 	if GdArrayTools.is_type_array(type) and (value as Array).is_empty():
 		return "<empty>"
+	# For Variant types we need to determine the original type
+	if type == GdObjects.TYPE_VARIANT:
+		type = typeof(value)
 	var decoder := _get_value_decoder(type)
 	if decoder == null:
 		push_error("No value decoder registered for type '%d'! Please open a Bug issue at 'https://github.com/MikeSchulze/gdUnit4/issues/new/choose'." % type)
@@ -267,6 +270,9 @@ static func decode(value: Variant) -> String:
 static func decode_typed(type: int, value: Variant) -> String:
 	if value == null:
 		return "null"
+	# For Variant types we need to determine the original type
+	if type == GdObjects.TYPE_VARIANT:
+		type = typeof(value)
 	var decoder := _get_value_decoder(type)
 	if decoder == null:
 		push_error("No value decoder registered for type '%d'! Please open a Bug issue at 'https://github.com/MikeSchulze/gdUnit4/issues/new/choose'." % type)

--- a/addons/gdUnit4/src/core/parse/GdFunctionArgument.gd
+++ b/addons/gdUnit4/src/core/parse/GdFunctionArgument.gd
@@ -57,7 +57,7 @@ func set_value(value: String) -> void:
 
 	if _type == TYPE_NIL or _type == GdObjects.TYPE_VARIANT:
 		_type = _extract_value_type(value)
-		if _type == GdObjects.TYPE_VARIANT:
+		if _type == GdObjects.TYPE_VARIANT and _default_value == null:
 			_default_value = value
 	if _default_value == null:
 		match _type:
@@ -131,7 +131,7 @@ func _to_string() -> String:
 		s += ": " + GdObjects.type_as_string(_type)
 	if _type_hint != TYPE_NIL:
 		s += "[%s]" % GdObjects.type_as_string(_type_hint)
-	if typeof(_default_value) != TYPE_STRING:
+	if has_default():
 		s += "=" + value_as_string()
 	return s
 

--- a/addons/gdUnit4/src/doubler/GdFunctionDoubler.gd
+++ b/addons/gdUnit4/src/doubler/GdFunctionDoubler.gd
@@ -200,8 +200,12 @@ static func typeless_args(descriptor: GdFunctionDescriptor) -> String:
 	var collect := PackedStringArray()
 	for arg in descriptor.args():
 		if arg.has_default():
-			@warning_ignore("return_value_discarded")
-			collect.push_back(arg.name() + "_" + "=" + arg.value_as_string())
+			# For Variant types we need to enforce the type in the signature
+			if arg.type() == GdObjects.TYPE_VARIANT:
+				collect.push_back("%s_:%s=%s" % [arg.name(), GdObjects.type_as_string(arg.type()), arg.value_as_string()])
+			else:
+				@warning_ignore("return_value_discarded")
+				collect.push_back("%s_=%s" % [arg.name(), arg.value_as_string()])
 		else:
 			@warning_ignore("return_value_discarded")
 			collect.push_back(arg.name() + "_")

--- a/addons/gdUnit4/test/core/parse/GdScriptParserTest.gd
+++ b/addons/gdUnit4/test/core/parse/GdScriptParserTest.gd
@@ -243,6 +243,32 @@ func test_parse_arguments_typed_dict() -> void:
 		.contains_key_value("arg3", "{}")
 
 
+func test_parse_arguments_variant() -> void:
+	# remove this line and complete your test
+	var args := _parser._parse_function_arguments('func generate(
+		ucids: Array[int],
+		position: Vector2i,
+		size: Vector2i,
+		style: int,
+		text: Variant = "",
+		button_name := "",
+		type_in := 0,
+		caption := "",
+		show_everywhere := false')
+
+	assert_dict(args)\
+		.has_size(9)\
+		.contains_key_value("ucids", GdFunctionArgument.UNDEFINED)\
+		.contains_key_value("position", GdFunctionArgument.UNDEFINED)\
+		.contains_key_value("size", GdFunctionArgument.UNDEFINED)\
+		.contains_key_value("style", GdFunctionArgument.UNDEFINED)\
+		.contains_key_value("text", '""')\
+		.contains_key_value("button_name", '""')\
+		.contains_key_value("type_in", '0')\
+		.contains_key_value("caption", '""')\
+		.contains_key_value("show_everywhere", 'false')
+
+
 func test_parse_arguments_typed_array() -> void:
 	# remove this line and complete your test
 	assert_dict(_parser._parse_function_arguments("func generate(arg1: Array, arg2: Array = [1,2,3], arg3: Array[int] = [4,5,6], arg4 := []) -> void:"))\
@@ -568,7 +594,7 @@ func test_parse_func_descriptor_with_fuzzers() -> void:
 		GdFunctionArgument.new("fuzzer_c", GdObjects.TYPE_FUZZER, "fuzz_c()"),
 		GdFunctionArgument.new("fuzzer", GdObjects.TYPE_FUZZER, "Fuzzers.rangei(-23, 22)"),
 		# untyped arg is TYPE_VARIANT
-		GdFunctionArgument.new("fuzzer_iterations", GdObjects.TYPE_VARIANT, "234"),
+		GdFunctionArgument.new("fuzzer_iterations", GdObjects.TYPE_VARIANT, 234),
 		# typed is TYPE_INT
 		GdFunctionArgument.new("fuzzer_seed", TYPE_INT, 100)
 	]))

--- a/addons/gdUnit4/test/core/parse/GdScriptParsingFunctionDescriptors.gd
+++ b/addons/gdUnit4/test/core/parse/GdScriptParsingFunctionDescriptors.gd
@@ -125,6 +125,26 @@ func test_default_args_callable() -> void:
 		)
 
 
+func test_default_args_variant() -> void:
+	var script: GDScript = load("res://addons/gdUnit4/test/core/resources/parsing/functions/ClassWithVariantTypeDefaultArguments.gd")
+
+	var fds := _parser.get_function_descriptors(script, [])
+	assert_that(fds[0])\
+		.is_equal(GdFunctionDescriptor
+			.create("add_button", script.resource_path, 4, GdObjects.TYPE_VOID, [
+				GdFunctionArgument.new("ucids", TYPE_ARRAY, GdFunctionArgument.UNDEFINED, TYPE_INT),
+				GdFunctionArgument.new("position", TYPE_VECTOR2I),
+				GdFunctionArgument.new("size", TYPE_VECTOR2I),
+				GdFunctionArgument.new("style", TYPE_INT),
+				GdFunctionArgument.new("text", GdObjects.TYPE_VARIANT, ""),
+				GdFunctionArgument.new("button_name", TYPE_STRING, ""),
+				GdFunctionArgument.new("type_in", TYPE_INT, 0),
+				GdFunctionArgument.new("caption", TYPE_STRING, ""),
+				GdFunctionArgument.new("show_everywhere", TYPE_BOOL, false),
+			])
+		)
+
+
 # Basic build-in-types
 func test_default_args_basic_type_int() -> void:
 	var script: GDScript = load("res://addons/gdUnit4/test/core/resources/parsing/functions/basic_build_in_types/ClassWithBasicTypeIntDefaultArguments.gd")

--- a/addons/gdUnit4/test/core/resources/parsing/functions/ClassWithVariantTypeDefaultArguments.gd
+++ b/addons/gdUnit4/test/core/resources/parsing/functions/ClassWithVariantTypeDefaultArguments.gd
@@ -1,0 +1,8 @@
+extends RefCounted
+
+@warning_ignore("unused_parameter")
+func add_button(
+	ucids: Array[int], position: Vector2i, size: Vector2i, style: int, text: Variant = "",
+	button_name := "", type_in := 0, caption := "", show_everywhere := false
+) -> void:
+	pass

--- a/addons/gdUnit4/test/mocker/GdUnitMockerTest.gd
+++ b/addons/gdUnit4/test/mocker/GdUnitMockerTest.gd
@@ -1239,3 +1239,7 @@ func test_mock_func_default_arg_dict() -> void:
 
 	assert_array(mock_obj.on_dictionary_case1({})).contains_exactly(["a", "b"])
 	verify(mock_obj).on_dictionary_case1({})
+
+func test_mock_with_variant_as_defaults() -> void:
+	var mock_obj: Variant = mock(ClassWithVariantDefaultArguments)
+	assert_object(mock_obj).is_not_null()

--- a/addons/gdUnit4/test/mocker/resources/ClassWithVariantDefaultArguments.gd
+++ b/addons/gdUnit4/test/mocker/resources/ClassWithVariantDefaultArguments.gd
@@ -1,0 +1,9 @@
+class_name ClassWithVariantDefaultArguments
+extends Resource
+
+@warning_ignore("unused_parameter")
+func add_button(
+	ucids: Array[int], position: Vector2i, size: Vector2i, style: int, text: Variant = "",
+	button_name := "", type_in := 0, caption := "", show_everywhere := false
+) -> void:
+	pass


### PR DESCRIPTION
# Why
When we try to mock a class containing functions with default argument typed Variant, the function doubling results into invalid function structure. The mocking fails with a parsing error.

# What
- The doubler respects the Variant type and build the function signature inclusive type information
- Fix bug in value decoder to determine the original type of Variant value before decoding
- Fix function argument value set do not overwrite existing default value
- Add test coverage for default arguments of type Variant

