### PR TITLE
DOC-826: Missing documentation of `assertFile`

### DIFF
--- a/_testing/assert-array.md
+++ b/_testing/assert-array.md
@@ -2,7 +2,6 @@
 layout: default
 title: Array Assert
 parent: Asserts
-nav_order: 5
 ---
 
 # Array Assertions

--- a/_testing/assert-bool.md
+++ b/_testing/assert-bool.md
@@ -2,7 +2,6 @@
 layout: default
 title: Boolean Assert
 parent: Asserts
-nav_order: 2
 ---
 
 # Boolean Assertions

--- a/_testing/assert-dictionary.md
+++ b/_testing/assert-dictionary.md
@@ -2,7 +2,6 @@
 layout: default
 title: Dictionary Assert
 parent: Asserts
-nav_order: 6
 ---
 
 # Dictionary Assertions

--- a/_testing/assert-error.md
+++ b/_testing/assert-error.md
@@ -2,7 +2,6 @@
 layout: default
 title: Error/Exception Assert
 parent: Asserts
-nav_order: 13
 ---
 
 # Error Assertion

--- a/_testing/assert-file.md
+++ b/_testing/assert-file.md
@@ -2,10 +2,11 @@
 layout: default
 title: File Assert
 parent: Asserts
-nav_order: 10
 ---
 
 # File Assertions
+
+An assertion tool to verify file resources and their properties.
 
 {% tabs assert-file-overview %}
 {% tab assert-file-overview GdScript %}
@@ -13,14 +14,14 @@ nav_order: 10
 
 | Function               |Description|
 |------------------------| --- |
-| [is_file](..)          | Verifies the given resource is a file |
-| [exists](..)           | Verifies the given resource exists |
-| [is_script](..)        | Verifies the given resource is a gd script |
-| [contains_exactly](..) | Verifies the given resource contains the content |
+| [is_file](/gdUnit4/testing/assert-file/#is_file) | Verifies the given resource is a file |
+| [exists](/gdUnit4/testing/assert-file/#exists) | Verifies the given resource exists |
+| [is_script](/gdUnit4/testing/assert-file/#is_script) | Verifies the given resource is a gd script |
+| [contains_exactly](/gdUnit4/testing/assert-file/#contains_exactly) | Verifies the given resource contains the content |
 
 {% endtab %}
 {% tab assert-file-overview C# %}
-Not yet supported!
+Not yet implemented!
 {% endtab %}
 {% endtabs %}
 
@@ -28,4 +29,103 @@ Not yet supported!
 
 ## File Assert Examples
 
-***<-TBD->***
+### is_file
+
+Verifies the given resource is a file that can be opened for reading.
+{% tabs assert-file-is_file %}
+{% tab assert-file-is_file GdScript %}
+```gd
+func assert_file(<current>).is_file() -> GdUnitFileAssert
+```
+```gd
+# this assertion succeeds if the file exists and can be opened
+assert_file("res://test.gd").is_file()
+
+# this assertion fails if the file doesn't exist or can't be opened
+assert_file("res://nonexistent.gd").is_file()
+assert_file("res://some_directory/").is_file()
+```
+{% endtab %}
+{% tab assert-file-is_file C# %}
+Not yet implemented!
+{% endtab %}
+{% endtabs %}
+
+### exists
+
+Verifies the given resource exists in the file system.
+{% tabs assert-file-exists %}
+{% tab assert-file-exists GdScript %}
+```gd
+func assert_file(<current>).exists() -> GdUnitFileAssert
+```
+```gd
+# this assertion succeeds if the file exists
+assert_file("res://test.gd").exists()
+
+# this assertion fails if the file doesn't exist
+assert_file("res://nonexistent.gd").exists()
+```
+{% endtab %}
+{% tab assert-file-exists C# %}
+Not yet implemented!
+{% endtab %}
+{% endtabs %}
+
+### is_script
+
+Verifies the given resource is a valid GDScript file.
+{% tabs assert-file-is_script %}
+{% tab assert-file-is_script GdScript %}
+```gd
+func assert_file(<current>).is_script() -> GdUnitFileAssert
+```
+```gd
+# this assertion succeeds if the file is a valid GDScript
+assert_file("res://test.gd").is_script()
+
+# this assertion fails if the file is not a GDScript
+assert_file("res://image.png").is_script()
+assert_file("res://data.json").is_script()
+
+# this assertion also fails if the file doesn't exist
+assert_file("res://nonexistent.gd").is_script()
+```
+{% endtab %}
+{% tab assert-file-is_script C# %}
+Not yet implemented!
+{% endtab %}
+{% endtabs %}
+
+### contains_exactly
+
+Verifies the given GDScript resource contains exactly the specified content as an array of lines.
+{% tabs assert-file-contains_exactly %}
+{% tab assert-file-contains_exactly GdScript %}
+```gd
+func assert_file(<current>).contains_exactly(<expected_rows> :Array) -> GdUnitFileAssert
+```
+```gd
+# this assertion succeeds if the script contains exactly these lines
+assert_file("res://test.gd").contains_exactly([
+    "extends Node",
+    "",
+    "func _ready():",
+    "\tprint(\"Hello World\")"
+])
+
+# this assertion fails if the content doesn't match exactly
+assert_file("res://test.gd").contains_exactly([
+    "extends Node",
+    "func _ready():",
+    "\tprint(\"Hello World\")"
+])  # missing empty line
+
+# this assertion also fails if the file is not a GDScript
+assert_file("res://data.json").contains_exactly(["some content"])
+```
+{% endtab %}
+{% tab assert-file-contains_exactly C# %}
+Not yet implemented!
+{% endtab %}
+{% endtabs %}

--- a/_testing/assert-float.md
+++ b/_testing/assert-float.md
@@ -2,7 +2,6 @@
 layout: default
 title: Float/Double Assert
 parent: Asserts
-nav_order: 4
 ---
 
 # Float/Double Assertions

--- a/_testing/assert-function.md
+++ b/_testing/assert-function.md
@@ -2,7 +2,6 @@
 layout: default
 title: Function/Method Assert
 parent: Asserts
-nav_order: 11
 ---
 
 # Function/Method Assertions

--- a/_testing/assert-integer.md
+++ b/_testing/assert-integer.md
@@ -2,7 +2,6 @@
 layout: default
 title: Integer Assert
 parent: Asserts
-nav_order: 3
 ---
 
 # Integer Assertions

--- a/_testing/assert-number.md
+++ b/_testing/assert-number.md
@@ -2,7 +2,6 @@
 layout: default
 title: Number Assert
 parent: Asserts
-nav_order: 3
 ---
 
 # Number Assertions (C# only)

--- a/_testing/assert-object.md
+++ b/_testing/assert-object.md
@@ -2,7 +2,6 @@
 layout: default
 title: Object Assert
 parent: Asserts
-nav_order: 7
 ---
 
 # Object Assertions

--- a/_testing/assert-signal.md
+++ b/_testing/assert-signal.md
@@ -2,7 +2,6 @@
 layout: default
 title: Signal Assert
 parent: Asserts
-nav_order: 12
 ---
 
 # Signal Assertions

--- a/_testing/assert-string.md
+++ b/_testing/assert-string.md
@@ -2,7 +2,6 @@
 layout: default
 title: String Assert
 parent: Asserts
-nav_order: 1
 ---
 
 # String Assertions

--- a/_testing/assert-that.md
+++ b/_testing/assert-that.md
@@ -2,7 +2,7 @@
 layout: default
 title: AssertThat
 parent: Asserts
-nav_order: 20
+nav_order: 0
 ---
 
 # AssertThat Assertions

--- a/_testing/assert-vector.md
+++ b/_testing/assert-vector.md
@@ -2,7 +2,6 @@
 layout: default
 title: Vector Assert
 parent: Asserts
-nav_order: 8
 ---
 
 # Vector Assertions


### PR DESCRIPTION
# Why
The documentation has no details and examples

# What
- add section for file assertions to the documentation
- show asserts ordered alphabetically
