### PR TITLE
GD-909: Add support for unicode characters

### DIFF
--- a/addons/gdUnit4/src/asserts/GdAssertMessages.gd
+++ b/addons/gdUnit4/src/asserts/GdAssertMessages.gd
@@ -58,17 +58,17 @@ static func input_event_as_text(event :InputEvent) -> String:
 	return text
 
 
-static func _colored_string_div(characters :String) -> String:
-	return colored_array_div(characters.to_utf8_buffer())
+static func _colored_string_div(characters: String) -> String:
+	return colored_array_div(characters.to_utf32_buffer().to_int32_array())
 
 
-static func colored_array_div(characters :PackedByteArray) -> String:
+static func colored_array_div(characters: PackedInt32Array) -> String:
 	if characters.is_empty():
 		return "<empty>"
-	var result := PackedByteArray()
+	var result := PackedInt32Array()
 	var index := 0
-	var missing_chars := PackedByteArray()
-	var additional_chars := PackedByteArray()
+	var missing_chars := PackedInt32Array()
+	var additional_chars := PackedInt32Array()
 
 	while index < characters.size():
 		var character := characters[index]
@@ -84,17 +84,17 @@ static func colored_array_div(characters :PackedByteArray) -> String:
 			_:
 				if not missing_chars.is_empty():
 					result.append_array(format_chars(missing_chars, SUB_COLOR))
-					missing_chars = PackedByteArray()
+					missing_chars = PackedInt32Array()
 				if not additional_chars.is_empty():
 					result.append_array(format_chars(additional_chars, ADD_COLOR))
-					additional_chars = PackedByteArray()
+					additional_chars = PackedInt32Array()
 				@warning_ignore("return_value_discarded")
 				result.append(character)
 		index += 1
 
 	result.append_array(format_chars(missing_chars, SUB_COLOR))
 	result.append_array(format_chars(additional_chars, ADD_COLOR))
-	return result.get_string_from_utf8()
+	return result.to_byte_array().get_string_from_utf32()
 
 
 static func _typed_value(value :Variant) -> String:
@@ -637,12 +637,12 @@ static func error_contains_exactly(current: Array, expected: Array) -> String:
 	return "%s\n %s\n but was\n %s" % [_error("Expecting exactly equal:"), _colored_value(expected), _colored_value(current)]
 
 
-static func format_chars(characters :PackedByteArray, type :Color) -> PackedByteArray:
+static func format_chars(characters: PackedInt32Array, type: Color) -> PackedInt32Array:
 	if characters.size() == 0:# or characters[0] == 10:
 		return characters
 
 	# Replace each control character with its readable form
-	var formatted_text := characters.get_string_from_utf8()
+	var formatted_text := characters.to_byte_array().get_string_from_utf32()
 	for control_char: String in CONTROL_CHARS:
 		var replace_text: String = CONTROL_CHARS[control_char]
 		formatted_text = formatted_text.replace(control_char, replace_text)
@@ -664,8 +664,8 @@ static func format_chars(characters :PackedByteArray, type :Color) -> PackedByte
 		ascii_text
 	]
 
-	var result := PackedByteArray()
-	result.append_array(message.to_utf8_buffer())
+	var result := PackedInt32Array()
+	result.append_array(message.to_utf32_buffer().to_int32_array())
 	return result
 
 

--- a/addons/gdUnit4/src/network/GdUnitTcpNode.gd
+++ b/addons/gdUnit4/src/network/GdUnitTcpNode.gd
@@ -4,7 +4,7 @@ extends Node
 
 func rpc_send(stream: StreamPeerTCP, data: RPC) -> void:
 	var package_buffer := StreamPeerBuffer.new()
-	var buffer := data.serialize().to_ascii_buffer()
+	var buffer := data.serialize().to_utf16_buffer()
 	package_buffer.put_u32(0xDEADBEEF)
 	package_buffer.put_u32(buffer.size())
 	var status_code := package_buffer.put_data(buffer)
@@ -59,7 +59,7 @@ func receive_packages(stream: StreamPeerTCP, rpc_cb: Callable = noop) -> Array[R
 		else:
 			data_package = buffer[1]
 
-		var json := data_package.get_string_from_ascii()
+		var json := data_package.get_string_from_utf16()
 		if json.is_empty():
 			push_warning("json is empty, can't process data")
 			continue

--- a/addons/gdUnit4/test/asserts/GdUnitSignalAssertImplTest.gd
+++ b/addons/gdUnit4/test/asserts/GdUnitSignalAssertImplTest.gd
@@ -1,3 +1,4 @@
+@warning_ignore_start("redundant_await")
 # GdUnit generated TestSuite
 #warning-ignore-all:unused_argument
 #warning-ignore-all:return_value_discarded

--- a/addons/gdUnit4/test/asserts/GdUnitStringAssertImplTest.gd
+++ b/addons/gdUnit4/test/asserts/GdUnitStringAssertImplTest.gd
@@ -63,7 +63,7 @@ func test_is_equal_ignoring_case() -> void:
 			Expecting:
 			 'This is a Message'
 			 but was
-			 'This is a test Mmessage' (ignoring case)""".dedent().trim_prefix("\n"))
+			 'This is a Mtest message' (ignoring case)""".dedent().trim_prefix("\n"))
 	assert_failure(func() -> void: assert_str(null).is_equal_ignoring_case("This is a Message")) \
 		.is_failed() \
 		.has_message("""
@@ -463,3 +463,14 @@ func test_is_failure() -> void:
 	assert_str(null).is_null()
 	# is true because we have an already failed assert
 	assert_bool(is_failure()).is_true()
+
+
+func test_日本語() -> void:
+	assert_str("test_日本語").is_equal("test_日本語")
+	assert_failure(func() -> void: assert_str("test_日本語").is_equal("test_本語")) \
+		.is_failed() \
+		.has_message("""
+			Expecting:
+			 'test_本語'
+			 but was
+			 'test_日本語'""".dedent().trim_prefix("\n"))

--- a/addons/gdUnit4/test/core/discovery/GdUnitTestDiscoverGuardTest.gd
+++ b/addons/gdUnit4/test/core/discovery/GdUnitTestDiscoverGuardTest.gd
@@ -50,7 +50,7 @@ func test_discover_new_suite_GDScript() -> void:
 	)
 
 	# verify the all tests are discovered
-	assert_array(discovered_tests).has_size(11)
+	assert_array(discovered_tests).has_size(12)
 	assert_array(discovered_tests).extractv(extr("test_name"), extr("attribute_index")).contains_exactly([
 		tuple("test_case1", -1),
 		tuple("test_case2", -1),
@@ -63,6 +63,7 @@ func test_discover_new_suite_GDScript() -> void:
 		tuple("test_parameterized_dynamic", 0),
 		tuple("test_parameterized_dynamic", 1),
 		tuple("test_parameterized_dynamic", 2),
+		tuple("test_日本語", -1),
 	])
 
 	# verify the cache now contains all discovered tests
@@ -89,7 +90,7 @@ func test_discover_deleted_test_GDScript() -> void:
 	)
 	# verify the expected tests are collected
 	assert_array(expected_deleted_tests).has_size(2)
-	assert_array(discovered_tests).has_size(11)
+	assert_array(discovered_tests).has_size(12)
 
 	# we simmulate deleted tests
 	script.source_code = script.source_code.replace("test_case1", "_test_case1").replace("test_case2", "_test_case2")
@@ -122,6 +123,7 @@ func test_discover_deleted_test_GDScript() -> void:
 			tuple(discovered_tests[8].guid, "test_parameterized_dynamic", 0, 35),
 			tuple(discovered_tests[9].guid, "test_parameterized_dynamic", 1, 35),
 			tuple(discovered_tests[10].guid, "test_parameterized_dynamic", 2, 35),
+			tuple(discovered_tests[11].guid, "test_日本語", -1, 41),
 		])
 
 
@@ -183,8 +185,9 @@ func test_discover_added_test_GDScript() -> void:
 			tuple(discovered_tests[8].guid, "test_parameterized_dynamic", 0, 35),
 			tuple(discovered_tests[9].guid, "test_parameterized_dynamic", 1, 35),
 			tuple(discovered_tests[10].guid, "test_parameterized_dynamic", 2, 35),
-			tuple(expected_added_tests[0].guid, "test_case3", -1, 47),
-			tuple(expected_added_tests[1].guid, "test_case4", -1, 51),
+			tuple(discovered_tests[11].guid, "test_日本語", -1, 41),
+			tuple(expected_added_tests[0].guid, "test_case3", -1, 51),
+			tuple(expected_added_tests[1].guid, "test_case4", -1, 55),
 		])
 
 
@@ -241,6 +244,7 @@ func test_discover_renamed_test_GDScript() -> void:
 			tuple(discovered_tests[8].guid, "test_parameterized_dynamic", 0, 35),
 			tuple(discovered_tests[9].guid, "test_parameterized_dynamic", 1, 35),
 			tuple(discovered_tests[10].guid, "test_parameterized_dynamic", 2, 35),
+			tuple(discovered_tests[11].guid, "test_日本語", -1, 41),
 		])
 
 
@@ -293,6 +297,7 @@ func test_discover_moved_test_GDScript() -> void:
 			tuple(expected_renamed_tests[3].guid, "test_parameterized_dynamic", 0, 37),
 			tuple(expected_renamed_tests[4].guid, "test_parameterized_dynamic", 1, 37),
 			tuple(expected_renamed_tests[5].guid, "test_parameterized_dynamic", 2, 37),
+			tuple(discovered_tests[11].guid, "test_日本語", -1, 43),
 		])
 	# and no added or removed tests
 	assert_array(discoverer._discovered_changes["deleted_tests"]).is_empty()
@@ -314,6 +319,7 @@ func test_discover_moved_test_GDScript() -> void:
 			tuple(discovered_tests[8].guid, "test_parameterized_dynamic", 0, 37),
 			tuple(discovered_tests[9].guid, "test_parameterized_dynamic", 1, 37),
 			tuple(discovered_tests[10].guid, "test_parameterized_dynamic", 2, 37),
+			tuple(discovered_tests[11].guid, "test_日本語", -1, 43),
 		])
 
 

--- a/addons/gdUnit4/test/core/discovery/GdUnitTestDiscovererTest.gd
+++ b/addons/gdUnit4/test/core/discovery/GdUnitTestDiscovererTest.gd
@@ -64,6 +64,7 @@ func test_discover_tests() -> void:
 			tuple("test_parameterized_dynamic", "test_parameterized_dynamic:0 (<null>)"),
 			tuple("test_parameterized_dynamic", "test_parameterized_dynamic:1 (%s)" % Vector2.ONE),
 			tuple("test_parameterized_dynamic", "test_parameterized_dynamic:2 (%s)" % Vector2i.ONE),
+			tuple("test_日本語", "test_日本語"),
 		])
 
 

--- a/addons/gdUnit4/test/core/discovery/resources/DiscoverExampleTestSuite.gd
+++ b/addons/gdUnit4/test/core/discovery/resources/DiscoverExampleTestSuite.gd
@@ -39,7 +39,7 @@ func test_parameterized_dynamic(value :Variant, test_parameters := data_set()) -
 
 
 func test_日本語() -> void:
-	assert_bool(true).is_true
+	assert_bool(true).is_true()
 
 
 func data_set() -> Array:

--- a/addons/gdUnit4/test/core/discovery/resources/DiscoverExampleTestSuite.gd
+++ b/addons/gdUnit4/test/core/discovery/resources/DiscoverExampleTestSuite.gd
@@ -38,6 +38,10 @@ func test_parameterized_dynamic(value :Variant, test_parameters := data_set()) -
 		.is_instanceof(GdUnitVectorAssert)
 
 
+func test_日本語() -> void:
+	assert_bool(true).is_true
+
+
 func data_set() -> Array:
 	var test_values := []
 	for index in 3:

--- a/addons/gdUnit4/test/core/parse/GdScriptParserTest.gd
+++ b/addons/gdUnit4/test/core/parse/GdScriptParserTest.gd
@@ -389,6 +389,8 @@ func test_parse_func_name() -> void:
 	assert_str(_parser.parse_func_name("func a() -> String:")).is_equal("a")
 	# function name contains tokens e.g func or class
 	assert_str(_parser.parse_func_name("func foo_func_class():")).is_equal("foo_func_class")
+	# unicode characters in the name
+	assert_str(_parser.parse_func_name("func test_日本語() -> void:")).is_equal("test_日本語")
 	# should fail
 	assert_str(_parser.parse_func_name("#func foo():")).is_empty()
 	assert_str(_parser.parse_func_name("var x")).is_empty()

--- a/addons/gdUnit4/test/core/runners/GdUnitTestCIRunnerTest.gd
+++ b/addons/gdUnit4/test/core/runners/GdUnitTestCIRunnerTest.gd
@@ -9,7 +9,7 @@ func test_discover_tests_on_path() -> void:
 	runner.add_test_suite("res://addons/gdUnit4/test/core/discovery/resources/")
 
 	var tests := runner.discover_tests()
-	assert_array(tests).has_size(11)
+	assert_array(tests).has_size(14)
 
 
 func test_discover_tests_on_file() -> void:
@@ -18,7 +18,7 @@ func test_discover_tests_on_file() -> void:
 	runner.add_test_suite("res://addons/gdUnit4/test/core/discovery/resources/DiscoverExampleTestSuite.gd")
 
 	var tests := runner.discover_tests()
-	assert_array(tests).has_size(11)
+	assert_array(tests).has_size(12)
 
 
 func test_discover_tests_on_path_and_skip_suite() -> void:

--- a/addons/gdUnit4/test/core/runners/GdUnitTestCIRunnerTest.gd
+++ b/addons/gdUnit4/test/core/runners/GdUnitTestCIRunnerTest.gd
@@ -9,7 +9,7 @@ func test_discover_tests_on_path() -> void:
 	runner.add_test_suite("res://addons/gdUnit4/test/core/discovery/resources/")
 
 	var tests := runner.discover_tests()
-	assert_array(tests).has_size(14)
+	assert_array(tests).has_size(12)
 
 
 func test_discover_tests_on_file() -> void:


### PR DESCRIPTION
# Why
The discovery of tests was failing when the name contains Unicode characters. The string comparison had also issues to compare strings containing Unicode.

# What
- Fixing the script parser to support Unicode characters as variables and names
- Fixing the netcode to transport Unicode characters by using utf16 encoding
- Fixing string comparison by using utf32 encoding to support Unicode characters
- Significant performance improvement of string diff building

