### PR TITLE
GD-741: Fix compile errors if no gdunit4.api dependencies defined

### DIFF
--- a/addons/gdUnit4/plugin.gd
+++ b/addons/gdUnit4/plugin.gd
@@ -30,8 +30,10 @@ func _enter_tree() -> void:
 	var control := add_control_to_bottom_panel(_gd_console, "gdUnitConsole")
 	@warning_ignore("unsafe_method_access")
 	await _gd_console.setup_update_notification(control)
-	if GdUnit4CSharpApiLoader.is_dotnet_supported():
+	if GdUnit4CSharpApiLoader.is_api_loaded():
 		prints("GdUnit4Net version '%s' loaded." % GdUnit4CSharpApiLoader.version())
+	else:
+		prints("No GdUnit4Net found.")
 	# Connect to be notified for script changes to be able to discover new tests
 	GdUnitTestDiscoverGuard.instance()
 	@warning_ignore("return_value_discarded")

--- a/addons/gdUnit4/src/core/GdUnitTestResourceLoader.gd
+++ b/addons/gdUnit4/src/core/GdUnitTestResourceLoader.gd
@@ -40,7 +40,7 @@ static func load_test_suite_gd(resource_path: String) -> GdUnitTestSuite:
 
 
 static func load_test_suite_cs(resource_path: String) -> Node:
-	if not GdUnit4CSharpApiLoader.is_dotnet_supported():
+	if not GdUnit4CSharpApiLoader.is_api_loaded():
 		return null
 	var script :Script = ClassDB.instantiate("CSharpScript")
 	script.source_code = GdUnitFileAccess.resource_as_string(resource_path)
@@ -50,7 +50,7 @@ static func load_test_suite_cs(resource_path: String) -> Node:
 
 
 static func load_cs_script(resource_path: String, debug_write := false) -> Script:
-	if not GdUnit4CSharpApiLoader.is_dotnet_supported():
+	if not GdUnit4CSharpApiLoader.is_api_loaded():
 		return null
 	var script :Script = ClassDB.instantiate("CSharpScript")
 	script.source_code = GdUnitFileAccess.resource_as_string(resource_path)

--- a/addons/gdUnit4/src/core/GdUnitTestSuiteScanner.gd
+++ b/addons/gdUnit4/src/core/GdUnitTestSuiteScanner.gd
@@ -224,7 +224,7 @@ static func is_test_suite(script: Script) -> bool:
 					return true
 				stack.push_back(base)
 	elif script != null and script.get_class() == "CSharpScript":
-		return GdUnit4CSharpApiLoader.is_test_suite(script)
+		return true
 	return false
 
 

--- a/addons/gdUnit4/src/core/discovery/GdUnitTestDiscoverer.gd
+++ b/addons/gdUnit4/src/core/discovery/GdUnitTestDiscoverer.gd
@@ -81,7 +81,7 @@ static func discover_tests(source_script: Script, discover_sink := default_disco
 			for test_case in resolver.resolve_test_cases(source_script as GDScript):
 				discover_sink.call(test_case)
 	elif source_script.get_class() == "CSharpScript":
-		if not GdUnit4CSharpApiLoader.is_dotnet_supported():
+		if not GdUnit4CSharpApiLoader.is_api_loaded():
 			return
 		for test_case in GdUnit4CSharpApiLoader.discover_tests(source_script):
 			discover_sink.call(test_case)

--- a/addons/gdUnit4/src/dotnet/GdUnit4CSharpApi.cs
+++ b/addons/gdUnit4/src/dotnet/GdUnit4CSharpApi.cs
@@ -1,204 +1,176 @@
 namespace gdUnit4.addons.gdUnit4.src.dotnet;
 
+#if GDUNIT4NET_API_V5
 using System;
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.Linq;
-using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 
+using GdUnit4;
 using GdUnit4.Api;
-using GdUnit4.Core.Discovery;
 
 using Godot;
 using Godot.Collections;
 
 // GdUnit4 GDScript - C# API wrapper
 // ReSharper disable once CheckNamespace
+public partial class GdUnit4CSharpApi : GdUnit4NetApiGodotBridge
+{
+	[Signal]
+	public delegate void ExecutionCompletedEventHandler();
+
+	private CancellationTokenSource? executionCts;
+
+	public override void _Notification(int what)
+	{
+		if (what != NotificationPredelete)
+			return;
+		executionCts?.Dispose();
+		executionCts = null;
+	}
+
+	public static bool IsApiLoaded()
+		=> true;
+
+	public static Array<Dictionary> DiscoverTests(CSharpScript sourceScript)
+	{
+		try
+		{
+			// Get the list of test case descriptors from the API
+			var testCaseDescriptors = DiscoverTestsFromScript(sourceScript);
+			// Convert each TestCaseDescriptor to a Dictionary
+			return testCaseDescriptors
+				.Select(descriptor => new Dictionary
+				{
+					["guid"] = descriptor.Id.ToString(),
+					["managed_type"] = descriptor.ManagedType,
+					["test_name"] = descriptor.ManagedMethod,
+					["source_file"] = sourceScript.ResourcePath,
+					["line_number"] = descriptor.LineNumber,
+					["attribute_index"] = descriptor.AttributeIndex,
+					["require_godot_runtime"] = descriptor.RequireRunningGodotEngine,
+					["code_file_path"] = descriptor.CodeFilePath ?? "",
+					["simple_name"] = descriptor.SimpleName,
+					["fully_qualified_name"] = descriptor.FullyQualifiedName,
+					["assembly_location"] = descriptor.AssemblyPath
+				})
+				.Aggregate(new Array<Dictionary>(), (array, dict) =>
+				{
+					array.Add(dict);
+					return array;
+				});
+		}
+		catch (Exception e)
+		{
+			GD.PrintErr($"Error discovering tests: {e.Message}\n{e.StackTrace}");
+			return new Array<Dictionary>();
+		}
+	}
+
+	public void ExecuteAsync(Array<Dictionary> tests, Callable listener)
+	{
+		try
+		{
+			// Cancel any ongoing execution
+			executionCts?.Cancel();
+			executionCts?.Dispose();
+
+			// Create new cancellation token source
+			executionCts = new CancellationTokenSource();
+
+			var testSuiteNodes = new List<TestSuiteNode> { BuildTestSuiteNodeFrom(tests) };
+			ExecuteAsync(testSuiteNodes, listener, executionCts.Token)
+				.GetAwaiter()
+				.OnCompleted(() => EmitSignal(SignalName.ExecutionCompleted));
+		}
+		catch (Exception e)
+		{
+			GD.PrintErr($"Error executing tests: {e.Message}\n{e.StackTrace}");
+			Task.Run(() => { }).GetAwaiter().OnCompleted(() => EmitSignal(SignalName.ExecutionCompleted));
+		}
+	}
+
+	public void CancelExecution()
+	{
+		try
+		{
+			executionCts?.Cancel();
+		}
+		catch (Exception e)
+		{
+			GD.PrintErr($"Error cancelling execution: {e.Message}");
+		}
+	}
+
+	// Convert a set of Tests stored as Dictionaries to TestSuiteNode
+	// all tests are assigned to a single test suit
+	internal static TestSuiteNode BuildTestSuiteNodeFrom(Array<Dictionary> tests)
+	{
+		if (tests.Count == 0)
+			throw new InvalidOperationException("Cant build 'TestSuiteNode' from an empty test set.");
+
+		// Create a suite ID
+		var suiteId = Guid.NewGuid();
+		var firstTest = tests[0];
+		var managedType = firstTest["managed_type"].AsString();
+		var assemblyLocation = firstTest["assembly_location"].AsString();
+		var sourceFile = firstTest["source_file"].AsString();
+
+		// Create TestCaseNodes for each test in the suite
+		var testCaseNodes = tests
+			.Select(test => new TestCaseNode
+				{
+					Id = Guid.Parse(test["guid"].AsString()),
+					ParentId = suiteId,
+					ManagedMethod = test["test_name"].AsString(),
+					LineNumber = test["line_number"].AsInt32(),
+					AttributeIndex = test["attribute_index"].AsInt32(),
+					RequireRunningGodotEngine = test["require_godot_runtime"].AsBool()
+				}
+			)
+			.ToList();
+
+		return new TestSuiteNode
+		{
+			Id = suiteId,
+			ParentId = Guid.Empty,
+			ManagedType = managedType,
+			AssemblyPath = assemblyLocation,
+			SourceFile = sourceFile,
+			Tests = testCaseNodes
+		};
+	}
+}
+#else
+using Godot;
+using Godot.Collections;
+
 public partial class GdUnit4CSharpApi : RefCounted
 {
-    [Signal]
-    public delegate void ExecutionCompletedEventHandler();
+	[Signal]
+	public delegate void ExecutionCompletedEventHandler();
 
-    private static readonly object LockObject = new();
-
-    private static Type? apiType;
-    private static Assembly? gdUnit4Api;
-    private CancellationTokenSource? executionCts;
-
-    public override void _Notification(int what)
-    {
-        if (what != NotificationPredelete)
-            return;
-        executionCts?.Dispose();
-        executionCts = null;
-    }
-
-    private static Assembly GetApi()
-    {
-        if (gdUnit4Api != null)
-            return gdUnit4Api;
-        lock (LockObject)
-            return gdUnit4Api ??= Assembly.Load("gdUnit4Api");
-    }
-
-    private static Type? GetApiType()
-    {
-        if (apiType != null)
-            return apiType;
-        apiType = GetApi().GetType("GdUnit4.GdUnit4NetApiGodotBridge");
-        return apiType;
-    }
-
-    private static Version? GdUnit4NetVersion()
-    {
-        try
-        {
-            return GetApi().GetName().Version;
-        }
-        catch (Exception)
-        {
-            return null;
-        }
-    }
-
-    private static T? InvokeApiMethod<T>(string methodName, params object[] args)
-    {
-        var method = GetApiType()?.GetMethod(methodName) ??
-                     throw new MethodAccessException($"Can't invoke method {methodName}");
-        return (T?)method.Invoke(null, args);
-    }
-
-    public static bool FindGdUnit4NetAssembly()
-    {
-        try
-        {
-            return GetApi().GetType("GdUnit4.GdUnit4NetApiGodotBridge") != null;
-        }
-        catch (Exception)
-        {
-            return false;
-        }
-    }
-
-    public static string Version()
-        => GdUnit4NetVersion()?.ToString()
-           ?? "Unknown";
-
-    public static bool IsTestSuite(CSharpScript script)
-        => InvokeApiMethod<bool>("IsTestSuite", script);
-
-    public static Array<Dictionary> DiscoverTests(CSharpScript sourceScript)
-    {
-        try
-        {
-            // Get the list of test case descriptors from the API
-            var testCaseDescriptors = InvokeApiMethod<ImmutableList<TestCaseDescriptor>>("DiscoverTestsFromScript", sourceScript)!;
-            // Convert each TestCaseDescriptor to a Dictionary
-            return testCaseDescriptors
-                .Select(descriptor => new Dictionary
-                {
-                    ["guid"] = descriptor.Id.ToString(),
-                    ["managed_type"] = descriptor.ManagedType,
-                    ["test_name"] = descriptor.ManagedMethod,
-                    ["source_file"] = sourceScript.ResourcePath,
-                    ["line_number"] = descriptor.LineNumber,
-                    ["attribute_index"] = descriptor.AttributeIndex,
-                    ["require_godot_runtime"] = descriptor.RequireRunningGodotEngine,
-                    ["code_file_path"] = descriptor.CodeFilePath ?? "",
-                    ["simple_name"] = descriptor.SimpleName,
-                    ["fully_qualified_name"] = descriptor.FullyQualifiedName,
-                    ["assembly_location"] = descriptor.AssemblyPath
-                })
-                .Aggregate(new Array<Dictionary>(), (array, dict) =>
-                {
-                    array.Add(dict);
-                    return array;
-                });
-        }
-        catch (Exception e)
-        {
-            GD.PrintErr($"Error discovering tests: {e.Message}\n{e.StackTrace}");
-            return new Array<Dictionary>();
-        }
-    }
-
-    public void ExecuteAsync(Array<Dictionary> tests, Callable listener)
-    {
-        try
-        {
-            // Cancel any ongoing execution
-            executionCts?.Cancel();
-            executionCts?.Dispose();
-
-            // Create new cancellation token source
-            executionCts = new CancellationTokenSource();
-
-            var testSuiteNodes = new List<TestSuiteNode> { BuildTestSuiteNodeFrom(tests) };
-            InvokeApiMethod<Task>("ExecuteAsync", testSuiteNodes, listener, executionCts.Token)?
-                .GetAwaiter()
-                .OnCompleted(() => EmitSignal(SignalName.ExecutionCompleted));
-        }
-        catch (Exception e)
-        {
-            GD.PrintErr($"Error executing tests: {e.Message}\n{e.StackTrace}");
-            Task.Run(() => { }).GetAwaiter().OnCompleted(() => EmitSignal(SignalName.ExecutionCompleted));
-        }
-    }
-
-    public void CancelExecution()
-    {
-        try
-        {
-            executionCts?.Cancel();
-        }
-        catch (Exception e)
-        {
-            GD.PrintErr($"Error cancelling execution: {e.Message}");
-        }
-    }
-
-    public static Dictionary CreateTestSuite(string sourcePath, int lineNumber, string testSuitePath)
-        => InvokeApiMethod<Dictionary>("CreateTestSuite", sourcePath, lineNumber, testSuitePath)!;
+	public static bool IsApiLoaded()
+	{
+		GD.PushWarning("No `gdunit4.api` dependency found, check your project dependencies.");
+		return false;
+	}
 
 
-    // Convert a set of Tests stored as Dictionaries to TestSuiteNode
-    // all tests are assigned to a single test suit
-    internal static TestSuiteNode BuildTestSuiteNodeFrom(Array<Dictionary> tests)
-    {
-        if (tests.Count == 0)
-            throw new InvalidOperationException("Cant build 'TestSuiteNode' from an empty test set.");
+	public static string Version()
+		=> "Unknown";
 
-        // Create a suite ID
-        var suiteId = Guid.NewGuid();
-        var firstTest = tests[0];
-        var managedType = firstTest["managed_type"].AsString();
-        var assemblyLocation = firstTest["assembly_location"].AsString();
-        var sourceFile = firstTest["source_file"].AsString();
+	public static Array<Dictionary> DiscoverTests(CSharpScript sourceScript) => new();
 
-        // Create TestCaseNodes for each test in the suite
-        var testCaseNodes = tests
-            .Select(test => new TestCaseNode
-                {
-                    Id = Guid.Parse(test["guid"].AsString()),
-                    ParentId = suiteId,
-                    ManagedMethod = test["test_name"].AsString(),
-                    LineNumber = test["line_number"].AsInt32(),
-                    AttributeIndex = test["attribute_index"].AsInt32(),
-                    RequireRunningGodotEngine = test["require_godot_runtime"].AsBool()
-                }
-            )
-            .ToList();
+	public void ExecuteAsync(Array<Dictionary> tests, Callable listener)
+	{
+	}
 
-        return new TestSuiteNode
-        {
-            Id = suiteId,
-            ParentId = Guid.Empty,
-            ManagedType = managedType,
-            AssemblyPath = assemblyLocation,
-            SourceFile = sourceFile,
-            Tests = testCaseNodes
-        };
-    }
+	public static bool IsTestSuite(CSharpScript script)
+		=> false;
+
+	public static Dictionary CreateTestSuite(string sourcePath, int lineNumber, string testSuitePath)
+		=> new();
 }
+#endif

--- a/addons/gdUnit4/src/dotnet/GdUnit4CSharpApiLoader.gd
+++ b/addons/gdUnit4/src/dotnet/GdUnit4CSharpApiLoader.gd
@@ -32,7 +32,7 @@ static var _test_event_listener := TestEventListener.new()
 ## Returns an instance of the GdUnit4CSharpApi wrapper.[br]
 ## @return Script: The loaded C# wrapper or null if .NET is not supported
 static func instance() -> Script:
-	if not GdUnit4CSharpApiLoader.is_dotnet_supported():
+	if not GdUnit4CSharpApiLoader.is_api_loaded():
 		return null
 
 	return _gdUnit4NetWrapper
@@ -41,7 +41,7 @@ static func instance() -> Script:
 ## Returns or creates a single instance of the API [br]
 ## This improves performance by reusing the same object
 static func api_instance() -> RefCounted:
-	if _api_instance == null and is_dotnet_supported():
+	if _api_instance == null and is_api_loaded():
 		@warning_ignore("unsafe_method_access")
 		_api_instance = instance().new()
 	return _api_instance
@@ -52,14 +52,8 @@ static func is_engine_version_supported(engine_version: int = Engine.get_version
 
 
 ## Checks if the .NET environment is properly configured and available.[br]
-## This performs multiple checks:[br]
-## 1. Verifies if the wrapper is already loaded[br]
-## 2. Confirms Godot has C# support[br]
-## 3. Validates the project's C# configuration[br]
-## 4. Attempts to load the wrapper and find the GdUnit4 assembly[br]
-##
 ## @return bool: True if .NET is fully supported and the assembly is found
-static func is_dotnet_supported() -> bool:
+static func is_api_loaded() -> bool:
 	# If the wrapper is already loaded we don't need to check again
 	if _gdUnit4NetWrapper != null:
 		return true
@@ -74,13 +68,14 @@ static func is_dotnet_supported() -> bool:
 
 	# Finally load the wrapper and check if the GdUnit4 assembly can be found
 	_gdUnit4NetWrapper = load("res://addons/gdUnit4/src/dotnet/GdUnit4CSharpApi.cs")
-	return _gdUnit4NetWrapper != null and _gdUnit4NetWrapper.call("FindGdUnit4NetAssembly")
+	@warning_ignore("unsafe_method_access")
+	return _gdUnit4NetWrapper.IsApiLoaded()
 
 
 ## Returns the version of the GdUnit4 .NET assembly.[br]
 ## @return String: The version string or "unknown" if .NET is not supported
 static func version() -> String:
-	if not GdUnit4CSharpApiLoader.is_dotnet_supported():
+	if not GdUnit4CSharpApiLoader.is_api_loaded():
 		return "unknown"
 	@warning_ignore("unsafe_method_access")
 	return instance().Version()
@@ -105,7 +100,7 @@ static func execute(tests: Array[GdUnitTestCase]) -> void:
 
 
 static func create_test_suite(source_path: String, line_number: int, test_suite_path: String) -> GdUnitResult:
-	if not GdUnit4CSharpApiLoader.is_dotnet_supported():
+	if not GdUnit4CSharpApiLoader.is_api_loaded():
 		return  GdUnitResult.error("Can't create test suite. No .NET support found.")
 	@warning_ignore("unsafe_method_access")
 	var result: Dictionary = instance().CreateTestSuite(source_path, line_number, test_suite_path)
@@ -114,11 +109,6 @@ static func create_test_suite(source_path: String, line_number: int, test_suite_
 	return  GdUnitResult.success(result)
 
 
-static func is_test_suite(script: Script) -> bool:
-	@warning_ignore("unsafe_method_access")
-	return instance().IsTestSuite(script)
-
-
 static func is_csharp_file(resource_path: String) -> bool:
 	var ext := resource_path.get_extension()
-	return ext == "cs" and GdUnit4CSharpApiLoader.is_dotnet_supported()
+	return ext == "cs" and GdUnit4CSharpApiLoader.is_api_loaded()

--- a/addons/gdUnit4/test/core/discovery/GdUnitTestDiscoverGuardTest.gd
+++ b/addons/gdUnit4/test/core/discovery/GdUnitTestDiscoverGuardTest.gd
@@ -318,7 +318,7 @@ func test_discover_moved_test_GDScript() -> void:
 
 
 @warning_ignore("unused_parameter")
-func _test_discover_on_CSharpScript(do_skip := !GdUnit4CSharpApiLoader.is_dotnet_supported()) -> void:
+func _test_discover_on_CSharpScript(do_skip := !GdUnit4CSharpApiLoader.is_api_loaded()) -> void:
 	var discoverer :GdUnitTestDiscoverGuard = spy(GdUnitTestDiscoverGuard.new())
 
 	# connect to catch the events emitted by the test discoverer

--- a/addons/gdUnit4/test/core/discovery/resources/DiscoverExampleTestSuite.cs
+++ b/addons/gdUnit4/test/core/discovery/resources/DiscoverExampleTestSuite.cs
@@ -1,5 +1,5 @@
 namespace gdUnit4.addons.gdUnit4.test.core.discovery.resources;
-
+#if GDUNIT4NET_API_V5
 using GdUnit4;
 
 using static GdUnit4.Assertions;
@@ -7,11 +7,12 @@ using static GdUnit4.Assertions;
 [TestSuite]
 public class DiscoverExampleTestSuite
 {
-	[TestCase]
-	public void TestCase1()
-		=> AssertBool(true).IsEqual(true);
+    [TestCase]
+    public void TestCase1()
+        => AssertBool(true).IsEqual(true);
 
-	[TestCase]
-	public void TestCase2()
-		=> AssertBool(false).IsEqual(false);
+    [TestCase]
+    public void TestCase2()
+        => AssertBool(false).IsEqual(false);
 }
+#endif

--- a/addons/gdUnit4/test/core/resources/testsuites/NotATestSuite.cs
+++ b/addons/gdUnit4/test/core/resources/testsuites/NotATestSuite.cs
@@ -1,14 +1,12 @@
-namespace GdUnit4.Tests.Resources
+namespace GdUnit4.Tests.Resources;
+#if GDUNIT4NET_API_V5
+using static Assertions;
+
+// will be ignored because of missing `[TestSuite]` anotation
+public class NotATestSuite
 {
-	using static Assertions;
-	
-	// will be ignored because of missing `[TestSuite]` anotation
-	public partial class NotATestSuite
-	{
-		[TestCase]
-		public void TestFoo()
-		{
-			AssertBool(true).IsEqual(false);
-		}
-	}
+    [TestCase]
+    public void TestFoo() => AssertBool(true).IsEqual(false);
 }
+
+#endif

--- a/addons/gdUnit4/test/dotnet/ExampleTestSuite.cs
+++ b/addons/gdUnit4/test/dotnet/ExampleTestSuite.cs
@@ -1,7 +1,7 @@
 // GdUnit generated TestSuite
 
 namespace gdUnit4.addons.gdUnit4.test.dotnet;
-
+#if GDUNIT4NET_API_V5
 using GdUnit4;
 
 using Godot;
@@ -34,3 +34,4 @@ public class ExampleTestSuite
         AssertObject(v.VariantType).IsEqual(type);
     }
 }
+#endif

--- a/addons/gdUnit4/test/dotnet/GdUnit4CSharpApiLoaderTest.gd
+++ b/addons/gdUnit4/test/dotnet/GdUnit4CSharpApiLoaderTest.gd
@@ -9,7 +9,7 @@ const GdUnitTools := preload("res://addons/gdUnit4/src/core/GdUnitTools.gd")
 
 
 @warning_ignore("unused_parameter")
-func before(do_skip := not GdUnit4CSharpApiLoader.is_dotnet_supported(), skip_reason := "Do run only for Godot .Net version") -> void:
+func before(do_skip := not GdUnit4CSharpApiLoader.is_api_loaded(), skip_reason := "Do run only for Godot .Net version") -> void:
 	pass
 
 

--- a/addons/gdUnit4/test/dotnet/GdUnit4CSharpApiTest.cs
+++ b/addons/gdUnit4/test/dotnet/GdUnit4CSharpApiTest.cs
@@ -1,5 +1,6 @@
 namespace gdUnit4.addons.gdUnit4.test.dotnet;
 
+#if GDUNIT4NET_API_V5
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -19,14 +20,6 @@ using static GdUnit4.Assertions;
 [RequireGodotRuntime]
 public partial class GdUnit4CSharpApiTest
 {
-    [TestCase]
-    public void IsTestSuite()
-    {
-        AssertThat(GdUnit4CSharpApi.IsTestSuite(GD.Load<CSharpScript>("res://addons/gdUnit4/src/dotnet/GdUnit4CSharpApi.cs"))).IsFalse();
-        AssertThat(GdUnit4CSharpApi.IsTestSuite(GD.Load<CSharpScript>("res://addons/gdUnit4/test/dotnet/ExampleTestSuite.cs"))).IsTrue();
-        AssertThat(GdUnit4CSharpApi.IsTestSuite(GD.Load<CSharpScript>("res://addons/gdUnit4/test/core/discovery/resources/DiscoverExampleTestSuite.cs"))).IsTrue();
-    }
-
     [TestCase]
     public void GetVersion()
     {
@@ -188,3 +181,4 @@ public partial class GdUnit4CSharpApiTest
             => EventReceived?.Invoke(eventData);
     }
 }
+#endif


### PR DESCRIPTION

# Why
We see compile errors when the gdunit.api dependencies are missing
```
CS0246: The type or namespace name 'GdUnit4' could not be found (are you missing a using directive or an assembly reference?) F:\gd740_gdunit4mpr\addons\gdUnit4\src\dotnet\GdUnit4CSharpApi.cs(11,7)
CS0246: The type or namespace name 'TestSuiteNode' could not be found (are you missing a using directive or an assembly reference?) F:\gd740_gdunit4mpr\addons\gdUnit4\src\dotnet\GdUnit4CSharpApi.cs(168,21)
```

# What
- Use the new compile constant `GDUNIT4NET_API_V5` to compile without gdunit4.api dependencies if not set
- Remove unnecessary usage of IsTestSuite from the GdUnit4CSharpApi, the test discovery already checks this

