### PR TITLE
GD-905: Convert base assert function is_not_equal to abstract (part4)

### DIFF
--- a/addons/gdUnit4/src/GdUnitArrayAssert.gd
+++ b/addons/gdUnit4/src/GdUnitArrayAssert.gd
@@ -22,9 +22,7 @@ func is_equal_ignoring_case(expected :Variant) -> GdUnitArrayAssert:
 
 
 ## Verifies that the current Array is not equal to the given one.
-@warning_ignore("unused_parameter")
-func is_not_equal(expected :Variant) -> GdUnitArrayAssert:
-	return self
+@abstract func is_not_equal(expected: Variant) -> GdUnitArrayAssert
 
 
 ## Verifies that the current Array is not equal to the given one, ignoring case considerations.

--- a/addons/gdUnit4/src/GdUnitAssert.gd
+++ b/addons/gdUnit4/src/GdUnitAssert.gd
@@ -16,10 +16,7 @@ extends RefCounted
 
 
 ## Verifies that the current value is not equal to expected one.
-@warning_ignore("unused_parameter")
-@warning_ignore("untyped_declaration")
-func is_not_equal(expected: Variant):
-	return self
+@abstract func is_not_equal(expected: Variant) -> GdUnitAssert
 
 
 ## Overrides the default failure message by given custom message.[br]

--- a/addons/gdUnit4/src/GdUnitBoolAssert.gd
+++ b/addons/gdUnit4/src/GdUnitBoolAssert.gd
@@ -16,9 +16,7 @@ extends GdUnitAssert
 
 
 ## Verifies that the current value is not equal to the given one.
-@warning_ignore("unused_parameter")
-func is_not_equal(expected :Variant) -> GdUnitBoolAssert:
-	return self
+@abstract func is_not_equal(expected: Variant) -> GdUnitBoolAssert
 
 
 ## Verifies that the current value is true.

--- a/addons/gdUnit4/src/GdUnitDictionaryAssert.gd
+++ b/addons/gdUnit4/src/GdUnitDictionaryAssert.gd
@@ -16,9 +16,7 @@ extends GdUnitAssert
 
 
 ## Verifies that the current dictionary is not equal to the given one, ignoring order.
-@warning_ignore("unused_parameter")
-func is_not_equal(expected :Variant) -> GdUnitDictionaryAssert:
-	return self
+@abstract func is_not_equal(expected: Variant) -> GdUnitDictionaryAssert
 
 
 ## Verifies that the current dictionary is empty, it has a size of 0.

--- a/addons/gdUnit4/src/GdUnitFailureAssert.gd
+++ b/addons/gdUnit4/src/GdUnitFailureAssert.gd
@@ -16,6 +16,10 @@ extends GdUnitAssert
 @abstract func is_equal(expected: Variant) -> GdUnitFailureAssert
 
 
+## Verifies that the current value is not equal to expected one.
+@abstract func is_not_equal(expected: Variant) -> GdUnitFailureAssert
+
+
 ## Verifies if the executed assert was successful
 func is_success() -> GdUnitFailureAssert:
 	return self

--- a/addons/gdUnit4/src/GdUnitFileAssert.gd
+++ b/addons/gdUnit4/src/GdUnitFileAssert.gd
@@ -14,6 +14,10 @@ extends GdUnitAssert
 @abstract func is_equal(expected: Variant) -> GdUnitFileAssert
 
 
+## Verifies that the current value is not equal to expected one.
+@abstract func is_not_equal(expected: Variant) -> GdUnitFileAssert
+
+
 func is_file() -> GdUnitFileAssert:
 	return self
 

--- a/addons/gdUnit4/src/GdUnitFloatAssert.gd
+++ b/addons/gdUnit4/src/GdUnitFloatAssert.gd
@@ -15,10 +15,8 @@ extends GdUnitAssert
 @abstract func is_equal(expected: Variant) -> GdUnitFloatAssert
 
 
-## Verifies that the current String is not equal to the given one.
-@warning_ignore("unused_parameter")
-func is_not_equal(expected :Variant) -> GdUnitFloatAssert:
-	return self
+## Verifies that the current value is not equal to expected one.
+@abstract func is_not_equal(expected: Variant) -> GdUnitFloatAssert
 
 
 ## Verifies that the current and expected value are approximately equal.

--- a/addons/gdUnit4/src/GdUnitFuncAssert.gd
+++ b/addons/gdUnit4/src/GdUnitFuncAssert.gd
@@ -15,11 +15,8 @@ extends GdUnitAssert
 @abstract func is_equal(expected: Variant) -> GdUnitFuncAssert
 
 
-## Verifies that the current value is not equal to the given one.
-@warning_ignore("unused_parameter")
-func is_not_equal(expected :Variant) -> GdUnitFuncAssert:
-	await (Engine.get_main_loop() as SceneTree).process_frame
-	return self
+## Verifies that the current value is not equal to expected one.
+@abstract func is_not_equal(expected: Variant) -> GdUnitFuncAssert
 
 
 ## Verifies that the current value is true.

--- a/addons/gdUnit4/src/GdUnitGodotErrorAssert.gd
+++ b/addons/gdUnit4/src/GdUnitGodotErrorAssert.gd
@@ -15,6 +15,10 @@ extends GdUnitAssert
 @abstract func is_equal(expected: Variant) -> GdUnitGodotErrorAssert
 
 
+## Verifies that the current value is not equal to expected one.
+@abstract func is_not_equal(expected: Variant) -> GdUnitGodotErrorAssert
+
+
 ## Verifies if the executed code runs without any runtime errors
 ## Usage:
 ##     [codeblock]

--- a/addons/gdUnit4/src/GdUnitIntAssert.gd
+++ b/addons/gdUnit4/src/GdUnitIntAssert.gd
@@ -15,10 +15,8 @@ extends GdUnitAssert
 @abstract func is_equal(expected: Variant) -> GdUnitIntAssert
 
 
-## Verifies that the current String is not equal to the given one.
-@warning_ignore("unused_parameter")
-func is_not_equal(expected :Variant) -> GdUnitIntAssert:
-	return self
+## Verifies that the current value is not equal to expected one.
+@abstract func is_not_equal(expected: Variant) -> GdUnitIntAssert
 
 
 ## Verifies that the current value is less than the given one.

--- a/addons/gdUnit4/src/GdUnitObjectAssert.gd
+++ b/addons/gdUnit4/src/GdUnitObjectAssert.gd
@@ -15,10 +15,8 @@ extends GdUnitAssert
 @abstract func is_equal(expected: Variant) -> GdUnitObjectAssert
 
 
-## Verifies that the current object is not equal to expected one.
-@warning_ignore("unused_parameter")
-func is_not_equal(expected: Variant) -> GdUnitObjectAssert:
-	return self
+## Verifies that the current value is not equal to expected one.
+@abstract func is_not_equal(expected: Variant) -> GdUnitObjectAssert
 
 
 ## Verifies that the current object is the same as the given one.

--- a/addons/gdUnit4/src/GdUnitResultAssert.gd
+++ b/addons/gdUnit4/src/GdUnitResultAssert.gd
@@ -15,6 +15,10 @@ extends GdUnitAssert
 @abstract func is_equal(expected: Variant) -> GdUnitResultAssert
 
 
+## Verifies that the current value is not equal to expected one.
+@abstract func is_not_equal(expected: Variant) -> GdUnitResultAssert
+
+
 ## Verifies that the result is ends up with empty
 func is_empty() -> GdUnitResultAssert:
 	return self

--- a/addons/gdUnit4/src/GdUnitSignalAssert.gd
+++ b/addons/gdUnit4/src/GdUnitSignalAssert.gd
@@ -15,6 +15,10 @@ extends GdUnitAssert
 @abstract func is_equal(expected: Variant) -> GdUnitSignalAssert
 
 
+## Verifies that the current value is not equal to expected one.
+@abstract func is_not_equal(expected: Variant) -> GdUnitSignalAssert
+
+
 ## Verifies that given signal is emitted until waiting time
 @warning_ignore("unused_parameter")
 func is_emitted(name :String, args := []) -> GdUnitSignalAssert:

--- a/addons/gdUnit4/src/GdUnitStringAssert.gd
+++ b/addons/gdUnit4/src/GdUnitStringAssert.gd
@@ -21,10 +21,8 @@ func is_equal_ignoring_case(expected :Variant) -> GdUnitStringAssert:
 	return self
 
 
-## Verifies that the current String is not equal to the given one.
-@warning_ignore("unused_parameter")
-func is_not_equal(expected :Variant) -> GdUnitStringAssert:
-	return self
+## Verifies that the current value is not equal to expected one.
+@abstract func is_not_equal(expected: Variant) -> GdUnitStringAssert
 
 
 ## Verifies that the current String is not equal to the given one, ignoring case considerations.

--- a/addons/gdUnit4/src/GdUnitVectorAssert.gd
+++ b/addons/gdUnit4/src/GdUnitVectorAssert.gd
@@ -16,9 +16,7 @@ extends GdUnitAssert
 
 
 ## Verifies that the current value is not equal to expected one.
-@warning_ignore("unused_parameter")
-func is_not_equal(expected :Variant) -> GdUnitVectorAssert:
-	return self
+@abstract func is_not_equal(expected: Variant) -> GdUnitVectorAssert
 
 
 ## Verifies that the current and expected value are approximately equal.

--- a/addons/gdUnit4/src/asserts/GdUnitAssertImpl.gd
+++ b/addons/gdUnit4/src/asserts/GdUnitAssertImpl.gd
@@ -73,8 +73,8 @@ func is_equal(expected: Variant) -> GdUnitAssert:
 	return report_success()
 
 
-func is_not_equal(expected :Variant) -> GdUnitAssert:
-	var current :Variant = current_value()
+func is_not_equal(expected: Variant) -> GdUnitAssert:
+	var current: Variant = current_value()
 	if GdObjects.equals(current, expected):
 		return report_error(GdAssertMessages.error_not_equal(current, expected))
 	return report_success()

--- a/addons/gdUnit4/src/asserts/GdUnitDictionaryAssertImpl.gd
+++ b/addons/gdUnit4/src/asserts/GdUnitDictionaryAssertImpl.gd
@@ -74,8 +74,8 @@ func is_equal(expected: Variant) -> GdUnitDictionaryAssert:
 	return report_success()
 
 
-func is_not_equal(expected :Variant) -> GdUnitDictionaryAssert:
-	var current :Variant = current_value()
+func is_not_equal(expected: Variant) -> GdUnitDictionaryAssert:
+	var current: Variant = current_value()
 	if GdObjects.equals(current, expected):
 		return report_error(GdAssertMessages.error_not_equal(current, expected))
 	return report_success()

--- a/addons/gdUnit4/src/asserts/GdUnitFailureAssertImpl.gd
+++ b/addons/gdUnit4/src/asserts/GdUnitFailureAssertImpl.gd
@@ -44,12 +44,10 @@ func _on_test_failed(value :bool) -> void:
 	_is_failed = value
 
 
-@warning_ignore("unused_parameter")
 func is_equal(_expected: Variant) -> GdUnitFailureAssert:
 	return _report_error("Not implemented")
 
 
-@warning_ignore("unused_parameter")
 func is_not_equal(_expected: Variant) -> GdUnitFailureAssert:
 	return _report_error("Not implemented")
 

--- a/addons/gdUnit4/src/asserts/GdUnitFileAssertImpl.gd
+++ b/addons/gdUnit4/src/asserts/GdUnitFileAssertImpl.gd
@@ -71,7 +71,7 @@ func is_equal(expected: Variant) -> GdUnitFileAssert:
 	return self
 
 
-func is_not_equal(expected :Variant) -> GdUnitFileAssert:
+func is_not_equal(expected: Variant) -> GdUnitFileAssert:
 	@warning_ignore("return_value_discarded")
 	_base.is_not_equal(expected)
 	return self

--- a/addons/gdUnit4/src/asserts/GdUnitFloatAssertImpl.gd
+++ b/addons/gdUnit4/src/asserts/GdUnitFloatAssertImpl.gd
@@ -69,7 +69,7 @@ func is_equal(expected: Variant) -> GdUnitFloatAssert:
 	return self
 
 
-func is_not_equal(expected :Variant) -> GdUnitFloatAssert:
+func is_not_equal(expected: Variant) -> GdUnitFloatAssert:
 	@warning_ignore("return_value_discarded")
 	_base.is_not_equal(expected)
 	return self

--- a/addons/gdUnit4/src/asserts/GdUnitFuncAssertImpl.gd
+++ b/addons/gdUnit4/src/asserts/GdUnitFuncAssertImpl.gd
@@ -103,7 +103,7 @@ func is_equal(expected: Variant) -> GdUnitFuncAssert:
 	return self
 
 
-func is_not_equal(expected :Variant) -> GdUnitFuncAssert:
+func is_not_equal(expected: Variant) -> GdUnitFuncAssert:
 	await _validate_callback(cb_is_not_equal, expected)
 	return self
 

--- a/addons/gdUnit4/src/asserts/GdUnitGodotErrorAssertImpl.gd
+++ b/addons/gdUnit4/src/asserts/GdUnitGodotErrorAssertImpl.gd
@@ -73,6 +73,10 @@ func is_equal(_expected: Variant) -> GdUnitGodotErrorAssert:
 	return _report_error("Not implemented")
 
 
+func is_not_equal(_expected: Variant) -> GdUnitGodotErrorAssert:
+	return _report_error("Not implemented")
+
+
 func is_success() -> GdUnitGodotErrorAssert:
 	var log_entries := await _execute()
 	if log_entries.is_empty():

--- a/addons/gdUnit4/src/asserts/GdUnitIntAssertImpl.gd
+++ b/addons/gdUnit4/src/asserts/GdUnitIntAssertImpl.gd
@@ -69,7 +69,7 @@ func is_equal(expected: Variant) -> GdUnitIntAssert:
 	return self
 
 
-func is_not_equal(expected :Variant) -> GdUnitIntAssert:
+func is_not_equal(expected: Variant) -> GdUnitIntAssert:
 	@warning_ignore("return_value_discarded")
 	_base.is_not_equal(expected)
 	return self

--- a/addons/gdUnit4/src/asserts/GdUnitResultAssertImpl.gd
+++ b/addons/gdUnit4/src/asserts/GdUnitResultAssertImpl.gd
@@ -71,6 +71,14 @@ func is_equal(expected: Variant) -> GdUnitResultAssert:
 	return is_value(expected)
 
 
+func is_not_equal(expected: Variant) -> GdUnitResultAssert:
+	var result := current_value()
+	var value :Variant = null if result == null else result.value()
+	if GdObjects.equals(value, expected):
+		return report_error(GdAssertMessages.error_not_equal(value, expected))
+	return report_success()
+
+
 func is_empty() -> GdUnitResultAssert:
 	var result := current_value()
 	if result == null or not result.is_empty():
@@ -112,7 +120,7 @@ func contains_message(expected :String) -> GdUnitResultAssert:
 	return report_success()
 
 
-func is_value(expected :Variant) -> GdUnitResultAssert:
+func is_value(expected: Variant) -> GdUnitResultAssert:
 	var result := current_value()
 	var value :Variant = null if result == null else result.value()
 	if not GdObjects.equals(value, expected):

--- a/addons/gdUnit4/src/asserts/GdUnitSignalAssertImpl.gd
+++ b/addons/gdUnit4/src/asserts/GdUnitSignalAssertImpl.gd
@@ -86,6 +86,10 @@ func is_equal(_expected: Variant) -> GdUnitSignalAssert:
 	return report_error("Not implemented")
 
 
+func is_not_equal(_expected: Variant) -> GdUnitSignalAssert:
+	return report_error("Not implemented")
+
+
 # Verifies the signal exists checked the emitter
 func is_signal_exists(signal_name :String) -> GdUnitSignalAssert:
 	if not _emitter.has_signal(signal_name):

--- a/addons/gdUnit4/src/asserts/GdUnitStringAssertImpl.gd
+++ b/addons/gdUnit4/src/asserts/GdUnitStringAssertImpl.gd
@@ -85,8 +85,8 @@ func is_equal_ignoring_case(expected :Variant) -> GdUnitStringAssert:
 	return report_success()
 
 
-func is_not_equal(expected :Variant) -> GdUnitStringAssert:
-	var current :Variant = current_value()
+func is_not_equal(expected: Variant) -> GdUnitStringAssert:
+	var current: Variant = current_value()
 	if GdObjects.equals(current, expected):
 		return report_error(GdAssertMessages.error_not_equal(current, expected))
 	return report_success()


### PR DESCRIPTION
# Why
The GdUnit4 assertion API faked interfaces to represent a small class with class documentation without overloaded implementation code. With Godot 4.5, GDScript now supports abstract classes and functions, so we should switch to that.

# What
- Convert `is_not_equal` to abstract and add missing implementation

