### PR TITLE
GD-941: Fixes max boundary check in StringFuzzer

### DIFF
--- a/addons/gdUnit4/src/fuzzers/StringFuzzer.gd
+++ b/addons/gdUnit4/src/fuzzers/StringFuzzer.gd
@@ -10,10 +10,10 @@ var _charset: PackedInt32Array
 
 
 func _init(min_length: int, max_length: int, pattern: String = DEFAULT_CHARSET) -> void:
-	assert(min_length > 0 and min_length < max_length)
-	assert(not null or not pattern.is_empty())
 	_min_length = min_length
 	_max_length = max_length + 1 # +1 for inclusive
+	assert(not null or not pattern.is_empty())
+	assert(_min_length > 0 and _min_length < _max_length)
 	_charset = StringFuzzer.extract_charset(pattern)
 
 

--- a/addons/gdUnit4/test/fuzzers/StringFuzzerTest.gd
+++ b/addons/gdUnit4/test/fuzzers/StringFuzzerTest.gd
@@ -33,7 +33,7 @@ func test_next_value() -> void:
 		assert_str(r.sub(value, "")).is_empty()
 
 
-func test_next_value_min_max_borders() -> void:
+func test_next_value_min_max_boundaries() -> void:
 	var boundaries := {}
 	var fuzzer := StringFuzzer.new(2, 3, "A")
 	for i in 200:
@@ -45,3 +45,17 @@ func test_next_value_min_max_borders() -> void:
 		.is_not_empty()\
 		.has_size(2)\
 		.contains_keys(2, 3)
+
+
+func test_next_value_min_max_same_boundaries() -> void:
+	var boundaries := {}
+	var fuzzer := StringFuzzer.new(2, 2, "A")
+	for i in 200:
+		var value :String = fuzzer.next_value()
+		boundaries[value.length()] = boundaries.get_or_add(value.length(), 0)
+
+	# verify it contains only values with length 2 or 3
+	assert_dict(boundaries)\
+		.is_not_empty()\
+		.has_size(1)\
+		.contains_keys(2)


### PR DESCRIPTION
# Why
The `StringFuzzer ` has a misleading assertion to verify the min max arguments.

# What
- Fixing the assertion to use the correct max boundary (inclusive)


