### PR TITLE
Add Godot v4.5.1 to ci workflows

### DIFF
--- a/.github/workflows/ci-dev.yml
+++ b/.github/workflows/ci-dev.yml
@@ -22,7 +22,7 @@ jobs:
       fail-fast: false
       max-parallel: 10
       matrix:
-        godot-version: ['4.5']
+        godot-version: ['4.5', '4.5.1']
         godot-status: ['stable']
         godot-net: ['.Net', '']
 

--- a/.github/workflows/ci-pr-example.yml
+++ b/.github/workflows/ci-pr-example.yml
@@ -33,8 +33,8 @@ jobs:
           lfs: true
       - uses: MikeSchulze/gdUnit4-action@v1
         with:
-          godot-version: '4.2.2'
-          version: 'v4.2.0'
+          godot-version: '4.5.1'
+          version: 'v6.0.3'
           paths: |
             res://project/tests/
           timeout: 5

--- a/.github/workflows/ci-pr-publish-report.yml
+++ b/.github/workflows/ci-pr-publish-report.yml
@@ -24,7 +24,7 @@ jobs:
       fail-fast: false
       max-parallel: 10
       matrix:
-        godot-version: ['4.5']
+        godot-version: ['4.5', '4.5.1']
         godot-status: ['stable']
         godot-net: ['-net', '']
         #include:

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -36,7 +36,7 @@ jobs:
       max-parallel: 10
       matrix:
         # If changes are made here, they must be transferred to `.github\workflows\ci-pr-publish-report.yml`
-        godot-version: ['4.5']
+        godot-version: ['4.5', '4.5.1']
         godot-status: ['stable']
         godot-net: ['.Net', '']
         #include:

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
   </thead>
   <tbody>
     <tr>
-      <td>v6.x+</td><td>v4.5</td>
+      <td>v6.x+</td><td>v4.5, v4.5.1</td>
     </tr>
     <tr>
       <td>v5.x+</td><td>v4.3, v4.4, v4.4.1</td>


### PR DESCRIPTION
# Why
Godot 4.5.1 is released and need to be added to the CI matrix
