### PR TITLE
Fix C# async/await example in sceneRunner documentation

### DIFF
--- a/_advanced_testing/sceneRunner.md
+++ b/_advanced_testing/sceneRunner.md
@@ -70,7 +70,7 @@ func test_simulate_frames(timeout = 5000) -> void:
 
 ```cs
 [TestCase]
-public void simulate_frame() {
+public async Task simulate_frame() {
     // Create the scene runner for scene `test_scene.tscn`
     ISceneRunner runner = ISceneRunner.Load("res://test_scene.tscn");
 


### PR DESCRIPTION
# Why
Fix C# example that would cause compilation error when using `await` with `void` return type instead of `async Task`.

# What
Changed method signature from `public void simulate_frame()` to `public async Task simulate_frame()`.
