### PR TITLE
[GD-905] Convert base assert functions to abstract (part2)

### DIFF
--- a/addons/gdUnit4/src/GdUnitArrayAssert.gd
+++ b/addons/gdUnit4/src/GdUnitArrayAssert.gd
@@ -8,8 +8,7 @@ extends GdUnitAssert
 
 
 ## Verifies that the current value is not null.
-func is_not_null() -> GdUnitArrayAssert:
-	return self
+@abstract func is_not_null() -> GdUnitArrayAssert
 
 
 ## Verifies that the current Array is equal to the given one.

--- a/addons/gdUnit4/src/GdUnitAssert.gd
+++ b/addons/gdUnit4/src/GdUnitAssert.gd
@@ -7,9 +7,7 @@ extends RefCounted
 @abstract func is_null() -> GdUnitAssert
 
 ## Verifies that the current value is not null.
-@warning_ignore("untyped_declaration")
-func is_not_null():
-	return self
+@abstract func is_not_null() -> GdUnitAssert
 
 
 ## Verifies that the current value is equal to expected one.

--- a/addons/gdUnit4/src/GdUnitBoolAssert.gd
+++ b/addons/gdUnit4/src/GdUnitBoolAssert.gd
@@ -8,8 +8,7 @@ extends GdUnitAssert
 
 
 ## Verifies that the current value is not null.
-func is_not_null() -> GdUnitBoolAssert:
-	return self
+@abstract func is_not_null() -> GdUnitBoolAssert
 
 
 ## Verifies that the current value is equal to the given one.

--- a/addons/gdUnit4/src/GdUnitDictionaryAssert.gd
+++ b/addons/gdUnit4/src/GdUnitDictionaryAssert.gd
@@ -8,8 +8,7 @@ extends GdUnitAssert
 
 
 ## Verifies that the current value is not null.
-func is_not_null() -> GdUnitDictionaryAssert:
-	return self
+@abstract func is_not_null() -> GdUnitDictionaryAssert
 
 
 ## Verifies that the current dictionary is equal to the given one, ignoring order.

--- a/addons/gdUnit4/src/GdUnitFailureAssert.gd
+++ b/addons/gdUnit4/src/GdUnitFailureAssert.gd
@@ -8,6 +8,10 @@ extends GdUnitAssert
 @abstract func is_null() -> GdUnitFailureAssert
 
 
+## Verifies that the current value is not null.
+@abstract func is_not_null() -> GdUnitFailureAssert
+
+
 ## Verifies if the executed assert was successful
 func is_success() -> GdUnitFailureAssert:
 	return self

--- a/addons/gdUnit4/src/GdUnitFileAssert.gd
+++ b/addons/gdUnit4/src/GdUnitFileAssert.gd
@@ -6,6 +6,10 @@ extends GdUnitAssert
 @abstract func is_null() -> GdUnitFileAssert
 
 
+## Verifies that the current value is not null.
+@abstract func is_not_null() -> GdUnitFileAssert
+
+
 func is_file() -> GdUnitFileAssert:
 	return self
 

--- a/addons/gdUnit4/src/GdUnitFloatAssert.gd
+++ b/addons/gdUnit4/src/GdUnitFloatAssert.gd
@@ -7,6 +7,10 @@ extends GdUnitAssert
 @abstract func is_null() -> GdUnitFloatAssert
 
 
+## Verifies that the current value is not null.
+@abstract func is_not_null() -> GdUnitFloatAssert
+
+
 ## Verifies that the current String is equal to the given one.
 @warning_ignore("unused_parameter")
 func is_equal(expected :Variant) -> GdUnitFloatAssert:

--- a/addons/gdUnit4/src/GdUnitFuncAssert.gd
+++ b/addons/gdUnit4/src/GdUnitFuncAssert.gd
@@ -8,9 +8,7 @@ extends GdUnitAssert
 
 
 ## Verifies that the current value is not null.
-func is_not_null() -> GdUnitFuncAssert:
-	await (Engine.get_main_loop() as SceneTree).process_frame
-	return self
+@abstract func is_not_null() -> GdUnitFuncAssert
 
 
 ## Verifies that the current value is equal to the given one.

--- a/addons/gdUnit4/src/GdUnitGodotErrorAssert.gd
+++ b/addons/gdUnit4/src/GdUnitGodotErrorAssert.gd
@@ -7,6 +7,10 @@ extends GdUnitAssert
 @abstract func is_null() -> GdUnitGodotErrorAssert
 
 
+## Verifies that the current value is not null.
+@abstract func is_not_null() -> GdUnitGodotErrorAssert
+
+
 ## Verifies if the executed code runs without any runtime errors
 ## Usage:
 ##     [codeblock]

--- a/addons/gdUnit4/src/GdUnitIntAssert.gd
+++ b/addons/gdUnit4/src/GdUnitIntAssert.gd
@@ -7,6 +7,10 @@ extends GdUnitAssert
 @abstract func is_null() -> GdUnitIntAssert
 
 
+## Verifies that the current value is not null.
+@abstract func is_not_null() -> GdUnitIntAssert
+
+
 ## Verifies that the current String is equal to the given one.
 @warning_ignore("unused_parameter")
 func is_equal(expected :Variant) -> GdUnitIntAssert:

--- a/addons/gdUnit4/src/GdUnitObjectAssert.gd
+++ b/addons/gdUnit4/src/GdUnitObjectAssert.gd
@@ -7,6 +7,10 @@ extends GdUnitAssert
 @abstract func is_null() -> GdUnitObjectAssert
 
 
+## Verifies that the current value is not null.
+@abstract func is_not_null() -> GdUnitObjectAssert
+
+
 ## Verifies that the current object is equal to expected one.
 @warning_ignore("unused_parameter")
 func is_equal(expected: Variant) -> GdUnitObjectAssert:
@@ -16,11 +20,6 @@ func is_equal(expected: Variant) -> GdUnitObjectAssert:
 ## Verifies that the current object is not equal to expected one.
 @warning_ignore("unused_parameter")
 func is_not_equal(expected: Variant) -> GdUnitObjectAssert:
-	return self
-
-
-## Verifies that the current object is not null.
-func is_not_null() -> GdUnitObjectAssert:
 	return self
 
 

--- a/addons/gdUnit4/src/GdUnitResultAssert.gd
+++ b/addons/gdUnit4/src/GdUnitResultAssert.gd
@@ -8,8 +8,7 @@ extends GdUnitAssert
 
 
 ## Verifies that the current value is not null.
-func is_not_null() -> GdUnitResultAssert:
-	return self
+@abstract func is_not_null() -> GdUnitResultAssert
 
 
 ## Verifies that the result is ends up with empty

--- a/addons/gdUnit4/src/GdUnitSignalAssert.gd
+++ b/addons/gdUnit4/src/GdUnitSignalAssert.gd
@@ -7,6 +7,10 @@ extends GdUnitAssert
 @abstract func is_null() -> GdUnitSignalAssert
 
 
+## Verifies that the current value is not null.
+@abstract func is_not_null() -> GdUnitSignalAssert
+
+
 ## Verifies that given signal is emitted until waiting time
 @warning_ignore("unused_parameter")
 func is_emitted(name :String, args := []) -> GdUnitSignalAssert:

--- a/addons/gdUnit4/src/GdUnitStringAssert.gd
+++ b/addons/gdUnit4/src/GdUnitStringAssert.gd
@@ -7,6 +7,10 @@ extends GdUnitAssert
 @abstract func is_null() -> GdUnitStringAssert
 
 
+## Verifies that the current value is not null.
+@abstract func is_not_null() -> GdUnitStringAssert
+
+
 ## Verifies that the current String is equal to the given one.
 @warning_ignore("unused_parameter")
 func is_equal(expected :Variant) -> GdUnitStringAssert:

--- a/addons/gdUnit4/src/GdUnitVectorAssert.gd
+++ b/addons/gdUnit4/src/GdUnitVectorAssert.gd
@@ -7,6 +7,10 @@ extends GdUnitAssert
 @abstract func is_null() -> GdUnitVectorAssert
 
 
+## Verifies that the current value is not null.
+@abstract func is_not_null() -> GdUnitVectorAssert
+
+
 ## Verifies that the current value is equal to expected one.
 @warning_ignore("unused_parameter")
 func is_equal(expected :Variant) -> GdUnitVectorAssert:

--- a/addons/gdUnit4/src/asserts/GdUnitBoolAssertImpl.gd
+++ b/addons/gdUnit4/src/asserts/GdUnitBoolAssertImpl.gd
@@ -57,7 +57,6 @@ func is_null() -> GdUnitBoolAssert:
 	return self
 
 
-# Verifies that the current value is not null.
 func is_not_null() -> GdUnitBoolAssert:
 	@warning_ignore("return_value_discarded")
 	_base.is_not_null()

--- a/addons/gdUnit4/src/asserts/GdUnitFileAssertImpl.gd
+++ b/addons/gdUnit4/src/asserts/GdUnitFileAssertImpl.gd
@@ -59,6 +59,12 @@ func is_null() -> GdUnitFileAssert:
 	return self
 
 
+func is_not_null() -> GdUnitFileAssert:
+	@warning_ignore("return_value_discarded")
+	_base.is_not_null()
+	return self
+
+
 func is_equal(expected :Variant) -> GdUnitFileAssert:
 	@warning_ignore("return_value_discarded")
 	_base.is_equal(expected)

--- a/addons/gdUnit4/src/asserts/GdUnitGodotErrorAssertImpl.gd
+++ b/addons/gdUnit4/src/asserts/GdUnitGodotErrorAssertImpl.gd
@@ -65,6 +65,10 @@ func is_null() -> GdUnitGodotErrorAssert:
 	return _report_error("Not implemented")
 
 
+func is_not_null() -> GdUnitGodotErrorAssert:
+	return _report_error("Not implemented")
+
+
 func is_success() -> GdUnitGodotErrorAssert:
 	var log_entries := await _execute()
 	if log_entries.is_empty():

--- a/addons/gdUnit4/src/asserts/GdUnitSignalAssertImpl.gd
+++ b/addons/gdUnit4/src/asserts/GdUnitSignalAssertImpl.gd
@@ -71,8 +71,14 @@ func wait_until(timeout := 2000) -> GdUnitSignalAssert:
 
 
 func is_null() -> GdUnitSignalAssert:
-	if _emitter == null:
+	if _emitter != null:
 		return report_error(GdAssertMessages.error_is_null(_emitter))
+	return report_success()
+
+
+func is_not_null() -> GdUnitSignalAssert:
+	if _emitter == null:
+		return report_error(GdAssertMessages.error_is_not_null())
 	return report_success()
 
 


### PR DESCRIPTION
# Why
The GdUnit4 assertion API faked interfaces to represent a small class with class documentation without overloaded implementation code. With Godot 4.5, GDScript now supports abstract classes and functions, so we should switch to that.

# What
- Convert `is_not_null` to abstract and add missing implementation
