### PR TITLE
GD-858: Fix `assert_dict` shows corrupted failure message on `is_equal`

### DIFF
--- a/addons/gdUnit4/src/asserts/GdUnitDictionaryAssertImpl.gd
+++ b/addons/gdUnit4/src/asserts/GdUnitDictionaryAssertImpl.gd
@@ -68,9 +68,7 @@ func is_equal(expected :Variant) -> GdUnitDictionaryAssert:
 	if not GdObjects.equals(current, expected):
 		var c := GdAssertMessages.format_dict(current)
 		var e := GdAssertMessages.format_dict(expected)
-		var diff := GdDiffTool.string_diff(c, e)
-		var curent_diff := GdAssertMessages.colored_array_div(diff[1])
-		return report_error(GdAssertMessages.error_equal(curent_diff, e))
+		return report_error(GdAssertMessages.error_equal(c, e))
 	return report_success()
 
 
@@ -89,9 +87,7 @@ func is_same(expected :Variant) -> GdUnitDictionaryAssert:
 	if not is_same(current, expected):
 		var c := GdAssertMessages.format_dict(current)
 		var e := GdAssertMessages.format_dict(expected)
-		var diff := GdDiffTool.string_diff(c, e)
-		var curent_diff := GdAssertMessages.colored_array_div(diff[1])
-		return report_error(GdAssertMessages.error_is_same(curent_diff, e))
+		return report_error(GdAssertMessages.error_is_same(c, e))
 	return report_success()
 
 

--- a/addons/gdUnit4/test/asserts/GdUnitDictionaryAssertImplTest.gd
+++ b/addons/gdUnit4/test/asserts/GdUnitDictionaryAssertImplTest.gd
@@ -82,7 +82,7 @@ func test_is_equal() -> void:
 			 but was
 			 '{
 				1: 1,
-				"key_ab": "value_ab"
+				"key_b": "value_b"
 			  }'"""
 			.dedent()
 			.trim_prefix("\n")


### PR DESCRIPTION
# Why
When using `assert_dict` by validate two dictionaries are equal the failure report shows mixed/corrupted meta information.

# What
- Removing the string diff building and show plain formatted metadata.
