### PR TITLE
GD-1002: Fixing `monitor_signals`  stores collected signals across test boundaries.

### DIFF
--- a/addons/gdUnit4/src/GdUnitTestSuite.gd
+++ b/addons/gdUnit4/src/GdUnitTestSuite.gd
@@ -278,7 +278,7 @@ func monitor_signals(source :Object, _auto_free := true) -> Object:
 	__lazy_load("res://addons/gdUnit4/src/core/thread/GdUnitThreadManager.gd")\
 		.get_current_context()\
 		.get_signal_collector()\
-		.register_emitter(source)
+		.register_emitter(source, true) # force recreate to start with a fresh monitoring
 	return auto_free(source) if _auto_free else source
 
 

--- a/addons/gdUnit4/src/core/GdUnitSignalCollector.gd
+++ b/addons/gdUnit4/src/core/GdUnitSignalCollector.gd
@@ -23,11 +23,16 @@ func clear() -> void:
 
 # connect to all possible signals defined by the emitter
 # prepares the signal collection to store received signals and arguments
-func register_emitter(emitter :Object) -> void:
+func register_emitter(emitter: Object, force_recreate := false) -> void:
 	if is_instance_valid(emitter):
 		# check emitter is already registerd
 		if _collected_signals.has(emitter):
-			return
+			if not force_recreate:
+				return
+			# If the flag recreate is set to true, emitters that are already registered must be deregistered before recreating,
+			# otherwise signals that have already been collected will be evaluated.
+			unregister_emitter(emitter)
+
 		_collected_signals[emitter] = Dictionary()
 		# connect to 'tree_exiting' of the emitter to finally release all acquired resources/connections.
 		if emitter is Node and !(emitter as Node).tree_exiting.is_connected(unregister_emitter):

--- a/addons/gdUnit4/test/core/GdUnitSignalMonitorTest.gd
+++ b/addons/gdUnit4/test/core/GdUnitSignalMonitorTest.gd
@@ -1,0 +1,56 @@
+extends GdUnitTestSuite
+@warning_ignore_start("redundant_await")
+
+# This test setup uses two monitors, which are created for each new test.
+# The monitors must be reinitialized for each run, otherwise signals from previous runs will be detected incorrectly.
+# See https://github.com/MikeSchulze/gdUnit4/issues/1002
+func before_test() -> void:
+	monitor_signals(o2.o1, false)
+	monitor_signals(o2, false)
+
+
+# This test runs first and emits on object o1 and o2 the signals and is cauched by both monitors
+func test_monitor_obj1() -> void:
+	o2.o1.emit()
+	await assert_signal(o2.o1).is_emitted("s1")
+	await assert_signal(o2).is_emitted("s2")
+	assert_int(o2.x).is_equal(2)
+
+
+# This test runs after `test_monitor_obj1` and must fail because the signal is not emitted yet
+func test_monitor_obj2() -> void:
+	var result := await assert_failure_await(await func() -> void:
+		await assert_signal(o2).wait_until(50).is_emitted("s2")
+	)
+	result.has_message("Expecting emit signal: 's2()' but timed out after 50ms")
+
+
+func test_monitor_obj2_success() -> void:
+	o2._on_s1()
+	await assert_signal(o2).wait_until(500).is_emitted("s2")
+
+class C1:
+	signal s1
+
+	func emit() -> void:
+		s1.emit()
+
+class C2:
+	signal s2
+	var x := 0
+	var o1: C1
+
+	func _init() -> void:
+		o1 = C1.new()
+		o1.s1.connect(_on_s1)
+		x = 1
+
+	func _on_s1() -> void:
+		s2.emit()
+		x = 2
+
+var o2: C2
+
+
+func before() -> void:
+	o2 = C2.new()


### PR DESCRIPTION
# Why
When a test used the signal monitor in test hooks, the collected signals were present across test boundaries, leading to false detections.

# What
The monitor now cleans up existing monitor instances each time it is created in order to start with a fresh signal collector.

