### PR TITLE
TASK-932: Allow to enable/disable session hooks

### DIFF
--- a/addons/gdUnit4/src/core/GdUnitProperty.gd
+++ b/addons/gdUnit4/src/core/GdUnitProperty.gd
@@ -46,7 +46,7 @@ func is_selectable_value() -> bool:
 	return not _value_set.is_empty()
 
 
-func set_value(p_value :Variant) -> void:
+func set_value(p_value: Variant) -> void:
 	match _type:
 		TYPE_STRING:
 			_value = str(p_value)
@@ -56,6 +56,8 @@ func set_value(p_value :Variant) -> void:
 			_value = type_convert(p_value, TYPE_INT)
 		TYPE_FLOAT:
 			_value = type_convert(p_value, TYPE_FLOAT)
+		TYPE_DICTIONARY:
+			_value = type_convert(p_value, TYPE_DICTIONARY)
 		_:
 			_value = p_value
 

--- a/addons/gdUnit4/src/core/GdUnitSettings.gd
+++ b/addons/gdUnit4/src/core/GdUnitSettings.gd
@@ -130,7 +130,7 @@ static func setup() -> void:
 		"Show 'Run overall Tests' button in the inspector toolbar")
 	create_property_if_need(TEMPLATE_TS_GD, GdUnitTestSuiteTemplate.default_GD_template(), "Test suite template to use")
 	create_shortcut_properties_if_need()
-	create_property_if_need(SESSION_HOOKS, PackedStringArray())
+	create_property_if_need(SESSION_HOOKS, {} as Dictionary[String,bool])
 	migrate_properties()
 
 
@@ -207,12 +207,15 @@ static func set_log_path(path :String) -> void:
 	ProjectSettings.save()
 
 
-static func get_session_hooks() -> PackedStringArray:
+static func get_session_hooks() -> Dictionary[String, bool]:
 	var property := get_property(SESSION_HOOKS)
-	return property.value() if property != null else []
+	if property == null:
+		return {}
+	var hooks: Dictionary[String, bool] = property.value()
+	return hooks
 
 
-static func set_session_hooks(hooks: PackedStringArray) -> void:
+static func set_session_hooks(hooks: Dictionary[String, bool]) -> void:
 	var property := get_property(SESSION_HOOKS)
 	property.set_value(hooks)
 	update_property(property)

--- a/addons/gdUnit4/src/core/hooks/GdUnitHtmlReporterTestSessionHook.gd
+++ b/addons/gdUnit4/src/core/hooks/GdUnitHtmlReporterTestSessionHook.gd
@@ -6,3 +6,4 @@ const GdUnitTools := preload("res://addons/gdUnit4/src/core/GdUnitTools.gd")
 
 func _init() -> void:
 	super(GdUnitHtmlReportWriter.new(), "GdUnitHtmlTestReporter", "The Html test reporting hook.", GdUnitTools.richtext_normalize)
+	set_meta("SYSTEM_HOOK", true)

--- a/addons/gdUnit4/src/core/hooks/GdUnitTestSessionHookService.gd
+++ b/addons/gdUnit4/src/core/hooks/GdUnitTestSessionHookService.gd
@@ -17,9 +17,9 @@ static func instance() -> GdUnitTestSessionHookService:
 		GdUnitSignals.instance().gdunit_message.emit("Installing GdUnit4 session system hooks.")
 		var service := GdUnitTestSessionHookService.new()
 		# Register default system hooks here
-		service.register(GdUnitHtmlReporterTestSessionHook.new(), true)
-		service.register(GdUnitXMLReporterTestSessionHook.new(), true)
 		service._save_settings = false
+		service.register(GdUnitHtmlReporterTestSessionHook.new())
+		service.register(GdUnitXMLReporterTestSessionHook.new())
 		service.load_hook_settings()
 		service._save_settings = true
 		return service
@@ -47,14 +47,22 @@ func load_hook(hook_resourc_path: String) -> GdUnitResult:
 	return GdUnitResult.success(script.new())
 
 
-func register(hook: GdUnitTestSessionHook, is_system_hook := false) -> GdUnitResult:
+func enable_hook(hook: GdUnitTestSessionHook, enabled: bool) -> void:
+	_enable_hook(hook, enabled)
+	GdUnitSignals.instance().gdunit_message.emit("Session hook '{name}' {enabled}.".format({
+		"name": hook.name,
+		"enabled": "enabled" if enabled else "disabled"})
+	)
+	save_hock_setttings()
+
+
+func register(hook: GdUnitTestSessionHook, enabled: bool = true) -> GdUnitResult:
 	if find_custom(hook) != -1:
 		return GdUnitResult.error("A hook instance of '%s' is already registered." % hook.get_script().resource_path)
 
-	hook.set_meta("SYSTEM_HOOK", is_system_hook)
+	_enable_hook(hook, enabled)
 	enigne_hooks.append(hook)
-	if not is_system_hook:
-		save_hock_setttings()
+	save_hock_setttings()
 	GdUnitSignals.instance().gdunit_message.emit("Session hook '%s' installed." % hook.name)
 
 	return GdUnitResult.success()
@@ -110,6 +118,8 @@ func execute(hook_func: String, session: GdUnitTestSession, reverse := false) ->
 	for hook_index in enigne_hooks.size():
 		var index := enigne_hooks.size()-hook_index-1 if reverse else hook_index
 		var hook: = enigne_hooks[index]
+		if not is_enabled(hook):
+			continue
 		if OS.is_stdout_verbose():
 			GdUnitSignals.instance().gdunit_message.emit("Session hook '%s' > %s()" % [hook.name, hook_func])
 		var result: GdUnitResult = await hook.call(hook_func, session)
@@ -131,24 +141,51 @@ func save_hock_setttings() -> void:
 	if not _save_settings:
 		return
 
-	GdUnitSettings.set_session_hooks(enigne_hooks
-		.filter(func(hook: GdUnitTestSessionHook) -> bool: return not hook.get_meta("SYSTEM_HOOK"))
-		.map(func(hook: GdUnitTestSessionHook) -> String: return hook.get_script().resource_path)
-	)
+	var hooks_to_save: Dictionary[String, bool] = {}
+	for hook in enigne_hooks:
+		var enabled: bool = hook.get_meta("enabled")
+		hooks_to_save[hook.get_script().resource_path] = enabled
+
+	GdUnitSettings.set_session_hooks(hooks_to_save)
 
 
 func load_hook_settings() -> void:
 	var hooks_resource_paths := GdUnitSettings.get_session_hooks()
-	if not hooks_resource_paths.is_empty():
-		GdUnitSignals.instance().gdunit_message.emit("Installing GdUnit4 session hooks.")
-	for hock_path in hooks_resource_paths:
+	if hooks_resource_paths.is_empty():
+		return
+
+	for hock_path: String in hooks_resource_paths.keys():
+		var enabled := hooks_resource_paths[hock_path]
+
+		# Do not reinstall already installed hooks
+		var existing_hook: GdUnitTestSessionHook = enigne_hooks.filter(func(element: GdUnitTestSessionHook) -> bool:
+			return element.get_script().resource_path == hock_path
+		).front()
+		# Applay enabled settings
+		if existing_hook != null:
+			_enable_hook(existing_hook, enabled)
+			continue
+
+		# Load additional hooks
 		var result := load_hook(hock_path)
 		if result.is_error():
 			push_error(result.error_message())
 			continue
 
+		GdUnitSignals.instance().gdunit_message.emit("Installing GdUnit4 session hooks.")
 		var hook: GdUnitTestSessionHook = result.value()
-		result = register(hook)
+
+		result = register(hook, enabled)
 		if result.is_error():
 			push_error(result.error_message())
 			continue
+
+
+static func is_enabled(hook: GdUnitTestSessionHook) -> bool:
+	if hook.has_meta("enabled"):
+		return hook.get_meta("enabled")
+	return true
+
+
+func _enable_hook(hook: GdUnitTestSessionHook, enabled: bool) -> void:
+	hook.set_meta("enabled", enabled)

--- a/addons/gdUnit4/src/core/hooks/GdUnitXMLReporterTestSessionHook.gd
+++ b/addons/gdUnit4/src/core/hooks/GdUnitXMLReporterTestSessionHook.gd
@@ -4,6 +4,7 @@ extends GdUnitBaseReporterTestSessionHook
 
 func _init() -> void:
 	super(JUnitXmlReportWriter.new(), "GdUnitXMLTestReporter", "The JUnit XML test reporting hook.", convert_report_message)
+	set_meta("SYSTEM_HOOK", true)
 
 
 func convert_report_message(value: String) -> String:


### PR DESCRIPTION
# Why
We want to allow to enable/disable installed session hooks. If a use does not want to auto generate the test reports, he can disable it.

# What
- Store hook settings as Dictionary with path and enable/disable flag
- Add enable/disable button to the hook settings
- Do only execute enabled hooks at test execution

