### PR TITLE
GD-904: Add variadic argument support to `assert_dict`

### DIFF
--- a/addons/gdUnit4/src/GdUnitDictionaryAssert.gd
+++ b/addons/gdUnit4/src/GdUnitDictionaryAssert.gd
@@ -51,7 +51,7 @@ extends GdUnitAssert
 
 ## Verifies that the current dictionary contains the given key(s).[br]
 ## The keys are compared by deep parameter comparision, for object reference compare you have to use [method contains_same_keys]
-@abstract func contains_keys(expected: Array) -> GdUnitDictionaryAssert
+@abstract func contains_keys(...expected: Array) -> GdUnitDictionaryAssert
 
 
 ## Verifies that the current dictionary contains the given key and value.[br]
@@ -61,7 +61,7 @@ extends GdUnitAssert
 
 ## Verifies that the current dictionary not contains the given key(s).[br]
 ## The keys are compared by deep parameter comparision, for object reference compare you have to use [method not_contains_same_keys]
-@abstract func not_contains_keys(expected: Array) -> GdUnitDictionaryAssert
+@abstract func not_contains_keys(...expected: Array) -> GdUnitDictionaryAssert
 
 
 ## Verifies that the current dictionary contains the given key(s).[br]
@@ -76,4 +76,4 @@ extends GdUnitAssert
 
 ## Verifies that the current dictionary not contains the given key(s).
 ## The keys are compared by object reference, for deep parameter comparision use [method not_contains_keys]
-@abstract func not_contains_same_keys(expected: Array) -> GdUnitDictionaryAssert
+@abstract func not_contains_same_keys(...expected: Array) -> GdUnitDictionaryAssert

--- a/addons/gdUnit4/src/asserts/GdUnitDictionaryAssertImpl.gd
+++ b/addons/gdUnit4/src/asserts/GdUnitDictionaryAssertImpl.gd
@@ -127,16 +127,17 @@ func has_size(expected: int) -> GdUnitDictionaryAssert:
 	return report_success()
 
 
-func _contains_keys(expected :Array, compare_mode :GdObjects.COMPARE_MODE) -> GdUnitDictionaryAssert:
+func _contains_keys(expected: Array, compare_mode: GdObjects.COMPARE_MODE) -> GdUnitDictionaryAssert:
 	var current :Variant = current_value()
+	var expected_value: Array = _extract_variadic_value(expected)
 	if current == null:
 		return report_error(GdAssertMessages.error_is_not_null())
 	# find expected keys
 	@warning_ignore("unsafe_cast")
-	var keys_not_found :Array = expected.filter(_filter_by_key.bind((current as Dictionary).keys(), compare_mode))
+	var keys_not_found :Array = expected_value.filter(_filter_by_key.bind((current as Dictionary).keys(), compare_mode))
 	if not keys_not_found.is_empty():
 		@warning_ignore("unsafe_cast")
-		return report_error(GdAssertMessages.error_contains_keys((current as Dictionary).keys() as Array, expected, keys_not_found, compare_mode))
+		return report_error(GdAssertMessages.error_contains_keys((current as Dictionary).keys() as Array, expected_value, keys_not_found, compare_mode))
 	return report_success()
 
 
@@ -154,18 +155,19 @@ func _contains_key_value(key :Variant, value :Variant, compare_mode :GdObjects.C
 	return report_success()
 
 
-func _not_contains_keys(expected :Array, compare_mode :GdObjects.COMPARE_MODE) -> GdUnitDictionaryAssert:
+func _not_contains_keys(expected: Array, compare_mode: GdObjects.COMPARE_MODE) -> GdUnitDictionaryAssert:
 	var current :Variant = current_value()
+	var expected_value: Array = _extract_variadic_value(expected)
 	if current == null:
 		return report_error(GdAssertMessages.error_is_not_null())
 	var dict_current: Dictionary = current
-	var keys_found :Array = dict_current.keys().filter(_filter_by_key.bind(expected, compare_mode, true))
+	var keys_found :Array = dict_current.keys().filter(_filter_by_key.bind(expected_value, compare_mode, true))
 	if not keys_found.is_empty():
-		return report_error(GdAssertMessages.error_not_contains_keys(dict_current.keys() as Array, expected, keys_found, compare_mode))
+		return report_error(GdAssertMessages.error_not_contains_keys(dict_current.keys() as Array, expected_value, keys_found, compare_mode))
 	return report_success()
 
 
-func contains_keys(expected :Array) -> GdUnitDictionaryAssert:
+func contains_keys(...expected: Array) -> GdUnitDictionaryAssert:
 	return _contains_keys(expected, GdObjects.COMPARE_MODE.PARAMETER_DEEP_TEST)
 
 
@@ -173,7 +175,7 @@ func contains_key_value(key :Variant, value :Variant) -> GdUnitDictionaryAssert:
 	return _contains_key_value(key, value, GdObjects.COMPARE_MODE.PARAMETER_DEEP_TEST)
 
 
-func not_contains_keys(expected :Array) -> GdUnitDictionaryAssert:
+func not_contains_keys(...expected: Array) -> GdUnitDictionaryAssert:
 	return _not_contains_keys(expected, GdObjects.COMPARE_MODE.PARAMETER_DEEP_TEST)
 
 
@@ -185,7 +187,7 @@ func contains_same_key_value(key :Variant, value :Variant) -> GdUnitDictionaryAs
 	return _contains_key_value(key, value, GdObjects.COMPARE_MODE.OBJECT_REFERENCE)
 
 
-func not_contains_same_keys(expected :Array) -> GdUnitDictionaryAssert:
+func not_contains_same_keys(...expected: Array) -> GdUnitDictionaryAssert:
 	return _not_contains_keys(expected, GdObjects.COMPARE_MODE.OBJECT_REFERENCE)
 
 
@@ -194,3 +196,11 @@ func _filter_by_key(element :Variant, values :Array, compare_mode :GdObjects.COM
 		if GdObjects.equals(key, element, false, compare_mode):
 			return is_not
 	return !is_not
+
+
+## Small helper to support the old expected arguments as single array and variadic arguments
+func _extract_variadic_value(values: Variant) -> Variant:
+	@warning_ignore("unsafe_method_access")
+	if values != null and values.size() == 1 and GdArrayTools.is_array_type(values[0]):
+		return values[0]
+	return values

--- a/addons/gdUnit4/test/asserts/GdUnitDictionaryAssertImplTest.gd
+++ b/addons/gdUnit4/test/asserts/GdUnitDictionaryAssertImplTest.gd
@@ -310,6 +310,57 @@ func test_contains_keys() -> void:
 			.dedent().trim_prefix("\n"))
 
 
+func test_contains_keys_variadic_args() -> void:
+	var key_a := TestObj.new()
+	var key_b := TestObj.new()
+	var key_c := TestObj.new()
+	var key_d := TestObj.new("D")
+
+	assert_dict({1:1, 2:2, 3:3}).contains_keys(2)
+	assert_dict({1:1, 2:2, "key_a": "value_a"}).contains_keys(2, "key_a")
+	assert_dict({key_a:1, key_b:2, key_c:3}).contains_keys(key_a, key_b)
+	assert_dict({key_a:1, key_c:3 }).contains_keys(key_b)
+	assert_dict({key_a:1, 3:3}).contains_keys(key_a, key_b)
+
+	assert_failure(func() -> void: assert_dict({1:1, 3:3}).contains_keys(2)) \
+		.is_failed() \
+		.has_message("""
+			Expecting contains keys:
+			 '[1, 3]'
+			 to contains:
+			 '[2]'
+			 but can't find key's:
+			 '[2]'"""
+			.dedent()
+			.trim_prefix("\n")
+		)
+	assert_failure(func() -> void: assert_dict({1:1, 3:3}).contains_keys(1, 4)) \
+		.is_failed() \
+		.has_message("""
+			Expecting contains keys:
+			 '[1, 3]'
+			 to contains:
+			 '[1, 4]'
+			 but can't find key's:
+			 '[4]'"""
+			.dedent()
+			.trim_prefix("\n")
+		)
+	assert_failure(func() -> void: assert_dict(null).contains_keys(1, 4)) \
+		.is_failed() \
+		.has_message("Expecting: not to be '<null>'")
+	assert_failure(func() -> void: assert_dict({key_a:1, 3:3}).contains_keys(key_a, key_d)) \
+		.is_failed() \
+		.has_message("""
+			 Expecting contains keys:
+			  '[class:Foo:0, 3]'
+			  to contains:
+			  '[class:Foo:0, class:D:0]'
+			  but can't find key's:
+			  '[class:D:0]'"""
+			.dedent().trim_prefix("\n"))
+
+
 func test_contains_key_value() -> void:
 	assert_dict({1:1}).contains_key_value(1, 1)
 	assert_dict({1:1, 2:2, 3:3}).contains_key_value(3, 3).contains_key_value(1, 1)
@@ -359,6 +410,40 @@ func test_not_contains_keys() -> void:
 			.trim_prefix("\n")
 		)
 	assert_failure(func() -> void: assert_dict(null).not_contains_keys([1, 4])) \
+		.is_failed() \
+		.has_message("Expecting: not to be '<null>'")
+
+
+func test_not_contains_keys_variadic_args() -> void:
+	assert_dict({}).not_contains_keys(2)
+	assert_dict({1:1, 3:3}).not_contains_keys(2)
+	assert_dict({1:1, 3:3}).not_contains_keys(2, 4)
+
+	assert_failure(func() -> void: assert_dict({1:1, 2:2, 3:3}).not_contains_keys(2, 4)) \
+		.is_failed() \
+		.has_message("""
+			Expecting NOT contains keys:
+			 '[1, 2, 3]'
+			 do not contains:
+			 '[2, 4]'
+			 but contains key's:
+			 '[2]'"""
+			.dedent()
+			.trim_prefix("\n")
+		)
+	assert_failure(func() -> void: assert_dict({1:1, 2:2, 3:3}).not_contains_keys(1, 2, 3, 4)) \
+		.is_failed() \
+		.has_message("""
+			Expecting NOT contains keys:
+			 '[1, 2, 3]'
+			 do not contains:
+			 '[1, 2, 3, 4]'
+			 but contains key's:
+			 '[1, 2, 3]'"""
+			.dedent()
+			.trim_prefix("\n")
+		)
+	assert_failure(func() -> void: assert_dict(null).not_contains_keys(1, 4)) \
 		.is_failed() \
 		.has_message("Expecting: not to be '<null>'")
 
@@ -428,6 +513,28 @@ func test_not_contains_same_keys() -> void:
 	assert_dict({key_a:1, key_b:2}).not_contains_same_keys([key_c, key_d])
 
 	assert_failure(func() -> void: assert_dict({key_a:1, key_b:2}).not_contains_same_keys([key_c, key_b])) \
+		.is_failed() \
+		.has_message("""
+			Expecting NOT contains SAME keys
+			 '[class:A:0, class:B:0]'
+			 do not contains:
+			 '[class:C:0, class:B:0]'
+			 but contains key's:
+			 '[class:B:0]'"""
+			.dedent().trim_prefix("\n")
+		)
+
+
+func test_not_contains_same_keys_variadic_args() -> void:
+	var key_a := TestObj.new("A")
+	var key_b := TestObj.new("B")
+	var key_c := TestObj.new("C")
+	var key_d := TestObj.new("A")
+
+	assert_dict({}).not_contains_same_keys(key_a)
+	assert_dict({key_a:1, key_b:2}).not_contains_same_keys(key_c, key_d)
+
+	assert_failure(func() -> void: assert_dict({key_a:1, key_b:2}).not_contains_same_keys(key_c, key_b)) \
 		.is_failed() \
 		.has_message("""
 			Expecting NOT contains SAME keys


### PR DESCRIPTION
# Why
Before, Godot 4.5 has no support for variadic function arguments, and we have to use arrays as arguments to define the expected values.

# What
- Extend the `assert_dict` to allow variadic function arguments

