### PR TITLE
Fix crash and invalid state on cmd tool when no tests found

### DIFF
--- a/addons/gdUnit4/src/core/runners/GdUnitTestCIRunner.gd
+++ b/addons/gdUnit4/src/core/runners/GdUnitTestCIRunner.gd
@@ -131,8 +131,7 @@ func get_exit_code() -> int:
 ## [br]
 ## [param code] The exit code to return.
 func quit(code: int) -> void:
-	if code != RETURN_SUCCESS:
-		_state = EXIT
+	_state = EXIT
 	GdUnitTools.dispose_all()
 	await GdUnitMemoryObserver.gc_on_guarded_instances()
 	await super(code)
@@ -389,6 +388,7 @@ func init_gd_unit() -> void:
 		console_info("No test cases found, abort test run!", Color.YELLOW)
 		console_info("Exit code: %d" % RETURN_SUCCESS, Color.DARK_SALMON)
 		quit(RETURN_SUCCESS)
+		return
 	_state = RUN
 
 


### PR DESCRIPTION
# Why
When using the cmd tool to run a test where not exists, the tool crashes with an error.
```
Debugger Break, Reason: 'Attempt to call function 'execute_startup' in base 'previously freed' on a null instance.'
*Frame 0 - res://addons/gdUnit4/src/core/runners/GdUnitTestSessionRunner.gd:120 in function '_process'
Enter "help" for assistance.
debug>
```

# What
Do exit the program with the correct state by return to avoid to set state to RUN

