### PR TITLE
GD-902: Fix `simulate_action_press` shows Godot error Input singleton…

### DIFF
--- a/addons/gdUnit4/src/GdUnitSceneRunner.gd
+++ b/addons/gdUnit4/src/GdUnitSceneRunner.gd
@@ -1,7 +1,7 @@
 ## The Scene Runner is a tool used for simulating interactions on a scene.
 ## With this tool, you can simulate input events such as keyboard or mouse input and/or simulate scene processing over a certain number of frames.
 ## This tool is typically used for integration testing a scene.
-class_name GdUnitSceneRunner
+@abstract class_name GdUnitSceneRunner
 extends RefCounted
 
 const NO_ARG = GdUnitConstants.NO_ARG
@@ -9,23 +9,20 @@ const NO_ARG = GdUnitConstants.NO_ARG
 
 ## Simulates that an action has been pressed.[br]
 ## [member action] : the action e.g. [code]"ui_up"[/code][br]
-@warning_ignore("unused_parameter")
-func simulate_action_pressed(action: String) -> GdUnitSceneRunner:
-	return self
+## [member event_index] : [url=https://docs.godotengine.org/en/4.4/classes/class_inputeventaction.html#class-inputeventaction-property-event-index]default=-1[/url][br]
+@abstract func simulate_action_pressed(action: String, event_index := -1) -> GdUnitSceneRunner
 
 
 ## Simulates that an action is pressed.[br]
 ## [member action] : the action e.g. [code]"ui_up"[/code][br]
-@warning_ignore("unused_parameter")
-func simulate_action_press(action: String) -> GdUnitSceneRunner:
-	return self
+## [member event_index] : [url=https://docs.godotengine.org/en/4.4/classes/class_inputeventaction.html#class-inputeventaction-property-event-index]default=-1[/url][br]
+@abstract func simulate_action_press(action: String, event_index := -1) -> GdUnitSceneRunner
 
 
 ## Simulates that an action has been released.[br]
 ## [member action] : the action e.g. [code]"ui_up"[/code][br]
-@warning_ignore("unused_parameter")
-func simulate_action_release(action: String) -> GdUnitSceneRunner:
-	return self
+## [member event_index] : [url=https://docs.godotengine.org/en/4.4/classes/class_inputeventaction.html#class-inputeventaction-property-event-index]default=-1[/url][br]
+@abstract func simulate_action_release(action: String, event_index := -1) -> GdUnitSceneRunner
 
 
 ## Simulates that a key has been pressed.[br]

--- a/addons/gdUnit4/src/core/GdUnitSceneRunnerImpl.gd
+++ b/addons/gdUnit4/src/core/GdUnitSceneRunnerImpl.gd
@@ -108,32 +108,28 @@ func _scene_tree() -> SceneTree:
 
 
 @warning_ignore("return_value_discarded")
-func simulate_action_pressed(action: String) -> GdUnitSceneRunner:
-	simulate_action_press(action)
-	simulate_action_release(action)
+func simulate_action_pressed(action: String, event_index := -1) -> GdUnitSceneRunner:
+	simulate_action_press(action, event_index)
+	simulate_action_release(action, event_index)
 	return self
 
 
-func simulate_action_press(action: String) -> GdUnitSceneRunner:
+func simulate_action_press(action: String, event_index := -1) -> GdUnitSceneRunner:
 	__print_current_focus()
 	var event := InputEventAction.new()
 	event.pressed = true
 	event.action = action
-	if Engine.get_version_info().hex >= 0x40300:
-		@warning_ignore("unsafe_property_access")
-		event.event_index = InputMap.get_actions().find(action)
+	event.event_index = event_index
 	_action_on_press.append(action)
 	return _handle_input_event(event)
 
 
-func simulate_action_release(action: String) -> GdUnitSceneRunner:
+func simulate_action_release(action: String, event_index := -1) -> GdUnitSceneRunner:
 	__print_current_focus()
 	var event := InputEventAction.new()
 	event.pressed = false
 	event.action = action
-	if Engine.get_version_info().hex >= 0x40300:
-		@warning_ignore("unsafe_property_access")
-		event.event_index = InputMap.get_actions().find(action)
+	event.event_index = event_index
 	_action_on_press.erase(action)
 	return _handle_input_event(event)
 


### PR DESCRIPTION
… does not support more than 32 events assigned to an action

# Why
Invoking scene runner's simulate_action_press with an action deep within Godot's action map produces errors.

# What
- Convert `GdUnitSceneRunner` to abstract class
- Extent functions by new default `event_index` parameter
  - simulate_action_pressed
  - simulate_action_press
  - simulate_action_release
- Sets the `event.event_index` by given `event_index` parameter or default -1
