### PR TITLE
GD-1010: C# When the project is recompiled, it causes a `duplicate key exception in ScriptTypeBiMap`

### DIFF
--- a/addons/gdUnit4/src/dotnet/GdUnit4CSharpApi.cs
+++ b/addons/gdUnit4/src/dotnet/GdUnit4CSharpApi.cs
@@ -21,7 +21,7 @@ using Godot.Collections;
 /// <summary>
 ///     The GdUnit4 GDScript - C# API wrapper.
 /// </summary>
-public partial class GdUnit4CSharpApi : GdUnit4NetApiGodotBridge
+public partial class GdUnit4CSharpApi : RefCounted
 {
     /// <summary>
     ///     The signal to be emitted when the execution is completed.
@@ -52,7 +52,7 @@ public partial class GdUnit4CSharpApi : GdUnit4NetApiGodotBridge
         try
         {
             // Get the list of test case descriptors from the API
-            var testCaseDescriptors = DiscoverTestsFromScript(sourceScript);
+            var testCaseDescriptors = GdUnit4NetApiGodotBridge.DiscoverTestsFromScript(sourceScript);
 
             // Convert each TestCaseDescriptor to a Dictionary
             return testCaseDescriptors
@@ -70,11 +70,13 @@ public partial class GdUnit4CSharpApi : GdUnit4NetApiGodotBridge
                     ["fully_qualified_name"] = descriptor.FullyQualifiedName,
                     ["assembly_location"] = descriptor.AssemblyPath
                 })
-                .Aggregate(new Array<Dictionary>(), (array, dict) =>
-                {
-                    array.Add(dict);
-                    return array;
-                });
+                .Aggregate(
+                    new Array<Dictionary>(),
+                    (array, dict) =>
+                        {
+                            array.Add(dict);
+                            return array;
+                        });
         }
 #pragma warning disable CA1031
         catch (Exception e)
@@ -86,6 +88,23 @@ public partial class GdUnit4CSharpApi : GdUnit4NetApiGodotBridge
 #pragma warning restore IDE0028 // Do not catch general exception types
         }
     }
+
+    /// <summary>
+    /// Creates a test suite based on the specified source path and line number.
+    /// </summary>
+    /// <param name="sourcePath">The path to the source file from which to create the test suite.</param>
+    /// <param name="lineNumber">The line number in the source file where the method to test is defined.</param>
+    /// <param name="testSuitePath">The path where the test suite should be created.</param>
+    /// <returns>A dictionary containing information about the created test suite.</returns>
+    public static Dictionary CreateTestSuite(string sourcePath, int lineNumber, string testSuitePath)
+        => GdUnit4NetApiGodotBridge.CreateTestSuite(sourcePath, lineNumber, testSuitePath);
+
+    /// <summary>
+    /// Gets the version of the GdUnit4 assembly.
+    /// </summary>
+    /// <returns>The version string of the GdUnit4 assembly.</returns>
+    public static string Version()
+        => GdUnit4NetApiGodotBridge.Version();
 
     /// <inheritdoc />
     public override void _Notification(int what)
@@ -114,7 +133,7 @@ public partial class GdUnit4CSharpApi : GdUnit4NetApiGodotBridge
 
             Debug.Assert(tests != null, nameof(tests) + " != null");
             var testSuiteNodes = new List<TestSuiteNode> { BuildTestSuiteNodeFrom(tests) };
-            ExecuteAsync(testSuiteNodes, listener, executionCts.Token)
+            GdUnit4NetApiGodotBridge.ExecuteAsync(testSuiteNodes, listener, executionCts.Token)
                 .GetAwaiter()
                 .OnCompleted(() => EmitSignal(SignalName.ExecutionCompleted));
         }

--- a/addons/gdUnit4/test/dotnet/GdUnit4CSharpApiTest.cs
+++ b/addons/gdUnit4/test/dotnet/GdUnit4CSharpApiTest.cs
@@ -1,7 +1,11 @@
 #if GDUNIT4NET_API_V5
 namespace gdUnit4.addons.gdUnit4.test.dotnet;
 
+using System;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using System.Threading.Tasks;
 
 using GdUnit4;
 
@@ -24,7 +28,7 @@ public partial class GdUnit4CSharpApiTest
     }
 
     [TestCase]
-    [SuppressMessage("Reliability", "CA2000:Objekte verwerfen, bevor Bereich verloren geht")]
+    [SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope")]
     public void DiscoverTestsFromScript()
     {
         var script = GD.Load<CSharpScript>("res://addons/gdUnit4/test/dotnet/ExampleTestSuite.cs");
@@ -46,18 +50,19 @@ public partial class GdUnit4CSharpApiTest
 
         AssertThat(testsWithoutGuids).HasSize(14)
             // Check for single test `IsFoo`
-            .Contains(new Dictionary
-            {
-                ["test_name"] = "IsFoo",
-                ["source_file"] = "res://addons/gdUnit4/test/dotnet/ExampleTestSuite.cs",
-                ["line_number"] = 16,
-                ["attribute_index"] = 0,
-                ["require_godot_runtime"] = true,
-                ["code_file_path"] = fullScriptPath,
-                ["fully_qualified_name"] = "gdUnit4.addons.gdUnit4.test.dotnet.ExampleTestSuite.IsFoo",
-                ["simple_name"] = "IsFoo",
-                ["managed_type"] = "gdUnit4.addons.gdUnit4.test.dotnet.ExampleTestSuite"
-            },
+            .Contains(
+                new Dictionary
+                {
+                    ["test_name"] = "IsFoo",
+                    ["source_file"] = "res://addons/gdUnit4/test/dotnet/ExampleTestSuite.cs",
+                    ["line_number"] = 16,
+                    ["attribute_index"] = 0,
+                    ["require_godot_runtime"] = true,
+                    ["code_file_path"] = fullScriptPath,
+                    ["fully_qualified_name"] = "gdUnit4.addons.gdUnit4.test.dotnet.ExampleTestSuite.IsFoo",
+                    ["simple_name"] = "IsFoo",
+                    ["managed_type"] = "gdUnit4.addons.gdUnit4.test.dotnet.ExampleTestSuite"
+                },
                 // Check exemplary two of the `ParameterizedTest` (index 0, index 11)
                 new Dictionary
                 {
@@ -110,16 +115,17 @@ public partial class GdUnit4CSharpApiTest
 
         // Create a TestEventHandler object to handle the events
         using var eventHandler = new TestEventHandler();
-        eventHandler!.EventReceived += eventData =>
+        eventHandler.EventReceived += eventData =>
         {
             // Track the event
-            receivedEvents.Add(new Dictionary
-            {
-                ["type"] = eventData["type"],
-                ["guid"] = eventData["guid"],
-                ["suite_name"] = eventData["suite_name"],
-                ["test_name"] = eventData["test_name"]
-            });
+            receivedEvents.Add(
+                new Dictionary
+                {
+                    ["type"] = eventData["type"],
+                    ["guid"] = eventData["guid"],
+                    ["suite_name"] = eventData["suite_name"],
+                    ["test_name"] = eventData["test_name"]
+                });
         };
 
         // Create a Callable that references the handler method
@@ -162,8 +168,7 @@ public partial class GdUnit4CSharpApiTest
                 ["guid"] = tests.First()["guid"],
                 ["suite_name"] = "ExampleTestSuite",
                 ["test_name"] = "IsFoo"
-            }
-        );
+            });
     }
 
     // Helper class to handle events


### PR DESCRIPTION
# Why
When the project is recompiled, this causes a “duplicate key exception in ScriptTypeBiMap” because the class ‘GdUnit4CSharpApi’ inherits from “GdUnit4NetApiGodotBridge”. The class “GdUnit4NetApiGodotBridge” is delivered by the NuGet package gdUnit4.api and contains non-Godot-compliant classes/objects that cause this problem.

# What
Instead of inheriting, we now delegate the method calls to the static methods provided by “GdUnit4NetApiGodotBridge”.


