### PR TITLE
GD-941: StringFuzzer should generate the values inclusive max length

### DIFF
--- a/addons/gdUnit4/src/fuzzers/StringFuzzer.gd
+++ b/addons/gdUnit4/src/fuzzers/StringFuzzer.gd
@@ -2,28 +2,28 @@ class_name StringFuzzer
 extends Fuzzer
 
 
-const DEFAULT_CHARSET = "a-zA-Z0-9+-_"
+const DEFAULT_CHARSET = "\\w\\p{L}\\p{N}+-_'"
 
-var _min_length :int
-var _max_length :int
-var _charset :PackedByteArray
+var _min_length: int
+var _max_length: int
+var _charset: PackedInt32Array
 
 
-func _init(min_length :int, max_length :int, pattern :String = DEFAULT_CHARSET) -> void:
-	assert(min_length>0 and min_length < max_length)
+func _init(min_length: int, max_length: int, pattern: String = DEFAULT_CHARSET) -> void:
+	assert(min_length > 0 and min_length < max_length)
 	assert(not null or not pattern.is_empty())
 	_min_length = min_length
-	_max_length = max_length
+	_max_length = max_length + 1 # +1 for inclusive
 	_charset = StringFuzzer.extract_charset(pattern)
 
 
-static func extract_charset(pattern :String) -> PackedByteArray:
+static func extract_charset(pattern: String) -> PackedInt32Array:
 	var reg := RegEx.new()
 	if reg.compile(pattern) != OK:
-		push_error("Invalid pattern to generate Strings! Use e.g  'a-zA-Z0-9+-_'")
-		return PackedByteArray()
+		push_error("Invalid pattern to generate Strings! Use e.g  '\\w\\p{L}\\p{N}+-_'")
+		return PackedInt32Array()
 
-	var charset := Array()
+	var charset := PackedInt32Array()
 	var char_before := -1
 	var index := 0
 	while index < pattern.length():
@@ -45,21 +45,21 @@ static func extract_charset(pattern :String) -> PackedByteArray:
 			continue
 		char_before = char_current
 		charset.append(char_current)
-	return PackedByteArray(charset)
+	return charset
 
 
-static func build_chars(from :int, to :int) -> Array[int]:
-	var characters :Array[int] = []
+static func build_chars(from: int, to: int) -> PackedInt32Array:
+	var characters := PackedInt32Array()
 	for character in range(from+1, to+1):
 		characters.append(character)
 	return characters
 
 
 func next_value() -> String:
-	var value := PackedByteArray()
+	var value := PackedInt32Array()
 	var max_char := len(_charset)
-	var length :int = max(_min_length, randi() % _max_length)
+	var length: int = max(_min_length, randi() % _max_length)
 	for i in length:
 		@warning_ignore("return_value_discarded")
 		value.append(_charset[randi() % max_char])
-	return value.get_string_from_utf8()
+	return value.to_byte_array().get_string_from_utf32()

--- a/addons/gdUnit4/test/fuzzers/StringFuzzerTest.gd
+++ b/addons/gdUnit4/test/fuzzers/StringFuzzerTest.gd
@@ -2,23 +2,22 @@
 class_name StringFuzzerTest
 extends GdUnitTestSuite
 
-# TestSuite generated from
-const __source = 'res://addons/gdUnit4/src/fuzzers/StringFuzzer.gd'
-
 
 func test_extract_charset() -> void:
-	assert_str(StringFuzzer.extract_charset("abc").get_string_from_utf8()).is_equal("abc")
-	assert_str(StringFuzzer.extract_charset("abcDXG").get_string_from_utf8()).is_equal("abcDXG")
-	assert_str(StringFuzzer.extract_charset("a-c").get_string_from_utf8()).is_equal("abc")
-	assert_str(StringFuzzer.extract_charset("a-z").get_string_from_utf8()).is_equal("abcdefghijklmnopqrstuvwxyz")
-	assert_str(StringFuzzer.extract_charset("A-Z").get_string_from_utf8()).is_equal("ABCDEFGHIJKLMNOPQRSTUVWXYZ")
+	assert_str(StringFuzzer.extract_charset("abc").to_byte_array().get_string_from_utf32()).is_equal("abc")
+	assert_str(StringFuzzer.extract_charset("abcDXG").to_byte_array().get_string_from_utf32()).is_equal("abcDXG")
+	assert_str(StringFuzzer.extract_charset("a-c").to_byte_array().get_string_from_utf32()).is_equal("abc")
+	assert_str(StringFuzzer.extract_charset("a-z").to_byte_array().get_string_from_utf32()).is_equal("abcdefghijklmnopqrstuvwxyz")
+	assert_str(StringFuzzer.extract_charset("A-Z").to_byte_array().get_string_from_utf32()).is_equal("ABCDEFGHIJKLMNOPQRSTUVWXYZ")
+	# unicode
+	assert_str(StringFuzzer.extract_charset("abc日本語DXG").to_byte_array().get_string_from_utf32()).is_equal("abc日本語DXG")
 
 	# range token at start
-	assert_str(StringFuzzer.extract_charset("-a-dA-D2-8+_").get_string_from_utf8()).is_equal("-abcdABCD2345678+_")
+	assert_str(StringFuzzer.extract_charset("-a-dA-D2-8+_").to_byte_array().get_string_from_utf32()).is_equal("-abcdABCD2345678+_")
 	# range token at end
-	assert_str(StringFuzzer.extract_charset("a-dA-D2-8+_-").get_string_from_utf8()).is_equal("abcdABCD2345678+_-")
+	assert_str(StringFuzzer.extract_charset("a-dA-D2-8+_-").to_byte_array().get_string_from_utf32()).is_equal("abcdABCD2345678+_-")
 	# range token in the middle
-	assert_str(StringFuzzer.extract_charset("a-d-A-D2-8+_").get_string_from_utf8()).is_equal("abcd-ABCD2345678+_")
+	assert_str(StringFuzzer.extract_charset("a-d-A-D2-8+_").to_byte_array().get_string_from_utf32()).is_equal("abcd-ABCD2345678+_")
 
 
 func test_next_value() -> void:
@@ -32,3 +31,17 @@ func test_next_value() -> void:
 		assert_int(value.length()).is_between(4, 128)
 		# using regex to remove_at all expected chars to verify the value only containing expected chars by is empty
 		assert_str(r.sub(value, "")).is_empty()
+
+
+func test_next_value_min_max_borders() -> void:
+	var boundaries := {}
+	var fuzzer := StringFuzzer.new(2, 3, "A")
+	for i in 200:
+		var value :String = fuzzer.next_value()
+		boundaries[value.length()] = boundaries.get_or_add(value.length(), 0)
+
+	# verify it contains only values with length 2 or 3
+	assert_dict(boundaries)\
+		.is_not_empty()\
+		.has_size(2)\
+		.contains_keys(2, 3)


### PR DESCRIPTION
# Why
The fuzzer generates strings with a length of (max-1), but the max length should be inclusive.

# What
- Fixing the max length generation
- Adding unicode support

