### PR TITLE
GD-984: assert_str on text containing BBCode breaks the failure report

### DIFF
--- a/addons/gdUnit4/src/asserts/GdAssertMessages.gd
+++ b/addons/gdUnit4/src/asserts/GdAssertMessages.gd
@@ -4,8 +4,8 @@ extends Resource
 const WARN_COLOR = "#EFF883"
 const ERROR_COLOR = "#CD5C5C"
 const VALUE_COLOR = "#1E90FF"
-const SUB_COLOR :=  Color(1, 0, 0, .3)
-const ADD_COLOR :=  Color(0, 1, 0, .3)
+const SUB_COLOR :=  Color(1, 0, 0, .15)
+const ADD_COLOR :=  Color(0, 1, 0, .15)
 
 
 # Dictionary of control characters and their readable representations

--- a/addons/gdUnit4/src/asserts/GdUnitStringAssertImpl.gd
+++ b/addons/gdUnit4/src/asserts/GdUnitStringAssertImpl.gd
@@ -64,25 +64,30 @@ func is_not_null() -> GdUnitStringAssert:
 
 
 func is_equal(expected: Variant) -> GdUnitStringAssert:
+	return _is_equal(expected, false, GdAssertMessages.error_equal)
+
+
+func is_equal_ignoring_case(expected: Variant) -> GdUnitStringAssert:
+	return _is_equal(expected, true, GdAssertMessages.error_equal_ignoring_case)
+
+
+@warning_ignore_start("unsafe_call_argument")
+func _is_equal(expected: Variant, ignore_case: bool, message_cb: Callable) -> GdUnitStringAssert:
 	var current: Variant = current_value()
 	if current == null:
-		return report_error(GdAssertMessages.error_equal(current, expected))
-	if not GdObjects.equals(current, expected):
-		var diffs := GdDiffTool.string_diff(current, expected)
+		return report_error(message_cb.call(current, expected))
+	var cur_value := str(current)
+	if not GdObjects.equals(cur_value, expected, ignore_case):
+		var exp_value := str(expected)
+		if contains_bbcode(cur_value):
+			# mask user bbcode
+			# https://docs.godotengine.org/en/4.5/tutorials/ui/bbcode_in_richtextlabel.html#handling-user-input-safely
+			return report_error(message_cb.call(cur_value.replace("[", "[lb]"), exp_value.replace("[", "[lb]")))
+		var diffs := GdDiffTool.string_diff(cur_value, exp_value)
 		var formatted_current := GdAssertMessages.colored_array_div(diffs[1])
-		return report_error(GdAssertMessages.error_equal(formatted_current, expected))
+		return report_error(message_cb.call(formatted_current, exp_value))
 	return report_success()
-
-
-func is_equal_ignoring_case(expected :Variant) -> GdUnitStringAssert:
-	var current :Variant = current_value()
-	if current == null:
-		return report_error(GdAssertMessages.error_equal_ignoring_case(current, expected))
-	if not GdObjects.equals(str(current), expected, true):
-		var diffs := GdDiffTool.string_diff(current, expected)
-		var formatted_current := GdAssertMessages.colored_array_div(diffs[1])
-		return report_error(GdAssertMessages.error_equal_ignoring_case(formatted_current, expected))
-	return report_success()
+@warning_ignore_restore("unsafe_call_argument")
 
 
 func is_not_equal(expected: Variant) -> GdUnitStringAssert:
@@ -192,3 +197,12 @@ func has_length(expected :int, comparator := Comparator.EQUAL) -> GdUnitStringAs
 		_:
 			return report_error("Comparator '%d' not implemented!" % comparator)
 	return report_success()
+
+
+func contains_bbcode(value: String) -> bool:
+	var rtl := RichTextLabel.new()
+	rtl.bbcode_enabled = true
+	rtl.parse_bbcode(value)
+	var has_bbcode := rtl.get_parsed_text() != value
+	rtl.free()
+	return has_bbcode

--- a/addons/gdUnit4/test/asserts/GdUnitStringAssertImplTest.gd
+++ b/addons/gdUnit4/test/asserts/GdUnitStringAssertImplTest.gd
@@ -474,3 +474,15 @@ func test_日本語() -> void:
 			 'test_本語'
 			 but was
 			 'test_日本語'""".dedent().trim_prefix("\n"))
+
+
+func test_is_equal_on_rich_text() -> void:
+	assert_failure(func() -> void:
+		assert_str("[color=ff00ff]test[/color]").is_equal("[color=ffff00]test[/color]")
+	).is_failed() \
+		# We expect for text containing bbcode tags is rendered with masked tags
+		.has_message("""
+			Expecting:
+			 '[lb]color=ffff00]test[lb]/color]'
+			 but was
+			 '[lb]color=ff00ff]test[lb]/color]'""".dedent().trim_prefix("\n"))


### PR DESCRIPTION
# Why
When testing strings that contain BBCode tags, test failure can cause the failure report to break formatting.

# What
Do mask BBCode to report as plain text in the failure reports

