### PR TITLE
GD-749: Fix `Internal Error: Can't find test id XXX-XXXX-XXXX-XXX`

### DIFF
--- a/addons/gdUnit4/src/core/GdUnitRunnerConfig.gd
+++ b/addons/gdUnit4/src/core/GdUnitRunnerConfig.gd
@@ -70,7 +70,7 @@ func save_config(path: String = CONFIG_FILE) -> GdUnitResult:
 
 func load_config(path: String = CONFIG_FILE) -> GdUnitResult:
 	if not FileAccess.file_exists(path):
-		return GdUnitResult.error("Can't find test runner configuration '%s'! Please select a test to run." % path)
+		return GdUnitResult.warn("Can't find test runner configuration '%s'! Please select a test to run." % path)
 	var file := FileAccess.open(path, FileAccess.READ)
 	if file == null:
 		var error := FileAccess.get_open_error()

--- a/addons/gdUnit4/src/core/discovery/GdUnitTestDiscoverer.gd
+++ b/addons/gdUnit4/src/core/discovery/GdUnitTestDiscoverer.gd
@@ -83,13 +83,9 @@ static func restore_last_session() -> void:
 
 
 static func recover_test_guid(current: GdUnitTestCase, recovered_tests: Array[GdUnitTestCase]) -> void:
-	if recovered_tests.is_empty():
-		return
-	var test_index := recovered_tests.find_custom(func (test: GdUnitTestCase) -> bool:
-		return test.fully_qualified_name == current.fully_qualified_name
-	)
-	if test_index != -1:
-		current.guid = recovered_tests[test_index].guid
+	for recovered_test in recovered_tests:
+		if recovered_test.fully_qualified_name == current.fully_qualified_name:
+			current.guid = recovered_test.guid
 
 
 static func console_log_discover_results(tests: Array[GdUnitTestCase]) -> void:

--- a/addons/gdUnit4/src/core/discovery/GdUnitTestDiscoverer.gd
+++ b/addons/gdUnit4/src/core/discovery/GdUnitTestDiscoverer.gd
@@ -11,6 +11,10 @@ static func run() -> Array[GdUnitTestCase]:
 	var t:= Thread.new()
 	@warning_ignore("return_value_discarded")
 	t.start(func () -> Array[GdUnitTestCase]:
+		# Loading previous test session
+		var runner_config := GdUnitRunnerConfig.new()
+		runner_config.load_config()
+		var recovered_tests := runner_config.test_cases()
 		var test_suite_directories :PackedStringArray = GdUnitCommandHandler.scan_all_test_directories(GdUnitSettings.test_root_folder())
 		var scanner := GdUnitTestSuiteScanner.new()
 
@@ -24,11 +28,15 @@ static func run() -> Array[GdUnitTestCase]:
 		await (Engine.get_main_loop() as SceneTree).process_frame
 		for test_suites_script in collected_test_suites:
 			discover_tests(test_suites_script, func(test_case: GdUnitTestCase) -> void:
+				# Sync test uid from last test session
+				recover_test_guid(test_case, recovered_tests)
 				collected_tests.append(test_case)
 				GdUnitTestDiscoverSink.discover(test_case)
 			)
 
 		console_log_discover_results(collected_tests)
+		if !recovered_tests.is_empty():
+			console_log("Recovery last test session successfully, %d tests restored." % recovered_tests.size(), true)
 		return collected_tests
 	)
 	# wait unblocked to the tread is finished
@@ -38,6 +46,50 @@ static func run() -> Array[GdUnitTestCase]:
 	var test_to_execute: Array[GdUnitTestCase] = await t.wait_to_finish()
 	GdUnitSignals.instance().gdunit_event.emit(GdUnitEventTestDiscoverEnd.new(0, 0))
 	return test_to_execute
+
+
+## Restores the last test run session by loading the test run config file and rediscover the tests
+static func restore_last_session() -> void:
+	if GdUnitSettings.is_test_discover_enabled():
+		return
+
+	var runner_config := GdUnitRunnerConfig.new()
+	var result := runner_config.load_config()
+	# Report possible config loading errors
+	if result.is_error():
+		console_log("Recovery of the last test session failed: %s" % result.error_message(), true)
+	# If no config file found, skip test recovery
+	if result.is_warn():
+		return
+
+	# If no tests recorded, skip test recovery
+	var test_cases := runner_config.test_cases()
+	if test_cases.size() == 0:
+		return
+
+	# We run the test session restoring in an extra thread so that the main thread is not blocked
+	var t:= Thread.new()
+	t.start(func () -> void:
+		# Do sync the main thread before emit the discovered test suites to the inspector
+		await (Engine.get_main_loop() as SceneTree).process_frame
+		console_log("Recovery last test session ..", true)
+		GdUnitSignals.instance().gdunit_event.emit(GdUnitEventTestDiscoverStart.new())
+		for test_case in test_cases:
+			GdUnitTestDiscoverSink.discover(test_case)
+		GdUnitSignals.instance().gdunit_event.emit(GdUnitEventTestDiscoverEnd.new(0, 0))
+		console_log("Recovery last test session successfully, %d tests restored." % test_cases.size(), true)
+	)
+	t.wait_to_finish()
+
+
+static func recover_test_guid(current: GdUnitTestCase, recovered_tests: Array[GdUnitTestCase]) -> void:
+	if recovered_tests.is_empty():
+		return
+	var test_index := recovered_tests.find_custom(func (test: GdUnitTestCase) -> bool:
+		return test.fully_qualified_name == current.fully_qualified_name
+	)
+	if test_index != -1:
+		current.guid = recovered_tests[test_index].guid
 
 
 static func console_log_discover_results(tests: Array[GdUnitTestCase]) -> void:
@@ -51,9 +103,10 @@ static func console_log_discover_results(tests: Array[GdUnitTestCase]) -> void:
 	console_log("")
 
 
-static func console_log(message: String) -> void:
+static func console_log(message: String, on_console := false) -> void:
 	prints(message)
-	#GdUnitSignals.instance().gdunit_message.emit(message)
+	if on_console:
+		GdUnitSignals.instance().gdunit_message.emit(message)
 
 
 static func filter_tests(method: Dictionary) -> bool:

--- a/addons/gdUnit4/src/ui/parts/InspectorTreeMainPanel.gd
+++ b/addons/gdUnit4/src/ui/parts/InspectorTreeMainPanel.gd
@@ -63,6 +63,7 @@ const STATE = GdUnitInspectorTreeConstants.STATE
 var _tree_root: TreeItem
 var _item_hash := Dictionary()
 var _current_tree_view_mode := GdUnitSettings.get_inspector_tree_view_mode()
+var _run_test_recovery := true
 
 
 func _build_cache_key(resource_path: String, test_name: String) -> Array:
@@ -195,6 +196,11 @@ func is_test_id(item: TreeItem, id: GdUnitGUID) -> bool:
 	var test_case: GdUnitTestCase = item.get_meta(META_TEST_CASE)
 	return test_case.guid.equals(id)
 
+
+func disable_test_recovery() -> void:
+	_run_test_recovery = false
+
+
 @warning_ignore("return_value_discarded")
 func _ready() -> void:
 	_context_menu.set_item_icon(CONTEXT_MENU_RUN_ID, GdUnitUiTools.get_icon("Play"))
@@ -215,6 +221,8 @@ func _ready() -> void:
 	var command_handler := GdUnitCommandHandler.instance()
 	command_handler.gdunit_runner_start.connect(_on_gdunit_runner_start)
 	command_handler.gdunit_runner_stop.connect(_on_gdunit_runner_stop)
+	if _run_test_recovery:
+		GdUnitTestDiscoverer.restore_last_session()
 
 
 # we need current to manually redraw bacause of the animation bug

--- a/addons/gdUnit4/test/core/GdUnitRunnerConfigTest.gd
+++ b/addons/gdUnit4/test/core/GdUnitRunnerConfigTest.gd
@@ -30,7 +30,7 @@ func test_load_fail() -> void:
 	var config := GdUnitRunnerConfig.new()
 
 	assert_result(config.load_config("invalid_path"))\
-		.is_error()\
+		.is_warning()\
 		.contains_message("Can't find test runner configuration 'invalid_path'! Please select a test to run.")
 
 

--- a/addons/gdUnit4/test/ui/parts/InspectorTreeMainPanelTest.gd
+++ b/addons/gdUnit4/test/ui/parts/InspectorTreeMainPanelTest.gd
@@ -27,6 +27,7 @@ var _inspector: InspectorTreeMainPanel
 func before_test() -> void:
 	@warning_ignore("unsafe_method_access")
 	_inspector = load("res://addons/gdUnit4/src/ui/parts/InspectorTreePanel.tscn").instantiate()
+	_inspector.disable_test_recovery()
 	add_child(_inspector)
 	_inspector.init_tree()
 	setup_example_tree()


### PR DESCRIPTION
# Why
On Godot start, the test inspector has initialed no test session data. When a user do press rerun tests, it will result into unresolvable guid's in the test inspector.

# What
- Implementing a test session recovery mode to load previous test session and inject into the test inspector
- If the auto test discovery is enabled, sync fresh discovered tests with the previous test session guid's

### Console output
![image](https://github.com/user-attachments/assets/5ba0cbf7-6265-4d0c-9f9b-cecd81fe14be)

