### PR TITLE
GD-664: Fix test discovery of inherit test suits results in invalid test tree structure

### DIFF
--- a/addons/gdUnit4/src/core/discovery/GdUnitTestCase.gd
+++ b/addons/gdUnit4/src/core/discovery/GdUnitTestCase.gd
@@ -9,6 +9,9 @@ extends RefCounted
 ## A unique identifier for the test case. Used to track and reference specific test instances.
 var guid := GdUnitGUID.new()
 
+## The resource path to the test suite
+var suite_resource_path: String
+
 ## The name of the test method/function. Should start with "test_" prefix.
 var test_name: String
 
@@ -52,6 +55,7 @@ var metadata: Dictionary = {}
 static func from_dict(dict: Dictionary) -> GdUnitTestCase:
 	var test := GdUnitTestCase.new()
 	test.guid = GdUnitGUID.new(str(dict["guid"]))
+	test.suite_resource_path = dict["suite_resource_path"]
 	test.suite_name = dict["managed_type"]
 	test.test_name = dict["test_name"]
 	test.display_name = dict["simple_name"]
@@ -67,6 +71,7 @@ static func from_dict(dict: Dictionary) -> GdUnitTestCase:
 static func to_dict(test: GdUnitTestCase) -> Dictionary:
 	return {
 		"guid": test.guid._guid,
+		"suite_resource_path": test.suite_resource_path,
 		"managed_type": test.suite_name,
 		"test_name" : test.test_name,
 		"simple_name" : test.display_name,
@@ -79,7 +84,7 @@ static func to_dict(test: GdUnitTestCase) -> Dictionary:
 	}
 
 
-static func from(_source_file: String, _line_number: int, _test_name: String, _attribute_index := -1, _test_parameters := "") -> GdUnitTestCase:
+static func from(_suite_resource_path: String, _source_file: String, _line_number: int, _test_name: String, _attribute_index := -1, _test_parameters := "") -> GdUnitTestCase:
 	if(_source_file == null or _source_file.is_empty()):
 		prints(_test_name)
 
@@ -87,13 +92,14 @@ static func from(_source_file: String, _line_number: int, _test_name: String, _a
 	assert(_source_file != null and not _source_file.is_empty(), "Precondition: The parameter 'source_file' is not set")
 
 	var test := GdUnitTestCase.new()
+	test.suite_resource_path = _suite_resource_path
 	test.test_name = _test_name
 	test.source_file = _source_file
 	test.line_number = _line_number
 	test.attribute_index = _attribute_index
 	test._build_suite_name()
 	test._build_display_name(_test_parameters)
-	test._build_fully_qualified_name()
+	test._build_fully_qualified_name(_suite_resource_path)
 	return test
 
 
@@ -109,8 +115,8 @@ func _build_display_name(_test_parameters: String) -> void:
 		display_name = "%s:%d (%s)" % [test_name, attribute_index, _test_parameters.trim_prefix("[").trim_suffix("]").replace('"', "'")]
 
 
-func _build_fully_qualified_name() -> void:
-	var name_space := source_file.trim_prefix("res://").trim_suffix(".gd").trim_suffix(".cs").replace("/", ".")
+func _build_fully_qualified_name(_resource_path: String) -> void:
+	var name_space := _resource_path.trim_prefix("res://").trim_suffix(".gd").trim_suffix(".cs").replace("/", ".")
 
 	if attribute_index == -1:
 		fully_qualified_name = "%s.%s" % [name_space, test_name]

--- a/addons/gdUnit4/src/core/execution/GdUnitTestSuiteExecutor.gd
+++ b/addons/gdUnit4/src/core/execution/GdUnitTestSuiteExecutor.gd
@@ -23,9 +23,9 @@ func execute(test_suite :GdUnitTestSuite) -> void:
 
 
 func run_and_wait(tests: Array[GdUnitTestCase]) -> void:
-	# first we group all tests by his parent suite
+	# first we group all tests by resource path
 	var grouped_by_suites := GdArrayTools.group_by(tests, func(test: GdUnitTestCase) -> String:
-		return test.source_file
+		return test.suite_resource_path
 	)
 	var scanner := GdUnitTestSuiteScanner.new()
 	for suite_path: String in grouped_by_suites.keys():

--- a/addons/gdUnit4/src/core/parse/GdFunctionParameterSetResolver.gd
+++ b/addons/gdUnit4/src/core/parse/GdFunctionParameterSetResolver.gd
@@ -26,7 +26,7 @@ func _init(fd: GdFunctionDescriptor) -> void:
 
 func resolve_test_cases(script: GDScript) -> Array[GdUnitTestCase]:
 	if not is_parameterized():
-		return [GdUnitTestCase.from(_fd.source_path(), _fd.line_number(), _fd.name())]
+		return [GdUnitTestCase.from(script.resource_path, _fd.source_path(), _fd.line_number(), _fd.name())]
 	return extract_test_cases_by_reflection(script)
 
 
@@ -94,7 +94,7 @@ func extract_test_cases_by_reflection(script: GDScript) -> Array[GdUnitTestCase]
 	# if no parameter set detected we need to resolve it by using reflection
 	if parameter_sets.size() == 0:
 		_is_static = false
-		return _extract_test_cases_by_reflection(source)
+		return _extract_test_cases_by_reflection(source, script)
 	else:
 		var test_cases: Array[GdUnitTestCase] = []
 		var property_names := _extract_property_names(source)
@@ -102,7 +102,7 @@ func extract_test_cases_by_reflection(script: GDScript) -> Array[GdUnitTestCase]
 			var parameter_set := parameter_sets[parameter_set_index]
 			_static_sets_by_index[parameter_set_index] = _is_static_parameter_set(parameter_set, property_names)
 			@warning_ignore("return_value_discarded")
-			test_cases.append(GdUnitTestCase.from(_fd.source_path(), _fd.line_number(), _fd.name(), parameter_set_index, parameter_set))
+			test_cases.append(GdUnitTestCase.from(script.resource_path, _fd.source_path(), _fd.line_number(), _fd.name(), parameter_set_index, parameter_set))
 			parameter_set_index += 1
 		return test_cases
 
@@ -122,13 +122,13 @@ func _is_static_parameter_set(parameters :String, property_names :PackedStringAr
 	return true
 
 
-func _extract_test_cases_by_reflection(source: Node) -> Array[GdUnitTestCase]:
+func _extract_test_cases_by_reflection(source: Node, script: GDScript) -> Array[GdUnitTestCase]:
 	var parameter_sets := load_parameter_sets(source)
 	var test_cases: Array[GdUnitTestCase] = []
 	for index in parameter_sets.size():
 		var parameter_set := str(parameter_sets[index])
 		@warning_ignore("return_value_discarded")
-		test_cases.append(GdUnitTestCase.from(_fd.source_path(), _fd.line_number(), _fd.name(), index, parameter_set))
+		test_cases.append(GdUnitTestCase.from(script.resource_path, _fd.source_path(), _fd.line_number(), _fd.name(), index, parameter_set))
 	return test_cases
 
 

--- a/addons/gdUnit4/src/ui/parts/InspectorTreeMainPanel.gd
+++ b/addons/gdUnit4/src/ui/parts/InspectorTreeMainPanel.gd
@@ -753,7 +753,7 @@ func show_failed_report(selected_item: TreeItem) -> void:
 func update_test_suite(event: GdUnitEvent) -> void:
 	var item := _find_tree_item_by_path(extract_resource_path(event), event.suite_name())
 	if not item:
-		push_error("[GdUnitInspector:731] Internal Error: Can't find tree item for\n %s" % event)
+		push_error("[InspectorTreeMainPanel.gd:753] Internal Error: Can't find tree item for\n %s" % event)
 		return
 	if event.type() == GdUnitEvent.TESTSUITE_BEFORE:
 		set_state_running(item)
@@ -791,10 +791,10 @@ func create_item(parent: TreeItem, test: GdUnitTestCase, item_name: String, type
 			item.set_meta(META_TEST_CASE, test)
 		GdUnitType.TEST_GROUP:
 			# We need to create a copy of the test record meta with a new uniqe guid
-			item.set_meta(META_TEST_CASE, GdUnitTestCase.from(test.source_file, test.line_number, test.test_name))
+			item.set_meta(META_TEST_CASE, GdUnitTestCase.from(test.suite_resource_path, test.source_file, test.line_number, test.test_name))
 		GdUnitType.TEST_SUITE:
 			# We need to create a copy of the test record meta with a new uniqe guid
-			item.set_meta(META_TEST_CASE, GdUnitTestCase.from(test.source_file, test.line_number, test.suite_name))
+			item.set_meta(META_TEST_CASE, GdUnitTestCase.from(test.suite_resource_path, test.source_file, test.line_number, test.suite_name))
 			# We need to add the suite item to the item cache by path because the guid is not provided
 			add_tree_item_to_cache(test.source_file, item_name, item)
 

--- a/addons/gdUnit4/test/core/GdUnitRunnerConfigTest.gd
+++ b/addons/gdUnit4/test/core/GdUnitRunnerConfigTest.gd
@@ -40,9 +40,9 @@ func test_save_load() -> void:
 	config.set_server_port(1000)
 	# create a set of test cases
 	var test_to_save: Array[GdUnitTestCase] = [
-		GdUnitTestCase.from("res://test/example_suite.gd", 10, "test_a"),
-		GdUnitTestCase.from("res://test/example_suite.gd", 14, "test_b"),
-		GdUnitTestCase.from("res://test/example_suite.gd", 16, "test_c")
+		GdUnitTestCase.from("res://test/example_suite.gd", "res://test/example_suite.gd", 10, "test_a"),
+		GdUnitTestCase.from("res://test/example_suite.gd", "res://test/example_suite.gd", 14, "test_b"),
+		GdUnitTestCase.from("res://test/example_suite.gd", "res://test/example_suite.gd", 16, "test_c")
 	]
 	config.add_test_cases(test_to_save)
 
@@ -65,9 +65,9 @@ func test_add_test_cases() -> void:
 	config.set_server_port(1000)
 	# create a set of test cases
 	config.add_test_cases([
-		GdUnitTestCase.from("res://test/example_suite.gd", 10, "test_a"),
-		GdUnitTestCase.from("res://test/example_suite.gd", 14, "test_b"),
-		GdUnitTestCase.from("res://test/example_suite.gd", 16, "test_c")
+		GdUnitTestCase.from("res://test/example_suite.gd", "res://test/example_suite.gd", 10, "test_a"),
+		GdUnitTestCase.from("res://test/example_suite.gd", "res://test/example_suite.gd", 14, "test_b"),
+		GdUnitTestCase.from("res://test/example_suite.gd", "res://test/example_suite.gd", 16, "test_c")
 	])
 
 	var config_file := create_temp_dir("test_save_load") + "/testconf.cfg"

--- a/addons/gdUnit4/test/core/discovery/GdUnitTestCaseTest.gd
+++ b/addons/gdUnit4/test/core/discovery/GdUnitTestCaseTest.gd
@@ -2,7 +2,11 @@ extends GdUnitTestSuite
 
 
 func test_from() -> void:
-	var test := GdUnitTestCase.from("res://addons/gdUnit4/test/ui/parts/InspectorTreeMainPanelTest.gd", 0, "test_foo")
+	var test := GdUnitTestCase.from(
+		"res://addons/gdUnit4/test/ui/parts/InspectorTreeMainPanelTest.gd",
+		"res://addons/gdUnit4/test/ui/parts/InspectorTreeMainPanelTest.gd",
+		0,
+		"test_foo")
 
 	assert_str(test.test_name).is_equal("test_foo")
 	assert_str(test.suite_name).is_equal("InspectorTreeMainPanelTest")

--- a/addons/gdUnit4/test/core/discovery/GdUnitTestDiscoverGuardTest.gd
+++ b/addons/gdUnit4/test/core/discovery/GdUnitTestDiscoverGuardTest.gd
@@ -14,8 +14,8 @@ func test_inital() -> void:
 
 func test_sync_cache() -> void:
 	# setup example tests
-	var test1 := GdUnitTestCase.from("res://test/my_test_suite.gd", 23, "test_a")
-	var test2 := GdUnitTestCase.from("res://test/my_test_suite.gd", 42, "test_b")
+	var test1 := GdUnitTestCase.from("res://test/my_test_suite.gd", "res://test/my_test_suite.gd", 23, "test_a")
+	var test2 := GdUnitTestCase.from("res://test/my_test_suite.gd", "res://test/my_test_suite.gd", 42, "test_b")
 
 	# simulate running test dicovery
 	var discoverer: GdUnitTestDiscoverGuard = auto_free(GdUnitTestDiscoverGuard.new())

--- a/addons/gdUnit4/test/core/discovery/GdUnitTestDiscovererTest.gd
+++ b/addons/gdUnit4/test/core/discovery/GdUnitTestDiscovererTest.gd
@@ -78,3 +78,21 @@ func test_discover_tests_on_GdUnitTestSuite() -> void:
 
 	# we expect no test covered from the base implementaion of GdUnitTestSuite
 	assert_array(discovered_tests).is_empty()
+
+
+func test_discover_tests_inherited() -> void:
+	var script: GDScript = load("res://addons/gdUnit4/test/core/resources/scan_testsuite_inheritance/by_class_name/ExtendsExtendedTest.gd")
+
+	var discovered_tests := []
+	GdUnitTestDiscoverer.discover_tests(script,\
+		func discover(test_case: GdUnitTestCase) -> void:
+			discovered_tests.append(test_case)
+	)
+
+	assert_array(discovered_tests)\
+		.extractv(extr("test_name"), extr("display_name"), extr("fully_qualified_name"))\
+		.contains_exactly([
+			tuple("test_foo3", "test_foo3", "addons.gdUnit4.test.core.resources.scan_testsuite_inheritance.by_class_name.ExtendsExtendedTest.test_foo3"),
+			tuple("test_foo2", "test_foo2", "addons.gdUnit4.test.core.resources.scan_testsuite_inheritance.by_class_name.ExtendsExtendedTest.test_foo2"),
+			tuple("test_foo1", "test_foo1", "addons.gdUnit4.test.core.resources.scan_testsuite_inheritance.by_class_name.ExtendsExtendedTest.test_foo1")
+		])

--- a/addons/gdUnit4/test/ui/parts/InspectorTreeMainPanelTest.gd
+++ b/addons/gdUnit4/test/ui/parts/InspectorTreeMainPanelTest.gd
@@ -534,10 +534,10 @@ func test_discover_tests() -> void:
 
 func test_on_test_case_discover_added() -> void:
 	_inspector.init_tree()
-	_inspector.on_test_case_discover_added(GdUnitTestCase.from("res://addons/gdUnit4/test/dir_a/dir_b/my_test_suite.gd", 0, "test_foo"))
-	_inspector.on_test_case_discover_added(GdUnitTestCase.from("res://addons/gdUnit4/test/dir_a/dir_b/my_test_suite.gd", 0, "test_bar"))
-	_inspector.on_test_case_discover_added(GdUnitTestCase.from("res://addons/gdUnit4/test/dir_a/dir_x/my_test_suite2.gd", 0, "test_foo"))
-	_inspector.on_test_case_discover_added(GdUnitTestCase.from("res://my_test_suite3.gd", 0, "test_foo"))
+	_inspector.on_test_case_discover_added(GdUnitTestCase.from("res://addons/gdUnit4/test/dir_a/dir_b/my_test_suite.gd", "res://addons/gdUnit4/test/dir_a/dir_b/my_test_suite.gd", 0, "test_foo"))
+	_inspector.on_test_case_discover_added(GdUnitTestCase.from("res://addons/gdUnit4/test/dir_a/dir_b/my_test_suite.gd", "res://addons/gdUnit4/test/dir_a/dir_b/my_test_suite.gd", 0, "test_bar"))
+	_inspector.on_test_case_discover_added(GdUnitTestCase.from("res://addons/gdUnit4/test/dir_a/dir_x/my_test_suite2.gd", "res://addons/gdUnit4/test/dir_a/dir_x/my_test_suite2.gd", 0, "test_foo"))
+	_inspector.on_test_case_discover_added(GdUnitTestCase.from("res://my_test_suite3.gd", "res://my_test_suite3.gd", 0, "test_foo"))
 
 	# create expected tree
 	var tree: Tree = auto_free(Tree.new())
@@ -560,8 +560,8 @@ func test_on_test_case_discover_added() -> void:
 
 func test_add_parameterized_test_case() -> void:
 	_inspector.init_tree()
-	_inspector.on_test_case_discover_added(GdUnitTestCase.from("res://addons/gdUnit4/test/dir_a/dir_b/my_test_suite.gd", 0, "test_parameterized", 0, "1.2"))
-	_inspector.on_test_case_discover_added(GdUnitTestCase.from("res://addons/gdUnit4/test/dir_a/dir_b/my_test_suite.gd", 0, "test_parameterized", 1, "2.2"))
+	_inspector.on_test_case_discover_added(GdUnitTestCase.from("res://addons/gdUnit4/test/dir_a/dir_b/my_test_suite.gd", "res://addons/gdUnit4/test/dir_a/dir_b/my_test_suite.gd", 0, "test_parameterized", 0, "1.2"))
+	_inspector.on_test_case_discover_added(GdUnitTestCase.from("res://addons/gdUnit4/test/dir_a/dir_b/my_test_suite.gd", "res://addons/gdUnit4/test/dir_a/dir_b/my_test_suite.gd", 0, "test_parameterized", 1, "2.2"))
 
 	# create expected tree
 	var tree: Tree = auto_free(Tree.new())


### PR DESCRIPTION
# Why
Test discovery of inherit test suits results in wrong tree structure and execution paths.

# What
- Store the original suite script resource path to build the fully_qualified_name, where is used in the inspector to build the tree.
- Fix test suite loading by use the new original base suite resource path


## Before Fix
![image](https://github.com/user-attachments/assets/ab09e898-9274-43c1-9809-d3fb73b0aeb0)

## After Fix
![image](https://github.com/user-attachments/assets/6f144d3c-6eb1-44c7-996a-c4bb41a2dd34)
