### PR TITLE
GD-774: Fix broken C# test discovery

### DIFF
--- a/addons/gdUnit4/src/core/discovery/GdUnitTestCase.gd
+++ b/addons/gdUnit4/src/core/discovery/GdUnitTestCase.gd
@@ -55,7 +55,7 @@ var metadata: Dictionary = {}
 static func from_dict(dict: Dictionary) -> GdUnitTestCase:
 	var test := GdUnitTestCase.new()
 	test.guid = GdUnitGUID.new(str(dict["guid"]))
-	test.suite_resource_path = dict["suite_resource_path"]
+	test.suite_resource_path = dict["suite_resource_path"] if dict.has("suite_resource_path") else dict["source_file"]
 	test.suite_name = dict["managed_type"]
 	test.test_name = dict["test_name"]
 	test.display_name = dict["simple_name"]

--- a/addons/gdUnit4/test/core/discovery/GdUnitTestDiscovererTest.gd
+++ b/addons/gdUnit4/test/core/discovery/GdUnitTestDiscovererTest.gd
@@ -96,3 +96,20 @@ func test_discover_tests_inherited() -> void:
 			tuple("test_foo2", "test_foo2", "addons.gdUnit4.test.core.resources.scan_testsuite_inheritance.by_class_name.ExtendsExtendedTest.test_foo2"),
 			tuple("test_foo1", "test_foo1", "addons.gdUnit4.test.core.resources.scan_testsuite_inheritance.by_class_name.ExtendsExtendedTest.test_foo1")
 		])
+
+
+#if GDUNIT4NET_API_V5
+func test_discover_csharp_tests(do_skip := !GdUnit4CSharpApiLoader.is_api_loaded()) -> void:
+	var script :Script = load("res://addons/gdUnit4/test/core/discovery/resources/DiscoverExampleTestSuite.cs")
+	var discovered_tests := []
+	GdUnitTestDiscoverer.discover_tests(script,\
+		func discover(test_case: GdUnitTestCase) -> void:
+			discovered_tests.append(test_case)
+	)
+	assert_array(discovered_tests)\
+		.extractv(extr("test_name"), extr("display_name"), extr("fully_qualified_name"))\
+		.contains_exactly([
+			tuple("TestCase1", "TestCase1", "gdUnit4.addons.gdUnit4.test.core.discovery.resources.DiscoverExampleTestSuite.TestCase1"),
+			tuple("TestCase2", "TestCase2", "gdUnit4.addons.gdUnit4.test.core.discovery.resources.DiscoverExampleTestSuite.TestCase2")
+		])
+#endif


### PR DESCRIPTION
# Why
The C# test discovery is broken since last release, it has introduced a new property `suite_resource_path` where is not present in C# test cases.

# What
- Add fallback to `source_file` to set the `suite_resource_path` property
- Add missing test coverage for C# test discovery

