### PR TITLE
GD-777: Add support for variadic functions

### DIFF
--- a/.github/workflows/ci-dev.yml
+++ b/.github/workflows/ci-dev.yml
@@ -22,7 +22,7 @@ jobs:
       fail-fast: false
       max-parallel: 10
       matrix:
-        godot-version: ['4.3', '4.4', '4.4.1']
+        godot-version: ['4.5']
         godot-status: ['stable']
         godot-net: ['.Net', '']
 

--- a/.github/workflows/ci-pr-publish-report.yml
+++ b/.github/workflows/ci-pr-publish-report.yml
@@ -24,12 +24,12 @@ jobs:
       fail-fast: false
       max-parallel: 10
       matrix:
-        godot-version: ['4.3', '4.4', '4.4.1']
+        godot-version: ['4.5']
         godot-status: ['stable']
         godot-net: ['-net', '']
-        include:
-          - godot-version: '4.5'
-            godot-status: 'dev5'
+        #include:
+        #  - godot-version: '4.5'
+        #    godot-status: 'dev5'
 
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -37,12 +37,12 @@ jobs:
       max-parallel: 10
       matrix:
         # If changes are made here, they must be transferred to `.github\workflows\ci-pr-publish-report.yml`
-        godot-version: ['4.3', '4.4', '4.4.1']
+        godot-version: ['4.5']
         godot-status: ['stable']
         godot-net: ['.Net', '']
-        include:
-          - godot-version: '4.5'
-            godot-status: 'dev5'
+        #include:
+        #  - godot-version: '4.6'
+        #    godot-status: 'dev1'
 
     permissions:
       actions: write

--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@
 <p align="center">
   <img src="https://img.shields.io/badge/Godot-v4.3-%23478cbf?logo=godot-engine&logoColor=cyian&color=green" alt="">
   <img src="https://img.shields.io/badge/Godot-v4.4-%23478cbf?logo=godot-engine&logoColor=cyian&color=green" alt="">
-<img src="https://img.shields.io/badge/Godot-v4.4.1-%23478cbf?logo=godot-engine&logoColor=cyian&color=green" alt="">
+  <img src="https://img.shields.io/badge/Godot-v4.4.1-%23478cbf?logo=godot-engine&logoColor=cyian&color=green" alt="">
+  <img src="https://img.shields.io/badge/Godot-v4.5-%23478cbf?logo=godot-engine&logoColor=cyian&color=yellow" alt="">
 </p>
 
 <h1 align="center">Compatibility Overview</h1>
@@ -24,7 +25,10 @@
   </thead>
   <tbody>
     <tr>
-      <td>v5.0.x, v5.1.x</td><td>v4.3, v4.4, v4.4.1</td>
+      <td>v6.x+ (not released yet)</td><td>v4.5</td>
+    </tr>
+    <tr>
+      <td>v5.x+</td><td>v4.3, v4.4, v4.4.1</td>
     </tr>
     <tr>
       <td>v4.4.0+</td><td>v4.2.0, v4.3, v4.4.dev2</td>

--- a/addons/gdUnit4/plugin.gd
+++ b/addons/gdUnit4/plugin.gd
@@ -26,8 +26,8 @@ func _enter_tree() -> void:
 		GdUnitCSIMessageWriter.new().prints_warning("It was recognized that GdUnit4 is running in a test environment, therefore the GdUnit4 plugin will not be executed!")
 		return
 
-	if Engine.get_version_info().hex < 0x40300:
-		prints("The GdUnit4 plugin requires Godot version 4.3 or higher to run.")
+	if Engine.get_version_info().hex < 0x40500:
+		prints("This GdUnit4 plugin version '%s' requires Godot version '4.5' or higher to run." % GdUnit4Version.current())
 		return
 	GdUnitSettings.setup()
 	# Install the GdUnit Inspector

--- a/addons/gdUnit4/src/doubler/CallableDoubler.gd
+++ b/addons/gdUnit4/src/doubler/CallableDoubler.gd
@@ -58,20 +58,8 @@ static func callable_functions() -> PackedStringArray:
 ## Callable functions stubing
 ## -----------------------------------------------------------------------------------------------------------------------------------------
 
-@warning_ignore("untyped_declaration")
-func bind(arg0=GdObjects.TYPE_VARARG_PLACEHOLDER_VALUE,
-	arg1=GdObjects.TYPE_VARARG_PLACEHOLDER_VALUE,
-	arg2=GdObjects.TYPE_VARARG_PLACEHOLDER_VALUE,
-	arg3=GdObjects.TYPE_VARARG_PLACEHOLDER_VALUE,
-	arg4=GdObjects.TYPE_VARARG_PLACEHOLDER_VALUE,
-	arg5=GdObjects.TYPE_VARARG_PLACEHOLDER_VALUE,
-	arg6=GdObjects.TYPE_VARARG_PLACEHOLDER_VALUE,
-	arg7=GdObjects.TYPE_VARARG_PLACEHOLDER_VALUE,
-	arg8=GdObjects.TYPE_VARARG_PLACEHOLDER_VALUE,
-	arg9=GdObjects.TYPE_VARARG_PLACEHOLDER_VALUE) -> Callable:
-	# save
-	var bind_values: Array = GdArrayTools.filter_value([arg0,arg1,arg2,arg3,arg4,arg5,arg6,arg7,arg8,arg9], GdObjects.TYPE_VARARG_PLACEHOLDER_VALUE)
-	_cb = _cb.bindv(bind_values)
+func bind(...args: Array) -> Callable:
+	_cb = _cb.bindv(args)
 	return _cb
 
 
@@ -80,18 +68,8 @@ func bindv(caller_args: Array) -> Callable:
 	return _cb
 
 
-@warning_ignore("untyped_declaration", "native_method_override", "unused_parameter")
-func call(arg0=null,
-	arg1=GdObjects.TYPE_VARARG_PLACEHOLDER_VALUE,
-	arg2=GdObjects.TYPE_VARARG_PLACEHOLDER_VALUE,
-	arg3=GdObjects.TYPE_VARARG_PLACEHOLDER_VALUE,
-	arg4=GdObjects.TYPE_VARARG_PLACEHOLDER_VALUE,
-	arg5=GdObjects.TYPE_VARARG_PLACEHOLDER_VALUE,
-	arg6=GdObjects.TYPE_VARARG_PLACEHOLDER_VALUE,
-	arg7=GdObjects.TYPE_VARARG_PLACEHOLDER_VALUE,
-	arg8=GdObjects.TYPE_VARARG_PLACEHOLDER_VALUE,
-	arg9=GdObjects.TYPE_VARARG_PLACEHOLDER_VALUE) -> Variant:
-
+@warning_ignore("native_method_override", "unused_parameter")
+func call(...args: Array) -> Variant:
 	# This is a placeholder function signanture without any functionallity!
 	# It is used by the function doubler to double function signature of Callable:call()
 	# The doubled function calls direct _cb.callv(<arguments>) see GdUnitSpyFunctionDoubler:TEMPLATE_CALLABLE_CALL template

--- a/addons/gdUnit4/src/doubler/GdUnitObjectInteractionsVerifier.gd
+++ b/addons/gdUnit4/src/doubler/GdUnitObjectInteractionsVerifier.gd
@@ -80,13 +80,3 @@ func verify_no_more_interactions() -> Dictionary:
 
 func reset_interactions() -> void:
 	saved_interactions.clear()
-
-
-func filter_vargs(arg_values: Array[Variant]) -> Array[Variant]:
-	var filtered: Array[Variant] = []
-	for index in arg_values.size():
-		var arg: Variant = arg_values[index]
-		if typeof(arg) == TYPE_STRING and arg == GdObjects.TYPE_VARARG_PLACEHOLDER_VALUE:
-			continue
-		filtered.append(arg)
-	return filtered

--- a/addons/gdUnit4/src/mocking/GdUnitMockBuilder.gd
+++ b/addons/gdUnit4/src/mocking/GdUnitMockBuilder.gd
@@ -22,6 +22,8 @@ static func build(clazz :Variant, mock_mode :String, debug_write := false) -> Va
 		return mock_on_scene(packed_scene, debug_write)
 	# mocking a script
 	var instance := create_instance(clazz)
+	if instance == null:
+		push_error("Can't create instance of class %s" % clazz)
 	var mock := mock_on_script(instance, clazz, [ "get_script"], debug_write)
 	if not instance is RefCounted:
 		instance.free()

--- a/addons/gdUnit4/src/mocking/GdUnitMockFunctionDoubler.gd
+++ b/addons/gdUnit4/src/mocking/GdUnitMockFunctionDoubler.gd
@@ -52,8 +52,7 @@ const TEMPLATE_FUNC_WITH_RETURN_VOID = """
 
 
 const TEMPLATE_FUNC_VARARG_RETURN_VALUE = """
-	var varargs__: Array = __get_verifier().filter_vargs([$(varargs)])
-	var args__: Array = ["$(func_name)", $(arguments)] + varargs__
+	var args__: Array = ["$(func_name)", $(arguments)] + varargs
 
 	if __is_prepare_return_value():
 		if $(push_errors):
@@ -71,34 +70,12 @@ const TEMPLATE_FUNC_VARARG_RETURN_VALUE = """
 			__verifier.save_function_interaction(args__)
 
 	if __do_call_real_func("$(func_name)", args__):
-		match varargs__.size():
-			@warning_ignore("unsafe_call_argument")
-			0: return $(await)super($(arguments))
-			@warning_ignore("unsafe_call_argument")
-			1: return $(await)super($(arguments), varargs__[0])
-			@warning_ignore("unsafe_call_argument")
-			2: return $(await)super($(arguments), varargs__[0], varargs__[1])
-			@warning_ignore("unsafe_call_argument")
-			3: return $(await)super($(arguments), varargs__[0], varargs__[1], varargs__[2])
-			@warning_ignore("unsafe_call_argument")
-			4: return $(await)super($(arguments), varargs__[0], varargs__[1], varargs__[2], varargs__[3])
-			@warning_ignore("unsafe_call_argument")
-			5: return $(await)super($(arguments), varargs__[0], varargs__[1], varargs__[2], varargs__[3], varargs__[4])
-			@warning_ignore("unsafe_call_argument")
-			6: return $(await)super($(arguments), varargs__[0], varargs__[1], varargs__[2], varargs__[3], varargs__[4], varargs__[5])
-			@warning_ignore("unsafe_call_argument")
-			7: return $(await)super($(arguments), varargs__[0], varargs__[1], varargs__[2], varargs__[3], varargs__[4], varargs__[5], varargs__[6])
-			@warning_ignore("unsafe_call_argument")
-			8: return $(await)super($(arguments), varargs__[0], varargs__[1], varargs__[2], varargs__[3], varargs__[4], varargs__[5], varargs__[6], varargs__[7])
-			@warning_ignore("unsafe_call_argument")
-			9: return $(await)super($(arguments), varargs__[0], varargs__[1], varargs__[2], varargs__[3], varargs__[4], varargs__[5], varargs__[6], varargs__[7], varargs__[8])
-			@warning_ignore("unsafe_call_argument")
-			10: return $(await)super($(arguments), varargs__[0], varargs__[1], varargs__[2], varargs__[3], varargs__[4], varargs__[5], varargs__[6], varargs__[7], varargs__[8], varargs__[9])
+		@warning_ignore("unsafe_call_argument")
+		return $(await)super($(arguments), varargs)
 
 	return __get_mocked_return_value_or_default(args__, ${default_return_value})
 
 """
-
 
 func _init(push_errors :bool = false) -> void:
 	super._init(push_errors)

--- a/addons/gdUnit4/test/dotnet/GdUnit4CSharpApiLoaderTest.gd
+++ b/addons/gdUnit4/test/dotnet/GdUnit4CSharpApiLoaderTest.gd
@@ -25,7 +25,7 @@ func test_is_engine_version_supported(version :int, expected :bool, test_paramet
 
 
 func test_api_version() -> void:
-	assert_str(GdUnit4CSharpApiLoader.version()).starts_with("5.0.0")
+	assert_str(GdUnit4CSharpApiLoader.version()).starts_with("5.1.0")
 
 
 func test_create_test_suite() -> void:

--- a/addons/gdUnit4/test/mocker/GdUnitMockBuilderTest.gd
+++ b/addons/gdUnit4/test/mocker/GdUnitMockBuilderTest.gd
@@ -121,9 +121,8 @@ func test_double_int_function_with_varargs() -> void:
 	var expected := """
 		@warning_ignore('shadowed_variable', 'untyped_declaration')
 		@warning_ignore("native_method_override")
-		func emit_signal(signal_, vararg0_="__null__", vararg1_="__null__", vararg2_="__null__", vararg3_="__null__", vararg4_="__null__", vararg5_="__null__", vararg6_="__null__", vararg7_="__null__", vararg8_="__null__", vararg9_="__null__") -> Error:
-			var varargs__: Array = __get_verifier().filter_vargs([vararg0_, vararg1_, vararg2_, vararg3_, vararg4_, vararg5_, vararg6_, vararg7_, vararg8_, vararg9_])
-			var args__: Array = ["emit_signal", signal_] + varargs__
+		func emit_signal(signal_, ...varargs: Array) -> Error:
+			var args__: Array = ["emit_signal", signal_] + varargs
 
 			if __is_prepare_return_value():
 				if false:
@@ -141,29 +140,8 @@ func test_double_int_function_with_varargs() -> void:
 					__verifier.save_function_interaction(args__)
 
 			if __do_call_real_func("emit_signal", args__):
-				match varargs__.size():
-					@warning_ignore("unsafe_call_argument")
-					0: return super(signal_)
-					@warning_ignore("unsafe_call_argument")
-					1: return super(signal_, varargs__[0])
-					@warning_ignore("unsafe_call_argument")
-					2: return super(signal_, varargs__[0], varargs__[1])
-					@warning_ignore("unsafe_call_argument")
-					3: return super(signal_, varargs__[0], varargs__[1], varargs__[2])
-					@warning_ignore("unsafe_call_argument")
-					4: return super(signal_, varargs__[0], varargs__[1], varargs__[2], varargs__[3])
-					@warning_ignore("unsafe_call_argument")
-					5: return super(signal_, varargs__[0], varargs__[1], varargs__[2], varargs__[3], varargs__[4])
-					@warning_ignore("unsafe_call_argument")
-					6: return super(signal_, varargs__[0], varargs__[1], varargs__[2], varargs__[3], varargs__[4], varargs__[5])
-					@warning_ignore("unsafe_call_argument")
-					7: return super(signal_, varargs__[0], varargs__[1], varargs__[2], varargs__[3], varargs__[4], varargs__[5], varargs__[6])
-					@warning_ignore("unsafe_call_argument")
-					8: return super(signal_, varargs__[0], varargs__[1], varargs__[2], varargs__[3], varargs__[4], varargs__[5], varargs__[6], varargs__[7])
-					@warning_ignore("unsafe_call_argument")
-					9: return super(signal_, varargs__[0], varargs__[1], varargs__[2], varargs__[3], varargs__[4], varargs__[5], varargs__[6], varargs__[7], varargs__[8])
-					@warning_ignore("unsafe_call_argument")
-					10: return super(signal_, varargs__[0], varargs__[1], varargs__[2], varargs__[3], varargs__[4], varargs__[5], varargs__[6], varargs__[7], varargs__[8], varargs__[9])
+				@warning_ignore("unsafe_call_argument")
+				return super(signal_, varargs)
 
 			return __get_mocked_return_value_or_default(args__, OK)
 
@@ -180,9 +158,8 @@ func test_double_untyped_function_with_varargs() -> void:
 		GdFunctionDescriptor._build_varargs(true))
 	var expected := """
 		@warning_ignore('shadowed_variable', 'untyped_declaration')
-		func emit_custom(signal_, vararg0_="__null__", vararg1_="__null__", vararg2_="__null__", vararg3_="__null__", vararg4_="__null__", vararg5_="__null__", vararg6_="__null__", vararg7_="__null__", vararg8_="__null__", vararg9_="__null__") -> void:
-			var varargs__: Array = __get_verifier().filter_vargs([vararg0_, vararg1_, vararg2_, vararg3_, vararg4_, vararg5_, vararg6_, vararg7_, vararg8_, vararg9_])
-			var args__: Array = ["emit_custom", signal_] + varargs__
+		func emit_custom(signal_, ...varargs: Array) -> void:
+			var args__: Array = ["emit_custom", signal_] + varargs
 
 			if __is_prepare_return_value():
 				if false:
@@ -200,29 +177,8 @@ func test_double_untyped_function_with_varargs() -> void:
 					__verifier.save_function_interaction(args__)
 
 			if __do_call_real_func("emit_custom", args__):
-				match varargs__.size():
-					@warning_ignore("unsafe_call_argument")
-					0: return super(signal_)
-					@warning_ignore("unsafe_call_argument")
-					1: return super(signal_, varargs__[0])
-					@warning_ignore("unsafe_call_argument")
-					2: return super(signal_, varargs__[0], varargs__[1])
-					@warning_ignore("unsafe_call_argument")
-					3: return super(signal_, varargs__[0], varargs__[1], varargs__[2])
-					@warning_ignore("unsafe_call_argument")
-					4: return super(signal_, varargs__[0], varargs__[1], varargs__[2], varargs__[3])
-					@warning_ignore("unsafe_call_argument")
-					5: return super(signal_, varargs__[0], varargs__[1], varargs__[2], varargs__[3], varargs__[4])
-					@warning_ignore("unsafe_call_argument")
-					6: return super(signal_, varargs__[0], varargs__[1], varargs__[2], varargs__[3], varargs__[4], varargs__[5])
-					@warning_ignore("unsafe_call_argument")
-					7: return super(signal_, varargs__[0], varargs__[1], varargs__[2], varargs__[3], varargs__[4], varargs__[5], varargs__[6])
-					@warning_ignore("unsafe_call_argument")
-					8: return super(signal_, varargs__[0], varargs__[1], varargs__[2], varargs__[3], varargs__[4], varargs__[5], varargs__[6], varargs__[7])
-					@warning_ignore("unsafe_call_argument")
-					9: return super(signal_, varargs__[0], varargs__[1], varargs__[2], varargs__[3], varargs__[4], varargs__[5], varargs__[6], varargs__[7], varargs__[8])
-					@warning_ignore("unsafe_call_argument")
-					10: return super(signal_, varargs__[0], varargs__[1], varargs__[2], varargs__[3], varargs__[4], varargs__[5], varargs__[6], varargs__[7], varargs__[8], varargs__[9])
+				@warning_ignore("unsafe_call_argument")
+				return super(signal_, varargs)
 
 			return __get_mocked_return_value_or_default(args__, null)
 

--- a/addons/gdUnit4/test/mocker/GdUnitMockerTest.gd
+++ b/addons/gdUnit4/test/mocker/GdUnitMockerTest.gd
@@ -167,8 +167,10 @@ func test_mock_extends_godot_class() -> void:
 
 
 var _test_signal_args := Array()
-func _emit_ready(a :String, b :String, c :Variant = null) -> void:
-	_test_signal_args = [a, b, c]
+func _emit_ready(...args: Array) -> void:
+	if args.is_empty():
+		return
+	_test_signal_args = args[0]
 
 
 @warning_ignore("unsafe_method_access")
@@ -211,7 +213,7 @@ func test_mock_Node_func_vararg_call_real_func() -> void:
 	# verify is emitted
 	verify(mocked_node).emit_signal("ready", "aa", "xxx")
 	await get_tree().process_frame
-	assert_that(_test_signal_args).is_equal(["aa", "xxx", null])
+	assert_that(_test_signal_args).is_equal(["aa", "xxx"])
 
 
 class ClassWithSignal:

--- a/project.godot
+++ b/project.godot
@@ -12,7 +12,7 @@ config_version=5
 
 config/name="gdUnit4"
 config/tags=PackedStringArray("addon", "godot4", "testing")
-config/features=PackedStringArray("4.4", "C#")
+config/features=PackedStringArray("4.5", "C#")
 config/icon="res://icon.png"
 
 [audio]
@@ -43,7 +43,6 @@ ui/inspector/node_collapse=false
 ui/toolbar/run_overall=true
 ui/inspector/tree_sort_mode=1
 report/godot/script_error=false
-settings/test/flaky_check_enable=true
 settings/common/update_notification_enabled=false
 
 [importer_defaults]


### PR DESCRIPTION
# Why
With Godot 4.5 there are breaking changes a.k. the support of variadic functions how breaks the doublers.

# What
- Convert the manual defined variadic functions signature by using the real variadic functions supported now by Godot 4.5
- Adding new default enums for vector axis
- Set the minimum required version to Godot 4.5

