### PR TITLE
TASK-848: Upgrade the C# project to use `.NET9`

### DIFF
--- a/.github/workflows/ci-dev.yml
+++ b/.github/workflows/ci-dev.yml
@@ -66,6 +66,7 @@ jobs:
           godot-version: ${{ matrix.godot-version }}
           godot-status: ${{ matrix.godot-status }}
           godot-net: true
+          dotnet-version: 'net9.0'
           version: master
           paths: |
             res://addons/gdUnit4/test/dotnet

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -87,6 +87,7 @@ jobs:
           godot-version: ${{ matrix.godot-version }}
           godot-status: ${{ matrix.godot-status }}
           godot-net: true
+          dotnet-version: 'net9.0'
           version: installed
           paths: |
             res://addons/gdUnit4/test/dotnet

--- a/gdUnit4.csproj
+++ b/gdUnit4.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Godot.NET.Sdk/4.4.1">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
-    <LangVersion>11.0</LangVersion>
+    <TargetFramework>net9.0</TargetFramework>
+    <LangVersion>13.0</LangVersion>
     <!--Force nullable warnings, you can disable if you want-->
     <Nullable>enable</Nullable>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>


### PR DESCRIPTION
# Why
We want to use .NET9 and set language version to 13.

# What
- Update the project file to TargetFramework .NET9
- Update language version to 13
- Update CI workflows to use .NET9

