### PR TITLE
GD-905: Convert assertion base classes to abstract classes `is_null`

### DIFF
--- a/addons/gdUnit4/src/GdUnitArrayAssert.gd
+++ b/addons/gdUnit4/src/GdUnitArrayAssert.gd
@@ -1,11 +1,10 @@
 ## An Assertion Tool to verify array values
-class_name GdUnitArrayAssert
+@abstract class_name GdUnitArrayAssert
 extends GdUnitAssert
 
 
 ## Verifies that the current value is null.
-func is_null() -> GdUnitArrayAssert:
-	return self
+@abstract func is_null() -> GdUnitArrayAssert
 
 
 ## Verifies that the current value is not null.

--- a/addons/gdUnit4/src/GdUnitAssert.gd
+++ b/addons/gdUnit4/src/GdUnitAssert.gd
@@ -1,13 +1,10 @@
 ## Base interface of all GdUnit asserts
-class_name GdUnitAssert
+@abstract class_name GdUnitAssert
 extends RefCounted
 
 
 ## Verifies that the current value is null.
-@warning_ignore("untyped_declaration")
-func is_null():
-	return self
-
+@abstract func is_null() -> GdUnitAssert
 
 ## Verifies that the current value is not null.
 @warning_ignore("untyped_declaration")

--- a/addons/gdUnit4/src/GdUnitBoolAssert.gd
+++ b/addons/gdUnit4/src/GdUnitBoolAssert.gd
@@ -1,11 +1,10 @@
 ## An Assertion Tool to verify boolean values
-class_name GdUnitBoolAssert
+@abstract class_name GdUnitBoolAssert
 extends GdUnitAssert
 
 
 ## Verifies that the current value is null.
-func is_null() -> GdUnitBoolAssert:
-	return self
+@abstract func is_null() -> GdUnitBoolAssert
 
 
 ## Verifies that the current value is not null.

--- a/addons/gdUnit4/src/GdUnitDictionaryAssert.gd
+++ b/addons/gdUnit4/src/GdUnitDictionaryAssert.gd
@@ -1,11 +1,10 @@
 ## An Assertion Tool to verify dictionary
-class_name GdUnitDictionaryAssert
+@abstract class_name GdUnitDictionaryAssert
 extends GdUnitAssert
 
 
 ## Verifies that the current value is null.
-func is_null() -> GdUnitDictionaryAssert:
-	return self
+@abstract func is_null() -> GdUnitDictionaryAssert
 
 
 ## Verifies that the current value is not null.

--- a/addons/gdUnit4/src/GdUnitFailureAssert.gd
+++ b/addons/gdUnit4/src/GdUnitFailureAssert.gd
@@ -1,7 +1,11 @@
 ## An assertion tool to verify GDUnit asserts.
 ## This assert is for internal use only, to verify that failed asserts work as expected.
-class_name GdUnitFailureAssert
+@abstract class_name GdUnitFailureAssert
 extends GdUnitAssert
+
+
+## Verifies that the current value is null.
+@abstract func is_null() -> GdUnitFailureAssert
 
 
 ## Verifies if the executed assert was successful

--- a/addons/gdUnit4/src/GdUnitFileAssert.gd
+++ b/addons/gdUnit4/src/GdUnitFileAssert.gd
@@ -1,5 +1,9 @@
-class_name GdUnitFileAssert
+@abstract class_name GdUnitFileAssert
 extends GdUnitAssert
+
+
+## Verifies that the current value is null.
+@abstract func is_null() -> GdUnitFileAssert
 
 
 func is_file() -> GdUnitFileAssert:

--- a/addons/gdUnit4/src/GdUnitFloatAssert.gd
+++ b/addons/gdUnit4/src/GdUnitFloatAssert.gd
@@ -1,6 +1,10 @@
 ## An Assertion Tool to verify float values
-class_name GdUnitFloatAssert
+@abstract class_name GdUnitFloatAssert
 extends GdUnitAssert
+
+
+## Verifies that the current value is null.
+@abstract func is_null() -> GdUnitFloatAssert
 
 
 ## Verifies that the current String is equal to the given one.

--- a/addons/gdUnit4/src/GdUnitFuncAssert.gd
+++ b/addons/gdUnit4/src/GdUnitFuncAssert.gd
@@ -1,12 +1,10 @@
 ## An Assertion Tool to verify function callback values
-class_name GdUnitFuncAssert
+@abstract class_name GdUnitFuncAssert
 extends GdUnitAssert
 
 
 ## Verifies that the current value is null.
-func is_null() -> GdUnitFuncAssert:
-	await (Engine.get_main_loop() as SceneTree).process_frame
-	return self
+@abstract func is_null() -> GdUnitFuncAssert
 
 
 ## Verifies that the current value is not null.

--- a/addons/gdUnit4/src/GdUnitGodotErrorAssert.gd
+++ b/addons/gdUnit4/src/GdUnitGodotErrorAssert.gd
@@ -1,6 +1,10 @@
 ## An assertion tool to verify for Godot runtime errors like assert() and push notifications like push_error().
-class_name GdUnitGodotErrorAssert
+@abstract class_name GdUnitGodotErrorAssert
 extends GdUnitAssert
+
+
+## Verifies that the current value is null.
+@abstract func is_null() -> GdUnitGodotErrorAssert
 
 
 ## Verifies if the executed code runs without any runtime errors

--- a/addons/gdUnit4/src/GdUnitIntAssert.gd
+++ b/addons/gdUnit4/src/GdUnitIntAssert.gd
@@ -1,6 +1,11 @@
 ## An Assertion Tool to verify integer values
-class_name GdUnitIntAssert
+@abstract class_name GdUnitIntAssert
 extends GdUnitAssert
+
+
+## Verifies that the current value is null.
+@abstract func is_null() -> GdUnitIntAssert
+
 
 ## Verifies that the current String is equal to the given one.
 @warning_ignore("unused_parameter")

--- a/addons/gdUnit4/src/GdUnitObjectAssert.gd
+++ b/addons/gdUnit4/src/GdUnitObjectAssert.gd
@@ -1,6 +1,10 @@
 ## An Assertion Tool to verify Object values
-class_name GdUnitObjectAssert
+@abstract class_name GdUnitObjectAssert
 extends GdUnitAssert
+
+
+## Verifies that the current value is null.
+@abstract func is_null() -> GdUnitObjectAssert
 
 
 ## Verifies that the current object is equal to expected one.
@@ -12,11 +16,6 @@ func is_equal(expected: Variant) -> GdUnitObjectAssert:
 ## Verifies that the current object is not equal to expected one.
 @warning_ignore("unused_parameter")
 func is_not_equal(expected: Variant) -> GdUnitObjectAssert:
-	return self
-
-
-## Verifies that the current object is null.
-func is_null() -> GdUnitObjectAssert:
 	return self
 
 

--- a/addons/gdUnit4/src/GdUnitResultAssert.gd
+++ b/addons/gdUnit4/src/GdUnitResultAssert.gd
@@ -1,11 +1,10 @@
 ## An Assertion Tool to verify Results
-class_name GdUnitResultAssert
+@abstract class_name GdUnitResultAssert
 extends GdUnitAssert
 
 
 ## Verifies that the current value is null.
-func is_null() -> GdUnitResultAssert:
-	return self
+@abstract func is_null() -> GdUnitResultAssert
 
 
 ## Verifies that the current value is not null.

--- a/addons/gdUnit4/src/GdUnitSignalAssert.gd
+++ b/addons/gdUnit4/src/GdUnitSignalAssert.gd
@@ -1,6 +1,10 @@
 ## An Assertion Tool to verify for emitted signals until a waiting time
-class_name GdUnitSignalAssert
+@abstract class_name GdUnitSignalAssert
 extends GdUnitAssert
+
+
+## Verifies that the current value is null.
+@abstract func is_null() -> GdUnitSignalAssert
 
 
 ## Verifies that given signal is emitted until waiting time

--- a/addons/gdUnit4/src/GdUnitStringAssert.gd
+++ b/addons/gdUnit4/src/GdUnitStringAssert.gd
@@ -1,6 +1,10 @@
 ## An Assertion Tool to verify String values
-class_name GdUnitStringAssert
+@abstract class_name GdUnitStringAssert
 extends GdUnitAssert
+
+
+## Verifies that the current value is null.
+@abstract func is_null() -> GdUnitStringAssert
 
 
 ## Verifies that the current String is equal to the given one.

--- a/addons/gdUnit4/src/GdUnitVectorAssert.gd
+++ b/addons/gdUnit4/src/GdUnitVectorAssert.gd
@@ -1,6 +1,10 @@
 ## An Assertion Tool to verify Vector values
-class_name GdUnitVectorAssert
+@abstract class_name GdUnitVectorAssert
 extends GdUnitAssert
+
+
+## Verifies that the current value is null.
+@abstract func is_null() -> GdUnitVectorAssert
 
 
 ## Verifies that the current value is equal to expected one.

--- a/addons/gdUnit4/src/asserts/GdUnitArrayAssertImpl.gd
+++ b/addons/gdUnit4/src/asserts/GdUnitArrayAssertImpl.gd
@@ -26,11 +26,13 @@ func _notification(event: int) -> void:
 
 
 func report_success() -> GdUnitArrayAssert:
+	@warning_ignore("return_value_discarded")
 	_base.report_success()
 	return self
 
 
 func report_error(error: String) -> GdUnitArrayAssert:
+	@warning_ignore("return_value_discarded")
 	_base.report_error(error)
 	return self
 
@@ -40,11 +42,13 @@ func failure_message() -> String:
 
 
 func override_failure_message(message: String) -> GdUnitArrayAssert:
+	@warning_ignore("return_value_discarded")
 	_base.override_failure_message(message)
 	return self
 
 
 func append_failure_message(message: String) -> GdUnitArrayAssert:
+	@warning_ignore("return_value_discarded")
 	_base.append_failure_message(message)
 	return self
 

--- a/addons/gdUnit4/src/asserts/GdUnitAssertions.gd
+++ b/addons/gdUnit4/src/asserts/GdUnitAssertions.gd
@@ -7,6 +7,7 @@ extends RefCounted
 func _init() -> void:
 	# preload all gdunit assertions to speedup testsuite loading time
 	# gdlint:disable=private-method-call
+	@warning_ignore_start("return_value_discarded")
 	GdUnitAssertions.__lazy_load("res://addons/gdUnit4/src/asserts/GdUnitAssertImpl.gd")
 	GdUnitAssertions.__lazy_load("res://addons/gdUnit4/src/asserts/GdUnitBoolAssertImpl.gd")
 	GdUnitAssertions.__lazy_load("res://addons/gdUnit4/src/asserts/GdUnitStringAssertImpl.gd")
@@ -22,6 +23,7 @@ func _init() -> void:
 	GdUnitAssertions.__lazy_load("res://addons/gdUnit4/src/asserts/GdUnitSignalAssertImpl.gd")
 	GdUnitAssertions.__lazy_load("res://addons/gdUnit4/src/asserts/GdUnitFailureAssertImpl.gd")
 	GdUnitAssertions.__lazy_load("res://addons/gdUnit4/src/asserts/GdUnitGodotErrorAssertImpl.gd")
+	@warning_ignore_restore("return_value_discarded")
 
 
 ### We now load all used asserts and tool scripts into the cache according to the principle of "lazy loading"

--- a/addons/gdUnit4/src/asserts/GdUnitBoolAssertImpl.gd
+++ b/addons/gdUnit4/src/asserts/GdUnitBoolAssertImpl.gd
@@ -24,11 +24,13 @@ func current_value() -> Variant:
 
 
 func report_success() -> GdUnitBoolAssert:
+	@warning_ignore("return_value_discarded")
 	_base.report_success()
 	return self
 
 
 func report_error(error :String) -> GdUnitBoolAssert:
+	@warning_ignore("return_value_discarded")
 	_base.report_error(error)
 	return self
 
@@ -49,7 +51,6 @@ func append_failure_message(message :String) -> GdUnitBoolAssert:
 	return self
 
 
-# Verifies that the current value is null.
 func is_null() -> GdUnitBoolAssert:
 	@warning_ignore("return_value_discarded")
 	_base.is_null()

--- a/addons/gdUnit4/src/asserts/GdUnitDictionaryAssertImpl.gd
+++ b/addons/gdUnit4/src/asserts/GdUnitDictionaryAssertImpl.gd
@@ -20,11 +20,13 @@ func _notification(event :int) -> void:
 
 
 func report_success() -> GdUnitDictionaryAssert:
+	@warning_ignore("return_value_discarded")
 	_base.report_success()
 	return self
 
 
 func report_error(error :String) -> GdUnitDictionaryAssert:
+	@warning_ignore("return_value_discarded")
 	_base.report_error(error)
 	return self
 

--- a/addons/gdUnit4/src/asserts/GdUnitFileAssertImpl.gd
+++ b/addons/gdUnit4/src/asserts/GdUnitFileAssertImpl.gd
@@ -26,11 +26,13 @@ func current_value() -> String:
 
 
 func report_success() -> GdUnitFileAssert:
+	@warning_ignore("return_value_discarded")
 	_base.report_success()
 	return self
 
 
 func report_error(error :String) -> GdUnitFileAssert:
+	@warning_ignore("return_value_discarded")
 	_base.report_error(error)
 	return self
 
@@ -48,6 +50,12 @@ func override_failure_message(message :String) -> GdUnitFileAssert:
 func append_failure_message(message :String) -> GdUnitFileAssert:
 	@warning_ignore("return_value_discarded")
 	_base.append_failure_message(message)
+	return self
+
+
+func is_null() -> GdUnitFileAssert:
+	@warning_ignore("return_value_discarded")
+	_base.is_null()
 	return self
 
 
@@ -97,5 +105,6 @@ func contains_exactly(expected_rows: Array) -> GdUnitFileAssert:
 	if script is GDScript:
 		var source_code := GdScriptParser.to_unix_format(script.source_code)
 		var rows := Array(source_code.split("\n"))
+		@warning_ignore("return_value_discarded")
 		GdUnitArrayAssertImpl.new(rows).contains_exactly(expected_rows)
 	return self

--- a/addons/gdUnit4/src/asserts/GdUnitFloatAssertImpl.gd
+++ b/addons/gdUnit4/src/asserts/GdUnitFloatAssertImpl.gd
@@ -24,11 +24,13 @@ func current_value() -> Variant:
 
 
 func report_success() -> GdUnitFloatAssert:
+	@warning_ignore("return_value_discarded")
 	_base.report_success()
 	return self
 
 
 func report_error(error :String) -> GdUnitFloatAssert:
+	@warning_ignore("return_value_discarded")
 	_base.report_error(error)
 	return self
 

--- a/addons/gdUnit4/src/asserts/GdUnitGodotErrorAssertImpl.gd
+++ b/addons/gdUnit4/src/asserts/GdUnitGodotErrorAssertImpl.gd
@@ -61,6 +61,10 @@ func _to_list(log_entries: Array[ErrorLogEntry]) -> String:
 	return value
 
 
+func is_null() -> GdUnitGodotErrorAssert:
+	return _report_error("Not implemented")
+
+
 func is_success() -> GdUnitGodotErrorAssert:
 	var log_entries := await _execute()
 	if log_entries.is_empty():

--- a/addons/gdUnit4/src/asserts/GdUnitIntAssertImpl.gd
+++ b/addons/gdUnit4/src/asserts/GdUnitIntAssertImpl.gd
@@ -24,11 +24,13 @@ func current_value() -> Variant:
 
 
 func report_success() -> GdUnitIntAssert:
+	@warning_ignore("return_value_discarded")
 	_base.report_success()
 	return self
 
 
 func report_error(error :String) -> GdUnitIntAssert:
+	@warning_ignore("return_value_discarded")
 	_base.report_error(error)
 	return self
 

--- a/addons/gdUnit4/src/asserts/GdUnitObjectAssertImpl.gd
+++ b/addons/gdUnit4/src/asserts/GdUnitObjectAssertImpl.gd
@@ -28,11 +28,13 @@ func current_value() -> Variant:
 
 
 func report_success() -> GdUnitObjectAssert:
+	@warning_ignore("return_value_discarded")
 	_base.report_success()
 	return self
 
 
 func report_error(error: String) -> GdUnitObjectAssert:
+	@warning_ignore("return_value_discarded")
 	_base.report_error(error)
 	return self
 

--- a/addons/gdUnit4/src/asserts/GdUnitResultAssertImpl.gd
+++ b/addons/gdUnit4/src/asserts/GdUnitResultAssertImpl.gd
@@ -28,11 +28,13 @@ func current_value() -> GdUnitResult:
 
 
 func report_success() -> GdUnitResultAssert:
+	@warning_ignore("return_value_discarded")
 	_base.report_success()
 	return self
 
 
 func report_error(error :String) -> GdUnitResultAssert:
+	@warning_ignore("return_value_discarded")
 	_base.report_error(error)
 	return self
 

--- a/addons/gdUnit4/src/asserts/GdUnitSignalAssertImpl.gd
+++ b/addons/gdUnit4/src/asserts/GdUnitSignalAssertImpl.gd
@@ -70,6 +70,12 @@ func wait_until(timeout := 2000) -> GdUnitSignalAssert:
 	return self
 
 
+func is_null() -> GdUnitSignalAssert:
+	if _emitter == null:
+		return report_error(GdAssertMessages.error_is_null(_emitter))
+	return report_success()
+
+
 # Verifies the signal exists checked the emitter
 func is_signal_exists(signal_name :String) -> GdUnitSignalAssert:
 	if not _emitter.has_signal(signal_name):

--- a/addons/gdUnit4/src/asserts/GdUnitStringAssertImpl.gd
+++ b/addons/gdUnit4/src/asserts/GdUnitStringAssertImpl.gd
@@ -28,11 +28,13 @@ func current_value() -> Variant:
 
 
 func report_success() -> GdUnitStringAssert:
+	@warning_ignore("return_value_discarded")
 	_base.report_success()
 	return self
 
 
 func report_error(error :String) -> GdUnitStringAssert:
+	@warning_ignore("return_value_discarded")
 	_base.report_error(error)
 	return self
 

--- a/addons/gdUnit4/src/asserts/GdUnitVectorAssertImpl.gd
+++ b/addons/gdUnit4/src/asserts/GdUnitVectorAssertImpl.gd
@@ -50,11 +50,13 @@ func current_value() -> Variant:
 
 
 func report_success() -> GdUnitVectorAssert:
+	@warning_ignore("return_value_discarded")
 	_base.report_success()
 	return self
 
 
 func report_error(error :String) -> GdUnitVectorAssert:
+	@warning_ignore("return_value_discarded")
 	_base.report_error(error)
 	return self
 

--- a/addons/gdUnit4/test/asserts/GdUnitFuncAssertImplTest.gd
+++ b/addons/gdUnit4/test/asserts/GdUnitFuncAssertImplTest.gd
@@ -1,7 +1,7 @@
 # GdUnit generated TestSuite
 class_name GdUnitFuncAssertImplTest
 extends GdUnitTestSuite
-@warning_ignore("unused_parameter")
+@warning_ignore_start("redundant_await")
 
 
 # TestSuite generated from


### PR DESCRIPTION
# Why
The GdUnit4 assertion API faked interfaces to represent a small class with class documentation without overloaded implementation code. With Godot 4.5, GDScript now supports abstract classes and functions, so we should switch to that.

# What
- Converted all GdUnit assert base classes to abstract class
- Convert function `is_null` to abstract and fix missing implementations
- Adding missing ignore warnings for 'return_value_discarded'

