### PR TITLE
GD-914,GD-893: Fix move_window_to_foreground

### DIFF
--- a/addons/gdUnit4/src/GdUnitSceneRunner.gd
+++ b/addons/gdUnit4/src/GdUnitSceneRunner.gd
@@ -289,6 +289,11 @@ extends RefCounted
 @abstract func move_window_to_foreground() -> GdUnitSceneRunner
 
 
+## Minimizes the scene window to a windowed mode and brings it to the background.[br]
+## This ensures that the scene is hidden during testing.
+@abstract func move_window_to_background() -> GdUnitSceneRunner
+
+
 ## Return the current value of the property with the name <name>.[br]
 ## [member name] : name of property[br]
 ## [member return] : the value of the property

--- a/addons/gdUnit4/src/core/GdUnitSceneRunnerImpl.gd
+++ b/addons/gdUnit4/src/core/GdUnitSceneRunnerImpl.gd
@@ -82,7 +82,8 @@ func _init(p_scene: Variant, p_verbose: bool, p_hide_push_errors := false) -> vo
 	)
 	_simulate_start_time = LocalTime.now()
 	# we need to set inital a valid window otherwise the warp_mouse() is not handled
-	DisplayServer.window_set_mode(DisplayServer.WINDOW_MODE_WINDOWED)
+	move_window_to_foreground()
+
 	# set inital mouse pos to 0,0
 	var max_iteration_to_wait := 0
 	while get_global_mouse_position() != Vector2.ZERO and max_iteration_to_wait < 100:
@@ -95,6 +96,7 @@ func _notification(what: int) -> void:
 		# reset time factor to normal
 		__deactivate_time_factor()
 		if is_instance_valid(_current_scene):
+			move_window_to_background()
 			_scene_tree().root.remove_child(_current_scene)
 			# do only free scenes instanciated by this runner
 			if _scene_auto_free:
@@ -441,8 +443,16 @@ func await_signal_on(source: Object, signal_name: String, args := [], timeout :=
 
 
 func move_window_to_foreground() -> GdUnitSceneRunner:
-	DisplayServer.window_set_mode(DisplayServer.WINDOW_MODE_WINDOWED)
-	DisplayServer.window_move_to_foreground()
+	if not Engine.is_embedded_in_editor():
+		DisplayServer.window_set_mode(DisplayServer.WINDOW_MODE_WINDOWED)
+		DisplayServer.window_move_to_foreground()
+	return self
+
+
+func move_window_to_background() -> GdUnitSceneRunner:
+	if not Engine.is_embedded_in_editor():
+		DisplayServer.window_set_mode(DisplayServer.WINDOW_MODE_WINDOWED)
+		DisplayServer.window_set_mode(DisplayServer.WINDOW_MODE_MINIMIZED)
 	return self
 
 

--- a/addons/gdUnit4/src/core/execution/stages/GdUnitTestSuiteAfterStage.gd
+++ b/addons/gdUnit4/src/core/execution/stages/GdUnitTestSuiteAfterStage.gd
@@ -25,4 +25,5 @@ func _execute(context :GdUnitExecutionContext) -> void:
 	# Guard that checks if all doubled (spy/mock) objects are released
 	await GdUnitClassDoubler.check_leaked_instances()
 	# we hide the scene/main window after runner is finished
-	DisplayServer.window_set_mode(DisplayServer.WINDOW_MODE_MINIMIZED)
+	if not Engine.is_embedded_in_editor():
+		DisplayServer.window_set_mode(DisplayServer.WINDOW_MODE_MINIMIZED)

--- a/addons/gdUnit4/src/core/runners/GdUnitTestRunner.gd
+++ b/addons/gdUnit4/src/core/runners/GdUnitTestRunner.gd
@@ -8,9 +8,9 @@ extends "res://addons/gdUnit4/src/core/runners/GdUnitTestSessionRunner.gd"
 ## - Messages to report progress[br]
 ## - Events to report test results[br]
 
-
 ## The TCP client used to connect to the GdUnit server
 @onready var _client: GdUnitTcpClient = $GdUnitTcpClient
+@onready var _version_label: Control = %Version
 
 
 func _init() -> void:
@@ -21,6 +21,7 @@ func _init() -> void:
 
 func _ready() -> void:
 	super()
+	GdUnit4Version.init_version_label(_version_label)
 
 	var config_result := _runner_config.load_config()
 	if config_result.is_error():

--- a/addons/gdUnit4/src/core/runners/GdUnitTestRunner.tscn
+++ b/addons/gdUnit4/src/core/runners/GdUnitTestRunner.tscn
@@ -8,3 +8,27 @@ script = ExtResource("1")
 
 [node name="GdUnitTcpClient" type="Node" parent="."]
 script = ExtResource("2")
+
+[node name="HBoxContainer" type="HBoxContainer" parent="."]
+custom_minimum_size = Vector2(0, 24)
+layout_direction = 2
+anchors_preset = 12
+anchor_top = 1.0
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 0
+size_flags_horizontal = 3
+size_flags_vertical = 10
+alignment = 2
+
+[node name="Version" type="RichTextLabel" parent="HBoxContainer"]
+unique_name_in_owner = true
+custom_minimum_size = Vector2(128, 0)
+layout_mode = 2
+size_flags_horizontal = 10
+bbcode_enabled = true
+scroll_active = false
+shortcut_keys_enabled = false
+horizontal_alignment = 1
+justification_flags = 0

--- a/addons/gdUnit4/src/core/runners/GdUnitTestSessionRunner.gd
+++ b/addons/gdUnit4/src/core/runners/GdUnitTestSessionRunner.gd
@@ -80,12 +80,13 @@ enum {
 }
 
 func _init() -> void:
-	# minimize scene window checked debug mode
 	if OS.get_cmdline_args().size() == 1:
 		DisplayServer.window_set_title("GdUnit4 Runner (Debug Mode)")
 	else:
 		DisplayServer.window_set_title("GdUnit4 Runner (Release Mode)")
-	DisplayServer.window_set_mode(DisplayServer.WINDOW_MODE_MINIMIZED)
+	if not Engine.is_embedded_in_editor():
+		# minimize scene window checked debug mode
+		DisplayServer.window_set_mode(DisplayServer.WINDOW_MODE_MINIMIZED)
 	# store current runner instance to engine meta data to can be access in as a singleton
 	Engine.set_meta(GDUNIT_RUNNER, self)
 

--- a/addons/gdUnit4/test/core/GdUnitSceneRunnerTest.gd
+++ b/addons/gdUnit4/test/core/GdUnitSceneRunnerTest.gd
@@ -462,10 +462,11 @@ func test_move_window_to_foreground() -> void:
 	runner.move_window_to_background()
 	await runner.simulate_frames(1)
 	if not Engine.is_embedded_in_editor():
-		assert_that(DisplayServer.window_get_mode()).is_equal(DisplayServer.WINDOW_MODE_MINIMIZED)
+		# We need a workaround because of https://github.com/godotengine/godot/issues/111119
+		var expecetd_mode := DisplayServer.WINDOW_MODE_WINDOWED if OS.get_name() == "Linux" else DisplayServer.WINDOW_MODE_WINDOWED
+		assert_that(DisplayServer.window_get_mode()).is_equal(expecetd_mode)
 	else:
 		assert_that(DisplayServer.window_get_mode()).is_equal(DisplayServer.WINDOW_MODE_WINDOWED)
-
 	# force window to foreground
 	runner.move_window_to_foreground()
 	await runner.simulate_frames(1)

--- a/addons/gdUnit4/test/core/GdUnitSceneRunnerTest.gd
+++ b/addons/gdUnit4/test/core/GdUnitSceneRunnerTest.gd
@@ -429,7 +429,6 @@ func test_touch_drag_and_drop_absolute() -> void:
 func test_touch_drag_and_drop() -> void:
 	var spy_scene :Variant = spy("res://addons/gdUnit4/test/core/resources/scenes/drag_and_drop/DragAndDropTestScene.tscn")
 	var runner := scene_runner(spy_scene)
-
 	var slot_left :TextureRect = $"/root/DragAndDropScene/left/TextureRect"
 	var slot_right :TextureRect = $"/root/DragAndDropScene/right/TextureRect"
 	var drag_start := slot_left.global_position + Vector2(50, 50)
@@ -455,6 +454,22 @@ func test_runner_GD_356() -> void:
 	# this results into releasing the scene while `simulate_mouse_move_relative` is processing the mouse move
 	runner.simulate_mouse_move_relative(Vector2(100, 100), 1.0)
 	assert_that(runner.scene()).is_not_null()
+
+
+func test_move_window_to_foreground() -> void:
+	var runner := scene_runner("res://addons/gdUnit4/test/core/resources/scenes/simple_scene.tscn")
+	# we set inital to background
+	runner.move_window_to_background()
+	await runner.simulate_frames(1)
+	if not Engine.is_embedded_in_editor():
+		assert_that(DisplayServer.window_get_mode()).is_equal(DisplayServer.WINDOW_MODE_MINIMIZED)
+	else:
+		assert_that(DisplayServer.window_get_mode()).is_equal(DisplayServer.WINDOW_MODE_WINDOWED)
+
+	# force window to foreground
+	runner.move_window_to_foreground()
+	await runner.simulate_frames(1)
+	assert_that(DisplayServer.window_get_mode()).is_equal(DisplayServer.WINDOW_MODE_WINDOWED)
 
 
 # we override the scene runner function for test purposes to hide push_error notifications


### PR DESCRIPTION
# Why
Calling runner.move_window_to_foreground() does not raise the testing window to the foreground.

# What
- Fixing move_window_to_foreground 
- Do set the correct window mode dependent to the embedded window mode
- Adding Linux specific test fix because of [Godot issue](https://github.com/godotengine/godot/issues/111119)

