### PR TITLE
TASK-924: Convert GdUnitSceneRunner to abstract class

### DIFF
--- a/addons/gdUnit4/src/GdUnitSceneRunner.gd
+++ b/addons/gdUnit4/src/GdUnitSceneRunner.gd
@@ -49,11 +49,6 @@ extends RefCounted
 @abstract func simulate_key_release(key_code: int, shift_pressed := false, ctrl_pressed := false) -> GdUnitSceneRunner
 
 
-## Sets the mouse cursor to given position relative to the viewport.
-## @deprecated: Use [set_mouse_position] instead.
-@abstract func set_mouse_pos(position: Vector2) -> GdUnitSceneRunner
-
-
 ## Sets the mouse position to the specified vector, provided in pixels and relative to an origin at the upper left corner of the currently focused Window Manager game window.[br]
 ## [member position] : The absolute position in pixels as Vector2
 @abstract func set_mouse_position(position: Vector2) -> GdUnitSceneRunner

--- a/addons/gdUnit4/src/core/GdUnitSceneRunnerImpl.gd
+++ b/addons/gdUnit4/src/core/GdUnitSceneRunnerImpl.gd
@@ -179,10 +179,6 @@ func simulate_key_release(key_code: int, shift_pressed := false, ctrl_pressed :=
 	return _handle_input_event(event)
 
 
-func set_mouse_pos(pos: Vector2) -> GdUnitSceneRunner:
-	return set_mouse_position(pos)
-
-
 func set_mouse_position(pos: Vector2) -> GdUnitSceneRunner:
 	var event := InputEventMouseMotion.new()
 	event.position = pos
@@ -282,7 +278,7 @@ func simulate_screen_touch_pressed(index: int, position: Vector2, double_tap := 
 func simulate_screen_touch_press(index: int, position: Vector2, double_tap := false) -> GdUnitSceneRunner:
 	if is_emulate_mouse_from_touch():
 		# we need to simulate in addition to the touch the mouse events
-		set_mouse_pos(position)
+		set_mouse_position(position)
 		simulate_mouse_button_press(MOUSE_BUTTON_LEFT)
 	# push touch press event at position
 	var event := InputEventScreenTouch.new()


### PR DESCRIPTION
# What
- remove deprecated method `set_mouse_pos` should use now `set_mouse_position`

