### PR TITLE
GD-1020: Fix scene runner error `'Condition "!is_inside_tree()" is true. Returning: false'`

### DIFF
--- a/addons/gdUnit4/src/core/GdUnitSceneRunnerImpl.gd
+++ b/addons/gdUnit4/src/core/GdUnitSceneRunnerImpl.gd
@@ -74,10 +74,8 @@ func _init(p_scene: Variant, p_verbose: bool, p_hide_push_errors := false) -> vo
 	_scene_tree().root.add_child(_current_scene)
 	# do finally reset all open input events when the scene is removed
 	@warning_ignore("return_value_discarded")
-	_scene_tree().root.child_exiting_tree.connect(func f(child :Node) -> void:
+	_scene_tree().root.child_exiting_tree.connect(func f(child: Node) -> void:
 		if child == _current_scene:
-			# we need to disable the processing to avoid input flush buffer errors
-			_current_scene.process_mode = Node.PROCESS_MODE_DISABLED
 			_reset_input_to_default()
 	)
 	_simulate_start_time = LocalTime.now()
@@ -485,6 +483,8 @@ func find_child(name: String, recursive: bool = true, owned: bool = false) -> No
 
 
 func _scene_name() -> String:
+	if scene() == null:
+		return "unknown"
 	var scene_script :GDScript = scene().get_script()
 	var scene_name :String = scene().get_name()
 	if not scene_script:

--- a/addons/gdUnit4/test/core/GdUnitSceneRunnerTest.gd
+++ b/addons/gdUnit4/test/core/GdUnitSceneRunnerTest.gd
@@ -473,6 +473,13 @@ func test_move_window_to_foreground() -> void:
 	assert_that(DisplayServer.window_get_mode()).is_equal(DisplayServer.WINDOW_MODE_WINDOWED)
 
 
+# https://github.com/MikeSchulze/gdUnit4/issues/1020
+func test_load_scene_with_audio_player() -> void:
+	var runner := scene_runner("res://addons/gdUnit4/test/core/resources/scenes/scene_audio.tscn")
+
+	await runner.simulate_frames(1)
+
+
 # we override the scene runner function for test purposes to hide push_error notifications
 func scene_runner(scene :Variant, verbose := false) -> GdUnitSceneRunner:
 	return auto_free(GdUnitSceneRunnerImpl.new(scene, verbose, true))

--- a/addons/gdUnit4/test/core/resources/scenes/scene_audio.tscn
+++ b/addons/gdUnit4/test/core/resources/scenes/scene_audio.tscn
@@ -1,0 +1,5 @@
+[gd_scene format=3 uid="uid://bi4lvq6pg2w81"]
+
+[node name="SceneAudio" type="Node2D"]
+
+[node name="AudioStreamPlayer2D" type="AudioStreamPlayer2D" parent="."]


### PR DESCRIPTION

# Why
Using AudioStreamPlayer in a scene loaded by SceneRunner causes runtime errors.

# What
removing `_current_scene.process_mode = Node.PROCESS_MODE_DISABLED` where was the root cause

