### PR TITLE
Add is_emitted_with_any_args assertion

### DIFF
--- a/addons/gdUnit4/src/asserts/GdUnitSignalAssertImpl.gd
+++ b/addons/gdUnit4/src/asserts/GdUnitSignalAssertImpl.gd
@@ -101,16 +101,22 @@ func is_signal_exists(signal_name :String) -> GdUnitSignalAssert:
 # Verifies that given signal is emitted until waiting time
 func is_emitted(name :String, args := []) -> GdUnitSignalAssert:
 	_line_number = GdUnitAssertions.get_line_number()
-	return await _wail_until_signal(name, args, false)
+	return await _wait_until_signal(name, args, false)
+
+
+# Verifies that given signal is emitted (with any arguments) until waiting time
+func is_emitted_with_any_args(name :String) -> GdUnitSignalAssert:
+       _line_number = GdUnitAssertions.get_line_number()
+       return await _wait_until_signal(name, [], false, true)
 
 
 # Verifies that given signal is NOT emitted until waiting time
 func is_not_emitted(name :String, args := []) -> GdUnitSignalAssert:
 	_line_number = GdUnitAssertions.get_line_number()
-	return await _wail_until_signal(name, args, true)
+	return await _wait_until_signal(name, args, true)
 
 
-func _wail_until_signal(signal_name :String, expected_args :Array, expect_not_emitted: bool) -> GdUnitSignalAssert:
+func _wait_until_signal(signal_name :String, expected_args :Array, expect_not_emitted: bool, is_any_args_ok := false) -> GdUnitSignalAssert:
 	if _emitter == null:
 		return report_error("Can't wait for signal checked a NULL object.")
 	# first verify the signal is defined
@@ -129,7 +135,9 @@ func _wail_until_signal(signal_name :String, expected_args :Array, expect_not_em
 	while not _interrupted and not is_signal_emitted:
 		await (Engine.get_main_loop() as SceneTree).process_frame
 		if is_instance_valid(_emitter):
-			is_signal_emitted = _signal_collector.match(_emitter, signal_name, expected_args)
+			is_signal_emitted = _signal_collector.match(_emitter, signal_name, expected_args) \
+				if not is_any_args_ok \
+				else _signal_collector.match_name(_emitter, signal_name)
 			if is_signal_emitted and expect_not_emitted:
 				@warning_ignore("return_value_discarded")
 				report_error(GdAssertMessages.error_signal_emitted(signal_name, expected_args, LocalTime.elapsed(int(_timeout-timer.time_left*1000))))

--- a/addons/gdUnit4/src/core/GdUnitSignalCollector.gd
+++ b/addons/gdUnit4/src/core/GdUnitSignalCollector.gd
@@ -118,6 +118,13 @@ func match(emitter :Object, signal_name :String, args :Array) -> bool:
 	return false
 
 
+func match_name(emitter :Object, signal_name :String) -> bool:
+	#prints("match", signal_name,  _collected_signals[emitter][signal_name]);
+	if _collected_signals.is_empty() or not _collected_signals.has(emitter):
+		return false
+	return _collected_signals[emitter][signal_name].size() > 0
+
+
 func _debug_signal_list(message :String) -> void:
 	prints("-----", message, "-------")
 	prints("senders {")


### PR DESCRIPTION
# Why
<!-- Enter a clean description why we need this changeset -->

Adds assertion documented in this issue: #1049 

# What
<!-- Describe exactly what you have changed and what the effects are -->
The changes are only additive. In, `addons/gdUnit4/src/asserts/GdUnitSignalAssertImpl.gd`, I added:

```gdscript
func is_emitted_with_any_args(name :String) -> GdUnitSignalAssert:
```

... which re-uses the existing `_wait_until_signal`. I added an additional argument to `_wait_until_signal` which defaults to `false` to keep the existing behavior. If it's `true`, then `_signal_collector.match_name` is used instead of `_signal_collector.match`.

In `addons/gdUnit4/src/core/GdUnitSignalCollector.gd`, I added:

```gdscript
func match_name(emitter :Object, signal_name :String) -> bool:
	#prints("match", signal_name,  _collected_signals[emitter][signal_name]);
	if _collected_signals.is_empty() or not _collected_signals.has(emitter):
		return false
	return _collected_signals[emitter][signal_name].size() > 0
```

... so regardless of what's in `_collected_signals[emitter][signal_name]`, as long as it's not empty - the assertion passes.