### PR TITLE
GD-707: Replace deprecated function `convert`

### DIFF
--- a/addons/gdUnit4/src/core/GdUnitProperty.gd
+++ b/addons/gdUnit4/src/core/GdUnitProperty.gd
@@ -51,11 +51,11 @@ func set_value(p_value :Variant) -> void:
 		TYPE_STRING:
 			_value = str(p_value)
 		TYPE_BOOL:
-			_value = convert(p_value, TYPE_BOOL)
+			_value = type_convert(p_value, TYPE_BOOL)
 		TYPE_INT:
-			_value = convert(p_value, TYPE_INT)
+			_value = type_convert(p_value, TYPE_INT)
 		TYPE_FLOAT:
-			_value = convert(p_value, TYPE_FLOAT)
+			_value = type_convert(p_value, TYPE_FLOAT)
 		_:
 			_value = p_value
 

--- a/addons/gdUnit4/src/core/GdUnitTestSuiteScanner.gd
+++ b/addons/gdUnit4/src/core/GdUnitTestSuiteScanner.gd
@@ -168,7 +168,7 @@ func _build_test_attribute(script: GDScript, fd: GdFunctionDescriptor) -> TestCa
 		else:
 			match arg.name():
 				ARGUMENT_TIMEOUT:
-					attribute.timeout = convert(arg.default(), TYPE_INT)
+					attribute.timeout = type_convert(arg.default(), TYPE_INT)
 				ARGUMENT_SKIP:
 					var result: Variant = _expression_runner.execute(script, arg.plain_value())
 					if result is bool:
@@ -178,9 +178,9 @@ func _build_test_attribute(script: GDScript, fd: GdFunctionDescriptor) -> TestCa
 				ARGUMENT_SKIP_REASON:
 					attribute.skip_reason = arg.plain_value()
 				Fuzzer.ARGUMENT_ITERATIONS:
-					attribute.fuzzer_iterations = convert(arg.default(), TYPE_INT)
+					attribute.fuzzer_iterations = type_convert(arg.default(), TYPE_INT)
 				Fuzzer.ARGUMENT_SEED:
-					attribute.test_seed = convert(arg.default(), TYPE_INT)
+					attribute.test_seed = type_convert(arg.default(), TYPE_INT)
 				ARGUMENT_PARAMETER_SET:
 					collected_unknown_aruments.clear()
 					pass

--- a/addons/gdUnit4/src/core/GodotVersionFixures.gd
+++ b/addons/gdUnit4/src/core/GodotVersionFixures.gd
@@ -3,16 +3,6 @@ class_name GodotVersionFixures
 extends RefCounted
 
 
-@warning_ignore("shadowed_global_identifier")
-static func type_convert(value: Variant, type: int) -> Variant:
-	return convert(value, type)
-
-
-@warning_ignore("shadowed_global_identifier")
-static func convert(value: Variant, type: int) -> Variant:
-	return type_convert(value, type)
-
-
 # handle global_position fixed by https://github.com/godotengine/godot/pull/88473
 static func set_event_global_position(event: InputEventMouseMotion, global_position: Vector2) -> void:
 	if Engine.get_version_info().hex >= 0x40202 or Engine.get_version_info().hex == 0x40104:

--- a/addons/gdUnit4/src/core/parse/GdFunctionArgument.gd
+++ b/addons/gdUnit4/src/core/parse/GdFunctionArgument.gd
@@ -42,7 +42,7 @@ func name() -> String:
 
 
 func default() -> Variant:
-	return GodotVersionFixures.convert(_default_value, _type)
+	return type_convert(_default_value, _type)
 
 
 func set_value(value: String) -> void:


### PR DESCRIPTION
# Why
The function `convert` is deprecated
`Deprecated: Use @GlobalScope.type_convert() instead.`

# What
Replace all occurrences by `type_convert`
