### PR TITLE
GD-699: Add support for argument matchers on assert_error

### DIFF
--- a/addons/gdUnit4/src/GdUnitGodotErrorAssert.gd
+++ b/addons/gdUnit4/src/GdUnitGodotErrorAssert.gd
@@ -19,7 +19,7 @@ func is_success() -> GdUnitGodotErrorAssert:
 ##		await assert_error(<callable>).is_runtime_error(<expected error message>)
 ##     [/codeblock]
 @warning_ignore("unused_parameter")
-func is_runtime_error(expected_error :String) -> GdUnitGodotErrorAssert:
+func is_runtime_error(expected_error: Variant) -> GdUnitGodotErrorAssert:
 	await (Engine.get_main_loop() as SceneTree).process_frame
 	return self
 
@@ -30,7 +30,7 @@ func is_runtime_error(expected_error :String) -> GdUnitGodotErrorAssert:
 ##		await assert_error(<callable>).is_push_warning(<expected push warning message>)
 ##     [/codeblock]
 @warning_ignore("unused_parameter")
-func is_push_warning(expected_warning :String) -> GdUnitGodotErrorAssert:
+func is_push_warning(expected_warning: Variant) -> GdUnitGodotErrorAssert:
 	await (Engine.get_main_loop() as SceneTree).process_frame
 	return self
 
@@ -41,6 +41,6 @@ func is_push_warning(expected_warning :String) -> GdUnitGodotErrorAssert:
 ##		await assert_error(<callable>).is_push_error(<expected push error message>)
 ##     [/codeblock]
 @warning_ignore("unused_parameter")
-func is_push_error(expected_error :String) -> GdUnitGodotErrorAssert:
+func is_push_error(expected_error: Variant) -> GdUnitGodotErrorAssert:
 	await (Engine.get_main_loop() as SceneTree).process_frame
 	return self

--- a/addons/gdUnit4/src/asserts/GdUnitGodotErrorAssertImpl.gd
+++ b/addons/gdUnit4/src/asserts/GdUnitGodotErrorAssertImpl.gd
@@ -1,13 +1,10 @@
 extends GdUnitGodotErrorAssert
 
-var _current_error_message :String
-var _callable :Callable
+var _current_error_message: String
+var _callable: Callable
 
 
-func _init(callable :Callable) -> void:
-	# we only support Godot 4.1.x+ because of await issue https://github.com/godotengine/godot/issues/80292
-	assert(Engine.get_version_info().hex >= 0x40100,
-			"This assertion is not supported for Godot 4.0.x. Please upgrade to the minimum version Godot 4.1.0!")
+func _init(callable: Callable) -> void:
 	# save the actual assert instance on the current thread context
 	GdUnitThreadManager.get_current_context().set_assert(self)
 	GdAssertReports.reset_last_error_line_number()
@@ -37,23 +34,23 @@ func _report_success() -> GdUnitAssert:
 	return self
 
 
-func _report_error(error_message :String, failure_line_number: int = -1) -> GdUnitAssert:
+func _report_error(error_message: String, failure_line_number: int = -1) -> GdUnitAssert:
 	var line_number := failure_line_number if failure_line_number != -1 else GdUnitAssertions.get_line_number()
 	_current_error_message = error_message
 	GdAssertReports.report_error(error_message, line_number)
 	return self
 
 
-func _has_log_entry(log_entries :Array[ErrorLogEntry], type :ErrorLogEntry.TYPE, error :String) -> bool:
+func _has_log_entry(log_entries: Array[ErrorLogEntry], type: ErrorLogEntry.TYPE, error: Variant) -> bool:
 	for entry in log_entries:
-		if entry._type == type and entry._message == error:
+		if entry._type == type and GdObjects.equals(entry._message, error):
 			# Erase the log entry we already handled it by this assertion, otherwise it will report at twice
 			_error_monitor().erase_log_entry(entry)
 			return true
 	return false
 
 
-func _to_list(log_entries :Array[ErrorLogEntry]) -> String:
+func _to_list(log_entries: Array[ErrorLogEntry]) -> String:
 	if log_entries.is_empty():
 		return "no errors"
 	if log_entries.size() == 1:
@@ -74,7 +71,7 @@ func is_success() -> GdUnitGodotErrorAssert:
 		""".dedent().trim_prefix("\n") % _to_list(log_entries))
 
 
-func is_runtime_error(expected_error :String) -> GdUnitGodotErrorAssert:
+func is_runtime_error(expected_error: Variant) -> GdUnitGodotErrorAssert:
 	var log_entries := await _execute()
 	if _has_log_entry(log_entries, ErrorLogEntry.TYPE.SCRIPT_ERROR, expected_error):
 		return _report_success()
@@ -85,7 +82,7 @@ func is_runtime_error(expected_error :String) -> GdUnitGodotErrorAssert:
 		""".dedent().trim_prefix("\n") % [expected_error, _to_list(log_entries)])
 
 
-func is_push_warning(expected_warning :String) -> GdUnitGodotErrorAssert:
+func is_push_warning(expected_warning: Variant) -> GdUnitGodotErrorAssert:
 	var log_entries := await _execute()
 	if _has_log_entry(log_entries, ErrorLogEntry.TYPE.PUSH_WARNING, expected_warning):
 		return _report_success()
@@ -96,7 +93,7 @@ func is_push_warning(expected_warning :String) -> GdUnitGodotErrorAssert:
 		""".dedent().trim_prefix("\n") % [expected_warning, _to_list(log_entries)])
 
 
-func is_push_error(expected_error :String) -> GdUnitGodotErrorAssert:
+func is_push_error(expected_error: Variant) -> GdUnitGodotErrorAssert:
 	var log_entries := await _execute()
 	if _has_log_entry(log_entries, ErrorLogEntry.TYPE.PUSH_ERROR, expected_error):
 		return _report_success()

--- a/addons/gdUnit4/test/asserts/GdUnitGodotErrorAssertImplTest.gd
+++ b/addons/gdUnit4/test/asserts/GdUnitGodotErrorAssertImplTest.gd
@@ -122,6 +122,21 @@ func test_is_push_warning() -> void:
 		""".dedent().trim_prefix("\n"))
 
 
+func test_is_push_warning_using_argument_matcher() -> void:
+	await assert_error(func() -> void: GodotErrorTestClass.new().test(2))\
+		.is_push_warning(any())
+	await assert_error(func() -> void: GodotErrorTestClass.new().test(2))\
+		.is_push_warning(any_string())
+
+	var assert_ := await assert_failure_await(func() -> void:
+		await assert_error(func() -> void: GodotErrorTestClass.new().test(2)).is_push_warning(any_int()))
+	assert_.is_failed().has_message("""
+		Expecting: push_warning() is called.
+			message: 'any_int()'
+			found: this is an push_warning
+		""".dedent().trim_prefix("\n"))
+
+
 func test_is_push_error() -> void:
 	await assert_error(func() -> void: GodotErrorTestClass.new().test(3))\
 		.is_push_error('this is an push_error')
@@ -135,6 +150,21 @@ func test_is_push_error() -> void:
 		""".dedent().trim_prefix("\n"))
 
 
+func test_is_push_error_using_argument_matcher() -> void:
+	await assert_error(func() -> void: GodotErrorTestClass.new().test(3))\
+		.is_push_error(any())
+	await assert_error(func() -> void: GodotErrorTestClass.new().test(3))\
+		.is_push_error(any_string())
+
+	var assert_ := await assert_failure_await(func() -> void:
+		await assert_error(func() -> void: GodotErrorTestClass.new().test(3)).is_push_error(any_int()))
+	assert_.is_failed().has_message("""
+		Expecting: push_error() is called.
+			message: 'any_int()'
+			found: this is an push_error
+		""".dedent().trim_prefix("\n"))
+
+
 func test_is_runtime_error() -> void:
 	await assert_error(func() -> void: GodotErrorTestClass.new().test(4))\
 		.is_runtime_error("Division by zero error in operator '/'.")
@@ -145,4 +175,19 @@ func test_is_runtime_error() -> void:
 		Expecting: a runtime error is triggered.
 			message: 'Division by zero error in operator '/'.'
 			found: no errors
+		""".dedent().trim_prefix("\n"))
+
+
+func test_is_runtime_error_using_argument_matcher() -> void:
+	await assert_error(func() -> void: GodotErrorTestClass.new().test(4))\
+		.is_runtime_error(any())
+	await assert_error(func() -> void: GodotErrorTestClass.new().test(4))\
+		.is_runtime_error(any_string())
+
+	var assert_ := await assert_failure_await(func() -> void:
+		await assert_error(func() -> void: GodotErrorTestClass.new().test(4)).is_runtime_error(any_int()))
+	assert_.is_failed().has_message("""
+		Expecting: a runtime error is triggered.
+			message: 'any_int()'
+			found: Division by zero error in operator '/'.
 		""".dedent().trim_prefix("\n"))


### PR DESCRIPTION
# Why
We want to test simply if a push_error is called without checking the content of the error message

# What
- Allow argument matcher as argument on `is_push_warning`, `is_push_error` and `is_runtime_error`
- fix formattings

