### PR TITLE
GD-882: Fixing SceneRunner SimulateKey to provide missing Unicode

### DIFF
--- a/addons/gdUnit4/src/core/GdUnitSceneRunnerImpl.gd
+++ b/addons/gdUnit4/src/core/GdUnitSceneRunnerImpl.gd
@@ -152,6 +152,7 @@ func simulate_key_press(key_code: int, shift_pressed := false, ctrl_pressed := f
 	event.pressed = true
 	event.keycode = key_code as Key
 	event.physical_keycode = key_code as Key
+	event.unicode = key_code
 	event.alt_pressed = key_code == KEY_ALT
 	event.shift_pressed = shift_pressed or key_code == KEY_SHIFT
 	event.ctrl_pressed = ctrl_pressed or key_code == KEY_CTRL
@@ -166,6 +167,7 @@ func simulate_key_release(key_code: int, shift_pressed := false, ctrl_pressed :=
 	event.pressed = false
 	event.keycode = key_code as Key
 	event.physical_keycode = key_code as Key
+	event.unicode = key_code
 	event.alt_pressed = key_code == KEY_ALT
 	event.shift_pressed = shift_pressed or key_code == KEY_SHIFT
 	event.ctrl_pressed = ctrl_pressed or key_code == KEY_CTRL

--- a/addons/gdUnit4/test/core/GdUnitSceneRunnerInputEventTest.gd
+++ b/addons/gdUnit4/test/core/GdUnitSceneRunnerInputEventTest.gd
@@ -798,3 +798,22 @@ func test_simulate_screen_touch_gesture_zoom_out() -> void:
 	# verify final position are correct
 	assert_that(_runner.get_screen_touch_drag_position(0)).is_equal(Vector2(300, 100))
 	assert_that(_runner.get_screen_touch_drag_position(1)).is_equal(Vector2(300, 350))
+
+
+func test_text_input_processing() -> void:
+	_runner.maximize_view()
+	var lineEdit := _runner.find_child("TextInput") as LineEdit
+
+	# Focus the text input and clear any existing content
+	lineEdit.grab_focus()
+	assert_that(lineEdit.has_focus()).is_true()
+	lineEdit.text = ""
+
+	# Type individual characters
+	_runner.simulate_key_pressed(KEY_H)
+	_runner.simulate_key_pressed(KEY_I)
+	await _runner.await_input_processed()
+	await _runner.simulate_frames(100)
+
+	# Verify text accumulation
+	assert_that(lineEdit.text).is_equal("HI");

--- a/addons/gdUnit4/test/core/GdUnitSceneRunnerInputEventTest.gd
+++ b/addons/gdUnit4/test/core/GdUnitSceneRunnerInputEventTest.gd
@@ -135,6 +135,7 @@ func test_simulate_key_press() -> void:
 		var event := InputEventKey.new()
 		event.keycode = key as Key
 		event.physical_keycode = key as Key
+		event.unicode = key
 		event.pressed = true
 		verify(_scene_spy, 1)._input(event)
 		assert_that(Input.is_key_pressed(key)).is_true()
@@ -160,6 +161,7 @@ func test_simulate_key_press_with_modifiers() -> void:
 	var event := InputEventKey.new()
 	event.keycode = KEY_SHIFT
 	event.physical_keycode = KEY_SHIFT
+	event.unicode = KEY_SHIFT as int
 	event.pressed = true
 	event.shift_pressed = true
 	verify(_scene_spy, 1)._input(event)
@@ -168,6 +170,7 @@ func test_simulate_key_press_with_modifiers() -> void:
 	event = InputEventKey.new()
 	event.keycode = KEY_A
 	event.physical_keycode = KEY_A
+	event.unicode = KEY_A as int
 	event.pressed = true
 	event.shift_pressed = true
 	verify(_scene_spy, 1)._input(event)

--- a/addons/gdUnit4/test/mocker/resources/scenes/TestScene.tscn
+++ b/addons/gdUnit4/test/mocker/resources/scenes/TestScene.tscn
@@ -45,9 +45,11 @@ text = "Test 3"
 layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 3
+current_tab = 0
 
 [node name="HBoxContainer" type="HBoxContainer" parent="VBoxContainer/PanelContainer"]
 layout_mode = 2
+metadata/_tab_index = 0
 
 [node name="Panel1" type="ColorRect" parent="VBoxContainer/PanelContainer/HBoxContainer"]
 custom_minimum_size = Vector2(100, 0)
@@ -115,6 +117,14 @@ offset_top = 529.0
 offset_right = 1123.0
 offset_bottom = 609.0
 text = "Exit"
+
+[node name="TextInput" type="LineEdit" parent="."]
+unique_name_in_owner = true
+layout_mode = 0
+offset_left = 694.0
+offset_top = 189.0
+offset_right = 1020.0
+offset_bottom = 268.0
 
 [connection signal="pressed" from="VBoxContainer/HBoxContainer/test1" to="." method="_on_test_pressed" binds= [1]]
 [connection signal="pressed" from="VBoxContainer/HBoxContainer/test2" to="." method="_on_test_pressed" binds= [2]]


### PR DESCRIPTION
# Why
The `SimulateKey ` produces an `InputEventKey` without setting the Unicode value. This will result in possible issues on text input components that act on Unicode values.

# What
- Set the missing `Unicode` on  `InputEventKey` creation
- Add test coverage to simulate a text input
