### PR TITLE
GD-905: Convert base assert function to abstract (part7)

### DIFF
--- a/addons/gdUnit4/src/GdUnitArrayAssert.gd
+++ b/addons/gdUnit4/src/GdUnitArrayAssert.gd
@@ -40,74 +40,56 @@ func is_not_equal_ignoring_case(expected :Variant) -> GdUnitArrayAssert:
 
 
 ## Verifies that the current Array is empty, it has a size of 0.
-func is_empty() -> GdUnitArrayAssert:
-	return self
+@abstract func is_empty() -> GdUnitArrayAssert
 
 
 ## Verifies that the current Array is not empty, it has a size of minimum 1.
-func is_not_empty() -> GdUnitArrayAssert:
-	return self
+@abstract func is_not_empty() -> GdUnitArrayAssert
+
 
 ## Verifies that the current Array is the same. [br]
 ## Compares the current by object reference equals
-@warning_ignore("unused_parameter", "shadowed_global_identifier")
-func is_same(expected :Variant) -> GdUnitArrayAssert:
-	return self
+@abstract func is_same(expected: Variant) -> GdUnitArrayAssert
 
 
 ## Verifies that the current Array is NOT the same. [br]
 ## Compares the current by object reference equals
-@warning_ignore("unused_parameter", "shadowed_global_identifier")
-func is_not_same(expected :Variant) -> GdUnitArrayAssert:
-	return self
+@abstract func is_not_same(expected: Variant) -> GdUnitArrayAssert
 
 
 ## Verifies that the current Array has a size of given value.
-@warning_ignore("unused_parameter")
-func has_size(expectd: int) -> GdUnitArrayAssert:
-	return self
+
+@abstract func has_size(expectd: int) -> GdUnitArrayAssert
 
 
 ## Verifies that the current Array contains the given values, in any order.[br]
 ## The values are compared by deep parameter comparision, for object reference compare you have to use [method contains_same]
-@warning_ignore("unused_parameter")
-func contains(expected :Variant) -> GdUnitArrayAssert:
-	return self
+@abstract func contains(expected: Variant) -> GdUnitArrayAssert
 
 
 ## Verifies that the current Array contains exactly only the given values and nothing else, in same order.[br]
 ## The values are compared by deep parameter comparision, for object reference compare you have to use [method contains_same_exactly]
-@warning_ignore("unused_parameter")
-func contains_exactly(expected :Variant) -> GdUnitArrayAssert:
-	return self
+@abstract func contains_exactly(expected: Variant) -> GdUnitArrayAssert
 
 
 ## Verifies that the current Array contains exactly only the given values and nothing else, in any order.[br]
 ## The values are compared by deep parameter comparision, for object reference compare you have to use [method contains_same_exactly_in_any_order]
-@warning_ignore("unused_parameter")
-func contains_exactly_in_any_order(expected :Variant) -> GdUnitArrayAssert:
-	return self
+@abstract func contains_exactly_in_any_order(expected: Variant) -> GdUnitArrayAssert
 
 
 ## Verifies that the current Array contains the given values, in any order.[br]
 ## The values are compared by object reference, for deep parameter comparision use [method contains]
-@warning_ignore("unused_parameter")
-func contains_same(expected :Variant) -> GdUnitArrayAssert:
-	return self
+@abstract func contains_same(expected: Variant) -> GdUnitArrayAssert
 
 
 ## Verifies that the current Array contains exactly only the given values and nothing else, in same order.[br]
 ## The values are compared by object reference, for deep parameter comparision use [method contains_exactly]
-@warning_ignore("unused_parameter")
-func contains_same_exactly(expected :Variant) -> GdUnitArrayAssert:
-	return self
+@abstract func contains_same_exactly(expected: Variant) -> GdUnitArrayAssert
 
 
 ## Verifies that the current Array contains exactly only the given values and nothing else, in any order.[br]
 ## The values are compared by object reference, for deep parameter comparision use [method contains_exactly_in_any_order]
-@warning_ignore("unused_parameter")
-func contains_same_exactly_in_any_order(expected :Variant) -> GdUnitArrayAssert:
-	return self
+@abstract func contains_same_exactly_in_any_order(expected: Variant) -> GdUnitArrayAssert
 
 
 ## Verifies that the current Array do NOT contains the given values, in any order.[br]
@@ -119,9 +101,7 @@ func contains_same_exactly_in_any_order(expected :Variant) -> GdUnitArrayAssert:
 ## # will fail
 ## assert_array([1, 2, 3, 4, 5]).not_contains([2, 6])
 ## [/codeblock]
-@warning_ignore("unused_parameter")
-func not_contains(expected :Variant) -> GdUnitArrayAssert:
-	return self
+@abstract func not_contains(expected: Variant) -> GdUnitArrayAssert
 
 
 ## Verifies that the current Array do NOT contains the given values, in any order.[br]
@@ -133,22 +113,17 @@ func not_contains(expected :Variant) -> GdUnitArrayAssert:
 ## # will fail
 ## assert_array([1, 2, 3, 4, 5]).not_contains([2, 6])
 ## [/codeblock]
-@warning_ignore("unused_parameter")
-func not_contains_same(expected :Variant) -> GdUnitArrayAssert:
-	return self
+@abstract func not_contains_same(expected: Variant) -> GdUnitArrayAssert
 
 
 ## Extracts all values by given function name and optional arguments into a new ArrayAssert.
 ## If the elements not accessible by `func_name` the value is converted to `"n.a"`, expecting null values
-@warning_ignore("unused_parameter")
-func extract(func_name: String, args := Array()) -> GdUnitArrayAssert:
-	return self
+@abstract func extract(func_name: String, args := Array()) -> GdUnitArrayAssert
 
 
 ## Extracts all values by given extractor's into a new ArrayAssert.
 ## If the elements not extractable than the value is converted to `"n.a"`, expecting null values
-@warning_ignore("unused_parameter")
-func extractv(
+@abstract func extractv(
 	extractor0 :GdUnitValueExtractor,
 	extractor1 :GdUnitValueExtractor = null,
 	extractor2 :GdUnitValueExtractor = null,
@@ -158,5 +133,4 @@ func extractv(
 	extractor6 :GdUnitValueExtractor = null,
 	extractor7 :GdUnitValueExtractor = null,
 	extractor8 :GdUnitValueExtractor = null,
-	extractor9 :GdUnitValueExtractor = null) -> GdUnitArrayAssert:
-	return self
+	extractor9 :GdUnitValueExtractor = null) -> GdUnitArrayAssert

--- a/addons/gdUnit4/src/GdUnitArrayAssert.gd
+++ b/addons/gdUnit4/src/GdUnitArrayAssert.gd
@@ -16,9 +16,7 @@ extends GdUnitAssert
 
 
 ## Verifies that the current Array is equal to the given one, ignoring case considerations.
-@warning_ignore("unused_parameter")
-func is_equal_ignoring_case(expected :Variant) -> GdUnitArrayAssert:
-	return self
+@abstract func is_equal_ignoring_case(expected: Variant) -> GdUnitArrayAssert
 
 
 ## Verifies that the current Array is not equal to the given one.
@@ -26,9 +24,7 @@ func is_equal_ignoring_case(expected :Variant) -> GdUnitArrayAssert:
 
 
 ## Verifies that the current Array is not equal to the given one, ignoring case considerations.
-@warning_ignore("unused_parameter")
-func is_not_equal_ignoring_case(expected :Variant) -> GdUnitArrayAssert:
-	return self
+@abstract func is_not_equal_ignoring_case(expected: Variant) -> GdUnitArrayAssert
 
 
 ## Overrides the default failure message by given custom message.
@@ -58,7 +54,6 @@ func is_not_equal_ignoring_case(expected :Variant) -> GdUnitArrayAssert:
 
 
 ## Verifies that the current Array has a size of given value.
-
 @abstract func has_size(expectd: int) -> GdUnitArrayAssert
 
 

--- a/addons/gdUnit4/src/GdUnitBoolAssert.gd
+++ b/addons/gdUnit4/src/GdUnitBoolAssert.gd
@@ -28,10 +28,8 @@ extends GdUnitAssert
 
 
 ## Verifies that the current value is true.
-func is_true() -> GdUnitBoolAssert:
-	return self
+@abstract func is_true() -> GdUnitBoolAssert
 
 
 ## Verifies that the current value is false.
-func is_false() -> GdUnitBoolAssert:
-	return self
+@abstract func is_false() -> GdUnitBoolAssert

--- a/addons/gdUnit4/src/GdUnitDictionaryAssert.gd
+++ b/addons/gdUnit4/src/GdUnitDictionaryAssert.gd
@@ -28,80 +28,52 @@ extends GdUnitAssert
 
 
 ## Verifies that the current dictionary is empty, it has a size of 0.
-func is_empty() -> GdUnitDictionaryAssert:
-	return self
+@abstract func is_empty() -> GdUnitDictionaryAssert
 
 
 ## Verifies that the current dictionary is not empty, it has a size of minimum 1.
-func is_not_empty() -> GdUnitDictionaryAssert:
-	return self
+@abstract func is_not_empty() -> GdUnitDictionaryAssert
 
 
 ## Verifies that the current dictionary is the same. [br]
 ## Compares the current by object reference equals
-@warning_ignore("unused_parameter", "shadowed_global_identifier")
-func is_same(expected :Variant) -> GdUnitDictionaryAssert:
-	return self
+@abstract func is_same(expected: Variant) -> GdUnitDictionaryAssert
 
 
 ## Verifies that the current dictionary is NOT the same. [br]
 ## Compares the current by object reference equals
-@warning_ignore("unused_parameter")
-func is_not_same(expected :Variant) -> GdUnitDictionaryAssert:
-	return self
+@abstract func is_not_same(expected: Variant) -> GdUnitDictionaryAssert
 
 
 ## Verifies that the current dictionary has a size of given value.
-@warning_ignore("unused_parameter")
-func has_size(expected: int) -> GdUnitDictionaryAssert:
-	return self
+@abstract func has_size(expected: int) -> GdUnitDictionaryAssert
 
 
 ## Verifies that the current dictionary contains the given key(s).[br]
 ## The keys are compared by deep parameter comparision, for object reference compare you have to use [method contains_same_keys]
-@warning_ignore("unused_parameter")
-func contains_keys(expected :Array) -> GdUnitDictionaryAssert:
-	return self
+@abstract func contains_keys(expected: Array) -> GdUnitDictionaryAssert
 
 
 ## Verifies that the current dictionary contains the given key and value.[br]
 ## The key and value are compared by deep parameter comparision, for object reference compare you have to use [method contains_same_key_value]
-@warning_ignore("unused_parameter")
-func contains_key_value(key :Variant, value :Variant) -> GdUnitDictionaryAssert:
-	return self
-
-
-## Verifies that the current dictionary not contains the given key(s).[br]
-## This function is [b]deprecated[/b] you have to use [method not_contains_keys] instead
-@warning_ignore("unused_parameter")
-func contains_not_keys(expected :Array) -> GdUnitDictionaryAssert:
-	push_warning("Deprecated: 'contains_not_keys' is deprectated and will be removed soon, use `not_contains_keys` instead!")
-	return not_contains_keys(expected)
+@abstract func contains_key_value(key: Variant, value: Variant) -> GdUnitDictionaryAssert
 
 
 ## Verifies that the current dictionary not contains the given key(s).[br]
 ## The keys are compared by deep parameter comparision, for object reference compare you have to use [method not_contains_same_keys]
-@warning_ignore("unused_parameter")
-func not_contains_keys(expected :Array) -> GdUnitDictionaryAssert:
-	return self
+@abstract func not_contains_keys(expected: Array) -> GdUnitDictionaryAssert
 
 
 ## Verifies that the current dictionary contains the given key(s).[br]
 ## The keys are compared by object reference, for deep parameter comparision use [method contains_keys]
-@warning_ignore("unused_parameter")
-func contains_same_keys(expected :Array) -> GdUnitDictionaryAssert:
-	return self
+@abstract func contains_same_keys(expected: Array) -> GdUnitDictionaryAssert
 
 
 ## Verifies that the current dictionary contains the given key and value.[br]
 ## The key and value are compared by object reference, for deep parameter comparision use [method contains_key_value]
-@warning_ignore("unused_parameter")
-func contains_same_key_value(key :Variant, value :Variant) -> GdUnitDictionaryAssert:
-	return self
+@abstract func contains_same_key_value(key: Variant, value: Variant) -> GdUnitDictionaryAssert
 
 
 ## Verifies that the current dictionary not contains the given key(s).
 ## The keys are compared by object reference, for deep parameter comparision use [method not_contains_keys]
-@warning_ignore("unused_parameter")
-func not_contains_same_keys(expected :Array) -> GdUnitDictionaryAssert:
-	return self
+@abstract func not_contains_same_keys(expected: Array) -> GdUnitDictionaryAssert

--- a/addons/gdUnit4/src/GdUnitFailureAssert.gd
+++ b/addons/gdUnit4/src/GdUnitFailureAssert.gd
@@ -29,33 +29,24 @@ extends GdUnitAssert
 
 
 ## Verifies if the executed assert was successful
-func is_success() -> GdUnitFailureAssert:
-	return self
+@abstract func is_success() -> GdUnitFailureAssert
+
 
 ## Verifies if the executed assert has failed
-func is_failed() -> GdUnitFailureAssert:
-	return self
+@abstract func is_failed() -> GdUnitFailureAssert
 
 
 ## Verifies the failure line is equal to expected one.
-@warning_ignore("unused_parameter")
-func has_line(expected :int) -> GdUnitFailureAssert:
-	return self
+@abstract func has_line(expected: int) -> GdUnitFailureAssert
 
 
 ## Verifies the failure message is equal to expected one.
-@warning_ignore("unused_parameter")
-func has_message(expected: String) -> GdUnitFailureAssert:
-	return self
+@abstract func has_message(expected: String) -> GdUnitFailureAssert
 
 
 ## Verifies that the failure message starts with the expected message.
-@warning_ignore("unused_parameter")
-func starts_with_message(expected: String) -> GdUnitFailureAssert:
-	return self
+@abstract func starts_with_message(expected: String) -> GdUnitFailureAssert
 
 
 ## Verifies that the failure message contains the expected message.
-@warning_ignore("unused_parameter")
-func contains_message(expected: String) -> GdUnitFailureAssert:
-	return self
+@abstract func contains_message(expected: String) -> GdUnitFailureAssert

--- a/addons/gdUnit4/src/GdUnitFileAssert.gd
+++ b/addons/gdUnit4/src/GdUnitFileAssert.gd
@@ -26,18 +26,13 @@ extends GdUnitAssert
 @abstract func append_failure_message(message: String) -> GdUnitFileAssert
 
 
-func is_file() -> GdUnitFileAssert:
-	return self
+@abstract func is_file() -> GdUnitFileAssert
 
 
-func exists() -> GdUnitFileAssert:
-	return self
+@abstract func exists() -> GdUnitFileAssert
 
 
-func is_script() -> GdUnitFileAssert:
-	return self
+@abstract func is_script() -> GdUnitFileAssert
 
 
-@warning_ignore("unused_parameter")
-func contains_exactly(expected_rows :Array) -> GdUnitFileAssert:
-	return self
+@abstract func contains_exactly(expected_rows :Array) -> GdUnitFileAssert

--- a/addons/gdUnit4/src/GdUnitFloatAssert.gd
+++ b/addons/gdUnit4/src/GdUnitFloatAssert.gd
@@ -20,9 +20,7 @@ extends GdUnitAssert
 
 
 ## Verifies that the current and expected value are approximately equal.
-@warning_ignore("unused_parameter", "shadowed_global_identifier")
-func is_equal_approx(expected :float, approx :float) -> GdUnitFloatAssert:
-	return self
+@abstract func is_equal_approx(expected: float, approx: float) -> GdUnitFloatAssert
 
 
 ## Overrides the default failure message by given custom message.
@@ -34,62 +32,44 @@ func is_equal_approx(expected :float, approx :float) -> GdUnitFloatAssert:
 
 
 ## Verifies that the current value is less than the given one.
-@warning_ignore("unused_parameter")
-func is_less(expected :float) -> GdUnitFloatAssert:
-	return self
+@abstract func is_less(expected: float) -> GdUnitFloatAssert
 
 
 ## Verifies that the current value is less than or equal the given one.
-@warning_ignore("unused_parameter")
-func is_less_equal(expected :float) -> GdUnitFloatAssert:
-	return self
+@abstract func is_less_equal(expected: float) -> GdUnitFloatAssert
 
 
 ## Verifies that the current value is greater than the given one.
-@warning_ignore("unused_parameter")
-func is_greater(expected :float) -> GdUnitFloatAssert:
-	return self
+@abstract func is_greater(expected: float) -> GdUnitFloatAssert
 
 
 ## Verifies that the current value is greater than or equal the given one.
-@warning_ignore("unused_parameter")
-func is_greater_equal(expected :float) -> GdUnitFloatAssert:
-	return self
+@abstract func is_greater_equal(expected: float) -> GdUnitFloatAssert
 
 
 ## Verifies that the current value is negative.
-func is_negative() -> GdUnitFloatAssert:
-	return self
+@abstract func is_negative() -> GdUnitFloatAssert
 
 
 ## Verifies that the current value is not negative.
-func is_not_negative() -> GdUnitFloatAssert:
-	return self
+@abstract func is_not_negative() -> GdUnitFloatAssert
 
 
 ## Verifies that the current value is equal to zero.
-func is_zero() -> GdUnitFloatAssert:
-	return self
+@abstract func is_zero() -> GdUnitFloatAssert
 
 
 ## Verifies that the current value is not equal to zero.
-func is_not_zero() -> GdUnitFloatAssert:
-	return self
+@abstract func is_not_zero() -> GdUnitFloatAssert
 
 
 ## Verifies that the current value is in the given set of values.
-@warning_ignore("unused_parameter")
-func is_in(expected :Array) -> GdUnitFloatAssert:
-	return self
+@abstract func is_in(expected: Array) -> GdUnitFloatAssert
 
 
 ## Verifies that the current value is not in the given set of values.
-@warning_ignore("unused_parameter")
-func is_not_in(expected :Array) -> GdUnitFloatAssert:
-	return self
+@abstract func is_not_in(expected: Array) -> GdUnitFloatAssert
 
 
 ## Verifies that the current value is between the given boundaries (inclusive).
-@warning_ignore("unused_parameter")
-func is_between(from :float, to :float) -> GdUnitFloatAssert:
-	return self
+@abstract func is_between(from: float, to: float) -> GdUnitFloatAssert

--- a/addons/gdUnit4/src/GdUnitFuncAssert.gd
+++ b/addons/gdUnit4/src/GdUnitFuncAssert.gd
@@ -28,21 +28,15 @@ extends GdUnitAssert
 
 
 ## Verifies that the current value is true.
-func is_true() -> GdUnitFuncAssert:
-	await (Engine.get_main_loop() as SceneTree).process_frame
-	return self
+@abstract func is_true() -> GdUnitFuncAssert
 
 
 ## Verifies that the current value is false.
-func is_false() -> GdUnitFuncAssert:
-	await (Engine.get_main_loop() as SceneTree).process_frame
-	return self
+@abstract func is_false() -> GdUnitFuncAssert
 
 
 ## Sets the timeout in ms to wait the function returnd the expected value, if the time over a failure is emitted.[br]
 ## e.g.[br]
 ## do wait until 5s the function `is_state` is returns 10 [br]
 ## [code]assert_func(instance, "is_state").wait_until(5000).is_equal(10)[/code]
-@warning_ignore("unused_parameter")
-func wait_until(timeout :int) -> GdUnitFuncAssert:
-	return self
+@abstract func wait_until(timeout: int) -> GdUnitFuncAssert

--- a/addons/gdUnit4/src/GdUnitGodotErrorAssert.gd
+++ b/addons/gdUnit4/src/GdUnitGodotErrorAssert.gd
@@ -32,9 +32,7 @@ extends GdUnitAssert
 ##     [codeblock]
 ##		await assert_error(<callable>).is_success()
 ##     [/codeblock]
-func is_success() -> GdUnitGodotErrorAssert:
-	await (Engine.get_main_loop() as SceneTree).process_frame
-	return self
+@abstract func is_success() -> GdUnitGodotErrorAssert
 
 
 ## Verifies if the executed code runs into a runtime error
@@ -42,10 +40,7 @@ func is_success() -> GdUnitGodotErrorAssert:
 ##     [codeblock]
 ##		await assert_error(<callable>).is_runtime_error(<expected error message>)
 ##     [/codeblock]
-@warning_ignore("unused_parameter")
-func is_runtime_error(expected_error: Variant) -> GdUnitGodotErrorAssert:
-	await (Engine.get_main_loop() as SceneTree).process_frame
-	return self
+@abstract func is_runtime_error(expected_error: Variant) -> GdUnitGodotErrorAssert
 
 
 ## Verifies if the executed code has a push_warning() used
@@ -53,10 +48,7 @@ func is_runtime_error(expected_error: Variant) -> GdUnitGodotErrorAssert:
 ##     [codeblock]
 ##		await assert_error(<callable>).is_push_warning(<expected push warning message>)
 ##     [/codeblock]
-@warning_ignore("unused_parameter")
-func is_push_warning(expected_warning: Variant) -> GdUnitGodotErrorAssert:
-	await (Engine.get_main_loop() as SceneTree).process_frame
-	return self
+@abstract func is_push_warning(expected_warning: Variant) -> GdUnitGodotErrorAssert
 
 
 ## Verifies if the executed code has a push_error() used
@@ -64,7 +56,4 @@ func is_push_warning(expected_warning: Variant) -> GdUnitGodotErrorAssert:
 ##     [codeblock]
 ##		await assert_error(<callable>).is_push_error(<expected push error message>)
 ##     [/codeblock]
-@warning_ignore("unused_parameter")
-func is_push_error(expected_error: Variant) -> GdUnitGodotErrorAssert:
-	await (Engine.get_main_loop() as SceneTree).process_frame
-	return self
+@abstract func is_push_error(expected_error: Variant) -> GdUnitGodotErrorAssert

--- a/addons/gdUnit4/src/GdUnitIntAssert.gd
+++ b/addons/gdUnit4/src/GdUnitIntAssert.gd
@@ -28,72 +28,52 @@ extends GdUnitAssert
 
 
 ## Verifies that the current value is less than the given one.
-@warning_ignore("unused_parameter")
-func is_less(expected :int) -> GdUnitIntAssert:
-	return self
+@abstract func is_less(expected: int) -> GdUnitIntAssert
 
 
 ## Verifies that the current value is less than or equal the given one.
-@warning_ignore("unused_parameter")
-func is_less_equal(expected :int) -> GdUnitIntAssert:
-	return self
+@abstract func is_less_equal(expected: int) -> GdUnitIntAssert
 
 
 ## Verifies that the current value is greater than the given one.
-@warning_ignore("unused_parameter")
-func is_greater(expected :int) -> GdUnitIntAssert:
-	return self
+@abstract func is_greater(expected: int) -> GdUnitIntAssert
 
 
 ## Verifies that the current value is greater than or equal the given one.
-@warning_ignore("unused_parameter")
-func is_greater_equal(expected :int) -> GdUnitIntAssert:
-	return self
+@abstract func is_greater_equal(expected: int) -> GdUnitIntAssert
 
 
 ## Verifies that the current value is even.
-func is_even() -> GdUnitIntAssert:
-	return self
+@abstract func is_even() -> GdUnitIntAssert
 
 
 ## Verifies that the current value is odd.
-func is_odd() -> GdUnitIntAssert:
-	return self
+@abstract func is_odd() -> GdUnitIntAssert
 
 
 ## Verifies that the current value is negative.
-func is_negative() -> GdUnitIntAssert:
-	return self
+@abstract func is_negative() -> GdUnitIntAssert
 
 
 ## Verifies that the current value is not negative.
-func is_not_negative() -> GdUnitIntAssert:
-	return self
+@abstract func is_not_negative() -> GdUnitIntAssert
 
 
 ## Verifies that the current value is equal to zero.
-func is_zero() -> GdUnitIntAssert:
-	return self
+@abstract func is_zero() -> GdUnitIntAssert
 
 
 ## Verifies that the current value is not equal to zero.
-func is_not_zero() -> GdUnitIntAssert:
-	return self
+@abstract func is_not_zero() -> GdUnitIntAssert
 
 
 ## Verifies that the current value is in the given set of values.
-@warning_ignore("unused_parameter")
-func is_in(expected :Array) -> GdUnitIntAssert:
-	return self
+@abstract func is_in(expected: Array) -> GdUnitIntAssert
 
 
 ## Verifies that the current value is not in the given set of values.
-@warning_ignore("unused_parameter")
-func is_not_in(expected :Array) -> GdUnitIntAssert:
-	return self
+@abstract func is_not_in(expected: Array) -> GdUnitIntAssert
 
 
 ## Verifies that the current value is between the given boundaries (inclusive).
-@warning_ignore("unused_parameter")
-func is_between(from :int, to :int) -> GdUnitIntAssert:
-	return self
+@abstract func is_between(from: int, to: int) -> GdUnitIntAssert

--- a/addons/gdUnit4/src/GdUnitObjectAssert.gd
+++ b/addons/gdUnit4/src/GdUnitObjectAssert.gd
@@ -28,36 +28,24 @@ extends GdUnitAssert
 
 
 ## Verifies that the current object is the same as the given one.
-@warning_ignore("unused_parameter", "shadowed_global_identifier")
-func is_same(expected: Variant) -> GdUnitObjectAssert:
-	return self
+@abstract func is_same(expected: Variant) -> GdUnitObjectAssert
 
 
 ## Verifies that the current object is not the same as the given one.
-@warning_ignore("unused_parameter")
-func is_not_same(expected: Variant) -> GdUnitObjectAssert:
-	return self
+@abstract func is_not_same(expected: Variant) -> GdUnitObjectAssert
 
 
 ## Verifies that the current object is an instance of the given type.
-@warning_ignore("unused_parameter")
-func is_instanceof(type: Variant) -> GdUnitObjectAssert:
-	return self
+@abstract func is_instanceof(type: Variant) -> GdUnitObjectAssert
 
 
 ## Verifies that the current object is not an instance of the given type.
-@warning_ignore("unused_parameter")
-func is_not_instanceof(type: Variant) -> GdUnitObjectAssert:
-	return self
+@abstract func is_not_instanceof(type: Variant) -> GdUnitObjectAssert
 
 
 ## Checks whether the current object inherits from the specified type.
-@warning_ignore("unused_parameter")
-func is_inheriting(type: Variant) -> GdUnitObjectAssert:
-	return self
+@abstract func is_inheriting(type: Variant) -> GdUnitObjectAssert
 
 
 ## Checks whether the current object does NOT inherit from the specified type.
-@warning_ignore("unused_parameter")
-func is_not_inheriting(type: Variant) -> GdUnitObjectAssert:
-	return self
+@abstract func is_not_inheriting(type: Variant) -> GdUnitObjectAssert

--- a/addons/gdUnit4/src/GdUnitResultAssert.gd
+++ b/addons/gdUnit4/src/GdUnitResultAssert.gd
@@ -28,32 +28,24 @@ extends GdUnitAssert
 
 
 ## Verifies that the result is ends up with empty
-func is_empty() -> GdUnitResultAssert:
-	return self
+@abstract func is_empty() -> GdUnitResultAssert
 
 
 ## Verifies that the result is ends up with success
-func is_success() -> GdUnitResultAssert:
-	return self
+@abstract func is_success() -> GdUnitResultAssert
 
 
 ## Verifies that the result is ends up with warning
-func is_warning() -> GdUnitResultAssert:
-	return self
+@abstract func is_warning() -> GdUnitResultAssert
 
 
 ## Verifies that the result is ends up with error
-func is_error() -> GdUnitResultAssert:
-	return self
+@abstract func is_error() -> GdUnitResultAssert
 
 
 ## Verifies that the result contains the given message
-@warning_ignore("unused_parameter")
-func contains_message(expected :String) -> GdUnitResultAssert:
-	return self
+@abstract func contains_message(expected: String) -> GdUnitResultAssert
 
 
 ## Verifies that the result contains the given value
-@warning_ignore("unused_parameter")
-func is_value(expected :Variant) -> GdUnitResultAssert:
-	return self
+@abstract func is_value(expected: Variant) -> GdUnitResultAssert

--- a/addons/gdUnit4/src/GdUnitSignalAssert.gd
+++ b/addons/gdUnit4/src/GdUnitSignalAssert.gd
@@ -28,29 +28,19 @@ extends GdUnitAssert
 
 
 ## Verifies that given signal is emitted until waiting time
-@warning_ignore("unused_parameter")
-func is_emitted(name :String, args := []) -> GdUnitSignalAssert:
-	await (Engine.get_main_loop() as SceneTree).process_frame
-	return self
+@abstract func is_emitted(name: String, args := []) -> GdUnitSignalAssert
 
 
 ## Verifies that given signal is NOT emitted until waiting time
-@warning_ignore("unused_parameter")
-func is_not_emitted(name :String, args := []) -> GdUnitSignalAssert:
-	await (Engine.get_main_loop() as SceneTree).process_frame
-	return self
+@abstract func is_not_emitted(name: String, args := []) -> GdUnitSignalAssert
 
 
 ## Verifies the signal exists checked the emitter
-@warning_ignore("unused_parameter")
-func is_signal_exists(name :String) -> GdUnitSignalAssert:
-	return self
+@abstract func is_signal_exists(name: String) -> GdUnitSignalAssert
 
 
 ## Sets the assert signal timeout in ms, if the time over a failure is reported.[br]
 ## e.g.[br]
 ## do wait until 5s the instance has emitted the signal `signal_a`[br]
 ## [code]assert_signal(instance).wait_until(5000).is_emitted("signal_a")[/code]
-@warning_ignore("unused_parameter")
-func wait_until(timeout :int) -> GdUnitSignalAssert:
-	return self
+@abstract func wait_until(timeout: int) -> GdUnitSignalAssert

--- a/addons/gdUnit4/src/GdUnitStringAssert.gd
+++ b/addons/gdUnit4/src/GdUnitStringAssert.gd
@@ -16,9 +16,7 @@ extends GdUnitAssert
 
 
 ## Verifies that the current String is equal to the given one, ignoring case considerations.
-@warning_ignore("unused_parameter")
-func is_equal_ignoring_case(expected :Variant) -> GdUnitStringAssert:
-	return self
+@abstract func is_equal_ignoring_case(expected: Variant) -> GdUnitStringAssert
 
 
 ## Verifies that the current value is not equal to expected one.
@@ -26,9 +24,7 @@ func is_equal_ignoring_case(expected :Variant) -> GdUnitStringAssert:
 
 
 ## Verifies that the current String is not equal to the given one, ignoring case considerations.
-@warning_ignore("unused_parameter")
-func is_not_equal_ignoring_case(expected :Variant) -> GdUnitStringAssert:
-	return self
+@abstract func is_not_equal_ignoring_case(expected: Variant) -> GdUnitStringAssert
 
 
 ## Overrides the default failure message by given custom message.
@@ -40,52 +36,36 @@ func is_not_equal_ignoring_case(expected :Variant) -> GdUnitStringAssert:
 
 
 ## Verifies that the current String is empty, it has a length of 0.
-func is_empty() -> GdUnitStringAssert:
-	return self
+@abstract func is_empty() -> GdUnitStringAssert
 
 
 ## Verifies that the current String is not empty, it has a length of minimum 1.
-func is_not_empty() -> GdUnitStringAssert:
-	return self
+@abstract func is_not_empty() -> GdUnitStringAssert
 
 
 ## Verifies that the current String contains the given String.
-@warning_ignore("unused_parameter")
-func contains(expected: String) -> GdUnitStringAssert:
-	return self
+@abstract func contains(expected: String) -> GdUnitStringAssert
 
 
 ## Verifies that the current String does not contain the given String.
-@warning_ignore("unused_parameter")
-func not_contains(expected: String) -> GdUnitStringAssert:
-	return self
+@abstract func not_contains(expected: String) -> GdUnitStringAssert
 
 
 ## Verifies that the current String does not contain the given String, ignoring case considerations.
-@warning_ignore("unused_parameter")
-func contains_ignoring_case(expected: String) -> GdUnitStringAssert:
-	return self
+@abstract func contains_ignoring_case(expected: String) -> GdUnitStringAssert
 
 
 ## Verifies that the current String does not contain the given String, ignoring case considerations.
-@warning_ignore("unused_parameter")
-func not_contains_ignoring_case(expected: String) -> GdUnitStringAssert:
-	return self
+@abstract func not_contains_ignoring_case(expected: String) -> GdUnitStringAssert
 
 
 ## Verifies that the current String starts with the given prefix.
-@warning_ignore("unused_parameter")
-func starts_with(expected: String) -> GdUnitStringAssert:
-	return self
+@abstract func starts_with(expected: String) -> GdUnitStringAssert
 
 
 ## Verifies that the current String ends with the given suffix.
-@warning_ignore("unused_parameter")
-func ends_with(expected: String) -> GdUnitStringAssert:
-	return self
+@abstract func ends_with(expected: String) -> GdUnitStringAssert
 
 
 ## Verifies that the current String has the expected length by used comparator.
-@warning_ignore("unused_parameter")
-func has_length(length: int, comparator: int = Comparator.EQUAL) -> GdUnitStringAssert:
-	return self
+@abstract func has_length(length: int, comparator: int = Comparator.EQUAL) -> GdUnitStringAssert

--- a/addons/gdUnit4/src/GdUnitVectorAssert.gd
+++ b/addons/gdUnit4/src/GdUnitVectorAssert.gd
@@ -20,9 +20,7 @@ extends GdUnitAssert
 
 
 ## Verifies that the current and expected value are approximately equal.
-@warning_ignore("unused_parameter", "shadowed_global_identifier")
-func is_equal_approx(expected :Variant, approx :Variant) -> GdUnitVectorAssert:
-	return self
+@abstract func is_equal_approx(expected: Variant, approx: Variant) -> GdUnitVectorAssert
 
 
 ## Overrides the default failure message by given custom message.
@@ -34,36 +32,24 @@ func is_equal_approx(expected :Variant, approx :Variant) -> GdUnitVectorAssert:
 
 
 ## Verifies that the current value is less than the given one.
-@warning_ignore("unused_parameter")
-func is_less(expected :Variant) -> GdUnitVectorAssert:
-	return self
+@abstract func is_less(expected: Variant) -> GdUnitVectorAssert
 
 
 ## Verifies that the current value is less than or equal the given one.
-@warning_ignore("unused_parameter")
-func is_less_equal(expected :Variant) -> GdUnitVectorAssert:
-	return self
+@abstract func is_less_equal(expected: Variant) -> GdUnitVectorAssert
 
 
 ## Verifies that the current value is greater than the given one.
-@warning_ignore("unused_parameter")
-func is_greater(expected :Variant) -> GdUnitVectorAssert:
-	return self
+@abstract func is_greater(expected: Variant) -> GdUnitVectorAssert
 
 
 ## Verifies that the current value is greater than or equal the given one.
-@warning_ignore("unused_parameter")
-func is_greater_equal(expected :Variant) -> GdUnitVectorAssert:
-	return self
+@abstract func is_greater_equal(expected: Variant) -> GdUnitVectorAssert
 
 
 ## Verifies that the current value is between the given boundaries (inclusive).
-@warning_ignore("unused_parameter")
-func is_between(from :Variant, to :Variant) -> GdUnitVectorAssert:
-	return self
+@abstract func is_between(from: Variant, to: Variant) -> GdUnitVectorAssert
 
 
 ## Verifies that the current value is not between the given boundaries (inclusive).
-@warning_ignore("unused_parameter")
-func is_not_between(from :Variant, to :Variant) -> GdUnitVectorAssert:
-	return self
+@abstract func is_not_between(from: Variant, to: Variant) -> GdUnitVectorAssert


### PR DESCRIPTION
# Why
The GdUnit4 assertion API faked interfaces to represent a small class with class documentation without overloaded implementation code. With Godot 4.5, GDScript now supports abstract classes and functions, so we should switch to that.

# What
- Convert functions to abstract

