### PR TITLE
TASK-924: Convert `GdUnitSceneRunner` to abstract class

### DIFF
--- a/addons/gdUnit4/src/GdUnitSceneRunner.gd
+++ b/addons/gdUnit4/src/GdUnitSceneRunner.gd
@@ -4,8 +4,6 @@
 @abstract class_name GdUnitSceneRunner
 extends RefCounted
 
-const NO_ARG = GdUnitConstants.NO_ARG
-
 
 ## Simulates that an action has been pressed.[br]
 ## [member action] : the action e.g. [code]"ui_up"[/code][br]
@@ -34,59 +32,44 @@ const NO_ARG = GdUnitConstants.NO_ARG
 ##       var runner = scene_runner("res://scenes/simple_scene.tscn")
 ##       await runner.simulate_key_pressed(KEY_SPACE)
 ## [/codeblock]
-@warning_ignore("unused_parameter")
-func simulate_key_pressed(key_code: int, shift_pressed := false, ctrl_pressed := false) -> GdUnitSceneRunner:
-	await (Engine.get_main_loop() as SceneTree).process_frame
-	return self
+@abstract func simulate_key_pressed(key_code: int, shift_pressed := false, ctrl_pressed := false) -> GdUnitSceneRunner
 
 
 ## Simulates that a key is pressed.[br]
 ## [member key_code] : the key code e.g. [constant KEY_ENTER][br]
 ## [member shift_pressed] : false by default set to true if simmulate shift is press[br]
 ## [member ctrl_pressed] : false by default set to true if simmulate control is press[br]
-@warning_ignore("unused_parameter")
-func simulate_key_press(key_code: int, shift_pressed := false, ctrl_pressed := false) -> GdUnitSceneRunner:
-	return self
+@abstract func simulate_key_press(key_code: int, shift_pressed := false, ctrl_pressed := false) -> GdUnitSceneRunner
 
 
 ## Simulates that a key has been released.[br]
 ## [member key_code] : the key code e.g. [constant KEY_ENTER][br]
 ## [member shift_pressed] : false by default set to true if simmulate shift is press[br]
 ## [member ctrl_pressed] : false by default set to true if simmulate control is press[br]
-@warning_ignore("unused_parameter")
-func simulate_key_release(key_code: int, shift_pressed := false, ctrl_pressed := false) -> GdUnitSceneRunner:
-	return self
+@abstract func simulate_key_release(key_code: int, shift_pressed := false, ctrl_pressed := false) -> GdUnitSceneRunner
 
 
 ## Sets the mouse cursor to given position relative to the viewport.
 ## @deprecated: Use [set_mouse_position] instead.
-@warning_ignore("unused_parameter")
-func set_mouse_pos(position: Vector2) -> GdUnitSceneRunner:
-	return self
+@abstract func set_mouse_pos(position: Vector2) -> GdUnitSceneRunner
 
 
 ## Sets the mouse position to the specified vector, provided in pixels and relative to an origin at the upper left corner of the currently focused Window Manager game window.[br]
 ## [member position] : The absolute position in pixels as Vector2
-@warning_ignore("unused_parameter")
-func set_mouse_position(position: Vector2) -> GdUnitSceneRunner:
-	return self
+@abstract func set_mouse_position(position: Vector2) -> GdUnitSceneRunner
 
 
 ## Returns the mouse's position in this Viewport using the coordinate system of this Viewport.
-func get_mouse_position() -> Vector2:
-	return Vector2.ZERO
+@abstract func get_mouse_position() -> Vector2
 
 
 ## Gets the current global mouse position of the current window
-func get_global_mouse_position() -> Vector2:
-	return Vector2.ZERO
+@abstract func get_global_mouse_position() -> Vector2
 
 
 ## Simulates a mouse moved to final position.[br]
 ## [member position] : The final mouse position
-@warning_ignore("unused_parameter")
-func simulate_mouse_move(position: Vector2) -> GdUnitSceneRunner:
-	return self
+@abstract func simulate_mouse_move(position: Vector2) -> GdUnitSceneRunner
 
 
 ## Simulates a mouse move to the relative coordinates (offset).[br]
@@ -100,10 +83,7 @@ func simulate_mouse_move(position: Vector2) -> GdUnitSceneRunner:
 ##       var runner = scene_runner("res://scenes/simple_scene.tscn")
 ##       await runner.simulate_mouse_move_relative(Vector2(100,100))
 ## [/codeblock]
-@warning_ignore("unused_parameter")
-func simulate_mouse_move_relative(relative: Vector2, time: float = 1.0, trans_type: Tween.TransitionType = Tween.TRANS_LINEAR) -> GdUnitSceneRunner:
-	await (Engine.get_main_loop() as SceneTree).process_frame
-	return self
+@abstract func simulate_mouse_move_relative(relative: Vector2, time: float = 1.0, trans_type: Tween.TransitionType = Tween.TRANS_LINEAR) -> GdUnitSceneRunner
 
 
 ## Simulates a mouse move to the absolute coordinates.[br]
@@ -117,59 +97,44 @@ func simulate_mouse_move_relative(relative: Vector2, time: float = 1.0, trans_ty
 ##       var runner = scene_runner("res://scenes/simple_scene.tscn")
 ##       await runner.simulate_mouse_move_absolute(Vector2(100,100))
 ## [/codeblock]
-@warning_ignore("unused_parameter")
-func simulate_mouse_move_absolute(position: Vector2, time: float = 1.0, trans_type: Tween.TransitionType = Tween.TRANS_LINEAR) -> GdUnitSceneRunner:
-	await (Engine.get_main_loop() as SceneTree).process_frame
-	return self
+@abstract func simulate_mouse_move_absolute(position: Vector2, time: float = 1.0, trans_type: Tween.TransitionType = Tween.TRANS_LINEAR) -> GdUnitSceneRunner
 
 
 ## Simulates a mouse button pressed.[br]
 ## [member button_index] : The mouse button identifier, one of the [enum MouseButton] or button wheel constants.
 ## [member double_click] : Set to true to simulate a double-click
-@warning_ignore("unused_parameter")
-func simulate_mouse_button_pressed(button_index: MouseButton, double_click := false) -> GdUnitSceneRunner:
-	return self
+@abstract func simulate_mouse_button_pressed(button_index: MouseButton, double_click := false) -> GdUnitSceneRunner
 
 
 ## Simulates a mouse button press (holding)[br]
 ## [member button_index] : The mouse button identifier, one of the [enum MouseButton] or button wheel constants.
 ## [member double_click] : Set to true to simulate a double-click
-@warning_ignore("unused_parameter")
-func simulate_mouse_button_press(button_index: MouseButton, double_click := false) -> GdUnitSceneRunner:
-	return self
+@abstract func simulate_mouse_button_press(button_index: MouseButton, double_click := false) -> GdUnitSceneRunner
 
 
 ## Simulates a mouse button released.[br]
 ## [member button_index] : The mouse button identifier, one of the [enum MouseButton] or button wheel constants.
-@warning_ignore("unused_parameter")
-func simulate_mouse_button_release(button_index: MouseButton) -> GdUnitSceneRunner:
-	return self
+@abstract func simulate_mouse_button_release(button_index: MouseButton) -> GdUnitSceneRunner
 
 
 ## Simulates a screen touch is pressed.[br]
 ## [member index] : The touch index in the case of a multi-touch event.[br]
 ## [member position] : The position to touch the screen.[br]
 ## [member double_tap] : If true, the touch's state is a double tab.
-@warning_ignore("unused_parameter")
-func simulate_screen_touch_pressed(index: int, position: Vector2, double_tap := false) -> GdUnitSceneRunner:
-	return self
+@abstract func simulate_screen_touch_pressed(index: int, position: Vector2, double_tap := false) -> GdUnitSceneRunner
 
 
 ## Simulates a screen touch press without releasing it immediately, effectively simulating a "hold" action.[br]
 ## [member index] : The touch index in the case of a multi-touch event.[br]
 ## [member position] : The position to touch the screen.[br]
 ## [member double_tap] : If true, the touch's state is a double tab.
-@warning_ignore("unused_parameter")
-func simulate_screen_touch_press(index: int, position: Vector2, double_tap := false) -> GdUnitSceneRunner:
-	return self
+@abstract func simulate_screen_touch_press(index: int, position: Vector2, double_tap := false) -> GdUnitSceneRunner
 
 
 ## Simulates a screen touch is released.[br]
 ## [member index] : The touch index in the case of a multi-touch event.[br]
 ## [member double_tap] : If true, the touch's state is a double tab.
-@warning_ignore("unused_parameter")
-func simulate_screen_touch_release(index: int, double_tap := false) -> GdUnitSceneRunner:
-	return self
+@abstract func simulate_screen_touch_release(index: int, double_tap := false) -> GdUnitSceneRunner
 
 
 ## Simulates a touch drag and drop event to a relative position.[br]
@@ -187,10 +152,7 @@ func simulate_screen_touch_release(index: int, double_tap := false) -> GdUnitSce
 ##       # and drop it at final at 150,50  relative (50,50 + 100,0)
 ##       await runner.simulate_screen_touch_drag_relative(1, Vector2(100,0))
 ## [/codeblock]
-@warning_ignore("unused_parameter")
-func simulate_screen_touch_drag_relative(index: int, relative: Vector2, time: float = 1.0, trans_type: Tween.TransitionType = Tween.TRANS_LINEAR) -> GdUnitSceneRunner:
-	await (Engine.get_main_loop() as SceneTree).process_frame
-	return self
+@abstract func simulate_screen_touch_drag_relative(index: int, relative: Vector2, time: float = 1.0, trans_type: Tween.TransitionType = Tween.TRANS_LINEAR) -> GdUnitSceneRunner
 
 
 ## Simulates a touch screen drop to the absolute coordinates (offset).[br]
@@ -208,10 +170,7 @@ func simulate_screen_touch_drag_relative(index: int, relative: Vector2, time: fl
 ##       # and drop it at 100,50
 ##       await runner.simulate_screen_touch_drag_absolute(1, Vector2(100,50))
 ## [/codeblock]
-@warning_ignore("unused_parameter")
-func simulate_screen_touch_drag_absolute(index: int, position: Vector2, time: float = 1.0, trans_type: Tween.TransitionType = Tween.TRANS_LINEAR) -> GdUnitSceneRunner:
-	await (Engine.get_main_loop() as SceneTree).process_frame
-	return self
+@abstract func simulate_screen_touch_drag_absolute(index: int, position: Vector2, time: float = 1.0, trans_type: Tween.TransitionType = Tween.TRANS_LINEAR) -> GdUnitSceneRunner
 
 
 ## Simulates a complete drag and drop event from one position to another.[br]
@@ -229,91 +188,47 @@ func simulate_screen_touch_drag_absolute(index: int, position: Vector2, time: fl
 ##       # start drag at position 50,50 and drop it at 100,50
 ##       await runner.simulate_screen_touch_drag_drop(1, Vector2(50, 50), Vector2(100,50))
 ## [/codeblock]
-@warning_ignore("unused_parameter")
-func simulate_screen_touch_drag_drop(index: int, position: Vector2, drop_position: Vector2, time: float = 1.0, trans_type: Tween.TransitionType = Tween.TRANS_LINEAR) -> GdUnitSceneRunner:
-	await (Engine.get_main_loop() as SceneTree).process_frame
-	return self
+@abstract func simulate_screen_touch_drag_drop(index: int, position: Vector2, drop_position: Vector2, time: float = 1.0, trans_type: Tween.TransitionType = Tween.TRANS_LINEAR) -> GdUnitSceneRunner
 
 
 ## Simulates a touch screen drag event to given position.[br]
 ## [member index] : The touch index in the case of a multi-touch event.[br]
 ## [member position] : The drag start position, indicating the drag position.[br]
-@warning_ignore("unused_parameter")
-func simulate_screen_touch_drag(index: int, position: Vector2) -> GdUnitSceneRunner:
-	return self
+@abstract func simulate_screen_touch_drag(index: int, position: Vector2) -> GdUnitSceneRunner
 
 
 ## Returns the actual position of the touchscreen drag position by given index.
 ## [member index] : The touch index in the case of a multi-touch event.[br]
-@warning_ignore("unused_parameter")
-func get_screen_touch_drag_position(index: int) -> Vector2:
-	return Vector2.ZERO
+@abstract func get_screen_touch_drag_position(index: int) -> Vector2
 
 
 ## Sets how fast or slow the scene simulation is processed (clock ticks versus the real).[br]
 ## It defaults to 1.0. A value of 2.0 means the game moves twice as fast as real life,
 ## whilst a value of 0.5 means the game moves at half the regular speed.
-
-
-## Sets the time factor for the scene simulation.
 ## [member time_factor] : A float representing the simulation speed.[br]
 ## - Default is 1.0, meaning the simulation runs at normal speed.[br]
 ## - A value of 2.0 means the simulation runs twice as fast as real time.[br]
 ## - A value of 0.5 means the simulation runs at half the regular speed.[br]
-@warning_ignore("unused_parameter")
-func set_time_factor(time_factor: float = 1.0) -> GdUnitSceneRunner:
-	return self
+@abstract func set_time_factor(time_factor: float = 1.0) -> GdUnitSceneRunner
 
 
 ## Simulates scene processing for a certain number of frames.[br]
 ## [member frames] : amount of frames to process[br]
 ## [member delta_milli] : the time delta between a frame in milliseconds
-@warning_ignore("unused_parameter")
-func simulate_frames(frames: int, delta_milli: int = -1) -> GdUnitSceneRunner:
-	await (Engine.get_main_loop() as SceneTree).process_frame
-	return self
+@abstract func simulate_frames(frames: int, delta_milli: int = -1) -> GdUnitSceneRunner
 
 
 ## Simulates scene processing until the given signal is emitted by the scene.[br]
 ## [member signal_name] : the signal to stop the simulation[br]
 ## [member args] : optional signal arguments to be matched for stop[br]
-@warning_ignore("unused_parameter")
-func simulate_until_signal(
-	signal_name: String,
-	arg0: Variant = NO_ARG,
-	arg1: Variant = NO_ARG,
-	arg2: Variant = NO_ARG,
-	arg3: Variant = NO_ARG,
-	arg4: Variant = NO_ARG,
-	arg5: Variant = NO_ARG,
-	arg6: Variant = NO_ARG,
-	arg7: Variant = NO_ARG,
-	arg8: Variant = NO_ARG,
-	arg9: Variant = NO_ARG) -> GdUnitSceneRunner:
-	await (Engine.get_main_loop() as SceneTree).process_frame
-	return self
+@abstract func simulate_until_signal(signal_name: String, ...args: Array) -> GdUnitSceneRunner
 
 
 ## Simulates scene processing until the given signal is emitted by the given object.[br]
 ## [member source] : the object that should emit the signal[br]
 ## [member signal_name] : the signal to stop the simulation[br]
 ## [member args] : optional signal arguments to be matched for stop
-@warning_ignore("unused_parameter")
-func simulate_until_object_signal(
-	source: Object,
-	signal_name: String,
-	arg0: Variant = NO_ARG,
-	arg1: Variant = NO_ARG,
-	arg2: Variant = NO_ARG,
-	arg3: Variant = NO_ARG,
-	arg4: Variant = NO_ARG,
-	arg5: Variant = NO_ARG,
-	arg6: Variant = NO_ARG,
-	arg7: Variant = NO_ARG,
-	arg8: Variant = NO_ARG,
-	arg9: Variant = NO_ARG) -> GdUnitSceneRunner:
-	await (Engine.get_main_loop() as SceneTree).process_frame
-	return self
+@abstract func simulate_until_object_signal(source: Object, signal_name: String, ...args: Array) -> GdUnitSceneRunner
 
 
 ## Waits for all input events to be processed by flushing any buffered input events
@@ -328,11 +243,7 @@ func simulate_until_object_signal(
 ## [codeblock]
 ## 	await await_input_processed()  # Ensure all inputs are processed before continuing
 ## [/codeblock]
-func await_input_processed() -> void:
-	if scene() != null and scene().process_mode != Node.PROCESS_MODE_DISABLED:
-		Input.flush_buffered_events()
-	await (Engine.get_main_loop() as SceneTree).process_frame
-	await (Engine.get_main_loop() as SceneTree).physics_frame
+@abstract func await_input_processed() -> void
 
 
 ## The await_func function pauses execution until a specified function in the scene returns a value.[br]
@@ -345,10 +256,7 @@ func await_input_processed() -> void:
 ## 	# Waits for 'calculate_score' function and verifies the result is equal to 100.
 ## 	await_func("calculate_score").is_equal(100)
 ## [/codeblock]
-@warning_ignore("unused_parameter")
-func await_func(func_name: String, args := []) -> GdUnitFuncAssert:
-	return null
-
+@abstract func await_func(func_name: String, ...args: Array) -> GdUnitFuncAssert
 
 
 ## The await_func_on function extends the functionality of await_func by allowing you to specify a source node within the scene.[br]
@@ -363,19 +271,14 @@ func await_func(func_name: String, args := []) -> GdUnitFuncAssert:
 ## 	var my_instance := ScoreCalculator.new()
 ## 	await_func(my_instance, "calculate_score").is_equal(100)
 ## [/codeblock]
-@warning_ignore("unused_parameter")
-func await_func_on(source: Object, func_name: String, args := []) -> GdUnitFuncAssert:
-	return null
+@abstract func await_func_on(source: Object, func_name: String, ...args: Array) -> GdUnitFuncAssert
 
 
 ## Waits for the specified signal to be emitted by the scene. If the signal is not emitted within the given timeout, the operation fails.[br]
 ## [member signal_name] : The name of the signal to wait for[br]
 ## [member args] : The signal arguments as an array[br]
 ## [member timeout] : The maximum duration (in milliseconds) to wait for the signal to be emitted before failing
-@warning_ignore("unused_parameter")
-func await_signal(signal_name: String, args := [], timeout := 2000 ) -> void:
-	await (Engine.get_main_loop() as SceneTree).process_frame
-	pass
+@abstract func await_signal(signal_name: String, args := [], timeout := 2000 ) -> void
 
 
 ## Waits for the specified signal to be emitted by a particular source node. If the signal is not emitted within the given timeout, the operation fails.[br]
@@ -383,69 +286,40 @@ func await_signal(signal_name: String, args := [], timeout := 2000 ) -> void:
 ## [member signal_name] : The name of the signal to wait for[br]
 ## [member args] : The signal arguments as an array[br]
 ## [member timeout] : tThe maximum duration (in milliseconds) to wait for the signal to be emitted before failing
-@warning_ignore("unused_parameter")
-func await_signal_on(source: Object, signal_name: String, args := [], timeout := 2000 ) -> void:
-	pass
+@abstract func await_signal_on(source: Object, signal_name: String, args := [], timeout := 2000 ) -> void
 
 
 ## Restores the scene window to a windowed mode and brings it to the foreground.[br]
 ## This ensures that the scene is visible and active during testing, making it easier to observe and interact with.
-func move_window_to_foreground() -> GdUnitSceneRunner:
-	return self
-
-
-## Restores the scene window to a windowed mode and brings it to the foreground.[br]
-## This ensures that the scene is visible and active during testing, making it easier to observe and interact with.
-## @deprecated: Use [move_window_to_foreground] instead.
-func maximize_view() -> GdUnitSceneRunner:
-	return self
+@abstract func move_window_to_foreground() -> GdUnitSceneRunner
 
 
 ## Return the current value of the property with the name <name>.[br]
 ## [member name] : name of property[br]
 ## [member return] : the value of the property
-@warning_ignore("unused_parameter")
-func get_property(name: String) -> Variant:
-	return null
+@abstract func get_property(name: String) -> Variant
+
 
 ## Set the  value <value> of the property with the name <name>.[br]
 ## [member name] : name of property[br]
 ## [member value] : value of property[br]
 ## [member return] : true|false depending on valid property name.
-@warning_ignore("unused_parameter")
-func set_property(name: String, value: Variant) -> bool:
-	return false
+@abstract func set_property(name: String, value: Variant) -> bool
 
 
 ## executes the function specified by <name> in the scene and returns the result.[br]
 ## [member name] : the name of the function to execute[br]
 ## [member args] : optional function arguments[br]
 ## [member return] : the function result
-@warning_ignore("unused_parameter")
-func invoke(
-	name: String,
-	arg0: Variant = NO_ARG,
-	arg1: Variant = NO_ARG,
-	arg2: Variant = NO_ARG,
-	arg3: Variant = NO_ARG,
-	arg4: Variant = NO_ARG,
-	arg5: Variant = NO_ARG,
-	arg6: Variant = NO_ARG,
-	arg7: Variant = NO_ARG,
-	arg8: Variant = NO_ARG,
-	arg9: Variant = NO_ARG) -> Variant:
-	return null
+@abstract func invoke(name: String, ...args: Array) -> Variant
 
 
 ## Searches for the specified node with the name in the current scene and returns it, otherwise null.[br]
 ## [member name] : the name of the node to find[br]
 ## [member recursive] : enables/disables seraching recursive[br]
 ## [member return] : the node if find otherwise null
-@warning_ignore("unused_parameter")
-func find_child(name: String, recursive: bool = true, owned: bool = false) -> Node:
-	return null
+@abstract func find_child(name: String, recursive: bool = true, owned: bool = false) -> Node
 
 
 ## Access to current running scene
-func scene() -> Node:
-	return null
+@abstract func scene() -> Node

--- a/addons/gdUnit4/src/core/GdUnitSceneRunnerImpl.gd
+++ b/addons/gdUnit4/src/core/GdUnitSceneRunnerImpl.gd
@@ -107,6 +107,13 @@ func _scene_tree() -> SceneTree:
 	return Engine.get_main_loop() as SceneTree
 
 
+func await_input_processed() -> void:
+	if scene() != null and scene().process_mode != Node.PROCESS_MODE_DISABLED:
+		Input.flush_buffered_events()
+	await (Engine.get_main_loop() as SceneTree).process_frame
+	await (Engine.get_main_loop() as SceneTree).physics_frame
+
+
 @warning_ignore("return_value_discarded")
 func simulate_action_pressed(action: String, event_index := -1) -> GdUnitSceneRunner:
 	simulate_action_press(action, event_index)
@@ -411,46 +418,21 @@ func simulate_frames(frames: int, delta_milli: int = -1) -> GdUnitSceneRunner:
 	return self
 
 
-func simulate_until_signal(
-	signal_name: String,
-	arg0: Variant = NO_ARG,
-	arg1: Variant = NO_ARG,
-	arg2: Variant = NO_ARG,
-	arg3: Variant = NO_ARG,
-	arg4: Variant = NO_ARG,
-	arg5: Variant = NO_ARG,
-	arg6: Variant = NO_ARG,
-	arg7: Variant = NO_ARG,
-	arg8: Variant = NO_ARG,
-	arg9: Variant = NO_ARG) -> GdUnitSceneRunner:
-	var args: Array = GdArrayTools.filter_value([arg0,arg1,arg2,arg3,arg4,arg5,arg6,arg7,arg8,arg9], NO_ARG)
+func simulate_until_signal(signal_name: String, ...args: Array) -> GdUnitSceneRunner:
 	await _awaiter.await_signal_idle_frames(scene(), signal_name, args, 10000)
 	return self
 
 
-func simulate_until_object_signal(
-	source: Object,
-	signal_name: String,
-	arg0: Variant = NO_ARG,
-	arg1: Variant = NO_ARG,
-	arg2: Variant = NO_ARG,
-	arg3: Variant = NO_ARG,
-	arg4: Variant = NO_ARG,
-	arg5: Variant = NO_ARG,
-	arg6: Variant = NO_ARG,
-	arg7: Variant = NO_ARG,
-	arg8: Variant = NO_ARG,
-	arg9: Variant = NO_ARG) -> GdUnitSceneRunner:
-	var args: Array = GdArrayTools.filter_value([arg0,arg1,arg2,arg3,arg4,arg5,arg6,arg7,arg8,arg9], NO_ARG)
+func simulate_until_object_signal(source: Object, signal_name: String, ...args: Array) -> GdUnitSceneRunner:
 	await _awaiter.await_signal_idle_frames(source, signal_name, args, 10000)
 	return self
 
 
-func await_func(func_name: String, args := []) -> GdUnitFuncAssert:
+func await_func(func_name: String, ...args: Array) -> GdUnitFuncAssert:
 	return GdUnitFuncAssertImpl.new(scene(), func_name, args)
 
 
-func await_func_on(instance: Object, func_name: String, args := []) -> GdUnitFuncAssert:
+func await_func_on(instance: Object, func_name: String, ...args: Array) -> GdUnitFuncAssert:
 	return GdUnitFuncAssertImpl.new(instance, func_name, args)
 
 
@@ -462,7 +444,7 @@ func await_signal_on(source: Object, signal_name: String, args := [], timeout :=
 	await _awaiter.await_signal_on(source, signal_name, args, timeout)
 
 
-func maximize_view() -> GdUnitSceneRunner:
+func move_window_to_foreground() -> GdUnitSceneRunner:
 	DisplayServer.window_set_mode(DisplayServer.WINDOW_MODE_WINDOWED)
 	DisplayServer.window_move_to_foreground()
 	return self
@@ -486,19 +468,7 @@ func set_property(name: String, value: Variant) -> bool:
 	return true
 
 
-func invoke(
-	name: String,
-	arg0: Variant = NO_ARG,
-	arg1: Variant = NO_ARG,
-	arg2: Variant = NO_ARG,
-	arg3: Variant = NO_ARG,
-	arg4: Variant = NO_ARG,
-	arg5: Variant = NO_ARG,
-	arg6: Variant = NO_ARG,
-	arg7: Variant = NO_ARG,
-	arg8: Variant = NO_ARG,
-	arg9: Variant = NO_ARG) -> Variant:
-	var args: Array = GdArrayTools.filter_value([arg0,arg1,arg2,arg3,arg4,arg5,arg6,arg7,arg8,arg9], NO_ARG)
+func invoke(name: String, ...args: Array) -> Variant:
 	if scene().has_method(name):
 		return await scene().callv(name, args)
 	return "The method '%s' not exist checked loaded scene." % name

--- a/addons/gdUnit4/test/core/GdUnitSceneRunnerInputEventTest.gd
+++ b/addons/gdUnit4/test/core/GdUnitSceneRunnerInputEventTest.gd
@@ -1,3 +1,4 @@
+@warning_ignore_start("redundant_await")
 # GdUnit generated TestSuite
 extends GdUnitTestSuite
 
@@ -804,7 +805,7 @@ func test_simulate_screen_touch_gesture_zoom_out() -> void:
 
 
 func test_text_input_processing() -> void:
-	_runner.maximize_view()
+	_runner.move_window_to_foreground()
 	var lineEdit := _runner.find_child("TextInput") as LineEdit
 
 	# Focus the text input and clear any existing content

--- a/addons/gdUnit4/test/core/GdUnitSceneRunnerTest.gd
+++ b/addons/gdUnit4/test/core/GdUnitSceneRunnerTest.gd
@@ -1,4 +1,5 @@
 # GdUnit generated TestSuite
+@warning_ignore_start("redundant_await")
 class_name GdUnitSceneRunnerTest
 extends GdUnitTestSuite
 
@@ -204,7 +205,7 @@ func test_await_signal_without_time_factor() -> void:
 		# should be interrupted is will never change to Color.KHAKI
 		await assert_failure_await(func x() -> void: await runner.await_signal( "panel_color_change", [box1, Color.KHAKI], 300))
 	).has_message("await_signal_on(panel_color_change, [%s, %s]) timed out after 300ms" % [str(box1), str(Color.KHAKI)])\
-		.has_line(205)
+		.has_line(206)
 
 
 func test_await_signal_with_time_factor() -> void:
@@ -221,7 +222,7 @@ func test_await_signal_with_time_factor() -> void:
 		# should be interrupted is will never change to Color.KHAKI
 		await assert_failure_await(func x() -> void: await runner.await_signal("panel_color_change", [box1, Color.KHAKI], 30))
 	).has_message("await_signal_on(panel_color_change, [%s, %s]) timed out after 30ms" % [str(box1), str(Color.KHAKI)])\
-		.has_line(222)
+		.has_line(223)
 
 
 func test_simulate_until_signal() -> void:


### PR DESCRIPTION
# Why
The GdUnit4 Scene Runner API faked interfaces to represent a small class with class documentation without overloaded implementation code. With Godot 4.5, GDScript now supports abstract classes and functions, so we should switch to that.

# What
- Convert it to abstract class
- Convert all functions to abstarct
- Removing deprecated func `maximize_view` using `move_window_to_foreground` instead
- Using variadic args on
  - simulate_until_signal
  - simulate_until_object_signal
  - await_func
