### PR TITLE
DOC-842] Improve the class documentaion for `append_error_message` and `override_error_message`

### DIFF
--- a/addons/gdUnit4/src/GdUnitAssert.gd
+++ b/addons/gdUnit4/src/GdUnitAssert.gd
@@ -29,21 +29,33 @@ func is_not_equal(expected: Variant):
 	return self
 
 
+## Overrides the default failure message by given custom message.[br]
+## This function allows you to replace the automatically generated failure message with a more specific
+## or user-friendly message that better describes the test failure context.[br]
+## Usage:
+##     [codeblock]
+##		# Override with custom context-specific message
+##		func test_player_inventory():
+##		    assert_int(player.get_item_count("sword"))\
+##		        .override_failure_message("Player should have exactly one sword")\
+##		        .is_equal(1)
+##     [/codeblock]
 @warning_ignore("untyped_declaration")
-func do_fail():
+func override_failure_message(_message: String):
 	return self
 
 
-## Overrides the default failure message by given custom message.
-@warning_ignore("unused_parameter")
+## Appends a custom message to the failure message.[br]
+## This can be used to add additional information to the generated failure message
+## while keeping the original assertion details for better debugging context.[br]
+## Usage:
+##     [codeblock]
+##		# Add context to existing failure message
+##		func test_player_health():
+##		    assert_int(player.health)\
+##		        .append_failure_message("Player was damaged by: %s" % last_damage_source)\
+##		        .is_greater(0)
+##     [/codeblock]
 @warning_ignore("untyped_declaration")
-func override_failure_message(message :String):
-	return self
-
-
-## Appends a custom message to the failure message.
-## This can be used to add additional infromations to the generated failure message.
-@warning_ignore("unused_parameter")
-@warning_ignore("untyped_declaration")
-func append_failure_message(message :String):
+func append_failure_message(_message: String):
 	return self


### PR DESCRIPTION
# Why
There a no examples on the function documentation and users can be struggled to use it in the right way.

# What
- Adding examples to show the usage.
- Removing the `do_fail` where is only an internal use case


