### PR TITLE
TASK-833: Add feature flag to hide the session hooks until 6.0.0 is released

### DIFF
--- a/addons/gdUnit4/src/core/GdUnitSettings.gd
+++ b/addons/gdUnit4/src/core/GdUnitSettings.gd
@@ -77,6 +77,10 @@ const SHORTCUT_FILESYSTEM_RUN_TEST_DEBUG = GROUP_SHORTCUT_FILESYSTEM + "/run_tes
 const GROUP_UI_TOOLBAR = UI_SETTINGS + "/toolbar"
 const INSPECTOR_TOOLBAR_BUTTON_RUN_OVERALL = GROUP_UI_TOOLBAR + "/run_overall"
 
+# Feature flags
+const GROUP_FEATURE = MAIN_CATEGORY + "/feature"
+const HOOK_SETTINGS_VISIBLE = GROUP_FEATURE + "/hook_settings_visible"
+
 # defaults
 # server connection timeout in minutes
 const DEFAULT_SERVER_TIMEOUT :int = 30
@@ -289,6 +293,10 @@ static func is_test_discover_enabled() -> bool:
 
 static func is_test_flaky_check_enabled() -> bool:
 	return get_setting(TEST_FLAKY_CHECK, false)
+
+
+static func is_feature_enabled(feature: String) -> bool:
+	return get_setting(feature, false)
 
 
 static func get_flaky_max_retries() -> int:

--- a/addons/gdUnit4/src/core/runners/GdUnitTestSessionRunner.gd
+++ b/addons/gdUnit4/src/core/runners/GdUnitTestSessionRunner.gd
@@ -29,7 +29,7 @@ var _runner_config := GdUnitRunnerConfig.new()
 
 ## The test suite executor instance
 var _executor: GdUnitTestSuiteExecutor
-var _hooks := GdUnitTestSessionHookService.instance()
+var _hooks : GdUnitTestSessionHookService
 
 ## Current runner state
 var _state := READY
@@ -112,6 +112,7 @@ func _process(_delta: float) -> void:
 	match _state:
 		INIT:
 			await init_runner()
+			_hooks = GdUnitTestSessionHookService.instance()
 		RUN:
 			_test_session = GdUnitTestSession.new(_test_cases, report_path)
 			GdUnitSignals.instance().gdunit_event.emit(GdUnitSessionStart.new())

--- a/addons/gdUnit4/src/ui/settings/GdUnitSettingsDialog.gd
+++ b/addons/gdUnit4/src/ui/settings/GdUnitSettingsDialog.gd
@@ -36,6 +36,9 @@ func _ready() -> void:
 	setup_properties(_properties_shortcuts, GdUnitSettings.SHORTCUT_SETTINGS)
 	check_for_update()
 
+	# Hide the hook settings behind a feature flag
+	_tab_container.set_tab_hidden(1, not GdUnitSettings.is_feature_enabled(GdUnitSettings.HOOK_SETTINGS_VISIBLE))
+
 
 func _sort_by_key(left: GdUnitProperty, right: GdUnitProperty) -> bool:
 	return left.name() < right.name()


### PR DESCRIPTION

# Why
The feature is not yet complete and will be announced for the first time with GdUnit4 v6.0.0.

# What
- Adding feature flag to hide the hook settings in the settings dialog It can be enabled by setting the project property  [gdunit4] `feature/hook_settings_visible=true`


