### PR TITLE
GD-905: Convert base assert function append_failure_message to abstract (part6)

### DIFF
--- a/addons/gdUnit4/src/GdUnitArrayAssert.gd
+++ b/addons/gdUnit4/src/GdUnitArrayAssert.gd
@@ -35,6 +35,10 @@ func is_not_equal_ignoring_case(expected :Variant) -> GdUnitArrayAssert:
 @abstract func override_failure_message(message: String) -> GdUnitArrayAssert
 
 
+## Appends a custom message to the failure message.
+@abstract func append_failure_message(message: String) -> GdUnitArrayAssert
+
+
 ## Verifies that the current Array is empty, it has a size of 0.
 func is_empty() -> GdUnitArrayAssert:
 	return self
@@ -155,9 +159,4 @@ func extractv(
 	extractor7 :GdUnitValueExtractor = null,
 	extractor8 :GdUnitValueExtractor = null,
 	extractor9 :GdUnitValueExtractor = null) -> GdUnitArrayAssert:
-	return self
-
-
-@warning_ignore("unused_parameter")
-func append_failure_message(message :String) -> GdUnitArrayAssert:
 	return self

--- a/addons/gdUnit4/src/GdUnitAssert.gd
+++ b/addons/gdUnit4/src/GdUnitAssert.gd
@@ -40,10 +40,8 @@ extends RefCounted
 ##     [codeblock]
 ##		# Add context to existing failure message
 ##		func test_player_health():
-##		    assert_int(player.health)\
+##		    assert_that(player.health)\
 ##		        .append_failure_message("Player was damaged by: %s" % last_damage_source)\
 ##		        .is_greater(0)
 ##     [/codeblock]
-@warning_ignore("untyped_declaration")
-func append_failure_message(_message: String):
-	return self
+@abstract func append_failure_message(message: String) -> GdUnitAssert

--- a/addons/gdUnit4/src/GdUnitBoolAssert.gd
+++ b/addons/gdUnit4/src/GdUnitBoolAssert.gd
@@ -23,6 +23,10 @@ extends GdUnitAssert
 @abstract func override_failure_message(message: String) -> GdUnitBoolAssert
 
 
+## Appends a custom message to the failure message.
+@abstract func append_failure_message(message: String) -> GdUnitBoolAssert
+
+
 ## Verifies that the current value is true.
 func is_true() -> GdUnitBoolAssert:
 	return self

--- a/addons/gdUnit4/src/GdUnitDictionaryAssert.gd
+++ b/addons/gdUnit4/src/GdUnitDictionaryAssert.gd
@@ -23,6 +23,10 @@ extends GdUnitAssert
 @abstract func override_failure_message(message: String) -> GdUnitDictionaryAssert
 
 
+## Appends a custom message to the failure message.
+@abstract func append_failure_message(message: String) -> GdUnitDictionaryAssert
+
+
 ## Verifies that the current dictionary is empty, it has a size of 0.
 func is_empty() -> GdUnitDictionaryAssert:
 	return self

--- a/addons/gdUnit4/src/GdUnitFailureAssert.gd
+++ b/addons/gdUnit4/src/GdUnitFailureAssert.gd
@@ -24,6 +24,10 @@ extends GdUnitAssert
 @abstract func override_failure_message(message: String) -> GdUnitFailureAssert
 
 
+## Appends a custom message to the failure message.
+@abstract func append_failure_message(message: String) -> GdUnitFailureAssert
+
+
 ## Verifies if the executed assert was successful
 func is_success() -> GdUnitFailureAssert:
 	return self

--- a/addons/gdUnit4/src/GdUnitFileAssert.gd
+++ b/addons/gdUnit4/src/GdUnitFileAssert.gd
@@ -22,6 +22,10 @@ extends GdUnitAssert
 @abstract func override_failure_message(message: String) -> GdUnitFileAssert
 
 
+## Appends a custom message to the failure message.
+@abstract func append_failure_message(message: String) -> GdUnitFileAssert
+
+
 func is_file() -> GdUnitFileAssert:
 	return self
 

--- a/addons/gdUnit4/src/GdUnitFloatAssert.gd
+++ b/addons/gdUnit4/src/GdUnitFloatAssert.gd
@@ -29,6 +29,10 @@ func is_equal_approx(expected :float, approx :float) -> GdUnitFloatAssert:
 @abstract func override_failure_message(message: String) -> GdUnitFloatAssert
 
 
+## Appends a custom message to the failure message.
+@abstract func append_failure_message(message: String) -> GdUnitFloatAssert
+
+
 ## Verifies that the current value is less than the given one.
 @warning_ignore("unused_parameter")
 func is_less(expected :float) -> GdUnitFloatAssert:

--- a/addons/gdUnit4/src/GdUnitFuncAssert.gd
+++ b/addons/gdUnit4/src/GdUnitFuncAssert.gd
@@ -23,6 +23,10 @@ extends GdUnitAssert
 @abstract func override_failure_message(message: String) -> GdUnitFuncAssert
 
 
+## Appends a custom message to the failure message.
+@abstract func append_failure_message(message: String) -> GdUnitFuncAssert
+
+
 ## Verifies that the current value is true.
 func is_true() -> GdUnitFuncAssert:
 	await (Engine.get_main_loop() as SceneTree).process_frame

--- a/addons/gdUnit4/src/GdUnitGodotErrorAssert.gd
+++ b/addons/gdUnit4/src/GdUnitGodotErrorAssert.gd
@@ -23,6 +23,10 @@ extends GdUnitAssert
 @abstract func override_failure_message(message: String) -> GdUnitGodotErrorAssert
 
 
+## Appends a custom message to the failure message.
+@abstract func append_failure_message(message: String) -> GdUnitGodotErrorAssert
+
+
 ## Verifies if the executed code runs without any runtime errors
 ## Usage:
 ##     [codeblock]

--- a/addons/gdUnit4/src/GdUnitIntAssert.gd
+++ b/addons/gdUnit4/src/GdUnitIntAssert.gd
@@ -23,6 +23,10 @@ extends GdUnitAssert
 @abstract func override_failure_message(message: String) -> GdUnitIntAssert
 
 
+## Appends a custom message to the failure message.
+@abstract func append_failure_message(message: String) -> GdUnitIntAssert
+
+
 ## Verifies that the current value is less than the given one.
 @warning_ignore("unused_parameter")
 func is_less(expected :int) -> GdUnitIntAssert:

--- a/addons/gdUnit4/src/GdUnitObjectAssert.gd
+++ b/addons/gdUnit4/src/GdUnitObjectAssert.gd
@@ -23,6 +23,10 @@ extends GdUnitAssert
 @abstract func override_failure_message(message: String) -> GdUnitObjectAssert
 
 
+## Appends a custom message to the failure message.
+@abstract func append_failure_message(message: String) -> GdUnitObjectAssert
+
+
 ## Verifies that the current object is the same as the given one.
 @warning_ignore("unused_parameter", "shadowed_global_identifier")
 func is_same(expected: Variant) -> GdUnitObjectAssert:

--- a/addons/gdUnit4/src/GdUnitResultAssert.gd
+++ b/addons/gdUnit4/src/GdUnitResultAssert.gd
@@ -23,6 +23,10 @@ extends GdUnitAssert
 @abstract func override_failure_message(message: String) -> GdUnitResultAssert
 
 
+## Appends a custom message to the failure message.
+@abstract func append_failure_message(message: String) -> GdUnitResultAssert
+
+
 ## Verifies that the result is ends up with empty
 func is_empty() -> GdUnitResultAssert:
 	return self

--- a/addons/gdUnit4/src/GdUnitSignalAssert.gd
+++ b/addons/gdUnit4/src/GdUnitSignalAssert.gd
@@ -23,6 +23,10 @@ extends GdUnitAssert
 @abstract func override_failure_message(message: String) -> GdUnitSignalAssert
 
 
+## Appends a custom message to the failure message.
+@abstract func append_failure_message(message: String) -> GdUnitSignalAssert
+
+
 ## Verifies that given signal is emitted until waiting time
 @warning_ignore("unused_parameter")
 func is_emitted(name :String, args := []) -> GdUnitSignalAssert:

--- a/addons/gdUnit4/src/GdUnitStringAssert.gd
+++ b/addons/gdUnit4/src/GdUnitStringAssert.gd
@@ -35,6 +35,10 @@ func is_not_equal_ignoring_case(expected :Variant) -> GdUnitStringAssert:
 @abstract func override_failure_message(message: String) -> GdUnitStringAssert
 
 
+## Appends a custom message to the failure message.
+@abstract func append_failure_message(message: String) -> GdUnitStringAssert
+
+
 ## Verifies that the current String is empty, it has a length of 0.
 func is_empty() -> GdUnitStringAssert:
 	return self

--- a/addons/gdUnit4/src/GdUnitVectorAssert.gd
+++ b/addons/gdUnit4/src/GdUnitVectorAssert.gd
@@ -29,6 +29,10 @@ func is_equal_approx(expected :Variant, approx :Variant) -> GdUnitVectorAssert:
 @abstract func override_failure_message(message: String) -> GdUnitVectorAssert
 
 
+## Appends a custom message to the failure message.
+@abstract func append_failure_message(message: String) -> GdUnitVectorAssert
+
+
 ## Verifies that the current value is less than the given one.
 @warning_ignore("unused_parameter")
 func is_less(expected :Variant) -> GdUnitVectorAssert:

--- a/addons/gdUnit4/src/asserts/GdUnitAssertImpl.gd
+++ b/addons/gdUnit4/src/asserts/GdUnitAssertImpl.gd
@@ -47,7 +47,7 @@ func override_failure_message(message: String) -> GdUnitAssert:
 	return self
 
 
-func append_failure_message(message :String) -> GdUnitAssert:
+func append_failure_message(message: String) -> GdUnitAssert:
 	_additional_failure_message = message
 	return self
 

--- a/addons/gdUnit4/src/asserts/GdUnitBoolAssertImpl.gd
+++ b/addons/gdUnit4/src/asserts/GdUnitBoolAssertImpl.gd
@@ -45,7 +45,7 @@ func override_failure_message(message: String) -> GdUnitBoolAssert:
 	return self
 
 
-func append_failure_message(message :String) -> GdUnitBoolAssert:
+func append_failure_message(message: String) -> GdUnitBoolAssert:
 	@warning_ignore("return_value_discarded")
 	_base.append_failure_message(message)
 	return self

--- a/addons/gdUnit4/src/asserts/GdUnitDictionaryAssertImpl.gd
+++ b/addons/gdUnit4/src/asserts/GdUnitDictionaryAssertImpl.gd
@@ -41,7 +41,7 @@ func override_failure_message(message: String) -> GdUnitDictionaryAssert:
 	return self
 
 
-func append_failure_message(message :String) -> GdUnitDictionaryAssert:
+func append_failure_message(message: String) -> GdUnitDictionaryAssert:
 	@warning_ignore("return_value_discarded")
 	_base.append_failure_message(message)
 	return self

--- a/addons/gdUnit4/src/asserts/GdUnitFailureAssertImpl.gd
+++ b/addons/gdUnit4/src/asserts/GdUnitFailureAssertImpl.gd
@@ -3,7 +3,10 @@ extends GdUnitFailureAssert
 const GdUnitTools := preload("res://addons/gdUnit4/src/core/GdUnitTools.gd")
 
 var _is_failed := false
-var _failure_message :String
+var _failure_message: String
+var _current_failure_message := ""
+var _custom_failure_message := ""
+var _additional_failure_message := ""
 
 
 func _set_do_expect_fail(enabled :bool = true) -> void:
@@ -60,8 +63,14 @@ func is_not_null() -> GdUnitFailureAssert:
 	return _report_error("Not implemented")
 
 
-func override_failure_message(_message: String) -> GdUnitFailureAssert:
-	return _report_error("Not implemented")
+func override_failure_message(message: String) -> GdUnitFailureAssert:
+	_custom_failure_message = message
+	return self
+
+
+func append_failure_message(message: String) -> GdUnitFailureAssert:
+	_additional_failure_message = message
+	return self
 
 
 func is_success() -> GdUnitFailureAssert:
@@ -117,7 +126,8 @@ func starts_with_message(expected :String) -> GdUnitFailureAssert:
 
 func _report_error(error_message :String, failure_line_number: int = -1) -> GdUnitAssert:
 	var line_number := failure_line_number if failure_line_number != -1 else GdUnitAssertions.get_line_number()
-	GdAssertReports.report_error(error_message, line_number)
+	_current_failure_message = GdAssertMessages.build_failure_message(error_message, _additional_failure_message, _custom_failure_message)
+	GdAssertReports.report_error(_current_failure_message, line_number)
 	return self
 
 

--- a/addons/gdUnit4/src/asserts/GdUnitFileAssertImpl.gd
+++ b/addons/gdUnit4/src/asserts/GdUnitFileAssertImpl.gd
@@ -47,7 +47,7 @@ func override_failure_message(message: String) -> GdUnitFileAssert:
 	return self
 
 
-func append_failure_message(message :String) -> GdUnitFileAssert:
+func append_failure_message(message: String) -> GdUnitFileAssert:
 	@warning_ignore("return_value_discarded")
 	_base.append_failure_message(message)
 	return self

--- a/addons/gdUnit4/src/asserts/GdUnitFloatAssertImpl.gd
+++ b/addons/gdUnit4/src/asserts/GdUnitFloatAssertImpl.gd
@@ -45,7 +45,7 @@ func override_failure_message(message: String) -> GdUnitFloatAssert:
 	return self
 
 
-func append_failure_message(message :String) -> GdUnitFloatAssert:
+func append_failure_message(message: String) -> GdUnitFloatAssert:
 	@warning_ignore("return_value_discarded")
 	_base.append_failure_message(message)
 	return self

--- a/addons/gdUnit4/src/asserts/GdUnitFuncAssertImpl.gd
+++ b/addons/gdUnit4/src/asserts/GdUnitFuncAssertImpl.gd
@@ -64,7 +64,7 @@ func override_failure_message(message: String) -> GdUnitFuncAssert:
 	return self
 
 
-func append_failure_message(message :String) -> GdUnitFuncAssert:
+func append_failure_message(message: String) -> GdUnitFuncAssert:
 	_additional_failure_message = message
 	return self
 

--- a/addons/gdUnit4/src/asserts/GdUnitGodotErrorAssertImpl.gd
+++ b/addons/gdUnit4/src/asserts/GdUnitGodotErrorAssertImpl.gd
@@ -1,6 +1,8 @@
 extends GdUnitGodotErrorAssert
 
-var _current_error_message: String
+var _current_failure_message := ""
+var _custom_failure_message := ""
+var _additional_failure_message := ""
 var _callable: Callable
 
 
@@ -26,7 +28,7 @@ func _error_monitor() -> GodotGdErrorMonitor:
 
 
 func failure_message() -> String:
-	return _current_error_message
+	return _current_failure_message
 
 
 func _report_success() -> GdUnitAssert:
@@ -36,8 +38,8 @@ func _report_success() -> GdUnitAssert:
 
 func _report_error(error_message: String, failure_line_number: int = -1) -> GdUnitAssert:
 	var line_number := failure_line_number if failure_line_number != -1 else GdUnitAssertions.get_line_number()
-	_current_error_message = error_message
-	GdAssertReports.report_error(error_message, line_number)
+	_current_failure_message = GdAssertMessages.build_failure_message(error_message, _additional_failure_message, _custom_failure_message)
+	GdAssertReports.report_error(_current_failure_message, line_number)
 	return self
 
 
@@ -77,8 +79,14 @@ func is_not_equal(_expected: Variant) -> GdUnitGodotErrorAssert:
 	return _report_error("Not implemented")
 
 
-func override_failure_message(_message: String) -> GdUnitGodotErrorAssert:
-	return _report_error("Not implemented")
+func override_failure_message(message: String) -> GdUnitGodotErrorAssert:
+	_custom_failure_message = message
+	return self
+
+
+func append_failure_message(message: String) -> GdUnitGodotErrorAssert:
+	_additional_failure_message = message
+	return self
 
 
 func is_success() -> GdUnitGodotErrorAssert:

--- a/addons/gdUnit4/src/asserts/GdUnitIntAssertImpl.gd
+++ b/addons/gdUnit4/src/asserts/GdUnitIntAssertImpl.gd
@@ -45,7 +45,7 @@ func override_failure_message(message: String) -> GdUnitIntAssert:
 	return self
 
 
-func append_failure_message(message :String) -> GdUnitIntAssert:
+func append_failure_message(message: String) -> GdUnitIntAssert:
 	@warning_ignore("return_value_discarded")
 	_base.append_failure_message(message)
 	return self

--- a/addons/gdUnit4/src/asserts/GdUnitResultAssertImpl.gd
+++ b/addons/gdUnit4/src/asserts/GdUnitResultAssertImpl.gd
@@ -49,7 +49,7 @@ func override_failure_message(message: String) -> GdUnitResultAssert:
 	return self
 
 
-func append_failure_message(message :String) -> GdUnitResultAssert:
+func append_failure_message(message: String) -> GdUnitResultAssert:
 	@warning_ignore("return_value_discarded")
 	_base.append_failure_message(message)
 	return self

--- a/addons/gdUnit4/src/asserts/GdUnitSignalAssertImpl.gd
+++ b/addons/gdUnit4/src/asserts/GdUnitSignalAssertImpl.gd
@@ -55,7 +55,7 @@ func override_failure_message(message: String) -> GdUnitSignalAssert:
 	return self
 
 
-func append_failure_message(message :String) -> GdUnitSignalAssert:
+func append_failure_message(message: String) -> GdUnitSignalAssert:
 	_additional_failure_message = message
 	return self
 

--- a/addons/gdUnit4/src/asserts/GdUnitStringAssertImpl.gd
+++ b/addons/gdUnit4/src/asserts/GdUnitStringAssertImpl.gd
@@ -45,7 +45,7 @@ func override_failure_message(message: String) -> GdUnitStringAssert:
 	return self
 
 
-func append_failure_message(message :String) -> GdUnitStringAssert:
+func append_failure_message(message: String) -> GdUnitStringAssert:
 	@warning_ignore("return_value_discarded")
 	_base.append_failure_message(message)
 	return self


### PR DESCRIPTION


# Why
The GdUnit4 assertion API faked interfaces to represent a small class with class documentation without overloaded implementation code. With Godot 4.5, GDScript now supports abstract classes and functions, so we should switch to that.

# What
- Convert `append_failure_message` to abstract and add missing implementation
