### PR TITLE
GD-862: Fixes `assert_str` shows different failure report as in the inspector

### DIFF
--- a/addons/gdUnit4/src/reporters/console/GdUnitConsoleTestReporter.gd
+++ b/addons/gdUnit4/src/reporters/console/GdUnitConsoleTestReporter.gd
@@ -1,8 +1,6 @@
 @tool
 class_name GdUnitConsoleTestReporter
 
-const GdUnitTools := preload("res://addons/gdUnit4/src/core/GdUnitTools.gd")
-
 
 var test_session: GdUnitTestSession:
 	get:
@@ -144,7 +142,7 @@ func _print_failure_report(reports: Array[GdUnitReport]) -> void:
 				.color(Color.DARK_TURQUOISE)\
 				.style(GdUnitMessageWritter.BOLD | GdUnitMessageWritter.UNDERLINE)\
 				.println_message("Report:")
-			var text := GdUnitTools.richtext_normalize(str(report))
+			var text := str(report)
 			for line in text.split("\n", false):
 				_writer.indent(2).color(Color.DARK_TURQUOISE).println_message(line)
 

--- a/addons/gdUnit4/test/core/writers/GdUnitCsiMessageWriterTest.gd
+++ b/addons/gdUnit4/test/core/writers/GdUnitCsiMessageWriterTest.gd
@@ -1,0 +1,30 @@
+# GdUnit generated TestSuite
+extends GdUnitTestSuite
+
+
+func test_bbcode_tags_to_csi_codes_empty() -> void:
+	var csi_formatted := GdUnitCSIMessageWriter.new()._bbcode_tags_to_csi_codes("")
+	assert_str(csi_formatted).is_empty()
+
+
+func test_bbcode_tags_to_csi_codes_color() -> void:
+	var bbcode:= "[color=green]line [/color][color=aqua]9:[/color] [color=#CD5C5C]Expecting:[/color]\n"
+	var csi_formatted := GdUnitCSIMessageWriter.new()._bbcode_tags_to_csi_codes(bbcode)
+	assert_str(csi_formatted)\
+		.is_equal("[38;2;0;255;0mline [0m[38;2;0;255;255m9:[0m [38;2;205;92;92mExpecting:[0m\n")
+
+
+func test_bbcode_tags_to_csi_codes_color_and_bgcolor() -> void:
+	var bbcode:= "[color=#1E90FF]This is a[bgcolor=#00ff004d][color=white]n[/color][/bgcolor] test"\
+		+ " [bgcolor=#ff00004d][color=white]m[/color][/bgcolor][bgcolor=#00ff004d][color=white]M[/color][/bgcolor]essage[/color]"
+	var csi_formatted := GdUnitCSIMessageWriter.new()._bbcode_tags_to_csi_codes(bbcode)
+	assert_str(csi_formatted)\
+		.is_equal("[38;2;30;144;255mThis is a[48;2;0;77;0m[38;2;255;255;255mn[0m[38;2;30;144;255m[48;2;0;77;0m[0m[38;2;30;144;255m test"\
+		 + " [48;2;77;0;0m[38;2;255;255;255mm[0m[38;2;30;144;255m[48;2;77;0;0m[0m[38;2;30;144;255m[48;2;0;77;0m[38;2;255;255;255mM"\
+		 + "[0m[38;2;30;144;255m[48;2;0;77;0m[0m[38;2;30;144;255message[0m")
+
+
+func test_bbcode_tags_to_csi_codes_text_styles() -> void:
+	var csi_formatted := GdUnitCSIMessageWriter.new()._bbcode_tags_to_csi_codes("This [b]is[/b] a [i]message[/i]")
+	assert_str(csi_formatted)\
+		.is_equal("This [1mis[0m a [3mmessage[0m")


### PR DESCRIPTION
# Why
When writing a test and using `assert_str` to validate for an expected string the failure messages are different in the inspector and console.

# What
- Removing the default richtext_normalize form the `GdUnitConsoleTestReporter`
- Adding bbcode to csi code converting in the `GdUnitCSIMessageWriter` to show colored reports on command line execution


## Outcome
```gd
func test_is_equal_example() -> void:
	assert_str("This is an test Message").is_equal("This is a test message")
```

- gdUnit4 inspector 
<img width="396" height="130" alt="image" src="https://github.com/user-attachments/assets/6291a873-5936-4de6-b795-f3b3344b6444" />

- gdUnit4 console
<img width="699" height="111" alt="image" src="https://github.com/user-attachments/assets/c6baa6fa-68bf-49f1-a46f-db910eb0cf6c" />

- gdUnit4 cmd tool
<img width="760" height="98" alt="image" src="https://github.com/user-attachments/assets/e2a8c11c-d776-4d38-8253-f07c5bd8438f" />
