### PR TITLE
GD-905: Convert base assert function is_equal to abstract (part3)

### DIFF
--- a/addons/gdUnit4/src/GdUnitArrayAssert.gd
+++ b/addons/gdUnit4/src/GdUnitArrayAssert.gd
@@ -12,9 +12,7 @@ extends GdUnitAssert
 
 
 ## Verifies that the current Array is equal to the given one.
-@warning_ignore("unused_parameter")
-func is_equal(expected :Variant) -> GdUnitArrayAssert:
-	return self
+@abstract func is_equal(expected: Variant) -> GdUnitArrayAssert
 
 
 ## Verifies that the current Array is equal to the given one, ignoring case considerations.

--- a/addons/gdUnit4/src/GdUnitAssert.gd
+++ b/addons/gdUnit4/src/GdUnitAssert.gd
@@ -6,15 +6,13 @@ extends RefCounted
 ## Verifies that the current value is null.
 @abstract func is_null() -> GdUnitAssert
 
+
 ## Verifies that the current value is not null.
 @abstract func is_not_null() -> GdUnitAssert
 
 
 ## Verifies that the current value is equal to expected one.
-@warning_ignore("unused_parameter")
-@warning_ignore("untyped_declaration")
-func is_equal(expected: Variant):
-	return self
+@abstract func is_equal(expected: Variant) -> GdUnitAssert
 
 
 ## Verifies that the current value is not equal to expected one.

--- a/addons/gdUnit4/src/GdUnitBoolAssert.gd
+++ b/addons/gdUnit4/src/GdUnitBoolAssert.gd
@@ -12,9 +12,7 @@ extends GdUnitAssert
 
 
 ## Verifies that the current value is equal to the given one.
-@warning_ignore("unused_parameter")
-func is_equal(expected :Variant) -> GdUnitBoolAssert:
-	return self
+@abstract func is_equal(expected: Variant) -> GdUnitBoolAssert
 
 
 ## Verifies that the current value is not equal to the given one.

--- a/addons/gdUnit4/src/GdUnitDictionaryAssert.gd
+++ b/addons/gdUnit4/src/GdUnitDictionaryAssert.gd
@@ -12,9 +12,7 @@ extends GdUnitAssert
 
 
 ## Verifies that the current dictionary is equal to the given one, ignoring order.
-@warning_ignore("unused_parameter")
-func is_equal(expected :Variant) -> GdUnitDictionaryAssert:
-	return self
+@abstract func is_equal(expected: Variant) -> GdUnitDictionaryAssert
 
 
 ## Verifies that the current dictionary is not equal to the given one, ignoring order.

--- a/addons/gdUnit4/src/GdUnitFailureAssert.gd
+++ b/addons/gdUnit4/src/GdUnitFailureAssert.gd
@@ -12,6 +12,10 @@ extends GdUnitAssert
 @abstract func is_not_null() -> GdUnitFailureAssert
 
 
+## Verifies that the current value is equal to the given one.
+@abstract func is_equal(expected: Variant) -> GdUnitFailureAssert
+
+
 ## Verifies if the executed assert was successful
 func is_success() -> GdUnitFailureAssert:
 	return self

--- a/addons/gdUnit4/src/GdUnitFileAssert.gd
+++ b/addons/gdUnit4/src/GdUnitFileAssert.gd
@@ -10,6 +10,10 @@ extends GdUnitAssert
 @abstract func is_not_null() -> GdUnitFileAssert
 
 
+## Verifies that the current value is equal to the given one.
+@abstract func is_equal(expected: Variant) -> GdUnitFileAssert
+
+
 func is_file() -> GdUnitFileAssert:
 	return self
 

--- a/addons/gdUnit4/src/GdUnitFloatAssert.gd
+++ b/addons/gdUnit4/src/GdUnitFloatAssert.gd
@@ -11,10 +11,8 @@ extends GdUnitAssert
 @abstract func is_not_null() -> GdUnitFloatAssert
 
 
-## Verifies that the current String is equal to the given one.
-@warning_ignore("unused_parameter")
-func is_equal(expected :Variant) -> GdUnitFloatAssert:
-	return self
+## Verifies that the current value is equal to the given one.
+@abstract func is_equal(expected: Variant) -> GdUnitFloatAssert
 
 
 ## Verifies that the current String is not equal to the given one.

--- a/addons/gdUnit4/src/GdUnitFuncAssert.gd
+++ b/addons/gdUnit4/src/GdUnitFuncAssert.gd
@@ -12,10 +12,7 @@ extends GdUnitAssert
 
 
 ## Verifies that the current value is equal to the given one.
-@warning_ignore("unused_parameter")
-func is_equal(expected :Variant) -> GdUnitFuncAssert:
-	await (Engine.get_main_loop() as SceneTree).process_frame
-	return self
+@abstract func is_equal(expected: Variant) -> GdUnitFuncAssert
 
 
 ## Verifies that the current value is not equal to the given one.

--- a/addons/gdUnit4/src/GdUnitGodotErrorAssert.gd
+++ b/addons/gdUnit4/src/GdUnitGodotErrorAssert.gd
@@ -11,6 +11,10 @@ extends GdUnitAssert
 @abstract func is_not_null() -> GdUnitGodotErrorAssert
 
 
+## Verifies that the current value is equal to the given one.
+@abstract func is_equal(expected: Variant) -> GdUnitGodotErrorAssert
+
+
 ## Verifies if the executed code runs without any runtime errors
 ## Usage:
 ##     [codeblock]

--- a/addons/gdUnit4/src/GdUnitIntAssert.gd
+++ b/addons/gdUnit4/src/GdUnitIntAssert.gd
@@ -11,10 +11,8 @@ extends GdUnitAssert
 @abstract func is_not_null() -> GdUnitIntAssert
 
 
-## Verifies that the current String is equal to the given one.
-@warning_ignore("unused_parameter")
-func is_equal(expected :Variant) -> GdUnitIntAssert:
-	return self
+## Verifies that the current value is equal to the given one.
+@abstract func is_equal(expected: Variant) -> GdUnitIntAssert
 
 
 ## Verifies that the current String is not equal to the given one.

--- a/addons/gdUnit4/src/GdUnitObjectAssert.gd
+++ b/addons/gdUnit4/src/GdUnitObjectAssert.gd
@@ -11,10 +11,8 @@ extends GdUnitAssert
 @abstract func is_not_null() -> GdUnitObjectAssert
 
 
-## Verifies that the current object is equal to expected one.
-@warning_ignore("unused_parameter")
-func is_equal(expected: Variant) -> GdUnitObjectAssert:
-	return self
+## Verifies that the current value is equal to the given one.
+@abstract func is_equal(expected: Variant) -> GdUnitObjectAssert
 
 
 ## Verifies that the current object is not equal to expected one.

--- a/addons/gdUnit4/src/GdUnitResultAssert.gd
+++ b/addons/gdUnit4/src/GdUnitResultAssert.gd
@@ -11,6 +11,10 @@ extends GdUnitAssert
 @abstract func is_not_null() -> GdUnitResultAssert
 
 
+## Verifies that the current value is equal to the given one.
+@abstract func is_equal(expected: Variant) -> GdUnitResultAssert
+
+
 ## Verifies that the result is ends up with empty
 func is_empty() -> GdUnitResultAssert:
 	return self

--- a/addons/gdUnit4/src/GdUnitSignalAssert.gd
+++ b/addons/gdUnit4/src/GdUnitSignalAssert.gd
@@ -11,6 +11,10 @@ extends GdUnitAssert
 @abstract func is_not_null() -> GdUnitSignalAssert
 
 
+## Verifies that the current value is equal to the given one.
+@abstract func is_equal(expected: Variant) -> GdUnitSignalAssert
+
+
 ## Verifies that given signal is emitted until waiting time
 @warning_ignore("unused_parameter")
 func is_emitted(name :String, args := []) -> GdUnitSignalAssert:

--- a/addons/gdUnit4/src/GdUnitStringAssert.gd
+++ b/addons/gdUnit4/src/GdUnitStringAssert.gd
@@ -11,10 +11,8 @@ extends GdUnitAssert
 @abstract func is_not_null() -> GdUnitStringAssert
 
 
-## Verifies that the current String is equal to the given one.
-@warning_ignore("unused_parameter")
-func is_equal(expected :Variant) -> GdUnitStringAssert:
-	return self
+## Verifies that the current value is equal to the given one.
+@abstract func is_equal(expected: Variant) -> GdUnitStringAssert
 
 
 ## Verifies that the current String is equal to the given one, ignoring case considerations.

--- a/addons/gdUnit4/src/GdUnitVectorAssert.gd
+++ b/addons/gdUnit4/src/GdUnitVectorAssert.gd
@@ -11,10 +11,8 @@ extends GdUnitAssert
 @abstract func is_not_null() -> GdUnitVectorAssert
 
 
-## Verifies that the current value is equal to expected one.
-@warning_ignore("unused_parameter")
-func is_equal(expected :Variant) -> GdUnitVectorAssert:
-	return self
+## Verifies that the current value is equal to the given one.
+@abstract func is_equal(expected: Variant) -> GdUnitVectorAssert
 
 
 ## Verifies that the current value is not equal to expected one.

--- a/addons/gdUnit4/src/asserts/GdUnitAssertImpl.gd
+++ b/addons/gdUnit4/src/asserts/GdUnitAssertImpl.gd
@@ -52,20 +52,6 @@ func append_failure_message(message :String) -> GdUnitAssert:
 	return self
 
 
-func is_equal(expected :Variant) -> GdUnitAssert:
-	var current :Variant = current_value()
-	if not GdObjects.equals(current, expected):
-		return report_error(GdAssertMessages.error_equal(current, expected))
-	return report_success()
-
-
-func is_not_equal(expected :Variant) -> GdUnitAssert:
-	var current :Variant = current_value()
-	if GdObjects.equals(current, expected):
-		return report_error(GdAssertMessages.error_not_equal(current, expected))
-	return report_success()
-
-
 func is_null() -> GdUnitAssert:
 	var current :Variant = current_value()
 	if current != null:
@@ -77,4 +63,18 @@ func is_not_null() -> GdUnitAssert:
 	var current :Variant = current_value()
 	if current == null:
 		return report_error(GdAssertMessages.error_is_not_null())
+	return report_success()
+
+
+func is_equal(expected: Variant) -> GdUnitAssert:
+	var current: Variant = current_value()
+	if not GdObjects.equals(current, expected):
+		return report_error(GdAssertMessages.error_equal(current, expected))
+	return report_success()
+
+
+func is_not_equal(expected :Variant) -> GdUnitAssert:
+	var current :Variant = current_value()
+	if GdObjects.equals(current, expected):
+		return report_error(GdAssertMessages.error_not_equal(current, expected))
 	return report_success()

--- a/addons/gdUnit4/src/asserts/GdUnitDictionaryAssertImpl.gd
+++ b/addons/gdUnit4/src/asserts/GdUnitDictionaryAssertImpl.gd
@@ -63,7 +63,7 @@ func is_not_null() -> GdUnitDictionaryAssert:
 	return self
 
 
-func is_equal(expected :Variant) -> GdUnitDictionaryAssert:
+func is_equal(expected: Variant) -> GdUnitDictionaryAssert:
 	var current :Variant = current_value()
 	if current == null:
 		return report_error(GdAssertMessages.error_equal(null, GdAssertMessages.format_dict(expected)))

--- a/addons/gdUnit4/src/asserts/GdUnitFileAssertImpl.gd
+++ b/addons/gdUnit4/src/asserts/GdUnitFileAssertImpl.gd
@@ -65,7 +65,7 @@ func is_not_null() -> GdUnitFileAssert:
 	return self
 
 
-func is_equal(expected :Variant) -> GdUnitFileAssert:
+func is_equal(expected: Variant) -> GdUnitFileAssert:
 	@warning_ignore("return_value_discarded")
 	_base.is_equal(expected)
 	return self

--- a/addons/gdUnit4/src/asserts/GdUnitFloatAssertImpl.gd
+++ b/addons/gdUnit4/src/asserts/GdUnitFloatAssertImpl.gd
@@ -63,7 +63,7 @@ func is_not_null() -> GdUnitFloatAssert:
 	return self
 
 
-func is_equal(expected :Variant) -> GdUnitFloatAssert:
+func is_equal(expected: Variant) -> GdUnitFloatAssert:
 	@warning_ignore("return_value_discarded")
 	_base.is_equal(expected)
 	return self

--- a/addons/gdUnit4/src/asserts/GdUnitFuncAssertImpl.gd
+++ b/addons/gdUnit4/src/asserts/GdUnitFuncAssertImpl.gd
@@ -98,7 +98,7 @@ func is_true() -> GdUnitFuncAssert:
 	return self
 
 
-func is_equal(expected :Variant) -> GdUnitFuncAssert:
+func is_equal(expected: Variant) -> GdUnitFuncAssert:
 	await _validate_callback(cb_is_equal, expected)
 	return self
 

--- a/addons/gdUnit4/src/asserts/GdUnitGodotErrorAssertImpl.gd
+++ b/addons/gdUnit4/src/asserts/GdUnitGodotErrorAssertImpl.gd
@@ -69,6 +69,10 @@ func is_not_null() -> GdUnitGodotErrorAssert:
 	return _report_error("Not implemented")
 
 
+func is_equal(_expected: Variant) -> GdUnitGodotErrorAssert:
+	return _report_error("Not implemented")
+
+
 func is_success() -> GdUnitGodotErrorAssert:
 	var log_entries := await _execute()
 	if log_entries.is_empty():

--- a/addons/gdUnit4/src/asserts/GdUnitIntAssertImpl.gd
+++ b/addons/gdUnit4/src/asserts/GdUnitIntAssertImpl.gd
@@ -63,7 +63,7 @@ func is_not_null() -> GdUnitIntAssert:
 	return self
 
 
-func is_equal(expected :Variant) -> GdUnitIntAssert:
+func is_equal(expected: Variant) -> GdUnitIntAssert:
 	@warning_ignore("return_value_discarded")
 	_base.is_equal(expected)
 	return self

--- a/addons/gdUnit4/src/asserts/GdUnitResultAssertImpl.gd
+++ b/addons/gdUnit4/src/asserts/GdUnitResultAssertImpl.gd
@@ -67,6 +67,10 @@ func is_not_null() -> GdUnitResultAssert:
 	return self
 
 
+func is_equal(expected: Variant) -> GdUnitResultAssert:
+	return is_value(expected)
+
+
 func is_empty() -> GdUnitResultAssert:
 	var result := current_value()
 	if result == null or not result.is_empty():
@@ -114,7 +118,3 @@ func is_value(expected :Variant) -> GdUnitResultAssert:
 	if not GdObjects.equals(value, expected):
 		return report_error(GdAssertMessages.error_result_is_value(value, expected))
 	return report_success()
-
-
-func is_equal(expected :Variant) -> GdUnitResultAssert:
-	return is_value(expected)

--- a/addons/gdUnit4/src/asserts/GdUnitSignalAssertImpl.gd
+++ b/addons/gdUnit4/src/asserts/GdUnitSignalAssertImpl.gd
@@ -82,6 +82,10 @@ func is_not_null() -> GdUnitSignalAssert:
 	return report_success()
 
 
+func is_equal(_expected: Variant) -> GdUnitSignalAssert:
+	return report_error("Not implemented")
+
+
 # Verifies the signal exists checked the emitter
 func is_signal_exists(signal_name :String) -> GdUnitSignalAssert:
 	if not _emitter.has_signal(signal_name):

--- a/addons/gdUnit4/src/asserts/GdUnitStringAssertImpl.gd
+++ b/addons/gdUnit4/src/asserts/GdUnitStringAssertImpl.gd
@@ -63,8 +63,8 @@ func is_not_null() -> GdUnitStringAssert:
 	return self
 
 
-func is_equal(expected :Variant) -> GdUnitStringAssert:
-	var current :Variant = current_value()
+func is_equal(expected: Variant) -> GdUnitStringAssert:
+	var current: Variant = current_value()
 	if current == null:
 		return report_error(GdAssertMessages.error_equal(current, expected))
 	if not GdObjects.equals(current, expected):


### PR DESCRIPTION
# Why
The GdUnit4 assertion API faked interfaces to represent a small class with class documentation without overloaded implementation code. With Godot 4.5, GDScript now supports abstract classes and functions, so we should switch to that.

# What
- Convert `is_equal` to abstract and add missing implementation
