### PR TITLE
GD-1053: Add meta_pressed parameter to simulate key methods

### DIFF
--- a/addons/gdUnit4/src/GdUnitSceneRunner.gd
+++ b/addons/gdUnit4/src/GdUnitSceneRunner.gd
@@ -25,28 +25,31 @@ extends RefCounted
 
 ## Simulates that a key has been pressed.[br]
 ## [member key_code] : the key code e.g. [constant KEY_ENTER][br]
-## [member shift_pressed] : false by default set to true if simmulate shift is press[br]
-## [member ctrl_pressed] : false by default set to true if simmulate control is press[br]
+## [member shift_pressed] : whether shift is pressed (default: false)[br]
+## [member ctrl_pressed] : whether control is pressed (default: false)[br]
+## [member meta_pressed] : whether meta is pressed (default: false)[br]
 ## [codeblock]
 ##    func test_key_presssed():
 ##       var runner = scene_runner("res://scenes/simple_scene.tscn")
 ##       await runner.simulate_key_pressed(KEY_SPACE)
 ## [/codeblock]
-@abstract func simulate_key_pressed(key_code: int, shift_pressed := false, ctrl_pressed := false) -> GdUnitSceneRunner
+@abstract func simulate_key_pressed(key_code: int, shift_pressed := false, ctrl_pressed := false, meta_pressed := false) -> GdUnitSceneRunner
 
 
 ## Simulates that a key is pressed.[br]
 ## [member key_code] : the key code e.g. [constant KEY_ENTER][br]
-## [member shift_pressed] : false by default set to true if simmulate shift is press[br]
-## [member ctrl_pressed] : false by default set to true if simmulate control is press[br]
-@abstract func simulate_key_press(key_code: int, shift_pressed := false, ctrl_pressed := false) -> GdUnitSceneRunner
+## [member shift_pressed] : whether shift is pressed (default: false)[br]
+## [member ctrl_pressed] : whether control is pressed (default: false)[br]
+## [member meta_pressed] : whether meta is pressed (default: false)[br]
+@abstract func simulate_key_press(key_code: int, shift_pressed := false, ctrl_pressed := false, meta_pressed := false) -> GdUnitSceneRunner
 
 
 ## Simulates that a key has been released.[br]
 ## [member key_code] : the key code e.g. [constant KEY_ENTER][br]
-## [member shift_pressed] : false by default set to true if simmulate shift is press[br]
-## [member ctrl_pressed] : false by default set to true if simmulate control is press[br]
-@abstract func simulate_key_release(key_code: int, shift_pressed := false, ctrl_pressed := false) -> GdUnitSceneRunner
+## [member shift_pressed] : whether shift is pressed (default: false)[br]
+## [member ctrl_pressed] : whether control is pressed (default: false)[br]
+## [member meta_pressed] : whether meta is pressed (default: false)[br]
+@abstract func simulate_key_release(key_code: int, shift_pressed := false, ctrl_pressed := false, meta_pressed := false) -> GdUnitSceneRunner
 
 
 ## Sets the mouse position to the specified vector, provided in pixels and relative to an origin at the upper left corner of the currently focused Window Manager game window.[br]

--- a/addons/gdUnit4/src/core/GdUnitSceneRunnerImpl.gd
+++ b/addons/gdUnit4/src/core/GdUnitSceneRunnerImpl.gd
@@ -142,14 +142,14 @@ func simulate_action_release(action: String, event_index := -1) -> GdUnitSceneRu
 
 
 @warning_ignore("return_value_discarded")
-func simulate_key_pressed(key_code: int, shift_pressed := false, ctrl_pressed := false) -> GdUnitSceneRunner:
-	simulate_key_press(key_code, shift_pressed, ctrl_pressed)
+func simulate_key_pressed(key_code: int, shift_pressed := false, ctrl_pressed := false, meta_pressed := false) -> GdUnitSceneRunner:
+	simulate_key_press(key_code, shift_pressed, ctrl_pressed, meta_pressed)
 	await _scene_tree().process_frame
-	simulate_key_release(key_code, shift_pressed, ctrl_pressed)
+	simulate_key_release(key_code, shift_pressed, ctrl_pressed, meta_pressed)
 	return self
 
 
-func simulate_key_press(key_code: int, shift_pressed := false, ctrl_pressed := false) -> GdUnitSceneRunner:
+func simulate_key_press(key_code: int, shift_pressed := false, ctrl_pressed := false, meta_pressed := false) -> GdUnitSceneRunner:
 	__print_current_focus()
 	var event := InputEventKey.new()
 	event.pressed = true
@@ -159,12 +159,13 @@ func simulate_key_press(key_code: int, shift_pressed := false, ctrl_pressed := f
 	event.alt_pressed = key_code == KEY_ALT
 	event.shift_pressed = shift_pressed or key_code == KEY_SHIFT
 	event.ctrl_pressed = ctrl_pressed or key_code == KEY_CTRL
+	event.meta_pressed = meta_pressed or key_code == KEY_META
 	_apply_input_modifiers(event)
 	_key_on_press.append(key_code)
 	return _handle_input_event(event)
 
 
-func simulate_key_release(key_code: int, shift_pressed := false, ctrl_pressed := false) -> GdUnitSceneRunner:
+func simulate_key_release(key_code: int, shift_pressed := false, ctrl_pressed := false, meta_pressed := false) -> GdUnitSceneRunner:
 	__print_current_focus()
 	var event := InputEventKey.new()
 	event.pressed = false
@@ -174,6 +175,7 @@ func simulate_key_release(key_code: int, shift_pressed := false, ctrl_pressed :=
 	event.alt_pressed = key_code == KEY_ALT
 	event.shift_pressed = shift_pressed or key_code == KEY_SHIFT
 	event.ctrl_pressed = ctrl_pressed or key_code == KEY_CTRL
+	event.meta_pressed = meta_pressed or key_code == KEY_META
 	_apply_input_modifiers(event)
 	_key_on_press.erase(key_code)
 	return _handle_input_event(event)

--- a/addons/gdUnit4/test/core/GdUnitSceneRunnerInputEventTest.gd
+++ b/addons/gdUnit4/test/core/GdUnitSceneRunnerInputEventTest.gd
@@ -200,6 +200,86 @@ func test_simulate_many_keys_press() -> void:
 	assert_that(Input.is_physical_key_pressed(KEY_Z)).is_true()
 
 
+func test_simulate_key_press_with_meta() -> void:
+	# press meta key + A
+	_runner.simulate_key_press(KEY_META)
+	_runner.simulate_key_press(KEY_A)
+	await _runner.await_input_processed()
+
+	# results in two events, first is the meta key is press
+	var event := InputEventKey.new()
+	event.keycode = KEY_META
+	event.physical_keycode = KEY_META
+	event.unicode = KEY_META as int
+	event.pressed = true
+	event.meta_pressed = true
+	verify(_scene_spy, 1)._input(event)
+
+	# second is the combination of current press meta and key A
+	event = InputEventKey.new()
+	event.keycode = KEY_A
+	event.physical_keycode = KEY_A
+	event.unicode = KEY_A as int
+	event.pressed = true
+	event.meta_pressed = true
+	verify(_scene_spy, 1)._input(event)
+	assert_that(Input.is_key_pressed(KEY_META)).is_true()
+	assert_that(Input.is_key_pressed(KEY_A)).is_true()
+
+
+func test_simulate_key_pressed_with_meta_parameter() -> void:
+	# simulate key C with meta modifier using the parameter
+	_runner.simulate_key_pressed(KEY_C, false, false, true)
+	await _runner.await_input_processed()
+
+	# verify the event was created with meta_pressed set to true
+	var event := InputEventKey.new()
+	event.keycode = KEY_C
+	event.physical_keycode = KEY_C
+	event.unicode = KEY_C as int
+	event.pressed = true
+	event.meta_pressed = true
+	verify(_scene_spy, 1)._input(event)
+
+	# verify release event also has meta_pressed set
+	event = InputEventKey.new()
+	event.keycode = KEY_C
+	event.physical_keycode = KEY_C
+	event.unicode = KEY_C as int
+	event.pressed = false
+	event.meta_pressed = true
+	verify(_scene_spy, 1)._input(event)
+	assert_that(Input.is_key_pressed(KEY_C)).is_false()
+
+
+func test_simulate_key_press_release_with_meta_parameter() -> void:
+	# simulate key press with meta modifier
+	_runner.simulate_key_press(KEY_D, false, false, true)
+	await _runner.await_input_processed()
+
+	var event := InputEventKey.new()
+	event.keycode = KEY_D
+	event.physical_keycode = KEY_D
+	event.unicode = KEY_D as int
+	event.pressed = true
+	event.meta_pressed = true
+	verify(_scene_spy, 1)._input(event)
+	assert_that(Input.is_key_pressed(KEY_D)).is_true()
+
+	# now release with meta modifier
+	_runner.simulate_key_release(KEY_D, false, false, true)
+	await _runner.await_input_processed()
+
+	event = InputEventKey.new()
+	event.keycode = KEY_D
+	event.physical_keycode = KEY_D
+	event.unicode = KEY_D as int
+	event.pressed = false
+	event.meta_pressed = true
+	verify(_scene_spy, 1)._input(event)
+	assert_that(Input.is_key_pressed(KEY_D)).is_false()
+
+
 @warning_ignore("unsafe_property_access")
 func test_simulate_keypressed_as_action() -> void:
 	# add custom action `player_jump` for key 'Space' is pressed

--- a/documentation/doc/_advanced_testing/scene_runner/keys.md
+++ b/documentation/doc/_advanced_testing/scene_runner/keys.md
@@ -81,7 +81,8 @@ It takes the following arguments:
 # key_code: an integer value representing the key code of the key being pressed, e.g. KEY_ENTER for the enter key.
 # shift: a boolean value indicating whether the shift key should be simulated as being pressed along with the main key. It is false by default.
 # control: a boolean value indicating whether the control key should be simulated as being pressed along with the main key. It is false by default.
-func simulate_key_pressed(key_code: int, shift := false, control := false) -> GdUnitSceneRunner:
+# meta: a boolean value indicating whether the meta key should be simulated as being pressed along with the main key. It is false by default.
+func simulate_key_pressed(key_code: int, shift := false, control := false, meta := false) -> GdUnitSceneRunner:
 ```
 
 Here is an example of how to use simulate_key_pressed:
@@ -110,8 +111,9 @@ It takes the following arguments:
 /// <param name="keyCode">an integer value representing the key code of the key being pressed, e.g. KEY_ENTER for the enter key.</param>
 /// <param name="shift">a boolean value indicating whether the shift key should be simulated as being pressed along with the main key. It is false by default.</param>
 /// <param name="control">a boolean value indicating whether the control key should be simulated as being pressed along with the main key. It is false by default.</param>
+/// <param name="meta">a boolean value indicating whether the meta key should be simulated as being pressed along with the main key. It is false by default.</param>
 /// <returns>SceneRunner</returns>
-ISceneRunner SimulateKeyPressed(KeyList keyCode, bool shift = false, bool control = false);
+ISceneRunner SimulateKeyPressed(KeyList keyCode, bool shift = false, bool control = false, bool meta = false);
 ```
 
 Here is an example of how to use SimulateKeyPressed:
@@ -148,7 +150,8 @@ It takes the following arguments:
 # key_code : an integer value representing the key code of the key being press e.g. KEY_ENTER for the enter key.
 # shift : a boolean value indicating whether the shift key should be simulated as being press along with the main key. It is false by default.
 # control : a boolean value indicating whether the control key should be simulated as being press along with the main key. It is false by default.
-func simulate_key_press(key_code: int, shift := false, control := false) -> GdUnitSceneRunner:
+# meta : a boolean value indicating whether the meta key should be simulated as being press along with the main key. It is false by default.
+func simulate_key_press(key_code: int, shift := false, control := false, meta := false) -> GdUnitSceneRunner:
 ```
 
 Here is an example of how to use simulate_key_press:
@@ -183,8 +186,9 @@ It takes the following arguments:
 /// <param name="keyCode">an integer value representing the key code of the key being press, e.g. KeyList.Enter for the enter key.</param>
 /// <param name="shift">a boolean value indicating whether the shift key should be simulated as being press along with the main key. It is false by default.</param>
 /// <param name="control">a boolean value indicating whether the control key should be simulated as being press along with the main key. It is false by default.</param>
+/// <param name="meta">a boolean value indicating whether the meta key should be simulated as being press along with the main key. It is false by default.</param>
 /// <returns>SceneRunner</returns>
-ISceneRunner SimulateKeyPress(KeyList keyCode, bool shift = false, bool control = false);
+ISceneRunner SimulateKeyPress(KeyList keyCode, bool shift = false, bool control = false, bool meta = false);
 ```
 
 Here is an example of how to use SimulateKeyPress:
@@ -226,8 +230,9 @@ It takes the following arguments:
 ```gd
 # key_code : an integer value representing the key code of the key being released, e.g. KEY_ENTER for the enter key.
 # shift : a boolean value indicating whether the shift key should be simulated as being released along with the main key. It is false by default.
-# control : fa boolean value indicating whether the control key should be simulated as being released along with the main key. It is false by default.
-func simulate_key_release(key_code: int, shift := false, control := false) -> GdUnitSceneRunner:
+# control : a boolean value indicating whether the control key should be simulated as being released along with the main key. It is false by default.
+# meta : a boolean value indicating whether the meta key should be simulated as being released along with the main key. It is false by default.
+func simulate_key_release(key_code: int, shift := false, control := false, meta := false) -> GdUnitSceneRunner:
 ```
 
 Here is an example of how to use simulate_key_release:
@@ -262,8 +267,9 @@ It takes the following arguments:
 /// <param name="keyCode">an integer value representing the key code of the key being released, e.g. KeyList.Enter for the enter key.</param>
 /// <param name="shift">a boolean value indicating whether the shift key should be simulated as being released along with the main key. It is false by default.</param>
 /// <param name="control">a boolean value indicating whether the control key should be simulated as being released along with the main key. It is false by default.</param>
+/// <param name="meta">a boolean value indicating whether the meta key should be simulated as being released along with the main key. It is false by default.</param>
 /// <returns>SceneRunner</returns>
-ISceneRunner SimulateKeyRelease(KeyList keyCode, bool shift = false, bool control = false);
+ISceneRunner SimulateKeyRelease(KeyList keyCode, bool shift = false, bool control = false, bool meta = false);
 ```
 
 Here is an example of how to use SimulateKeyRelease:


### PR DESCRIPTION
Add meta_pressed parameter to simulate_key_pressed() Add meta_pressed parameter to simulate_key_press() Add meta_pressed parameter to simulate_key_release()

# Why

To add META key press support to the scene runner's simulate key press/ed, release functions.


# What

Add meta_pressed parameter to simulate_key_pressed()
Add meta_pressed parameter to simulate_key_press()
Add meta_pressed parameter to simulate_key_release()

NOT INCLUDED: C# part. I guess that's in a separate repo? Should I remove the C# additions in the docs to keep them without `meta` support?
Will be implemented by https://github.com/godot-gdunit-labs/gdUnit4Net/issues/388