### PR TITLE
DOC-1001: Fix "How to fail fast" link

### DIFF
--- a/documentation/doc/_testing/assert.md
+++ b/documentation/doc/_testing/assert.md
@@ -194,7 +194,7 @@ and get clearer failure reports.
 In debug mode, accessing properties on null objects will cause the debugger to break with runtime errors,
 stopping test execution unexpectedly.
 
-For more detailed information about fail fast techniques, see [How to fail fast]({{site.baseurl}}/testing/first-test/#multiple-assertions-fail-fast).
+For more detailed information about fail fast techniques, see [How to fail fast]({{site.baseurl}}/testing/test-case/#multiple-assertions-fail-fast).
 
 ---
 


### PR DESCRIPTION
# Why
"How to fail fast" link at https://mikeschulze.github.io/gdUnit4/latest/testing/assert/#use-fail-fast-with-multiple-assertions results into page error 404

# What
fixes the link