### PR TITLE
[DOC-856] Update  `await_input_processed` examples

### DIFF
--- a/_advanced_testing/scene_runner/actions.md
+++ b/_advanced_testing/scene_runner/actions.md
@@ -62,7 +62,7 @@ These functions allow you to mimic user key inputs as actions for testing purpos
   
 {% include advice.html
 content="To ensure input events are processed correctly, you must wait at least one frame cycle after simulating inputs.
-Use the <b>await await_input_processed()</b> function to accomplish this."
+Use the <b>await runner.await_input_processed()</b> function to accomplish this."
 %}
 See [Synchronize Inputs Events](/gdUnit4/advanced_testing/scene_runner/sync_inputs/#synchronize-inputs-events)
 
@@ -88,7 +88,7 @@ var runner := scene_runner("res://test_scene.tscn")
 
 # Simulate the UP key is pressed by using the input action "ui_up"
 runner.simulate_action_pressed("ui_up")
-await await_input_processed()
+await runner.await_input_processed()
 ```
 
 {% endtab %}
@@ -141,7 +141,7 @@ var runner := scene_runner("res://test_scene.tscn")
 
 # Simulate the UP key is press by using the action "ui_up"
 runner.simulate_action_press("ui_up")
-await await_input_processed()
+await runner.await_input_processed()
 ```
 
 {% endtab %}
@@ -195,7 +195,7 @@ var runner := scene_runner("res://test_scene.tscn")
 
 # Simulate the UP key is released by using the action "ui_up"
 runner.simulate_action_release("ui-up")
-await await_input_processed()
+await runner.await_input_processed()
 ```
 
 {% endtab %}

--- a/_advanced_testing/scene_runner/keys.md
+++ b/_advanced_testing/scene_runner/keys.md
@@ -62,7 +62,7 @@ These functions allow you to mimic user key inputs for testing purposes. There a
   
 {% include advice.html
 content="To ensure input events are processed correctly, you must wait at least one frame cycle after simulating inputs.
-Use the <b>await await_input_processed()</b> function to accomplish this."
+Use the <b>await runner.await_input_processed()</b> function to accomplish this."
 %}
 See [Synchronize Inputs Events](/gdUnit4/advanced_testing/scene_runner/sync_inputs/#synchronize-inputs-events)
 
@@ -91,11 +91,11 @@ var runner := scene_runner("res://test_scene.tscn")
 
 # Simulate the enter key is pressed
 runner.simulate_key_pressed(KEY_ENTER)
-await await_input_processed()
+await runner.await_input_processed()
 
 # Simulates key combination ctrl+C is pressed
 runner.simulate_key_pressed(KEY_C, false, true)
-await await_input_processed()
+await runner.await_input_processed()
 ```
 
 {% endtab %}
@@ -158,17 +158,17 @@ var runner := scene_runner("res://test_scene.tscn")
 
 # Simulate the enter key is press
 runner.simulate_key_press(KEY_ENTER)
-await await_input_processed()
+await runner.await_input_processed()
 
 # Simulates key combination ctrl+C is press in one function call
 runner.simulate_key_press(KEY_C, false, true)
-await await_input_processed()
+await runner.await_input_processed()
 
 # Simulates multi key combination ctrl+alt+C is press
 runner.simulate_key_press(KEY_CTRL)
 runner.simulate_key_press(KEY_ALT)
 runner.simulate_key_press(KEY_C)
-await await_input_processed()
+await runner.await_input_processed()
 ```
 
 {% endtab %}
@@ -237,17 +237,17 @@ var runner := scene_runner("res://test_scene.tscn")
 
 # Simulate a enter key is released
 runner.simulate_key_release(KEY_ENTER)
-await await_input_processed()
+await runner.await_input_processed()
 
 # Simulates key combination ctrl+C is released in one function call
 runner.simulate_key_release(KEY_C, false, true)
-await await_input_processed()
+await runner.await_input_processed()
 
 # Simulates multi key combination ctrl+alt+C is released
 runner.simulate_key_release(KEY_CTRL)
 runner.simulate_key_release(KEY_ALT)
 runner.simulate_key_release(KEY_C)
-await await_input_processed()
+await runner.await_input_processed()
 ```
 
 {% endtab %}

--- a/_advanced_testing/scene_runner/mouse.md
+++ b/_advanced_testing/scene_runner/mouse.md
@@ -84,7 +84,7 @@ These functions allow you to mimic user mouse inputs for testing purposes. There
   
 {% include advice.html
 content="To ensure input events are processed correctly, you must wait at least one frame cycle after simulating inputs.
-Use the <b>await await_input_processed()</b> function to accomplish this."
+Use the <b>await runner.await_input_processed()</b> function to accomplish this."
 %}
 See [Synchronize Inputs Events](/gdUnit4/advanced_testing/scene_runner/sync_inputs/#synchronize-inputs-events)
 
@@ -112,7 +112,7 @@ var runner := scene_runner("res://test_scene.tscn")
 
 # sets the current mouse position to 100, 100
 runner.set_mouse_position(Vector2(100, 100))
-await await_input_processed()
+await runner.await_input_processed()
 ```
 
 {% endtab %}
@@ -210,11 +210,11 @@ var runner := scene_runner("res://test_scene.tscn")
 
 # Set mouse position to a initial position
 runner.set_mouse_pos(Vector2(160, 20))
-await await_input_processed()
+await runner.await_input_processed()
 
 # Simulates a mouse move to final position 200, 40
 runner.simulate_mouse_move(Vector2(200, 40))
-await await_input_processed()
+await runner.await_input_processed()
 ```
 
 {% endtab %}
@@ -275,7 +275,7 @@ var runner := scene_runner("res://test_scene.tscn")
 
 # Set mouse position to an initial position
 runner.set_mouse_pos(Vector2(10, 20))
-await await_input_processed()
+await runner.await_input_processed()
 
 # Simulate a mouse move from the current position to the relative position within 1 second
 # the final position will be (410, 220) when is completed
@@ -337,7 +337,7 @@ var runner := scene_runner("res://test_scene.tscn")
 
 # Set mouse position to an initial position
 runner.set_mouse_pos(Vector2(10, 20))
-await await_input_processed()
+await runner.await_input_processed()
 
 # Simulate a mouse move from the current position to the absolute position within 1 second
 # the final position will be (400, 200) when is completed
@@ -397,7 +397,7 @@ var runner := scene_runner("res://test_scene.tscn")
 
 # Simulates pressing the left mouse button
 runner.simulate_mouse_button_pressed(BUTTON_LEFT)
-await await_input_processed()
+await runner.await_input_processed()
 ```
 
 {% endtab %}
@@ -452,7 +452,7 @@ var runner := scene_runner("res://test_scene.tscn")
 
 # simulates mouse left button is press
 runner.simulate_mouse_button_press(BUTTON_LEFT)
-await await_input_processed()
+await runner.await_input_processed()
 ```
 
 {% endtab %}
@@ -507,7 +507,7 @@ var runner := scene_runner("res://test_scene.tscn")
 
 # Simulates a mouse left button is released
 runner.simulate_mouse_button_release(BUTTON_LEFT)
-await await_input_processed()
+await runner.await_input_processed()
 ```
 
 {% endtab %}

--- a/_advanced_testing/scene_runner/sync_inputs.md
+++ b/_advanced_testing/scene_runner/sync_inputs.md
@@ -34,7 +34,7 @@ var runner := scene_runner("res://test_scene.tscn")
 runner.simulate_key_pressed(KEY_C, false, true)
 
 # finalize the input event processing
-await await_input_processed()
+await runner.await_input_processed()
 ```
 
 {% endtab %}

--- a/_advanced_testing/scene_runner/touchscreen.md
+++ b/_advanced_testing/scene_runner/touchscreen.md
@@ -79,7 +79,7 @@ These functions allow you to mimic user touchscreen inputs for testing purposes.
   
 {% include advice.html
 content="To ensure input events are processed correctly, you must wait at least one frame cycle after simulating inputs.
-Use the <b>await await_input_processed()</b> function to accomplish this."
+Use the <b>await runner.await_input_processed()</b> function to accomplish this."
 %}
 See [Synchronize Inputs Events](/gdUnit4/advanced_testing/scene_runner/sync_inputs/#synchronize-inputs-events)
 


### PR DESCRIPTION
# Why

Example commands are wrong and need to be fixed for better developer experience.


# What

Change `await_input_processed` to `runner.await_input_processed`.

See https://github.com/MikeSchulze/gdUnit4/issues/856 for full details
