### PR TITLE
GD-903: Add support for variadic argument to assert_array

### DIFF
--- a/.github/workflows/gdlint.yml
+++ b/.github/workflows/gdlint.yml
@@ -42,8 +42,9 @@ jobs:
           gdlint addons/gdUnit4/bin/ | tee reports/gdlint/gdlint.txt
           gdlint addons/gdUnit4/src/cmd/ | tee reports/gdlint/cmd.txt
           gdlint addons/gdUnit4/src/reporters/ | tee reports/gdlint/report.txt
-          gdlint addons/gdUnit4/src/asserts | tee reports/gdlint/gdlint_asserts.txt
           gdlint addons/gdUnit4/src/network | tee reports/gdlint/gdlint_networkcode.txt
+        # temporary disable until https://github.com/Scony/godot-gdscript-toolkit/issues/399 is fixed
+        # gdlint addons/gdUnit4/src/asserts | tee reports/gdlint/gdlint_asserts.txt
 
       - name: Upload GDLint Report
         if: failure()

--- a/addons/gdUnit4/src/GdUnitArrayAssert.gd
+++ b/addons/gdUnit4/src/GdUnitArrayAssert.gd
@@ -12,19 +12,19 @@ extends GdUnitAssert
 
 
 ## Verifies that the current Array is equal to the given one.
-@abstract func is_equal(expected: Variant) -> GdUnitArrayAssert
+@abstract func is_equal(...expected: Array) -> GdUnitArrayAssert
 
 
 ## Verifies that the current Array is equal to the given one, ignoring case considerations.
-@abstract func is_equal_ignoring_case(expected: Variant) -> GdUnitArrayAssert
+@abstract func is_equal_ignoring_case(...expected: Array) -> GdUnitArrayAssert
 
 
 ## Verifies that the current Array is not equal to the given one.
-@abstract func is_not_equal(expected: Variant) -> GdUnitArrayAssert
+@abstract func is_not_equal(...expected: Array) -> GdUnitArrayAssert
 
 
 ## Verifies that the current Array is not equal to the given one, ignoring case considerations.
-@abstract func is_not_equal_ignoring_case(expected: Variant) -> GdUnitArrayAssert
+@abstract func is_not_equal_ignoring_case(...expected: Array) -> GdUnitArrayAssert
 
 
 ## Overrides the default failure message by given custom message.
@@ -59,32 +59,32 @@ extends GdUnitAssert
 
 ## Verifies that the current Array contains the given values, in any order.[br]
 ## The values are compared by deep parameter comparision, for object reference compare you have to use [method contains_same]
-@abstract func contains(expected: Variant) -> GdUnitArrayAssert
+@abstract func contains(...expected: Array) -> GdUnitArrayAssert
 
 
 ## Verifies that the current Array contains exactly only the given values and nothing else, in same order.[br]
 ## The values are compared by deep parameter comparision, for object reference compare you have to use [method contains_same_exactly]
-@abstract func contains_exactly(expected: Variant) -> GdUnitArrayAssert
+@abstract func contains_exactly(...expected: Array) -> GdUnitArrayAssert
 
 
 ## Verifies that the current Array contains exactly only the given values and nothing else, in any order.[br]
 ## The values are compared by deep parameter comparision, for object reference compare you have to use [method contains_same_exactly_in_any_order]
-@abstract func contains_exactly_in_any_order(expected: Variant) -> GdUnitArrayAssert
+@abstract func contains_exactly_in_any_order(...expected: Array) -> GdUnitArrayAssert
 
 
 ## Verifies that the current Array contains the given values, in any order.[br]
 ## The values are compared by object reference, for deep parameter comparision use [method contains]
-@abstract func contains_same(expected: Variant) -> GdUnitArrayAssert
+@abstract func contains_same(...expected: Array) -> GdUnitArrayAssert
 
 
 ## Verifies that the current Array contains exactly only the given values and nothing else, in same order.[br]
 ## The values are compared by object reference, for deep parameter comparision use [method contains_exactly]
-@abstract func contains_same_exactly(expected: Variant) -> GdUnitArrayAssert
+@abstract func contains_same_exactly(...expected: Array) -> GdUnitArrayAssert
 
 
 ## Verifies that the current Array contains exactly only the given values and nothing else, in any order.[br]
 ## The values are compared by object reference, for deep parameter comparision use [method contains_exactly_in_any_order]
-@abstract func contains_same_exactly_in_any_order(expected: Variant) -> GdUnitArrayAssert
+@abstract func contains_same_exactly_in_any_order(...expected: Array) -> GdUnitArrayAssert
 
 
 ## Verifies that the current Array do NOT contains the given values, in any order.[br]
@@ -92,11 +92,11 @@ extends GdUnitAssert
 ## [b]Example:[/b]
 ## [codeblock]
 ## # will succeed
-## assert_array([1, 2, 3, 4, 5]).not_contains([6])
+## assert_array([1, 2, 3, 4, 5]).not_contains(6)
 ## # will fail
-## assert_array([1, 2, 3, 4, 5]).not_contains([2, 6])
+## assert_array([1, 2, 3, 4, 5]).not_contains(2, 6)
 ## [/codeblock]
-@abstract func not_contains(expected: Variant) -> GdUnitArrayAssert
+@abstract func not_contains(...expected: Array) -> GdUnitArrayAssert
 
 
 ## Verifies that the current Array do NOT contains the given values, in any order.[br]
@@ -104,28 +104,19 @@ extends GdUnitAssert
 ## [b]Example:[/b]
 ## [codeblock]
 ## # will succeed
-## assert_array([1, 2, 3, 4, 5]).not_contains([6])
+## assert_array([1, 2, 3, 4, 5]).not_contains(6)
 ## # will fail
-## assert_array([1, 2, 3, 4, 5]).not_contains([2, 6])
+## assert_array([1, 2, 3, 4, 5]).not_contains(2, 6)
 ## [/codeblock]
-@abstract func not_contains_same(expected: Variant) -> GdUnitArrayAssert
+@abstract func not_contains_same(...expected: Array) -> GdUnitArrayAssert
 
 
 ## Extracts all values by given function name and optional arguments into a new ArrayAssert.
 ## If the elements not accessible by `func_name` the value is converted to `"n.a"`, expecting null values
-@abstract func extract(func_name: String, args := Array()) -> GdUnitArrayAssert
+@abstract func extract(func_name: String, ...func_args: Array) -> GdUnitArrayAssert
 
 
 ## Extracts all values by given extractor's into a new ArrayAssert.
 ## If the elements not extractable than the value is converted to `"n.a"`, expecting null values
-@abstract func extractv(
-	extractor0 :GdUnitValueExtractor,
-	extractor1 :GdUnitValueExtractor = null,
-	extractor2 :GdUnitValueExtractor = null,
-	extractor3 :GdUnitValueExtractor = null,
-	extractor4 :GdUnitValueExtractor = null,
-	extractor5 :GdUnitValueExtractor = null,
-	extractor6 :GdUnitValueExtractor = null,
-	extractor7 :GdUnitValueExtractor = null,
-	extractor8 :GdUnitValueExtractor = null,
-	extractor9 :GdUnitValueExtractor = null) -> GdUnitArrayAssert
+## -- The argument type is Array[GdUnitValueExtractor]
+@abstract func extractv(...extractors: Array) -> GdUnitArrayAssert

--- a/addons/gdUnit4/src/asserts/GdUnitArrayAssertImpl.gd
+++ b/addons/gdUnit4/src/asserts/GdUnitArrayAssertImpl.gd
@@ -116,14 +116,14 @@ func _array_div(compare_mode: GdObjects.COMPARE_MODE, left: Array[Variant], righ
 func _contains(expected: Array, compare_mode: GdObjects.COMPARE_MODE) -> GdUnitArrayAssert:
 	var by_reference := compare_mode == GdObjects.COMPARE_MODE.OBJECT_REFERENCE
 	var current_value: Variant = get_current_value()
-	var expected_value := _extract_variadic_value(expected)
+	var expected_value: Variant = _extract_variadic_value(expected)
 	if not _validate_value_type(expected_value):
 		return report_error("ERROR: expected value: <%s>\n is not a Array Type!" % GdObjects.typeof_as_string(expected_value))
 
 	if current_value == null:
 		return report_error(GdAssertMessages.error_arr_contains(current_value, expected_value, [], expected_value, by_reference))
 	@warning_ignore("unsafe_cast")
-	var diffs := _array_div(compare_mode, current_value as Array[Variant], expected_value)
+	var diffs := _array_div(compare_mode, current_value as Array[Variant], expected_value as Array[Variant])
 	#var not_expect := diffs[0] as Array
 	var not_found: Array = diffs[1]
 	if not not_found.is_empty():
@@ -133,7 +133,7 @@ func _contains(expected: Array, compare_mode: GdObjects.COMPARE_MODE) -> GdUnitA
 
 func _contains_exactly(expected: Array, compare_mode: GdObjects.COMPARE_MODE) -> GdUnitArrayAssert:
 	var current_value: Variant = get_current_value()
-	var expected_value := _extract_variadic_value(expected)
+	var expected_value: Variant = _extract_variadic_value(expected)
 	if not _validate_value_type(expected_value):
 		return report_error("ERROR: expected value: <%s>\n is not a Array Type!" % GdObjects.typeof_as_string(expected_value))
 
@@ -149,7 +149,7 @@ func _contains_exactly(expected: Array, compare_mode: GdObjects.COMPARE_MODE) ->
 	@warning_ignore("unsafe_cast")
 	var diffs := _array_div(compare_mode,
 		current_value as Array[Variant],
-		expected_value,
+		expected_value as Array[Variant],
 		GdObjects.COMPARE_MODE.PARAMETER_DEEP_TEST)
 	var not_expect: Array[Variant] = diffs[0]
 	var not_found: Array[Variant] = diffs[1]
@@ -158,7 +158,7 @@ func _contains_exactly(expected: Array, compare_mode: GdObjects.COMPARE_MODE) ->
 
 func _contains_exactly_in_any_order(expected: Array, compare_mode: GdObjects.COMPARE_MODE) -> GdUnitArrayAssert:
 	var current_value: Variant = get_current_value()
-	var expected_value := _extract_variadic_value(expected)
+	var expected_value: Variant = _extract_variadic_value(expected)
 	if not _validate_value_type(expected_value):
 		return report_error("ERROR: expected value: <%s>\n is not a Array Type!" % GdObjects.typeof_as_string(expected_value))
 
@@ -166,7 +166,7 @@ func _contains_exactly_in_any_order(expected: Array, compare_mode: GdObjects.COM
 		return report_error(GdAssertMessages.error_arr_contains_exactly_in_any_order(current_value, expected_value, [], expected_value, compare_mode))
 	# find the difference
 	@warning_ignore("unsafe_cast")
-	var diffs := _array_div(compare_mode, current_value as Array[Variant], expected_value, false)
+	var diffs := _array_div(compare_mode, current_value as Array[Variant], expected_value as Array[Variant], false)
 	var not_expect: Array[Variant] = diffs[0]
 	var not_found: Array[Variant] = diffs[1]
 	if not_expect.is_empty() and not_found.is_empty():
@@ -176,19 +176,19 @@ func _contains_exactly_in_any_order(expected: Array, compare_mode: GdObjects.COM
 
 func _not_contains(expected: Array, compare_mode: GdObjects.COMPARE_MODE) -> GdUnitArrayAssert:
 	var current_value: Variant = get_current_value()
-	var expected_value := _extract_variadic_value(expected)
+	var expected_value: Variant = _extract_variadic_value(expected)
 	if not _validate_value_type(expected_value):
 		return report_error("ERROR: expected value: <%s>\n is not a Array Type!" % GdObjects.typeof_as_string(expected_value))
 	if current_value == null:
 		return report_error(GdAssertMessages.error_arr_contains_exactly_in_any_order(current_value, expected_value, [], expected_value, compare_mode))
 	@warning_ignore("unsafe_cast")
-	var diffs := _array_div(compare_mode, current_value as Array[Variant], expected_value)
+	var diffs := _array_div(compare_mode, current_value as Array[Variant], expected_value as Array[Variant])
 	var found: Array[Variant] = diffs[0]
 	@warning_ignore("unsafe_cast")
 	if found.size() == (current_value as Array).size():
 		return report_success()
 	@warning_ignore("unsafe_cast")
-	var diffs2 := _array_div(compare_mode, expected_value, diffs[1] as Array[Variant])
+	var diffs2 := _array_div(compare_mode, expected_value as Array[Variant], diffs[1] as Array[Variant])
 	return report_error(GdAssertMessages.error_arr_not_contains(current_value, expected_value, diffs2[0], compare_mode))
 
 
@@ -206,7 +206,7 @@ func is_not_null() -> GdUnitArrayAssert:
 
 func is_equal(...expected: Array) -> GdUnitArrayAssert:
 	var current_value: Variant = get_current_value()
-	var expected_value := _extract_variadic_value(expected)
+	var expected_value: Variant= _extract_variadic_value(expected)
 	if not _validate_value_type(expected_value):
 		return report_error("ERROR: expected value: <%s>\n is not a Array Type!" % GdObjects.typeof_as_string(expected_value))
 	if current_value == null and expected_value != null:
@@ -224,7 +224,7 @@ func is_equal(...expected: Array) -> GdUnitArrayAssert:
 # Verifies that the current Array is equal to the given one, ignoring case considerations.
 func is_equal_ignoring_case(...expected: Array) -> GdUnitArrayAssert:
 	var current_value: Variant = get_current_value()
-	var expected_value := _extract_variadic_value(expected)
+	var expected_value: Variant = _extract_variadic_value(expected)
 	if not _validate_value_type(expected_value):
 		return report_error("ERROR: expected value: <%s>\n is not a Array Type!" % GdObjects.typeof_as_string(expected_value))
 	if current_value == null and expected_value != null:
@@ -243,7 +243,7 @@ func is_equal_ignoring_case(...expected: Array) -> GdUnitArrayAssert:
 
 func is_not_equal(...expected: Array) -> GdUnitArrayAssert:
 	var current_value: Variant = get_current_value()
-	var expected_value := _extract_variadic_value(expected)
+	var expected_value: Variant = _extract_variadic_value(expected)
 	if not _validate_value_type(expected_value):
 		return report_error("ERROR: expected value: <%s>\n is not a Array Type!" % GdObjects.typeof_as_string(expected_value))
 
@@ -254,7 +254,7 @@ func is_not_equal(...expected: Array) -> GdUnitArrayAssert:
 
 func is_not_equal_ignoring_case(...expected: Array) -> GdUnitArrayAssert:
 	var current_value: Variant = get_current_value()
-	var expected_value := _extract_variadic_value(expected)
+	var expected_value: Variant = _extract_variadic_value(expected)
 	if not _validate_value_type(expected_value):
 		return report_error("ERROR: expected value: <%s>\n is not a Array Type!" % GdObjects.typeof_as_string(expected_value))
 
@@ -352,7 +352,7 @@ func is_instanceof(expected: Variant) -> GdUnitAssert:
 
 func extract(func_name: String, ...func_args: Array) -> GdUnitArrayAssert:
 	var extracted_elements := Array()
-	var args := _extract_variadic_value(func_args)
+	var args: Array = _extract_variadic_value(func_args)
 	var extractor := GdUnitFuncValueExtractor.new(func_name, args)
 	var current: Variant = get_current_value()
 	if current == null:
@@ -396,7 +396,8 @@ func extractv(...extractors: Array) -> GdUnitArrayAssert:
 
 
 ## Small helper to support the old expected arguments as single array and variadic arguments
-func _extract_variadic_value(values: Array) -> Array:
+func _extract_variadic_value(values: Variant) -> Variant:
+	@warning_ignore("unsafe_method_access")
 	if values != null and values.size() == 1 and GdArrayTools.is_array_type(values[0]):
 		return values[0]
 	return values

--- a/addons/gdUnit4/src/asserts/GdUnitArrayAssertImpl.gd
+++ b/addons/gdUnit4/src/asserts/GdUnitArrayAssertImpl.gd
@@ -113,76 +113,83 @@ func _array_div(compare_mode: GdObjects.COMPARE_MODE, left: Array[Variant], righ
 	return [not_expect, not_found]
 
 
-func _contains(expected: Variant, compare_mode: GdObjects.COMPARE_MODE) -> GdUnitArrayAssert:
-	if not _validate_value_type(expected):
-		return report_error("ERROR: expected value: <%s>\n is not a Array Type!" % GdObjects.typeof_as_string(expected))
+func _contains(expected: Array, compare_mode: GdObjects.COMPARE_MODE) -> GdUnitArrayAssert:
 	var by_reference := compare_mode == GdObjects.COMPARE_MODE.OBJECT_REFERENCE
 	var current_value: Variant = get_current_value()
+	var expected_value := _extract_variadic_value(expected)
+	if not _validate_value_type(expected_value):
+		return report_error("ERROR: expected value: <%s>\n is not a Array Type!" % GdObjects.typeof_as_string(expected_value))
+
 	if current_value == null:
-		return report_error(GdAssertMessages.error_arr_contains(current_value, expected, [], expected, by_reference))
+		return report_error(GdAssertMessages.error_arr_contains(current_value, expected_value, [], expected_value, by_reference))
 	@warning_ignore("unsafe_cast")
-	var diffs := _array_div(compare_mode, current_value as Array[Variant], expected as Array[Variant])
+	var diffs := _array_div(compare_mode, current_value as Array[Variant], expected_value)
 	#var not_expect := diffs[0] as Array
 	var not_found: Array = diffs[1]
 	if not not_found.is_empty():
-		return report_error(GdAssertMessages.error_arr_contains(current_value, expected, [], not_found, by_reference))
+		return report_error(GdAssertMessages.error_arr_contains(current_value, expected_value, [], not_found, by_reference))
 	return report_success()
 
 
-func _contains_exactly(expected: Variant, compare_mode: GdObjects.COMPARE_MODE) -> GdUnitArrayAssert:
-	if not _validate_value_type(expected):
-		return report_error("ERROR: expected value: <%s>\n is not a Array Type!" % GdObjects.typeof_as_string(expected))
+func _contains_exactly(expected: Array, compare_mode: GdObjects.COMPARE_MODE) -> GdUnitArrayAssert:
 	var current_value: Variant = get_current_value()
+	var expected_value := _extract_variadic_value(expected)
+	if not _validate_value_type(expected_value):
+		return report_error("ERROR: expected value: <%s>\n is not a Array Type!" % GdObjects.typeof_as_string(expected_value))
+
 	if current_value == null:
-		return report_error(GdAssertMessages.error_arr_contains_exactly(null, expected, [], expected, compare_mode))
+		return report_error(GdAssertMessages.error_arr_contains_exactly(null, expected_value, [], expected_value, compare_mode))
 	# has same content in same order
-	if _is_equal(current_value, expected, false, compare_mode):
+	if _is_equal(current_value, expected_value, false, compare_mode):
 		return report_success()
 	# check has same elements but in different order
-	if _is_equals_sorted(current_value, expected, false, compare_mode):
-		return report_error(GdAssertMessages.error_arr_contains_exactly(current_value, expected, [], [], compare_mode))
+	if _is_equals_sorted(current_value, expected_value, false, compare_mode):
+		return report_error(GdAssertMessages.error_arr_contains_exactly(current_value, expected_value, [], [], compare_mode))
 	# find the difference
 	@warning_ignore("unsafe_cast")
 	var diffs := _array_div(compare_mode,
 		current_value as Array[Variant],
-		expected as Array[Variant],
+		expected_value,
 		GdObjects.COMPARE_MODE.PARAMETER_DEEP_TEST)
 	var not_expect: Array[Variant] = diffs[0]
 	var not_found: Array[Variant] = diffs[1]
-	return report_error(GdAssertMessages.error_arr_contains_exactly(current_value, expected, not_expect, not_found, compare_mode))
+	return report_error(GdAssertMessages.error_arr_contains_exactly(current_value, expected_value, not_expect, not_found, compare_mode))
 
 
-func _contains_exactly_in_any_order(expected: Variant, compare_mode: GdObjects.COMPARE_MODE) -> GdUnitArrayAssert:
-	if not _validate_value_type(expected):
-		return report_error("ERROR: expected value: <%s>\n is not a Array Type!" % GdObjects.typeof_as_string(expected))
+func _contains_exactly_in_any_order(expected: Array, compare_mode: GdObjects.COMPARE_MODE) -> GdUnitArrayAssert:
 	var current_value: Variant = get_current_value()
+	var expected_value := _extract_variadic_value(expected)
+	if not _validate_value_type(expected_value):
+		return report_error("ERROR: expected value: <%s>\n is not a Array Type!" % GdObjects.typeof_as_string(expected_value))
+
 	if current_value == null:
-		return report_error(GdAssertMessages.error_arr_contains_exactly_in_any_order(current_value, expected, [], expected, compare_mode))
+		return report_error(GdAssertMessages.error_arr_contains_exactly_in_any_order(current_value, expected_value, [], expected_value, compare_mode))
 	# find the difference
 	@warning_ignore("unsafe_cast")
-	var diffs := _array_div(compare_mode, current_value as Array[Variant], expected as Array[Variant], false)
+	var diffs := _array_div(compare_mode, current_value as Array[Variant], expected_value, false)
 	var not_expect: Array[Variant] = diffs[0]
 	var not_found: Array[Variant] = diffs[1]
 	if not_expect.is_empty() and not_found.is_empty():
 		return report_success()
-	return report_error(GdAssertMessages.error_arr_contains_exactly_in_any_order(current_value, expected, not_expect, not_found, compare_mode))
+	return report_error(GdAssertMessages.error_arr_contains_exactly_in_any_order(current_value, expected_value, not_expect, not_found, compare_mode))
 
 
-func _not_contains(expected: Variant, compare_mode: GdObjects.COMPARE_MODE) -> GdUnitArrayAssert:
-	if not _validate_value_type(expected):
-		return report_error("ERROR: expected value: <%s>\n is not a Array Type!" % GdObjects.typeof_as_string(expected))
+func _not_contains(expected: Array, compare_mode: GdObjects.COMPARE_MODE) -> GdUnitArrayAssert:
 	var current_value: Variant = get_current_value()
+	var expected_value := _extract_variadic_value(expected)
+	if not _validate_value_type(expected_value):
+		return report_error("ERROR: expected value: <%s>\n is not a Array Type!" % GdObjects.typeof_as_string(expected_value))
 	if current_value == null:
-		return report_error(GdAssertMessages.error_arr_contains_exactly_in_any_order(current_value, expected, [], expected, compare_mode))
+		return report_error(GdAssertMessages.error_arr_contains_exactly_in_any_order(current_value, expected_value, [], expected_value, compare_mode))
 	@warning_ignore("unsafe_cast")
-	var diffs := _array_div(compare_mode, current_value as Array[Variant], expected as Array[Variant])
+	var diffs := _array_div(compare_mode, current_value as Array[Variant], expected_value)
 	var found: Array[Variant] = diffs[0]
 	@warning_ignore("unsafe_cast")
 	if found.size() == (current_value as Array).size():
 		return report_success()
 	@warning_ignore("unsafe_cast")
-	var diffs2 := _array_div(compare_mode, expected as Array[Variant], diffs[1] as Array[Variant])
-	return report_error(GdAssertMessages.error_arr_not_contains(current_value, expected, diffs2[0], compare_mode))
+	var diffs2 := _array_div(compare_mode, expected_value, diffs[1] as Array[Variant])
+	return report_error(GdAssertMessages.error_arr_not_contains(current_value, expected_value, diffs2[0], compare_mode))
 
 
 func is_null() -> GdUnitArrayAssert:
@@ -197,15 +204,16 @@ func is_not_null() -> GdUnitArrayAssert:
 	return self
 
 
-# Verifies that the current String is equal to the given one.
-func is_equal(expected: Variant) -> GdUnitArrayAssert:
-	if _type_check and not _validate_value_type(expected):
-		return report_error("ERROR: expected value: <%s>\n is not a Array Type!" % GdObjects.typeof_as_string(expected))
+func is_equal(...expected: Array) -> GdUnitArrayAssert:
 	var current_value: Variant = get_current_value()
-	if current_value == null and expected != null:
-		return report_error(GdAssertMessages.error_equal(null, expected))
-	if not _is_equal(current_value, expected):
-		var diff := _array_equals_div(current_value, expected)
+	var expected_value := _extract_variadic_value(expected)
+	if not _validate_value_type(expected_value):
+		return report_error("ERROR: expected value: <%s>\n is not a Array Type!" % GdObjects.typeof_as_string(expected_value))
+	if current_value == null and expected_value != null:
+		return report_error(GdAssertMessages.error_equal(null, expected_value))
+
+	if not _is_equal(current_value, expected_value):
+		var diff := _array_equals_div(current_value, expected_value)
 		var expected_as_list := GdArrayTools.as_string(diff[0], false)
 		var current_as_list := GdArrayTools.as_string(diff[1], false)
 		var index_report: Array = diff[2]
@@ -214,16 +222,18 @@ func is_equal(expected: Variant) -> GdUnitArrayAssert:
 
 
 # Verifies that the current Array is equal to the given one, ignoring case considerations.
-func is_equal_ignoring_case(expected: Variant) -> GdUnitArrayAssert:
-	if _type_check and not _validate_value_type(expected):
-		return report_error("ERROR: expected value: <%s>\n is not a Array Type!" % GdObjects.typeof_as_string(expected))
+func is_equal_ignoring_case(...expected: Array) -> GdUnitArrayAssert:
 	var current_value: Variant = get_current_value()
-	if current_value == null and expected != null:
+	var expected_value := _extract_variadic_value(expected)
+	if not _validate_value_type(expected_value):
+		return report_error("ERROR: expected value: <%s>\n is not a Array Type!" % GdObjects.typeof_as_string(expected_value))
+	if current_value == null and expected_value != null:
 		@warning_ignore("unsafe_cast")
-		return report_error(GdAssertMessages.error_equal(null, GdArrayTools.as_string(expected as Array)))
-	if not _is_equal(current_value, expected, true):
+		return report_error(GdAssertMessages.error_equal(null, GdArrayTools.as_string(expected_value)))
+
+	if not _is_equal(current_value, expected_value, true):
 		@warning_ignore("unsafe_cast")
-		var diff := _array_equals_div(current_value as Array[Variant], expected as Array[Variant], true)
+		var diff := _array_equals_div(current_value, expected_value, true)
 		var expected_as_list := GdArrayTools.as_string(diff[0])
 		var current_as_list := GdArrayTools.as_string(diff[1])
 		var index_report: Array = diff[2]
@@ -231,24 +241,28 @@ func is_equal_ignoring_case(expected: Variant) -> GdUnitArrayAssert:
 	return report_success()
 
 
-func is_not_equal(expected: Variant) -> GdUnitArrayAssert:
-	if not _validate_value_type(expected):
-		return report_error("ERROR: expected value: <%s>\n is not a Array Type!" % GdObjects.typeof_as_string(expected))
+func is_not_equal(...expected: Array) -> GdUnitArrayAssert:
 	var current_value: Variant = get_current_value()
-	if _is_equal(current_value, expected):
-		return report_error(GdAssertMessages.error_not_equal(current_value, expected))
+	var expected_value := _extract_variadic_value(expected)
+	if not _validate_value_type(expected_value):
+		return report_error("ERROR: expected value: <%s>\n is not a Array Type!" % GdObjects.typeof_as_string(expected_value))
+
+	if _is_equal(current_value, expected_value):
+		return report_error(GdAssertMessages.error_not_equal(current_value, expected_value))
 	return report_success()
 
 
-func is_not_equal_ignoring_case(expected: Variant) -> GdUnitArrayAssert:
-	if not _validate_value_type(expected):
-		return report_error("ERROR: expected value: <%s>\n is not a Array Type!" % GdObjects.typeof_as_string(expected))
+func is_not_equal_ignoring_case(...expected: Array) -> GdUnitArrayAssert:
 	var current_value: Variant = get_current_value()
-	if _is_equal(current_value, expected, true):
+	var expected_value := _extract_variadic_value(expected)
+	if not _validate_value_type(expected_value):
+		return report_error("ERROR: expected value: <%s>\n is not a Array Type!" % GdObjects.typeof_as_string(expected_value))
+
+	if _is_equal(current_value, expected_value, true):
 		@warning_ignore("unsafe_cast")
 		var c := GdArrayTools.as_string(current_value as Array)
 		@warning_ignore("unsafe_cast")
-		var e := GdArrayTools.as_string(expected as Array)
+		var e := GdArrayTools.as_string(expected_value)
 		return report_error(GdAssertMessages.error_not_equal_case_insensetiv(c, e))
 	return report_success()
 
@@ -298,35 +312,35 @@ func has_size(expected: int) -> GdUnitArrayAssert:
 	return report_success()
 
 
-func contains(expected: Variant) -> GdUnitArrayAssert:
+func contains(...expected: Array) -> GdUnitArrayAssert:
 	return _contains(expected, GdObjects.COMPARE_MODE.PARAMETER_DEEP_TEST)
 
 
-func contains_exactly(expected: Variant) -> GdUnitArrayAssert:
+func contains_exactly(...expected: Array) -> GdUnitArrayAssert:
 	return _contains_exactly(expected, GdObjects.COMPARE_MODE.PARAMETER_DEEP_TEST)
 
 
-func contains_exactly_in_any_order(expected: Variant) -> GdUnitArrayAssert:
+func contains_exactly_in_any_order(...expected: Array) -> GdUnitArrayAssert:
 	return _contains_exactly_in_any_order(expected, GdObjects.COMPARE_MODE.PARAMETER_DEEP_TEST)
 
 
-func contains_same(expected: Variant) -> GdUnitArrayAssert:
+func contains_same(...expected: Array) -> GdUnitArrayAssert:
 	return _contains(expected, GdObjects.COMPARE_MODE.OBJECT_REFERENCE)
 
 
-func contains_same_exactly(expected: Variant) -> GdUnitArrayAssert:
+func contains_same_exactly(...expected: Array) -> GdUnitArrayAssert:
 	return _contains_exactly(expected, GdObjects.COMPARE_MODE.OBJECT_REFERENCE)
 
 
-func contains_same_exactly_in_any_order(expected: Variant) -> GdUnitArrayAssert:
+func contains_same_exactly_in_any_order(...expected: Array) -> GdUnitArrayAssert:
 	return _contains_exactly_in_any_order(expected, GdObjects.COMPARE_MODE.OBJECT_REFERENCE)
 
 
-func not_contains(expected: Variant) -> GdUnitArrayAssert:
+func not_contains(...expected: Array) -> GdUnitArrayAssert:
 	return _not_contains(expected, GdObjects.COMPARE_MODE.PARAMETER_DEEP_TEST)
 
 
-func not_contains_same(expected: Variant) -> GdUnitArrayAssert:
+func not_contains_same(...expected: Array) -> GdUnitArrayAssert:
 	return _not_contains(expected, GdObjects.COMPARE_MODE.OBJECT_REFERENCE)
 
 
@@ -336,9 +350,9 @@ func is_instanceof(expected: Variant) -> GdUnitAssert:
 	return self
 
 
-func extract(func_name: String, args := Array()) -> GdUnitArrayAssert:
+func extract(func_name: String, ...func_args: Array) -> GdUnitArrayAssert:
 	var extracted_elements := Array()
-
+	var args := _extract_variadic_value(func_args)
 	var extractor := GdUnitFuncValueExtractor.new(func_name, args)
 	var current: Variant = get_current_value()
 	if current == null:
@@ -350,18 +364,7 @@ func extract(func_name: String, args := Array()) -> GdUnitArrayAssert:
 	return self
 
 
-func extractv(
-	extr0: GdUnitValueExtractor,
-	extr1: GdUnitValueExtractor = null,
-	extr2: GdUnitValueExtractor = null,
-	extr3: GdUnitValueExtractor = null,
-	extr4: GdUnitValueExtractor = null,
-	extr5: GdUnitValueExtractor = null,
-	extr6: GdUnitValueExtractor = null,
-	extr7: GdUnitValueExtractor = null,
-	extr8: GdUnitValueExtractor = null,
-	extr9: GdUnitValueExtractor = null) -> GdUnitArrayAssert:
-	var extractors: Variant = GdArrayTools.filter_value([extr0, extr1, extr2, extr3, extr4, extr5, extr6, extr7, extr8, extr9], null)
+func extractv(...extractors: Array) -> GdUnitArrayAssert:
 	var extracted_elements := Array()
 	var current: Variant = get_current_value()
 	if current == null:
@@ -380,17 +383,23 @@ func extractv(
 				GdUnitTuple.NO_ARG,
 				GdUnitTuple.NO_ARG
 			]
-			@warning_ignore("unsafe_cast")
-			for index: int in (extractors as Array).size():
+
+			for index: int in extractors.size():
 				var extractor: GdUnitValueExtractor = extractors[index]
 				ev[index] = extractor.extract_value(element)
-			@warning_ignore("unsafe_cast")
-			if (extractors as Array).size() > 1:
+			if extractors.size() > 1:
 				extracted_elements.append(GdUnitTuple.new(ev[0], ev[1], ev[2], ev[3], ev[4], ev[5], ev[6], ev[7], ev[8], ev[9]))
 			else:
 				extracted_elements.append(ev[0])
 		_current_value_provider = DefaultValueProvider.new(extracted_elements)
 	return self
+
+
+## Small helper to support the old expected arguments as single array and variadic arguments
+func _extract_variadic_value(values: Array) -> Array:
+	if values != null and values.size() == 1 and GdArrayTools.is_array_type(values[0]):
+		return values[0]
+	return values
 
 
 @warning_ignore("incompatible_ternary")

--- a/addons/gdUnit4/src/core/GdArrayTools.gd
+++ b/addons/gdUnit4/src/core/GdArrayTools.gd
@@ -14,11 +14,12 @@ const ARRAY_TYPES := [
 	TYPE_PACKED_STRING_ARRAY,
 	TYPE_PACKED_VECTOR2_ARRAY,
 	TYPE_PACKED_VECTOR3_ARRAY,
+	TYPE_PACKED_VECTOR4_ARRAY,
 	TYPE_PACKED_COLOR_ARRAY
 ]
 
 
-static func is_array_type(value :Variant) -> bool:
+static func is_array_type(value: Variant) -> bool:
 	return is_type_array(typeof(value))
 
 

--- a/addons/gdUnit4/test/asserts/GdUnitArrayAssertImplTest.gd
+++ b/addons/gdUnit4/test/asserts/GdUnitArrayAssertImplTest.gd
@@ -75,6 +75,49 @@ func test_is_equal() -> void:
 			.dedent().trim_prefix("\n"))
 
 
+func test_is_equal_variadic_args() -> void:
+	assert_array([1, 2, 3, 4, 2, 5]).is_equal(1, 2, 3, 4, 2, 5)
+	# should fail because the array not contains same elements and has diff size
+	assert_failure(func() -> void: assert_array([1, 2, 4, 5]).is_equal(1, 2, 3, 4, 2, 5)) \
+		.is_failed()
+	assert_failure(func() -> void: assert_array([1, 2, 3, 4, 5]).is_equal(1, 2, 3, 4)) \
+		.is_failed()
+	# current array is bigger than expected
+	assert_failure(func() -> void: assert_array([1, 2222, 3, 4, 5, 6]).is_equal(1, 2, 3, 4)) \
+		.is_failed() \
+		.has_message("""
+			Expecting:
+			 '[1,    2, 3, 4]'
+			 but was
+			 '[1, 2222, 3, 4, 5, 6]'
+
+			Differences found:
+			Index	Current	Expected	1	2222	2	4	5	<N/A>	5	6	<N/A>	"""
+			.dedent().trim_prefix("\n"))
+
+	# expected array is bigger than current
+	assert_failure(func() -> void: assert_array([1, 222, 3, 4]).is_equal(1, 2, 3, 4, 5, 6)) \
+		.is_failed() \
+		.has_message("""
+			Expecting:
+			 '[1,   2, 3, 4, 5, 6]'
+			 but was
+			 '[1, 222, 3, 4]'
+
+			Differences found:
+			Index	Current	Expected	1	222	2	4	<N/A>	5	5	<N/A>	6	"""
+			.dedent().trim_prefix("\n"))
+
+	assert_failure(func() -> void: assert_array(null).is_equal(1, 2, 3)) \
+		.is_failed() \
+		.has_message("""
+			Expecting:
+			 '[1, 2, 3]'
+			 but was
+			 '<null>'"""
+			.dedent().trim_prefix("\n"))
+
+
 func test_is_equal_big_arrays() -> void:
 	var expeted := Array()
 	expeted.resize(1000)
@@ -114,6 +157,21 @@ func test_is_equal_ignoring_case() -> void:
 			.dedent().trim_prefix("\n"))
 
 
+func test_is_equal_ignoring_case_variadic_args() -> void:
+	assert_array(["this", "is", "a", "message"]).is_equal_ignoring_case("This", "is", "a", "Message")
+	# should fail because the array not contains same elements
+	assert_failure(func() -> void: assert_array(["this", "is", "a", "message"]).is_equal_ignoring_case("This", "is", "an", "Message")) \
+		.is_failed()
+	assert_failure(func() -> void: assert_array(null).is_equal_ignoring_case(["This", "is"])) \
+		.is_failed() \
+		.has_message("""
+			Expecting:
+			 '["This", "is"]'
+			 but was
+			 '<null>'"""
+			.dedent().trim_prefix("\n"))
+
+
 func test_is_not_equal() -> void:
 	assert_array(null).is_not_equal([1, 2, 3])
 	assert_array([1, 2, 3, 4, 5]).is_not_equal([1, 2, 3, 4, 5, 6])
@@ -128,11 +186,39 @@ func test_is_not_equal() -> void:
 			.dedent().trim_prefix("\n"))
 
 
+func test_is_not_equal_variadic_args() -> void:
+	assert_array(null).is_not_equal(1, 2, 3)
+	assert_array([1, 2, 3, 4, 5]).is_not_equal(1, 2, 3, 4, 5, 6)
+	# should fail because the array  contains same elements
+	assert_failure(func() -> void: assert_array([1, 2, 3, 4, 5]).is_not_equal(1, 2, 3, 4, 5)) \
+		.is_failed() \
+		.has_message("""
+			Expecting:
+			 '[1, 2, 3, 4, 5]'
+			 not equal to
+			 '[1, 2, 3, 4, 5]'"""
+			.dedent().trim_prefix("\n"))
+
+
 func test_is_not_equal_ignoring_case() -> void:
 	assert_array(null).is_not_equal_ignoring_case(["This", "is", "an", "Message"])
 	assert_array(["this", "is", "a", "message"]).is_not_equal_ignoring_case(["This", "is", "an", "Message"])
 	# should fail because the array contains same elements ignoring case sensitive
 	assert_failure(func() -> void: assert_array(["this", "is", "a", "message"]).is_not_equal_ignoring_case(["This", "is", "a", "Message"])) \
+		.is_failed() \
+		.has_message("""
+			Expecting:
+			 '["This", "is", "a", "Message"]'
+			 not equal to (case insensitiv)
+			 '["this", "is", "a", "message"]'"""
+			.dedent().trim_prefix("\n"))
+
+
+func test_is_not_equal_ignoring_case_varadic_args() -> void:
+	assert_array(null).is_not_equal_ignoring_case("This", "is", "an", "Message")
+	assert_array(["this", "is", "a", "message"]).is_not_equal_ignoring_case("This", "is", "an", "Message")
+	# should fail because the array contains same elements ignoring case sensitive
+	assert_failure(func() -> void: assert_array(["this", "is", "a", "message"]).is_not_equal_ignoring_case("This", "is", "a", "Message")) \
 		.is_failed() \
 		.has_message("""
 			Expecting:
@@ -252,6 +338,49 @@ func test_contains() -> void:
 			.dedent().trim_prefix("\n"))
 
 
+func test_contains_variadic_args() -> void:
+	assert_array([1, 2, 3, 4, 5]).contains()
+	assert_array([1, 2, 3, 4, 5]).contains(5, 2)
+	assert_array([1, 2, 3, 4, 5]).contains(5, 4, 3, 2, 1)
+	var valueA := TestObj.new("A", 0)
+	var valueB := TestObj.new("B", 0)
+	assert_array([valueA, valueB]).contains(TestObj.new("A", 0))
+
+	# should fail because the array not contains 7 and 6
+	assert_failure(func() -> void: assert_array([1, 2, 3, 4, 5]).contains(2, 7, 6)) \
+		.is_failed() \
+		.has_message("""
+			Expecting contains elements:
+			 '[1, 2, 3, 4, 5]'
+			 do contains (in any order)
+			 '[2, 7, 6]'
+			but could not find elements:
+			 '[7, 6]'"""
+			.dedent().trim_prefix("\n"))
+
+	assert_failure(func() -> void: assert_array(null).contains(2, 7, 6)) \
+		.is_failed() \
+		.has_message("""
+			Expecting contains elements:
+			 '<null>'
+			 do contains (in any order)
+			 '[2, 7, 6]'
+			but could not find elements:
+			 '[2, 7, 6]'"""
+			.dedent().trim_prefix("\n"))
+
+	assert_failure(func() -> void: assert_array([valueA, valueB]).contains(TestObj.new("C", 0))) \
+		.is_failed() \
+		.has_message("""
+			Expecting contains elements:
+			 '[class:A, class:B]'
+			 do contains (in any order)
+			 '[class:C]'
+			but could not find elements:
+			 '[class:C]'"""
+			.dedent().trim_prefix("\n"))
+
+
 func test_contains_exactly() -> void:
 	assert_array([1, 2, 3, 4, 5]).contains_exactly([1, 2, 3, 4, 5])
 	var valueA := TestObj.new("A", 0)
@@ -306,6 +435,71 @@ func test_contains_exactly() -> void:
 			.dedent().trim_prefix("\n"))
 
 	assert_failure(func() -> void: assert_array([valueA, valueB]).contains_exactly([valueB, TestObj.new("A", 0)])) \
+		.is_failed() \
+		.has_message("""
+			Expecting contains exactly elements:
+			 '[class:A, class:B]'
+			 do contains (in same order)
+			 '[class:B, class:A]'
+			 but has different order at position '0'
+			 'class:A' vs 'class:B'"""
+		.dedent().trim_prefix("\n"))
+
+
+func test_contains_exactly_variadic_args() -> void:
+	assert_array([1, 2, 3, 4, 5]).contains_exactly(1, 2, 3, 4, 5)
+	var valueA := TestObj.new("A", 0)
+	var valueB := TestObj.new("B", 0)
+	assert_array([valueA, valueB]).contains_exactly(TestObj.new("A", 0), valueB)
+
+	# should fail because the array contains the same elements but in a different order
+	assert_failure(func() -> void: assert_array([1, 2, 3, 4, 5]).contains_exactly(1, 4, 3, 2, 5)) \
+		.is_failed() \
+		.has_message("""
+			Expecting contains exactly elements:
+			 '[1, 2, 3, 4, 5]'
+			 do contains (in same order)
+			 '[1, 4, 3, 2, 5]'
+			 but has different order at position '1'
+			 '2' vs '4'"""
+			.dedent().trim_prefix("\n"))
+
+	# should fail because the array contains more elements and in a different order
+	assert_failure(func() -> void: assert_array([1, 2, 3, 4, 5, 6, 7]).contains_exactly(1, 4, 3, 2, 5)) \
+		.is_failed() \
+		.has_message("""
+			Expecting contains exactly elements:
+			 '[1, 2, 3, 4, 5, 6, 7]'
+			 do contains (in same order)
+			 '[1, 4, 3, 2, 5]'
+			but some elements where not expected:
+			 '[6, 7]'"""
+			.dedent().trim_prefix("\n"))
+
+	# should fail because the array contains less elements and in a different order
+	assert_failure(func() -> void: assert_array([1, 2, 3, 4, 5]).contains_exactly(1, 4, 3, 2, 5, 6, 7)) \
+		.is_failed() \
+		.has_message("""
+			Expecting contains exactly elements:
+			 '[1, 2, 3, 4, 5]'
+			 do contains (in same order)
+			 '[1, 4, 3, 2, 5, 6, 7]'
+			but could not find elements:
+			 '[6, 7]'"""
+			.dedent().trim_prefix("\n"))
+
+	assert_failure(func() -> void: assert_array(null).contains_exactly(1, 4, 3)) \
+		.is_failed() \
+		.has_message("""
+			Expecting contains exactly elements:
+			 '<null>'
+			 do contains (in same order)
+			 '[1, 4, 3]'
+			but could not find elements:
+			 '[1, 4, 3]'"""
+			.dedent().trim_prefix("\n"))
+
+	assert_failure(func() -> void: assert_array([valueA, valueB]).contains_exactly(valueB, TestObj.new("A", 0))) \
 		.is_failed() \
 		.has_message("""
 			Expecting contains exactly elements:
@@ -378,6 +572,67 @@ func test_contains_exactly_in_any_order() -> void:
 			.dedent().trim_prefix("\n"))
 
 
+func test_contains_exactly_in_any_order_variadic_args() -> void:
+	assert_array([1, 2, 3, 4, 5]).contains_exactly_in_any_order(1, 2, 3, 4, 5)
+	assert_array([1, 2, 3, 4, 5]).contains_exactly_in_any_order(5, 3, 2, 4, 1)
+	assert_array([1, 2, 3, 4, 5]).contains_exactly_in_any_order(5, 1, 2, 4, 3)
+	var valueA := TestObj.new("A", 0)
+	var valueB := TestObj.new("B", 0)
+	assert_array([valueA, valueB]).contains_exactly_in_any_order(valueB, TestObj.new("A", 0))
+
+	# should fail because the array contains not exactly the same elements in any order
+	assert_failure(func() -> void: assert_array([1, 2, 6, 4, 5]).contains_exactly_in_any_order(5, 3, 2, 4, 1, 9, 10)) \
+		.is_failed() \
+		.has_message("""
+			Expecting contains exactly elements:
+			 '[1, 2, 6, 4, 5]'
+			 do contains exactly (in any order)
+			 '[5, 3, 2, 4, 1, 9, 10]'
+			but some elements where not expected:
+			 '[6]'
+			and could not find elements:
+			 '[3, 9, 10]'"""
+			.dedent().trim_prefix("\n"))
+
+	#should fail because the array contains the same elements but in a different order
+	assert_failure(func() -> void: assert_array([1, 2, 6, 9, 10, 4, 5]).contains_exactly_in_any_order(5, 3, 2, 4, 1)) \
+		.is_failed() \
+		.has_message("""
+			Expecting contains exactly elements:
+			 '[1, 2, 6, 9, 10, 4, 5]'
+			 do contains exactly (in any order)
+			 '[5, 3, 2, 4, 1]'
+			but some elements where not expected:
+			 '[6, 9, 10]'
+			and could not find elements:
+			 '[3]'"""
+			.dedent().trim_prefix("\n"))
+
+	assert_failure(func() -> void: assert_array(null).contains_exactly_in_any_order(1, 4, 3)) \
+		.is_failed() \
+		.has_message("""
+			Expecting contains exactly elements:
+			 '<null>'
+			 do contains exactly (in any order)
+			 '[1, 4, 3]'
+			but could not find elements:
+			 '[1, 4, 3]'"""
+			.dedent().trim_prefix("\n"))
+
+	assert_failure(func() -> void:  assert_array([valueA, valueB]).contains_exactly_in_any_order(valueB, TestObj.new("C", 0))) \
+		.is_failed() \
+		.has_message("""
+			Expecting contains exactly elements:
+			 '[class:A, class:B]'
+			 do contains exactly (in any order)
+			 '[class:B, class:C]'
+			but some elements where not expected:
+			 '[class:A]'
+			and could not find elements:
+			 '[class:C]'"""
+			.dedent().trim_prefix("\n"))
+
+
 func test_contains_same() -> void:
 	var valueA := TestObj.new("A", 0)
 	var valueB := TestObj.new("B", 0)
@@ -385,6 +640,24 @@ func test_contains_same() -> void:
 	assert_array([valueA, valueB]).contains_same([valueA])
 
 	assert_failure(func() -> void: assert_array([valueA, valueB]).contains_same([TestObj.new("A", 0)])) \
+		.is_failed() \
+		.has_message("""
+			Expecting contains SAME elements:
+			 '[class:A, class:B]'
+			 do contains (in any order)
+			 '[class:A]'
+			but could not find elements:
+			 '[class:A]'"""
+			.dedent().trim_prefix("\n"))
+
+
+func test_contains_same_variadic_args() -> void:
+	var valueA := TestObj.new("A", 0)
+	var valueB := TestObj.new("B", 0)
+
+	assert_array([valueA, valueB]).contains_same(valueA)
+
+	assert_failure(func() -> void: assert_array([valueA, valueB]).contains_same(TestObj.new("A", 0))) \
 		.is_failed() \
 		.has_message("""
 			Expecting contains SAME elements:
@@ -432,6 +705,25 @@ func test_contains_same_exactly_in_any_order() -> void:
 	assert_array([valueA, valueB]).contains_same_exactly_in_any_order([valueB, valueA])
 
 	assert_failure(func() -> void:  assert_array([valueA, valueB]).contains_same_exactly_in_any_order([valueB, TestObj.new("A", 0)])) \
+		.is_failed() \
+		.has_message("""
+			Expecting contains SAME exactly elements:
+			 '[class:A, class:B]'
+			 do contains exactly (in any order)
+			 '[class:B, class:A]'
+			but some elements where not expected:
+			 '[class:A]'
+			and could not find elements:
+			 '[class:A]'"""
+			.dedent().trim_prefix("\n"))
+
+
+func test_contains_same_exactly_in_any_order_variadic_args() -> void:
+	var valueA := TestObj.new("A", 0)
+	var valueB := TestObj.new("B", 0)
+	assert_array([valueA, valueB]).contains_same_exactly_in_any_order(valueB, valueA)
+
+	assert_failure(func() -> void:  assert_array([valueA, valueB]).contains_same_exactly_in_any_order(valueB, TestObj.new("A", 0))) \
 		.is_failed() \
 		.has_message("""
 			Expecting contains SAME exactly elements:
@@ -502,6 +794,63 @@ func test_not_contains() -> void:
 		)
 
 
+func test_not_contains_variadic_args() -> void:
+	assert_array([]).not_contains(0)
+	assert_array([1, 2, 3, 4, 5]).not_contains(0)
+	assert_array([1, 2, 3, 4, 5]).not_contains(0, 6)
+	var valueA := TestObj.new("A", 0)
+	var valueB := TestObj.new("B", 0)
+	assert_array([valueA, valueB]).not_contains(TestObj.new("C", 0))
+
+	assert_failure(func() -> void: assert_array([1, 2, 3, 4, 5]).not_contains(5))\
+		.is_failed() \
+		.has_message("""
+			Expecting:
+			 '[1, 2, 3, 4, 5]'
+			 do not contains
+			 '[5]'
+			 but found elements:
+			 '[5]'"""
+			.dedent().trim_prefix("\n")
+		)
+
+	assert_failure(func() -> void: assert_array([1, 2, 3, 4, 5]).not_contains(1, 4, 6)) \
+		.is_failed() \
+		.has_message("""
+			Expecting:
+			 '[1, 2, 3, 4, 5]'
+			 do not contains
+			 '[1, 4, 6]'
+			 but found elements:
+			 '[1, 4]'"""
+			.dedent().trim_prefix("\n")
+		)
+
+	assert_failure(func() -> void: assert_array([1, 2, 3, 4, 5]).not_contains(6, 4, 1)) \
+		.is_failed() \
+		.has_message("""
+			Expecting:
+			 '[1, 2, 3, 4, 5]'
+			 do not contains
+			 '[6, 4, 1]'
+			 but found elements:
+			 '[4, 1]'"""
+			.dedent().trim_prefix("\n")
+		)
+
+	assert_failure(func() -> void: assert_array([valueA, valueB]).not_contains(TestObj.new("A", 0))) \
+		.is_failed() \
+		.has_message("""
+			Expecting:
+			 '[class:A, class:B]'
+			 do not contains
+			 '[class:A]'
+			 but found elements:
+			 '[class:A]'"""
+			.dedent().trim_prefix("\n")
+		)
+
+
 func test_not_contains_same() -> void:
 	var valueA := TestObj.new("A", 0)
 	var valueB := TestObj.new("B", 0)
@@ -509,6 +858,25 @@ func test_not_contains_same() -> void:
 	assert_array([valueA, valueB]).not_contains_same([valueC])
 
 	assert_failure(func() -> void: assert_array([valueA, valueB]).not_contains_same([valueB])) \
+		.is_failed() \
+		.has_message("""
+			Expecting SAME:
+			 '[class:A, class:B]'
+			 do not contains
+			 '[class:B]'
+			 but found elements:
+			 '[class:B]'"""
+			.dedent().trim_prefix("\n")
+		)
+
+
+func test_not_contains_same_variadic_args() -> void:
+	var valueA := TestObj.new("A", 0)
+	var valueB := TestObj.new("B", 0)
+	var valueC := TestObj.new("B", 0)
+	assert_array([valueA, valueB]).not_contains_same(valueC)
+
+	assert_failure(func() -> void: assert_array([valueA, valueB]).not_contains_same(valueB)) \
 		.is_failed() \
 		.has_message("""
 			Expecting SAME:
@@ -548,22 +916,25 @@ func test_must_fail_has_invlalid_type() -> void:
 func test_extract() -> void:
 	# try to extract checked base types
 	assert_array([1, false, 3.14, null, Color.ALICE_BLUE]).extract("get_class") \
-		.contains_exactly(["n.a.", "n.a.", "n.a.", null, "n.a."])
+		.contains_exactly("n.a.", "n.a.", "n.a.", null, "n.a.")
 	# extracting by a func without arguments
 	assert_array([RefCounted.new(), 2, AStar3D.new(), auto_free(Node.new())]).extract("get_class") \
-		.contains_exactly(["RefCounted", "n.a.", "AStar3D", "Node"])
+		.contains_exactly("RefCounted", "n.a.", "AStar3D", "Node")
 	# extracting by a func with arguments
 	assert_array([RefCounted.new(), 2, AStar3D.new(), auto_free(Node.new())]).extract("has_signal", ["tree_entered"]) \
-		.contains_exactly([false, "n.a.", false, true])
+		.contains_exactly(false, "n.a.", false, true)
+	# extracting by a func with arguments using variadic syntax
+	assert_array([RefCounted.new(), 2, AStar3D.new(), auto_free(Node.new())]).extract("has_signal", "tree_entered") \
+		.contains_exactly(false, "n.a.", false, true)
 
 	# try extract checked object via a func that not exists
 	assert_array([RefCounted.new(), 2, AStar3D.new(), auto_free(Node.new())]).extract("invalid_func") \
-		.contains_exactly(["n.a.", "n.a.", "n.a.", "n.a."])
+		.contains_exactly("n.a.", "n.a.", "n.a.", "n.a.")
 	# try extract checked object via a func that has no return value
 	assert_array([RefCounted.new(), 2, AStar3D.new(), auto_free(Node.new())]).extract("remove_meta", [""]) \
-		.contains_exactly([null, "n.a.", null, null])
+		.contains_exactly(null, "n.a.", null, null)
 
-	assert_failure(func() -> void: assert_array(null).extract("get_class").contains_exactly(["AStar3D", "Node"])) \
+	assert_failure(func() -> void: assert_array(null).extract("get_class").contains_exactly("AStar3D", "Node")) \
 		.is_failed() \
 		.has_message("""
 			Expecting contains exactly elements:
@@ -573,7 +944,6 @@ func test_extract() -> void:
 			but could not find elements:
 			 '["AStar3D", "Node"]'"""
 			.dedent().trim_prefix("\n"))
-
 
 
 class TestObj:
@@ -630,20 +1000,20 @@ func test_extractv() -> void:
 	# single extract
 	assert_array([1, false, 3.14, null, Color.ALICE_BLUE])\
 		.extractv(extr("get_class"))\
-		.contains_exactly(["n.a.", "n.a.", "n.a.", null, "n.a."])
+		.contains_exactly("n.a.", "n.a.", "n.a.", null, "n.a.")
 	# tuple of two
 	assert_array([TestObj.new("A", 10), TestObj.new("B", "foo"), Color.ALICE_BLUE, TestObj.new("C", 11)])\
 		.extractv(extr("get_name"), extr("get_value"))\
-		.contains_exactly([tuple("A", 10), tuple("B", "foo"), tuple("n.a.", "n.a."), tuple("C", 11)])
+		.contains_exactly(tuple("A", 10), tuple("B", "foo"), tuple("n.a.", "n.a."), tuple("C", 11))
 	# tuple of three
 	assert_array([TestObj.new("A", 10), TestObj.new("B", "foo", "bar"), TestObj.new("C", 11, 42)])\
 		.extractv(extr("get_name"), extr("get_value"), extr("get_x"))\
-		.contains_exactly([tuple("A", 10, null), tuple("B", "foo", "bar"), tuple("C", 11, 42)])
+		.contains_exactly(tuple("A", 10, null), tuple("B", "foo", "bar"), tuple("C", 11, 42))
 
 	assert_failure(func() -> void:
 			assert_array(null) \
 				.extractv(extr("get_name"), extr("get_value"), extr("get_x")) \
-				.contains_exactly([tuple("A", 10, null), tuple("B", "foo", "bar"), tuple("C", 11, 42)])) \
+				.contains_exactly(tuple("A", 10, null), tuple("B", "foo", "bar"), tuple("C", 11, 42))) \
 		.is_failed() \
 		.has_message("""
 			Expecting contains exactly elements:
@@ -666,13 +1036,13 @@ func test_extractv_chained_func() -> void:
 
 	assert_array([obj_a, obj_b, obj_c, obj_x, obj_y])\
 		.extractv(extr("get_name"), extr("get_value.get_name"))\
-		.contains_exactly([
+		.contains_exactly(
 			tuple("A", "root_a"),
 			tuple("B", "root_a"),
 			tuple("C", "root_a"),
 			tuple("X", "root_b"),
 			tuple("Y", "root_b")
-			])
+			)
 
 
 func test_extract_chained_func() -> void:
@@ -686,13 +1056,13 @@ func test_extract_chained_func() -> void:
 
 	assert_array([obj_a, obj_b, obj_c, obj_x, obj_y])\
 		.extract("get_value.get_name")\
-		.contains_exactly([
+		.contains_exactly(
 			"root_a",
 			"root_a",
 			"root_a",
 			"root_b",
 			"root_b",
-			])
+			)
 
 
 func test_extractv_max_args() -> void:
@@ -708,10 +1078,10 @@ func test_extractv_max_args() -> void:
 			extr("get_x7"),
 			extr("get_x8"),
 			extr("get_x9"))\
-		.contains_exactly([
+		.contains_exactly(
 			tuple("A", "x1", "x2", "x3", "x4", "x5", "x6", "x7", "x8", "x9"),
 			tuple("B", "x1", "x2", "x3", "x4", "x5", "x6", "x7", "x8", "x9"),
-			tuple("C", "x1", "x2", "x3", "x4", "x5", "x6", "x7", "x8", "x9")])
+			tuple("C", "x1", "x2", "x3", "x4", "x5", "x6", "x7", "x8", "x9"))
 
 
 func test_override_failure_message() -> void:
@@ -786,7 +1156,7 @@ func test_contains_exactly_stuck() -> void:
 		.add_child(ExampleTestClass.new())
 	# this test was stuck and ends after a while into an aborted test case
 	# https://github.com/MikeSchulze/gdUnit3/issues/244
-	assert_failure(func() -> void: assert_array([example_a, example_b]).contains_exactly([example_a, example_b, example_a]))\
+	assert_failure(func() -> void: assert_array([example_a, example_b]).contains_exactly(example_a, example_b, example_a))\
 		.is_failed()
 	# manual free because of cross references
 	example_a.dispose()


### PR DESCRIPTION
# Why
Before, Godot 4.5 has no support for variadic function arguments, and we have to use arrays as arguments to define the expected values.

# What
- Extend the `assert_array` to allow variadic function arguments
- temporary disable until https://github.com/Scony/godot-gdscript-toolkit/issues/399 is fixed