### PR TITLE
GD-756: Fix inspector tree disappears during test execution

### DIFF
--- a/addons/gdUnit4/plugin.cfg
+++ b/addons/gdUnit4/plugin.cfg
@@ -3,5 +3,5 @@
 name="gdUnit4"
 description="Unit Testing Framework for Godot Scripts"
 author="Mike Schulze"
-version="5.0.2"
+version="5.0.3"
 script="plugin.gd"

--- a/addons/gdUnit4/src/ui/parts/InspectorTreeMainPanel.gd
+++ b/addons/gdUnit4/src/ui/parts/InspectorTreeMainPanel.gd
@@ -572,6 +572,8 @@ func set_state_running(item: TreeItem) -> void:
 
 
 func set_state_succeded(item: TreeItem) -> void:
+	if item == _tree_root:
+		return
 	item.set_custom_color(0, Color.GREEN)
 	item.set_custom_color(1, Color.GREEN)
 	item.set_meta(META_GDUNIT_STATE, STATE.SUCCESS)


### PR DESCRIPTION
# Why
When the `node_collapse` is set to true, the inspector tree disappears during test execution and reappear at the end of the run.

# What
- Do not call `set_state_succeded` on tree root node. Collapse on  the root note will hide the complete tree because the root node it is not visible.
