### PR TITLE
GD-784: Parse Error on startup when set inferred_declaration to error

### DIFF
--- a/addons/gdUnit4/src/core/templates/test_suite/GdUnitTestSuiteDefaultTemplate.gd
+++ b/addons/gdUnit4/src/core/templates/test_suite/GdUnitTestSuiteDefaultTemplate.gd
@@ -10,7 +10,7 @@ const DEFAULT_TEMP_TS_GD ="""
 	@warning_ignore('return_value_discarded')
 
 	# TestSuite generated from
-	const __source = '${source_resource_path}'
+	const __source: String = '${source_resource_path}'
 """
 
 

--- a/addons/gdUnit4/src/mocking/GdUnitMockBuilder.gd
+++ b/addons/gdUnit4/src/mocking/GdUnitMockBuilder.gd
@@ -101,6 +101,10 @@ static func mock_on_script(instance :Object, clazz :Variant, function_excludes :
 	var clazz_name :String = class_info.get("class_name")
 	var clazz_path :PackedStringArray = class_info.get("class_path", [clazz_name])
 	lines += double_functions(instance, clazz_name, clazz_path, function_doubler, function_excludes)
+	# We disable warning/errors for inferred_declaration
+	if Engine.get_version_info().hex >= 0x40400:
+		lines.insert(0, '@warning_ignore_start("inferred_declaration")')
+		lines.append('@warning_ignore_restore("inferred_declaration")')
 
 	var mock := GDScript.new()
 	mock.source_code = "\n".join(lines)

--- a/addons/gdUnit4/src/spy/GdUnitSpyBuilder.gd
+++ b/addons/gdUnit4/src/spy/GdUnitSpyBuilder.gd
@@ -74,6 +74,10 @@ static func spy_on_script(instance :Variant, function_excludes :PackedStringArra
 	var lines := load_template(SPY_TEMPLATE.source_code, class_info, instance as Object)
 	@warning_ignore("unsafe_cast")
 	lines += double_functions(instance as Object, clazz_name, clazz_path, GdUnitSpyFunctionDoubler.new(), function_excludes)
+	# We disable warning/errors for inferred_declaration
+	if Engine.get_version_info().hex >= 0x40400:
+		lines.insert(0, '@warning_ignore_start("inferred_declaration")')
+		lines.append('@warning_ignore_restore("inferred_declaration")')
 
 	var spy := GDScript.new()
 	spy.source_code = "\n".join(lines)

--- a/addons/gdUnit4/test/core/GdUnitTestSuiteScannerTest.gd
+++ b/addons/gdUnit4/test/core/GdUnitTestSuiteScannerTest.gd
@@ -115,7 +115,7 @@ func test_create_test_suite_pascal_case_path() -> void:
 			"@warning_ignore('return_value_discarded')",
 			"",
 			"# TestSuite generated from",
-			"const __source = '%s'" % source_path,
+			"const __source: String = '%s'" % source_path,
 			""])
 	# checked source with class_name is NOT set
 	source_path = "res://addons/gdUnit4/test/core/resources/naming_conventions/PascalCaseWithoutClassName.gd"
@@ -134,7 +134,7 @@ func test_create_test_suite_pascal_case_path() -> void:
 			"@warning_ignore('return_value_discarded')",
 			"",
 			"# TestSuite generated from",
-			"const __source = '%s'" % source_path,
+			"const __source: String = '%s'" % source_path,
 			""])
 
 
@@ -157,7 +157,7 @@ func test_create_test_suite_snake_case_path() -> void:
 			"@warning_ignore('return_value_discarded')",
 			"",
 			"# TestSuite generated from",
-			"const __source = '%s'" % source_path,
+			"const __source: String = '%s'" % source_path,
 			""])
 	# checked source with class_name is NOT set
 	source_path ="res://addons/gdUnit4/test/core/resources/naming_conventions/snake_case_without_class_name.gd"
@@ -176,7 +176,7 @@ func test_create_test_suite_snake_case_path() -> void:
 			"@warning_ignore('return_value_discarded')",
 			"",
 			"# TestSuite generated from",
-			"const __source = '%s'" % source_path,
+			"const __source: String = '%s'" % source_path,
 			""])
 
 
@@ -201,7 +201,7 @@ func test_create_test_case() -> void:
 			"@warning_ignore('return_value_discarded')",
 			"",
 			"# TestSuite generated from",
-			"const __source = '%s'" % source_path,
+			"const __source: String = '%s'" % source_path,
 			"",
 			"",
 			"func test_last_name() -> void:",

--- a/addons/gdUnit4/test/core/parse/GdScriptParserTest.gd
+++ b/addons/gdUnit4/test/core/parse/GdScriptParserTest.gd
@@ -378,11 +378,11 @@ func test_parse_func_description() -> void:
 			pass
 
 		@warning_ignore("unused_parameter")
-		static func foo1(arg1 :int, arg2:=false) -> String:
+		static func foo1(arg1: int, arg2: bool =false) -> String:
 			return ""
 
 		@warning_ignore("untyped_declaration", "unused_parameter")
-		static func foo2(arg1 :int, arg2:=true):
+		static func foo2(arg1: int, arg2: bool =true):
 			pass
 	""")
 	var fds := _parser.get_function_descriptors(script)
@@ -523,7 +523,7 @@ func test_extract_func_signature_multiline() -> void:
 func test_parse_func_description_paramized_test() -> void:
 	var script := build_tmp_script("""
 		@warning_ignore("unused_parameter")
-		func test_parameterized(a: int, b: int, c: int, expected: int, test_parameters := [[1,2,3,6],[3,4,5,11],[6,7,8,21]]) -> Variant:
+		func test_parameterized(a: int, b: int, c: int, expected: int, test_parameters: Array = [[1,2,3,6],[3,4,5,11],[6,7,8,21]]) -> Variant:
 			return null
 	""")
 	var fds := GdScriptParser.new().get_function_descriptors(script, ["test_parameterized"])
@@ -577,7 +577,7 @@ func test_parse_func_descriptor_with_fuzzers() -> void:
 		func fuzz_c() -> Fuzzer:
 			return Fuzzers.rangef(0, 10)
 
-		@warning_ignore("untyped_declaration", "unused_parameter")
+		@warning_ignore("untyped_declaration", "unused_parameter", "inferred_declaration")
 		func test_foo(fuzzer_a = fuzz_a(), fuzzer_b := fuzz_b(),
 			fuzzer_c :Fuzzer = fuzz_c(),
 			fuzzer = Fuzzers.rangei(-23, 22),

--- a/addons/gdUnit4/test/core/resources/testsuites/TestSuiteFailAndOrpahnsDetected.resource
+++ b/addons/gdUnit4/test/core/resources/testsuites/TestSuiteFailAndOrpahnsDetected.resource
@@ -1,7 +1,7 @@
 # this test suite fails on multiple stages and detects orphans
 extends GdUnitTestSuite
 
-var _orphans := Array()
+var _orphans: Array = Array()
 
 func before() -> void:
 	# create a node where never freed (orphan)

--- a/addons/gdUnit4/test/core/templates/test_suite/GdUnitTestSuiteTemplateTest.gd
+++ b/addons/gdUnit4/test/core/templates/test_suite/GdUnitTestSuiteTemplateTest.gd
@@ -38,7 +38,7 @@ func test_build_template_default() -> void:
 		@warning_ignore('return_value_discarded')
 
 		# TestSuite generated from
-		const __source = 'res://addons/gdUnit4/test/core/resources/script_with_class_name.gd'
+		const __source: String = 'res://addons/gdUnit4/test/core/resources/script_with_class_name.gd'
 		""".dedent().trim_prefix("\n")
 	assert_str(template).is_equal(expected)
 

--- a/project.godot
+++ b/project.godot
@@ -28,6 +28,7 @@ gdscript/warnings/unsafe_property_access=1
 gdscript/warnings/unsafe_method_access=1
 gdscript/warnings/unsafe_cast=1
 gdscript/warnings/unsafe_call_argument=1
+gdscript/warnings/inferred_declaration=2
 
 [dotnet]
 


### PR DESCRIPTION
# Why
The console shows error on startup when inferred_declaration` is set to error.

# What
-Fixed errors by using explicit static typing
- Add error on startup `It is recomended to upgrade to Godot v4.4.x or higher` when inferred_declaration is set and Godot less 4.4.0
