### PR TITLE
TASK-912: Reenable the temporay disabled GDLint checks on assertions on CI

### DIFF
--- a/.github/workflows/gdlint.yml
+++ b/.github/workflows/gdlint.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Setup GDLint
         uses: Scony/godot-gdscript-toolkit@master
         with:
-          version: 4.3.3
+          version: 4.5.0
 
       - name: Run GDLint
         id: run-gdlint
@@ -43,8 +43,7 @@ jobs:
           gdlint addons/gdUnit4/src/cmd/ | tee reports/gdlint/cmd.txt
           gdlint addons/gdUnit4/src/reporters/ | tee reports/gdlint/report.txt
           gdlint addons/gdUnit4/src/network | tee reports/gdlint/gdlint_networkcode.txt
-        # temporary disable until https://github.com/Scony/godot-gdscript-toolkit/issues/399 is fixed
-        # gdlint addons/gdUnit4/src/asserts | tee reports/gdlint/gdlint_asserts.txt
+          gdlint addons/gdUnit4/src/asserts | tee reports/gdlint/gdlint_asserts.txt
 
       - name: Upload GDLint Report
         if: failure()

--- a/addons/gdUnit4/src/asserts/GdUnitArrayAssertImpl.gd
+++ b/addons/gdUnit4/src/asserts/GdUnitArrayAssertImpl.gd
@@ -163,7 +163,8 @@ func _contains_exactly_in_any_order(expected: Array, compare_mode: GdObjects.COM
 		return report_error("ERROR: expected value: <%s>\n is not a Array Type!" % GdObjects.typeof_as_string(expected_value))
 
 	if current_value == null:
-		return report_error(GdAssertMessages.error_arr_contains_exactly_in_any_order(current_value, expected_value, [], expected_value, compare_mode))
+		return report_error(GdAssertMessages.error_arr_contains_exactly_in_any_order(current_value, expected_value, [],
+			expected_value, compare_mode))
 	# find the difference
 	@warning_ignore("unsafe_cast")
 	var diffs := _array_div(compare_mode, current_value as Array[Variant], expected_value as Array[Variant], false)
@@ -171,7 +172,8 @@ func _contains_exactly_in_any_order(expected: Array, compare_mode: GdObjects.COM
 	var not_found: Array[Variant] = diffs[1]
 	if not_expect.is_empty() and not_found.is_empty():
 		return report_success()
-	return report_error(GdAssertMessages.error_arr_contains_exactly_in_any_order(current_value, expected_value, not_expect, not_found, compare_mode))
+	return report_error(GdAssertMessages.error_arr_contains_exactly_in_any_order(current_value, expected_value, not_expect,
+		not_found, compare_mode))
 
 
 func _not_contains(expected: Array, compare_mode: GdObjects.COMPARE_MODE) -> GdUnitArrayAssert:
@@ -180,7 +182,8 @@ func _not_contains(expected: Array, compare_mode: GdObjects.COMPARE_MODE) -> GdU
 	if not _validate_value_type(expected_value):
 		return report_error("ERROR: expected value: <%s>\n is not a Array Type!" % GdObjects.typeof_as_string(expected_value))
 	if current_value == null:
-		return report_error(GdAssertMessages.error_arr_contains_exactly_in_any_order(current_value, expected_value, [], expected_value, compare_mode))
+		return report_error(GdAssertMessages.error_arr_contains_exactly_in_any_order(current_value, expected_value, [],
+			expected_value, compare_mode))
 	@warning_ignore("unsafe_cast")
 	var diffs := _array_div(compare_mode, current_value as Array[Variant], expected_value as Array[Variant])
 	var found: Array[Variant] = diffs[0]

--- a/addons/gdUnit4/src/asserts/GdUnitDictionaryAssertImpl.gd
+++ b/addons/gdUnit4/src/asserts/GdUnitDictionaryAssertImpl.gd
@@ -137,7 +137,8 @@ func _contains_keys(expected: Array, compare_mode: GdObjects.COMPARE_MODE) -> Gd
 	var keys_not_found :Array = expected_value.filter(_filter_by_key.bind((current as Dictionary).keys(), compare_mode))
 	if not keys_not_found.is_empty():
 		@warning_ignore("unsafe_cast")
-		return report_error(GdAssertMessages.error_contains_keys((current as Dictionary).keys() as Array, expected_value, keys_not_found, compare_mode))
+		return report_error(GdAssertMessages.error_contains_keys((current as Dictionary).keys() as Array, expected_value,
+			keys_not_found, compare_mode))
 	return report_success()
 
 


### PR DESCRIPTION
# Why
We had needed to disable the lint checks on assertions because of Scony/godot-gdscript-toolkit#399 until a new fix version is released

# What
- Update to gdlint 4.5.0

