### PR TITLE
GD-872: Fix Internal errors when running C# tests

### DIFF
--- a/addons/gdUnit4/src/ui/parts/InspectorTreeMainPanel.gd
+++ b/addons/gdUnit4/src/ui/parts/InspectorTreeMainPanel.gd
@@ -64,22 +64,8 @@ const STATE = GdUnitInspectorTreeConstants.STATE
 
 var _tree_root: TreeItem
 var _current_selected_item: TreeItem = null
-var _item_hash := Dictionary()
 var _current_tree_view_mode := GdUnitSettings.get_inspector_tree_view_mode()
 var _run_test_recovery := true
-
-
-func _build_cache_key(resource_path: String, test_name: String) -> Array:
-	return [resource_path, test_name]
-
-
-func add_tree_item_to_cache(resource_path: String, test_name: String, item: TreeItem) -> void:
-	var key := _build_cache_key(resource_path, test_name)
-	_item_hash[key] = item
-
-
-func clear_tree_item_cache() -> void:
-	_item_hash.clear()
 
 
 ## Used for debugging purposes only
@@ -114,15 +100,16 @@ func _find_tree_item_by_id(parent: TreeItem, id: GdUnitGUID) -> TreeItem:
 	return null
 
 
-func _find_tree_item_by_path(resource_path: String, item_name: String) -> TreeItem:
-	var key := _build_cache_key(resource_path, item_name)
-	return _item_hash.get(key, null)
-
-
-func _find_by_resource_path(current: TreeItem, resource_path: String) -> TreeItem:
-	for item in current.get_children():
-		if get_item_source_file(item) == resource_path:
-			return item
+func _find_tree_item_by_test_suite(parent: TreeItem, suite_path: String, suite_name: String) -> TreeItem:
+	for child in parent.get_children():
+		if child.get_meta(META_GDUNIT_TYPE) == GdUnitType.TEST_SUITE:
+			var test_case: GdUnitTestCase = child.get_meta(META_TEST_CASE)
+			if test_case.suite_resource_path == suite_path and test_case.suite_name == suite_name:
+				return child
+		if child.get_child_count() > 0:
+			var item := _find_tree_item_by_test_suite(child, suite_path, suite_name)
+			if item != null:
+				return item
 	return null
 
 
@@ -261,7 +248,6 @@ func init_tree() -> void:
 
 func cleanup_tree() -> void:
 	clear_reports()
-	clear_tree_item_cache()
 	if not _tree_root:
 		return
 	_free_recursive()
@@ -777,9 +763,9 @@ func show_failed_report(selected_item: TreeItem) -> void:
 
 
 func update_test_suite(event: GdUnitEvent) -> void:
-	var item := _find_tree_item_by_path(extract_resource_path(event), event.suite_name())
+	var item := _find_tree_item_by_test_suite(_tree_root, event.resource_path(), event.suite_name())
 	if not item:
-		push_error("[InspectorTreeMainPanel#update_test_suite] Internal Error: Can't find tree item for\n %s" % event)
+		push_error("[InspectorTreeMainPanel#update_test_suite] Internal Error: Can't find test suite item '{_suite_name}' for {_resource_path} ".format(event))
 		return
 	if event.type() == GdUnitEvent.TESTSUITE_AFTER:
 		update_item_elapsed_time_counter(item, event.elapsed_time())
@@ -820,8 +806,6 @@ func create_item(parent: TreeItem, test: GdUnitTestCase, item_name: String, type
 		GdUnitType.TEST_SUITE:
 			# We need to create a copy of the test record meta with a new uniqe guid
 			item.set_meta(META_TEST_CASE, GdUnitTestCase.from(test.suite_resource_path, test.source_file, test.line_number, test.suite_name))
-			# We need to add the suite item to the item cache by path because the guid is not provided
-			add_tree_item_to_cache(test.source_file, item_name, item)
 
 	item.set_meta(META_GDUNIT_NAME, item_name)
 	set_state_initial(item, type)
@@ -986,7 +970,7 @@ func get_icon_by_file_type(path: String, state: STATE, orphans: bool) -> Texture
 
 func on_test_case_discover_added(test_case: GdUnitTestCase) -> void:
 	var test_root_folder := GdUnitSettings.test_root_folder().replace("res://", "")
-	var fully_qualified_name := test_case.fully_qualified_name.trim_prefix(test_root_folder).trim_suffix(test_case.display_name)
+	var fully_qualified_name := test_case.fully_qualified_name.trim_suffix(test_case.display_name)
 	var parts := fully_qualified_name.split(".", false)
 	parts.append(test_case.display_name)
 	# Skip tree structure until test root folder
@@ -1004,13 +988,14 @@ func on_test_case_discover_added(test_case: GdUnitTestCase) -> void:
 func create_items_tree_mode_tree(test_case: GdUnitTestCase, parts: PackedStringArray) -> void:
 	var parent := _tree_root
 	var is_suite_assigned := false
+	var suite_name := test_case.suite_name.split(".")[-1]
 	for item_name in parts:
 		var next := _find_tree_item(parent, item_name)
 		if next != null:
 			parent = next
 			continue
 
-		if not is_suite_assigned and test_case.suite_name.ends_with(item_name):
+		if not is_suite_assigned and suite_name == item_name:
 			next = create_item(parent, test_case, item_name, GdUnitType.TEST_SUITE)
 			is_suite_assigned = true
 		elif item_name == test_case.display_name:

--- a/addons/gdUnit4/test/ui/parts/resources/gd_872/ATests.cs
+++ b/addons/gdUnit4/test/ui/parts/resources/gd_872/ATests.cs
@@ -1,0 +1,20 @@
+using GdUnit4;
+
+namespace Minimal.Tests
+{
+	[TestSuite]
+	public class ATests
+	{
+		[TestCase]
+		public void TestExample()
+		{
+			Assertions.AssertBool(true).IsTrue();
+		}
+
+		[TestCase]
+		public void TestExample2()
+		{
+			Assertions.AssertBool(false).IsFalse();
+		}
+	}
+}

--- a/addons/gdUnit4/test/ui/parts/resources/gd_872/AZTests.cs
+++ b/addons/gdUnit4/test/ui/parts/resources/gd_872/AZTests.cs
@@ -1,0 +1,20 @@
+using GdUnit4;
+
+namespace Minimal.Tests
+{
+	[TestSuite]
+	public class AZTests
+	{
+		[TestCase]
+		public void TestExample()
+		{
+			Assertions.AssertBool(true).IsTrue();
+		}
+
+		[TestCase]
+		public void TestExample2()
+		{
+			Assertions.AssertBool(false).IsFalse();
+		}
+	}
+}


### PR DESCRIPTION
# Why
When running C# tests, an internal error is shown, and the tree structure looks also invalid.

# What
- Removed the internal item cache and resolve test suite items by search over all items by path and name.
- Adding test coverage to rebuild the original error scenario


