### PR TITLE
GD-1045: Resolve class_name conflicts with named `Effect`

### DIFF
--- a/addons/gdUnit4/src/core/writers/GdUnitCSIMessageWriter.gd
+++ b/addons/gdUnit4/src/core/writers/GdUnitCSIMessageWriter.gd
@@ -162,7 +162,7 @@ func _println_message(_message: String, _color: Color, _indent: int, _flags: int
 
 
 ## Implementation of positioned message output with formatting.
-func _print_at(_message: String, cursor_pos: int, _color: Color, _effect: Effect, _align: Align, _flags: int) -> void:
+func _print_at(_message: String, cursor_pos: int, _color: Color, _effect: GdUnitMessageWriter.Effect, _align: Align, _flags: int) -> void:
 	if _align == Align.RIGHT:
 		cursor_pos = cursor_pos - _message.length()
 

--- a/addons/gdUnit4/src/core/writers/GdUnitMessageWriter.gd
+++ b/addons/gdUnit4/src/core/writers/GdUnitMessageWriter.gd
@@ -64,7 +64,7 @@ var _current_flags := 0
 var _current_align := Align.LEFT
 
 ## The current text effect to be used for the next output operation
-var _current_effect := Effect.NONE
+var _current_effect := GdUnitMessageWriter.Effect.NONE
 
 
 ## Sets the text color for the next output operation.[br]
@@ -98,7 +98,7 @@ func style(value: int) -> GdUnitMessageWriter:
 ## [br]
 ## [param value] The effect to apply to the text (NONE, WAVE).
 ## Returns self for method chaining.
-func effect(value: Effect) -> GdUnitMessageWriter:
+func effect(value: GdUnitMessageWriter.Effect) -> GdUnitMessageWriter:
 	_current_effect = value
 	return self
 
@@ -203,7 +203,7 @@ func _println_message(_message: String, _color: Color, _indent: int, _flags: int
 ## [param effect] The effect to apply.[br]
 ## [param align] The text alignment.[br]
 ## [param flags] The style flags to apply.
-func _print_at(_message: String, _cursor_pos: int, _color: Color, _effect: Effect, _align: Align, _flags: int) -> void:
+func _print_at(_message: String, _cursor_pos: int, _color: Color, _effect: GdUnitMessageWriter.Effect, _align: Align, _flags: int) -> void:
 	pass
 
 

--- a/addons/gdUnit4/src/core/writers/GdUnitRichTextMessageWriter.gd
+++ b/addons/gdUnit4/src/core/writers/GdUnitRichTextMessageWriter.gd
@@ -85,7 +85,7 @@ func _println_message(message: String, _color: Color, _indent: int, flags: int) 
 ## [param _effect] The text effect to apply (e.g. wave).[br]
 ## [param _align] The text alignment (left or right).[br]
 ## [param flags] The text style flags to apply.
-func _print_at(message: String, cursor_pos: int, _color: Color, _effect: Effect, _align: Align, flags: int) -> void:
+func _print_at(message: String, cursor_pos: int, _color: Color, _effect: GdUnitMessageWriter.Effect, _align: Align, flags: int) -> void:
 	if _align == Align.RIGHT:
 		cursor_pos = cursor_pos - message.length()
 


### PR DESCRIPTION
# Why
The GdUnit4 API defines an enumeration called “Effect” and conflicts with a user-defined class that is also called “Effect.”

# What
Resolve the issue by using the fully qualified enumeration name `GdUnitMessageWriter.Effect`

