### PR TITLE
GD-742: Fix mock failing on wrong parsed coroutine functions

### DIFF
--- a/addons/gdUnit4/test/core/parse/GdScriptParserTest.gd
+++ b/addons/gdUnit4/test/core/parse/GdScriptParserTest.gd
@@ -598,3 +598,35 @@ func test_parse_func_descriptor_with_fuzzers() -> void:
 		# typed is TYPE_INT
 		GdFunctionArgument.new("fuzzer_seed", TYPE_INT, 100)
 	]))
+
+
+func test_is_func_coroutine() -> void:
+	var script := """
+	extends RefCounted:
+		func normal_function() -> void:
+			print("normal")
+
+
+		func await_function() -> void:
+			print(await _await_function())
+
+
+		func _await_function() -> String:
+			await get_tree().process_frame
+			return "test"
+
+
+		func check_is_waiting() -> String:
+			return is_await()
+
+
+		func print_message() -> String:
+			return "do await for timeout"
+	"""
+
+	var rows := script.split("\n")
+	assert_bool(_parser.is_func_coroutine(rows, 2)).is_false()
+	assert_bool(_parser.is_func_coroutine(rows, 6)).is_true()
+	assert_bool(_parser.is_func_coroutine(rows, 10)).is_true()
+	assert_bool(_parser.is_func_coroutine(rows, 15)).is_false()
+	assert_bool(_parser.is_func_coroutine(rows, 19)).is_false()

--- a/addons/gdUnit4/test/mocker/GdUnitMockerTest.gd
+++ b/addons/gdUnit4/test/mocker/GdUnitMockerTest.gd
@@ -1240,6 +1240,19 @@ func test_mock_func_default_arg_dict() -> void:
 	assert_array(mock_obj.on_dictionary_case1({})).contains_exactly(["a", "b"])
 	verify(mock_obj).on_dictionary_case1({})
 
+
 func test_mock_with_variant_as_defaults() -> void:
 	var mock_obj: Variant = mock(ClassWithVariantDefaultArguments)
 	assert_object(mock_obj).is_not_null()
+
+
+# https://github.com/MikeSchulze/gdUnit4/issues/742
+func test_mock_with_await_function() -> void:
+	@warning_ignore("unsafe_cast")
+	var mocked_instance := mock(ClassWithAwaitFunc, CALL_REAL_FUNC) as ClassWithAwaitFunc
+	add_child(mocked_instance)
+
+	mocked_instance.await_function()
+
+	@warning_ignore("unsafe_method_access")
+	verify(mocked_instance, 1).await_function()

--- a/addons/gdUnit4/test/mocker/resources/ClassWithAwaitFunc.gd
+++ b/addons/gdUnit4/test/mocker/resources/ClassWithAwaitFunc.gd
@@ -1,0 +1,15 @@
+class_name ClassWithAwaitFunc
+extends Node
+
+
+func normal_function() -> void:
+	print("normal")
+
+
+func await_function() -> void:
+	print(await _await_function())
+
+
+func _await_function() -> String:
+	await get_tree().process_frame
+	return "test"


### PR DESCRIPTION
# Why
The mocking of class with using await as function names or containing phrases fails by an error `Error: ''"await" keyword is unnecessary`

# What
- Fixing the function parsing for await syntax to detect the function is a coroutine.

