### PR TITLE
DOC-958: GdUnit4 inspector doc button link to current version

### DIFF
--- a/addons/gdUnit4/src/core/GdUnit4Version.gd
+++ b/addons/gdUnit4/src/core/GdUnit4Version.gd
@@ -59,3 +59,7 @@ static func init_version_label(label :Control) -> void:
 
 func _to_string() -> String:
 	return "v%d.%d.%d" % [_major, _minor, _patch]
+
+
+func documentation_version() -> String:
+	return "v%d.%d.x" % [_major, _minor]

--- a/addons/gdUnit4/src/ui/parts/InspectorToolBar.gd
+++ b/addons/gdUnit4/src/ui/parts/InspectorToolBar.gd
@@ -101,8 +101,9 @@ func _on_gdunit_settings_changed(_property: GdUnitProperty) -> void:
 
 
 func _on_wiki_pressed() -> void:
-	@warning_ignore("return_value_discarded")
-	OS.shell_open("https://mikeschulze.github.io/gdUnit4/")
+	var status := OS.shell_open("https://mikeschulze.github.io/gdUnit4/%s" % GdUnit4Version.current().documentation_version())
+	if status != OK:
+		push_error("Can't open GdUnit4 documentaion page: %s" % error_string(status))
 
 
 func _on_btn_tool_pressed() -> void:


### PR DESCRIPTION
# Why
We want to open the correct documentation version for the current plugin version

# What
using GdUnit4 version info to build the link to the documentation page


