### PR TITLE
GD-809: Run test shows ERROR:  [InspectorTreeMainPanel.gd:765] Internal Error: Can't find tree item for

### DIFF
--- a/addons/gdUnit4/src/matchers/GdUnitArgumentMatchers.gd
+++ b/addons/gdUnit4/src/matchers/GdUnitArgumentMatchers.gd
@@ -36,7 +36,7 @@ static func is_variant_string_matching(value: Variant) -> GdUnitResult:
 	if value is String or value is StringName:
 		return GdUnitResult.success()
 	if value is GdUnitArgumentMatcher:
-		if value._to_string() == "any()" or value._to_string() == "any_string()":
+		if str(value) == "any()" or str(value) == "any_string()":
 			return GdUnitResult.success()
 		return GdUnitResult.error("Only 'any()' and 'any_string()' argument matchers are allowed!")
 	return GdUnitResult.error("Only String or StringName types are allowed!")

--- a/addons/gdUnit4/src/ui/parts/InspectorTreeMainPanel.gd
+++ b/addons/gdUnit4/src/ui/parts/InspectorTreeMainPanel.gd
@@ -762,7 +762,7 @@ func show_failed_report(selected_item: TreeItem) -> void:
 func update_test_suite(event: GdUnitEvent) -> void:
 	var item := _find_tree_item_by_path(extract_resource_path(event), event.suite_name())
 	if not item:
-		push_error("[InspectorTreeMainPanel.gd:753] Internal Error: Can't find tree item for\n %s" % event)
+		push_error("[InspectorTreeMainPanel#update_test_suite] Internal Error: Can't find tree item for\n %s" % event)
 		return
 	if event.type() == GdUnitEvent.TESTSUITE_BEFORE:
 		set_state_running(item)
@@ -1003,19 +1003,21 @@ func on_test_case_discover_added(test_case: GdUnitTestCase) -> void:
 
 func create_items_tree_mode_tree(test_case: GdUnitTestCase, parts: PackedStringArray) -> void:
 	var parent := _tree_root
+	var is_suite_assigned := false
 	for item_name in parts:
 		var next := _find_tree_item(parent, item_name)
 		if next != null:
 			parent = next
 			continue
 
-		if item_name == test_case.display_name:
+		if not is_suite_assigned and test_case.suite_name.ends_with(item_name):
+			next = create_item(parent, test_case, item_name, GdUnitType.TEST_SUITE)
+			is_suite_assigned = true
+		elif item_name == test_case.display_name:
 			next = create_item(parent, test_case, item_name, GdUnitType.TEST_CASE)
 		# On grouped tests (parameterized tests)
 		elif item_name == test_case.test_name:
 			next = create_item(parent, test_case, item_name, GdUnitType.TEST_GROUP)
-		elif test_case.suite_name.ends_with(item_name):
-			next = create_item(parent, test_case, item_name, GdUnitType.TEST_SUITE)
 		else:
 			next = create_item(parent, test_case, item_name, GdUnitType.FOLDER)
 		parent = next

--- a/addons/gdUnit4/test/ui/parts/InspectorTreeMainPanelTest.gd
+++ b/addons/gdUnit4/test/ui/parts/InspectorTreeMainPanelTest.gd
@@ -114,6 +114,43 @@ func test_find_item_by_id() -> void:
 	assert_object(item).is_not_null()
 
 
+# Tests a special case, the test is named equal to the test suite
+func test_find_item_by_id_GD809() -> void:
+	# clear the cache before discover new tests
+	_inspector.clear_tree_item_cache()
+	var suite_script := GdUnitTestResourceLoader.load_gd_script("res://addons/gdUnit4/test/ui/parts/resources/gd_809/test_example.resource")
+	var discovered_tests := {}
+	GdUnitTestDiscoverer.discover_tests(suite_script, func(discover_test: GdUnitTestCase) -> void:
+		discover_sink(discover_test)
+		discovered_tests[discover_test.test_name] = discover_test
+	)
+	assert_dict(discovered_tests).contains_keys(["test_example", "test_example_b"])
+	var test_aa: GdUnitTestCase = discovered_tests["test_example"]
+	var item := _inspector._find_tree_item_by_id(_inspector._tree_root, test_aa.guid)
+	assert_object(item).is_not_null()
+
+
+# Tests a special case, the test is named equal to the test suite
+func test_find_item_by_path_GD809() -> void:
+	# clear the cache before discover new tests
+	_inspector.clear_tree_item_cache()
+	var suite_script := GdUnitTestResourceLoader.load_gd_script("res://addons/gdUnit4/test/ui/parts/resources/gd_809/test_example.resource")
+	var discovered_tests := {}
+	GdUnitTestDiscoverer.discover_tests(suite_script, func(discover_test: GdUnitTestCase) -> void:
+		discover_sink(discover_test)
+		discovered_tests[discover_test.test_name] = discover_test
+	)
+	assert_dict(discovered_tests).contains_keys(["test_example", "test_example_b"])
+	var test_example: GdUnitTestCase = discovered_tests["test_example"]
+	var test_example_b: GdUnitTestCase = discovered_tests["test_example"]
+	# find test_suite by path
+	var item := _inspector._find_tree_item_by_path(test_example.suite_resource_path, "test_example")
+	assert_object(item).is_not_null()
+	# find tests by id
+	assert_object(_inspector._find_tree_item_by_id(_inspector._tree_root, test_example.guid)).is_not_null()
+	assert_object(_inspector._find_tree_item_by_id(_inspector._tree_root, test_example_b.guid)).is_not_null()
+
+
 func test_select_first_failure() -> void:
 	# test initial nothing is selected
 	assert_object(_inspector._tree.get_selected()).is_null()

--- a/addons/gdUnit4/test/ui/parts/resources/gd_809/test_example.resource
+++ b/addons/gdUnit4/test/ui/parts/resources/gd_809/test_example.resource
@@ -1,0 +1,9 @@
+extends GdUnitTestSuite
+
+
+func test_example() -> void:
+	pass
+
+
+func test_example_b() -> void:
+	pass


### PR DESCRIPTION


# Why
When executing a test named like the test suite, it shows errors like this.
```
  ERROR: core/variant/variant_utility.cpp:1098 - [InspectorTreeMainPanel.gd:765] Internal Error: Can't find tree item for
  ERROR:  Event: 2 id:95410990-ba4a43a-2a86297-0bb76d3212 test_foo:before, {  }, []
  ERROR: core/variant/variant_utility.cpp:1098 - [InspectorTreeMainPanel.gd:765] Internal Error: Can't find tree item for
  ERROR:  Event: 3 id:76ed63cc-3a8e4e8-3b5956f-dc8edcd896 test_foo:after, { "elapsed_time": 47.0, "error_count": 0.0, "errors": false, "failed": false, "failed_count": 0.0, "flaky": false, "orphan_nodes": 0.0, "retry_count": 0.0, "skipped": false, "skipped_count": 0.0, "warnings": false }, []
```

# What
- fix warnings from `GdUnitArgumentMatchers`
- fix `create_items_tree_mode_tree` to try to create first the test suite if not created and afterward the test case


