### PR TITLE
GD-738: Run tests context sensitive

### DIFF
--- a/addons/gdUnit4/src/core/discovery/GdUnitTestDiscoverGuard.gd
+++ b/addons/gdUnit4/src/core/discovery/GdUnitTestDiscoverGuard.gd
@@ -151,6 +151,10 @@ func find_test_by_id(id: GdUnitGUID) -> GdUnitTestCase:
 ## [param script] The test script to analyze[br]
 ## [param discover_sink] Optional callback for test discovery events
 func discover(script: Script, discover_sink: Callable = default_discover_sink) -> void:
+	# Verify the script has no errors before run test discovery
+	var result := script.reload(true)
+	if result != OK:
+		return
 
 	if _is_debug:
 		_discovered_changes["changed_tests"] = Array([], TYPE_OBJECT, "RefCounted", GdUnitTestCase)


### PR DESCRIPTION
# Why
When a user to modify the tests and press the run button it sometimes shows errors like ` Internal Error: Can't find test id 353d9484-a8544e9-0908b80-db6812d5a5` That happen because the run loads the last stored session config, but the inspector contains outdated items

# What
- The inspector toolbar buttons are now context-sensitive and respects the inspector selection to run the selected tests. This will collect the selected tests and rewrite the  session config file to by synchrony before the execution starts.
- Skip test detection during processing for corrupted scripts to prevent false positive test changes from being detected.

