### PR TITLE
GD-704 Fix action strength of `action_press` input handling

### DIFF
--- a/addons/gdUnit4/src/core/GdUnitSceneRunnerImpl.gd
+++ b/addons/gdUnit4/src/core/GdUnitSceneRunnerImpl.gd
@@ -569,7 +569,7 @@ func _handle_actions(event: InputEventAction) -> bool:
 		return false
 	__print("	process action %s (%s) <- %s" % [scene(), _scene_name(), event.as_text()])
 	if event.is_pressed():
-		Input.action_press(event.action, InputMap.action_get_deadzone(event.action))
+		Input.action_press(event.action, event.get_strength())
 	else:
 		Input.action_release(event.action)
 	return true

--- a/addons/gdUnit4/test/core/GdUnitSceneRunnerInputEventTest.gd
+++ b/addons/gdUnit4/test/core/GdUnitSceneRunnerInputEventTest.gd
@@ -97,6 +97,11 @@ func test_simulate_action_press() -> void:
 
 		assert_that(Input.is_action_pressed(action))\
 			.override_failure_message("Expect the action '%s' is pressed" % action).is_true()
+		assert_float(Input.get_action_strength(action))\
+			.is_equal_approx(1.0, 0.1)
+		assert_float(_runner.get_property("_last_pressed_strength"))\
+			.is_equal_approx(1.0, 0.1)
+
 	# other actions are not pressed
 	for action :String in ["ui_accept", "ui_select", "ui_cancel"]:
 		assert_that(Input.is_action_pressed(action))\

--- a/addons/gdUnit4/test/core/resources/scenes/input_actions/InputEventTestScene.tscn
+++ b/addons/gdUnit4/test/core/resources/scenes/input_actions/InputEventTestScene.tscn
@@ -1,6 +1,6 @@
 [gd_scene load_steps=2 format=3 uid="uid://cvklb72mxqh1h"]
 
-[ext_resource type="Script" uid="uid://cgk00pw4s4par" path="res://addons/gdUnit4/test/core/resources/scenes/input_actions/InputEventTestScene.gd" id="1_wslmn"]
+[ext_resource type="Script"  path="res://addons/gdUnit4/test/core/resources/scenes/input_actions/InputEventTestScene.gd" id="1_wslmn"]
 
 [node name="InputEventTestScene" type="Control"]
 layout_mode = 3

--- a/addons/gdUnit4/test/mocker/resources/scenes/TestScene.gd
+++ b/addons/gdUnit4/test/mocker/resources/scenes/TestScene.gd
@@ -14,6 +14,8 @@ const COLOR_CYCLE := [Color.ROYAL_BLUE, Color.CHARTREUSE, Color.YELLOW_GREEN]
 @warning_ignore("unused_private_class_variable")
 var _nullable :Object
 
+var _last_pressed_strength: float
+
 
 func _ready() -> void:
 	panel_color_change.connect(_on_panel_color_changed)
@@ -99,6 +101,10 @@ func _destroy_spell(spell :Spell) -> void:
 func _input(event :InputEvent) -> void:
 	if event.is_action_released("ui_accept"):
 		add_child(create_spell())
+
+	if event is InputEventAction:
+		_last_pressed_strength = (event as InputEventAction).strength
+
 	#prints(event.as_text())
 
 

--- a/addons/gdUnit4/test/mocker/resources/scenes/TestScene.tscn
+++ b/addons/gdUnit4/test/mocker/resources/scenes/TestScene.tscn
@@ -1,7 +1,7 @@
 [gd_scene load_steps=3 format=3 uid="uid://bf24pr1xj60o6"]
 
-[ext_resource type="Script" uid="uid://b7b4gqmqsssib" path="res://addons/gdUnit4/test/mocker/resources/scenes/TestScene.gd" id="1"]
-[ext_resource type="Texture2D" uid="uid://btx5kcrsngasl" path="res://addons/gdUnit4/src/core/assets/touch-button.png" id="2_xgglm"]
+[ext_resource type="Script" path="res://addons/gdUnit4/test/mocker/resources/scenes/TestScene.gd" id="1"]
+[ext_resource type="Texture2D" path="res://addons/gdUnit4/src/core/assets/touch-button.png" id="2_xgglm"]
 
 [node name="Control" type="Control"]
 layout_mode = 3


### PR DESCRIPTION
# Why
The action strength is wrong set by the value of deadzone.

# What
- Using event strength instead of deadzone
- Removed invalid uid's from the test scenes where resulting in loading warnings

