### PR TITLE
GD-1055: Revisit the `simulate_key_..` API and make the modifier arguments deprecated

### DIFF
--- a/addons/gdUnit4/src/GdUnitSceneRunner.gd
+++ b/addons/gdUnit4/src/GdUnitSceneRunner.gd
@@ -24,9 +24,8 @@ extends RefCounted
 
 
 ## Simulates that a key has been pressed.[br]
+## @deprecated: the modifier [b]shift_pressed[/b] and [b]ctrl_pressed[/b] will be removed in v7.0
 ## [member key_code] : the key code e.g. [constant KEY_ENTER][br]
-## [member shift_pressed] : false by default set to true if simmulate shift is press[br]
-## [member ctrl_pressed] : false by default set to true if simmulate control is press[br]
 ## [codeblock]
 ##    func test_key_presssed():
 ##       var runner = scene_runner("res://scenes/simple_scene.tscn")
@@ -35,17 +34,43 @@ extends RefCounted
 @abstract func simulate_key_pressed(key_code: int, shift_pressed := false, ctrl_pressed := false) -> GdUnitSceneRunner
 
 
-## Simulates that a key is pressed.[br]
+## Simulates that a key is pressing.[br]
+## @deprecated: the modifier [b]shift_pressed[/b] and [b]ctrl_pressed[/b] will be removed in v7.0[br]See `test_key_shift_and_A_presssing` for example using key combinations
 ## [member key_code] : the key code e.g. [constant KEY_ENTER][br]
-## [member shift_pressed] : false by default set to true if simmulate shift is press[br]
-## [member ctrl_pressed] : false by default set to true if simmulate control is press[br]
+## [codeblock]
+##    # Do simulate key pressing A
+##    func test_key_A_presssing():
+##       var runner = scene_runner("res://scenes/simple_scene.tscn")
+##       await runner.simulate_key_press(KEY_A)
+##
+##
+##    # Do simulate keycombination pressing shift+A
+##    func test_key_shift_and_A_presssing():
+##       var runner = scene_runner("res://scenes/simple_scene.tscn")
+##       runner.simulate_key_press(KEY_SHIFT)
+##       runner.simulate_key_press(KEY_A)
+##       await _runner.await_input_processed()
+## [/codeblock]
 @abstract func simulate_key_press(key_code: int, shift_pressed := false, ctrl_pressed := false) -> GdUnitSceneRunner
 
 
 ## Simulates that a key has been released.[br]
 ## [member key_code] : the key code e.g. [constant KEY_ENTER][br]
-## [member shift_pressed] : false by default set to true if simmulate shift is press[br]
-## [member ctrl_pressed] : false by default set to true if simmulate control is press[br]
+## [codeblock]
+##    # Do simulate releasing key A
+##    func test_key_A_releasing():
+##       var runner = scene_runner("res://scenes/simple_scene.tscn")
+##       await runner.simulate_key_release(KEY_A)
+##
+##
+##    # Do simulate keycombination pressing shift+A
+##    func test_key_shift_and_A_releasing(():
+##       var runner = scene_runner("res://scenes/simple_scene.tscn")
+##       runner.simulate_key_release(KEY_SHIFT)
+##       runner.simulate_key_release(KEY_A)
+##       await _runner.await_input_processed()
+## [/codeblock]
+## @deprecated: the modifier [b]shift_pressed[/b] and [b]ctrl_pressed[/b] will be removed in v7.0[br]See `test_key_shift_and_A_releasing` for example using key combinations
 @abstract func simulate_key_release(key_code: int, shift_pressed := false, ctrl_pressed := false) -> GdUnitSceneRunner
 
 

--- a/addons/gdUnit4/src/asserts/GdAssertMessages.gd
+++ b/addons/gdUnit4/src/asserts/GdAssertMessages.gd
@@ -40,22 +40,40 @@ static func input_event_as_text(event :InputEvent) -> String:
 	var text := ""
 	if event is InputEventKey:
 		var key_event := event as InputEventKey
-		text += "InputEventKey : key='%s', pressed=%s, keycode=%d, physical_keycode=%s" % [
-					event.as_text(), key_event.pressed, key_event.keycode, key_event.physical_keycode]
+		text += """
+			InputEventKey : keycode=%s (%s) pressed: %s
+				physical_keycode: %s
+				location: %s
+				echo: %s""" % [
+					key_event.keycode,
+					event.as_text_keycode(),
+					key_event.pressed,
+					key_event.physical_keycode,
+					key_event.location,
+					key_event.echo]
 	else:
 		text += event.as_text()
 	if event is InputEventMouse:
 		var mouse_event := event as InputEventMouse
-		text += ", global_position %s" % mouse_event.global_position
+		text += """
+				global_position: %s""" % mouse_event.global_position
 	if event is InputEventWithModifiers:
 		var mouse_event := event as InputEventWithModifiers
-		text += ", shift=%s, alt=%s, control=%s, meta=%s, command=%s" % [
+		text += """
+				--------
+				mods: %s
+				shift: %s
+				alt: %s
+				control: %s
+				meta: %s
+				command: %s""" % [
+					mouse_event.get_modifiers_mask(),
 					mouse_event.shift_pressed,
 					mouse_event.alt_pressed,
 					mouse_event.ctrl_pressed,
 					mouse_event.meta_pressed,
 					mouse_event.command_or_control_autoremap]
-	return text
+	return text.dedent()
 
 
 static func _colored_string_div(characters: String) -> String:

--- a/addons/gdUnit4/src/core/GdUnitSceneRunnerImpl.gd
+++ b/addons/gdUnit4/src/core/GdUnitSceneRunnerImpl.gd
@@ -143,6 +143,7 @@ func simulate_action_release(action: String, event_index := -1) -> GdUnitSceneRu
 
 @warning_ignore("return_value_discarded")
 func simulate_key_pressed(key_code: int, shift_pressed := false, ctrl_pressed := false) -> GdUnitSceneRunner:
+	_push_warning_deprecated_arguments(shift_pressed, ctrl_pressed)
 	simulate_key_press(key_code, shift_pressed, ctrl_pressed)
 	await _scene_tree().process_frame
 	simulate_key_release(key_code, shift_pressed, ctrl_pressed)
@@ -150,30 +151,33 @@ func simulate_key_pressed(key_code: int, shift_pressed := false, ctrl_pressed :=
 
 
 func simulate_key_press(key_code: int, shift_pressed := false, ctrl_pressed := false) -> GdUnitSceneRunner:
+	_push_warning_deprecated_arguments(shift_pressed, ctrl_pressed)
 	__print_current_focus()
 	var event := InputEventKey.new()
 	event.pressed = true
 	event.keycode = key_code as Key
 	event.physical_keycode = key_code as Key
 	event.unicode = key_code
-	event.alt_pressed = key_code == KEY_ALT
-	event.shift_pressed = shift_pressed or key_code == KEY_SHIFT
-	event.ctrl_pressed = ctrl_pressed or key_code == KEY_CTRL
+	event.set_alt_pressed(key_code == KEY_ALT)
+	event.set_shift_pressed(shift_pressed)
+	event.set_ctrl_pressed(ctrl_pressed)
+	event.get_modifiers_mask()
 	_apply_input_modifiers(event)
 	_key_on_press.append(key_code)
 	return _handle_input_event(event)
 
 
 func simulate_key_release(key_code: int, shift_pressed := false, ctrl_pressed := false) -> GdUnitSceneRunner:
+	_push_warning_deprecated_arguments(shift_pressed, ctrl_pressed)
 	__print_current_focus()
 	var event := InputEventKey.new()
 	event.pressed = false
 	event.keycode = key_code as Key
 	event.physical_keycode = key_code as Key
 	event.unicode = key_code
-	event.alt_pressed = key_code == KEY_ALT
-	event.shift_pressed = shift_pressed or key_code == KEY_SHIFT
-	event.ctrl_pressed = ctrl_pressed or key_code == KEY_CTRL
+	event.set_alt_pressed(key_code == KEY_ALT)
+	event.set_shift_pressed(shift_pressed)
+	event.set_ctrl_pressed(ctrl_pressed)
 	_apply_input_modifiers(event)
 	_key_on_press.erase(key_code)
 	return _handle_input_event(event)
@@ -515,6 +519,13 @@ func _apply_input_modifiers(event: InputEvent) -> void:
 		_event.ctrl_pressed = _event.ctrl_pressed or last_input_event.ctrl_pressed
 		# this line results into reset the control_pressed state!!!
 		#event.command_or_control_autoremap = event.command_or_control_autoremap or _last_input_event.command_or_control_autoremap
+	if _last_input_event is InputEventKey and event is InputEventWithModifiers:
+		var last_input_event := _last_input_event as InputEventKey
+		var _event := event as InputEventWithModifiers
+		_event.shift_pressed = _event.shift_pressed or last_input_event.keycode == KEY_SHIFT
+		_event.alt_pressed = _event.alt_pressed or last_input_event.keycode == KEY_ALT
+		_event.ctrl_pressed = _event.ctrl_pressed or last_input_event.keycode == KEY_CTRL
+		_event.meta_pressed = _event.meta_pressed or  last_input_event.keycode == KEY_META
 
 
 # copy over current active mouse mask and combine with curren mask
@@ -620,3 +631,10 @@ func scene() -> Node:
 	if not _is_disposed:
 		push_error("The current scene instance is not valid anymore! check your test is valid. e.g. check for missing awaits.")
 	return null
+
+
+func _push_warning_deprecated_arguments(shift_pressed: bool, ctrl_pressed: bool) -> void:
+	if shift_pressed:
+		push_warning("Deprecated! Don't use 'shift_pressed' it will be removed in v7.0, checkout the documentaion how to use key combinations.")
+	if ctrl_pressed:
+		push_warning("Deprecated! Don't use 'ctrl_pressed' it will be removed in v7.0, checkout the documentaion how to use key combinations.")

--- a/addons/gdUnit4/test/core/GdUnitSceneRunnerInputEventTest.gd
+++ b/addons/gdUnit4/test/core/GdUnitSceneRunnerInputEventTest.gd
@@ -20,6 +20,7 @@ func before_test() -> void:
 	assert_inital_key_state()
 	# reset to inital state
 	reset(_scene_spy)
+	verify_no_more_interactions(_scene_spy)
 
 
 # asserts to action strings
@@ -126,7 +127,6 @@ func test_simulate_action_release() -> void:
 			.override_failure_message("Expect the action '%s' is NOT pressed" % action).is_false()
 
 
-
 func test_simulate_key_press() -> void:
 	# iterate over some example keys
 	for key :int in [KEY_A, KEY_D, KEY_X, KEY_0]:
@@ -152,31 +152,269 @@ func test_simulate_key_press() -> void:
 	assert_that(Input.is_key_pressed(KEY_1)).is_false()
 
 
-func test_simulate_key_press_with_modifiers() -> void:
-	# press shift key + A
+# Simulates pressing shift+A
+# Verified with "res://addons/gdUnit4/test/core/InputEventTestScene.tscn"
+func test_simulate_key_press_SHIFT_and_A() -> void:
+	# press shift + A
 	_runner.simulate_key_press(KEY_SHIFT)
 	_runner.simulate_key_press(KEY_A)
 	await _runner.await_input_processed()
 
-	# results in two events, first is the shift key is press
+	# We expect key A is pressed and also the modifier shift key
+	assert_that(Input.is_key_pressed(KEY_A)).is_true()
+	assert_that(Input.is_key_pressed(KEY_SHIFT)).is_true()
+	assert_that(Input.is_key_pressed(KEY_ALT)).is_false()
+	assert_that(Input.is_key_pressed(KEY_CTRL)).is_false()
+	assert_that(Input.is_key_pressed(KEY_META)).is_false()
+
+	# In addition we need to verify we emit two input events:
+	# first the shift key is pressing (Shift)
 	var event := InputEventKey.new()
 	event.keycode = KEY_SHIFT
 	event.physical_keycode = KEY_SHIFT
 	event.unicode = KEY_SHIFT as int
 	event.pressed = true
-	event.shift_pressed = true
+	event.shift_pressed = false
+	event.alt_pressed = false
+	event.ctrl_pressed = false
+	event.meta_pressed = false
 	verify(_scene_spy, 1)._input(event)
 
-	# second is the comnbination of current press shift and key A
+	# second in addition the key A is pressing (Shift+A)
 	event = InputEventKey.new()
 	event.keycode = KEY_A
 	event.physical_keycode = KEY_A
 	event.unicode = KEY_A as int
 	event.pressed = true
 	event.shift_pressed = true
+	event.alt_pressed = false
+	event.ctrl_pressed = false
+	event.meta_pressed = false
 	verify(_scene_spy, 1)._input(event)
-	assert_that(Input.is_key_pressed(KEY_SHIFT)).is_true()
+	verify_no_more_interactions(_scene_spy)
+
+
+# Simulate pressing key A and shift
+# Verified with "res://addons/gdUnit4/test/core/InputEventTestScene.tscn"
+func test_simulate_key_press_A_and_SHIFT() -> void:
+	# press key A + shift
+	_runner.simulate_key_press(KEY_A)
+	_runner.simulate_key_press(KEY_SHIFT)
+	await _runner.await_input_processed()
+
+	# We expect key A is pressed and also the modifier shift key
 	assert_that(Input.is_key_pressed(KEY_A)).is_true()
+	assert_that(Input.is_key_pressed(KEY_SHIFT)).is_true()
+	assert_that(Input.is_key_pressed(KEY_ALT)).is_false()
+	assert_that(Input.is_key_pressed(KEY_CTRL)).is_false()
+	assert_that(Input.is_key_pressed(KEY_META)).is_false()
+
+	# In addition we need to verify we emit two input events:
+	# first the shift a is pressing (A)
+	var event := InputEventKey.new()
+	event.keycode = KEY_A
+	event.physical_keycode = KEY_A
+	event.unicode = KEY_A as int
+	event.pressed = true
+	event.shift_pressed = false
+	event.alt_pressed = false
+	event.ctrl_pressed = false
+	event.meta_pressed = false
+	verify(_scene_spy, 1)._input(event)
+
+	# second in addition the key shift is pressing (Shift)
+	event = InputEventKey.new()
+	event.keycode = KEY_SHIFT
+	event.physical_keycode = KEY_SHIFT
+	event.unicode = KEY_SHIFT as int
+	event.pressed = true
+	event.shift_pressed = false
+	event.alt_pressed = false
+	event.ctrl_pressed = false
+	event.meta_pressed = false
+	verify(_scene_spy, 1)._input(event)
+	verify_no_more_interactions(_scene_spy)
+
+
+# Simulate releasing key shift+A
+# Verified with "res://addons/gdUnit4/test/core/InputEventTestScene.tscn"
+func test_simulate_key_released_SHIFT_and_A() -> void:
+	# release shift + A
+	_runner.simulate_key_release(KEY_SHIFT)
+	_runner.simulate_key_release(KEY_A)
+	await _runner.await_input_processed()
+
+	# We expect key A is NOT pressed (it was released) and no modifier keys
+	assert_that(Input.is_key_pressed(KEY_A)).is_false()
+	assert_that(Input.is_key_pressed(KEY_SHIFT)).is_false()
+	assert_that(Input.is_key_pressed(KEY_ALT)).is_false()
+	assert_that(Input.is_key_pressed(KEY_CTRL)).is_false()
+	assert_that(Input.is_key_pressed(KEY_META)).is_false()
+
+	# In addition we need to verify we emit two input events:
+	# first the shift+a key is released (Shift+A)
+	var event := InputEventKey.new()
+	event.keycode = KEY_A
+	event.physical_keycode = KEY_A
+	event.unicode = KEY_A as int
+	event.pressed = false
+	event.shift_pressed = true
+	event.alt_pressed = false
+	event.ctrl_pressed = false
+	event.meta_pressed = false
+	verify(_scene_spy, 1)._input(event)
+
+	# second in addition the shift is released (Shift)
+	event = InputEventKey.new()
+	event.keycode = KEY_SHIFT
+	event.physical_keycode = KEY_SHIFT
+	event.unicode = KEY_SHIFT as int
+	event.pressed = false
+	event.shift_pressed = false
+	event.alt_pressed = false
+	event.ctrl_pressed = false
+	event.meta_pressed = false
+	verify(_scene_spy, 1)._input(event)
+	verify_no_more_interactions(_scene_spy)
+
+
+# Simulate pressed key shift+A
+# Verified with "res://addons/gdUnit4/test/core/InputEventTestScene.tscn"
+func test_simulate_key_pressed_SHIFT_and_A() -> void:
+	# release shift + A
+	await _runner.simulate_key_pressed(KEY_SHIFT)
+	await _runner.simulate_key_pressed(KEY_A)
+
+	# We expect key A is NOT pressed (it was press and released) and no modifier keys
+	assert_that(Input.is_key_pressed(KEY_A)).is_false()
+	assert_that(Input.is_key_pressed(KEY_SHIFT)).is_false()
+	assert_that(Input.is_key_pressed(KEY_ALT)).is_false()
+	assert_that(Input.is_key_pressed(KEY_CTRL)).is_false()
+	assert_that(Input.is_key_pressed(KEY_META)).is_false()
+
+	# In addition, we need to check whether we output two input events:
+	# first the shift key is pressing (Shift+A)
+	var event := InputEventKey.new()
+	event.keycode = KEY_A
+	event.physical_keycode = KEY_A
+	event.unicode = KEY_A as int
+	event.pressed = true
+	event.shift_pressed = true
+	event.alt_pressed = false
+	event.ctrl_pressed = false
+	event.meta_pressed = false
+	verify(_scene_spy, 1)._input(event)
+
+	# second in addition the key A is released (Shift+A)
+	event = InputEventKey.new()
+	event.keycode = KEY_A
+	event.physical_keycode = KEY_A
+	event.unicode = KEY_A as int
+	event.pressed = false
+	event.shift_pressed = true
+	event.alt_pressed = false
+	event.ctrl_pressed = false
+	event.meta_pressed = false
+	verify(_scene_spy, 1)._input(event)
+
+
+# Simulate pressing key A + set shift modifier
+# @deprecated
+func test_simulate_key_press_A_with_shift_modifier() -> void:
+	# press key A + modifier shift
+	_runner.simulate_key_press(KEY_A, true)
+	await _runner.await_input_processed()
+
+	# We expect key A is pressing only and no modifier keys
+	assert_that(Input.is_key_pressed(KEY_A)).is_true()
+	assert_that(Input.is_key_pressed(KEY_SHIFT)).is_false()
+	assert_that(Input.is_key_pressed(KEY_ALT)).is_false()
+	assert_that(Input.is_key_pressed(KEY_CTRL)).is_false()
+	assert_that(Input.is_key_pressed(KEY_META)).is_false()
+
+	# In addition we need to verify we emit one input events:
+	# the key A + modifier shift is pressing (Shift+A)
+	var event := InputEventKey.new()
+	event = InputEventKey.new()
+	event.keycode = KEY_A
+	event.physical_keycode = KEY_A
+	event.unicode = KEY_A as int
+	event.pressed = true
+	event.shift_pressed = true
+	event.alt_pressed = false
+	event.ctrl_pressed = false
+	event.meta_pressed = false
+	verify(_scene_spy, 1)._input(event)
+	verify_no_more_interactions(_scene_spy)
+
+
+# Simulate releasing key A + set shift modifier
+# @deprecated
+func test_simulate_key_released_A_with_shift_modifier() -> void:
+	# release key A + modifiere shift
+	_runner.simulate_key_release(KEY_A, true)
+	await _runner.await_input_processed()
+
+	# We expect key A is NOT pressing and also no modifier keys
+	assert_that(Input.is_key_pressed(KEY_A)).is_false()
+	assert_that(Input.is_key_pressed(KEY_SHIFT)).is_false()
+	assert_that(Input.is_key_pressed(KEY_ALT)).is_false()
+	assert_that(Input.is_key_pressed(KEY_CTRL)).is_false()
+	assert_that(Input.is_key_pressed(KEY_META)).is_false()
+
+	# In addition we need to verify we emit one input events:
+	# The key A and modifier shift is released (Shift+A)
+	var event := InputEventKey.new()
+	event.keycode = KEY_A
+	event.physical_keycode = KEY_A
+	event.unicode = KEY_A as int
+	event.pressed = false
+	event.shift_pressed = true
+	event.alt_pressed = false
+	event.ctrl_pressed = false
+	event.meta_pressed = false
+	verify(_scene_spy, 1)._input(event)
+	verify_no_more_interactions(_scene_spy)
+
+
+# Simulate pressed key A + set shift modifier
+# @deprecated
+func test_simulate_key_pressed_A_with_shift_modifier() -> void:
+	# release key A + modifier shift
+	await _runner.simulate_key_pressed(KEY_A, true)
+
+	# We expect key A is NOT pressing (was press and released) and also no modifier keys
+	assert_that(Input.is_key_pressed(KEY_SHIFT)).is_false()
+	assert_that(Input.is_key_pressed(KEY_ALT)).is_false()
+	assert_that(Input.is_key_pressed(KEY_CTRL)).is_false()
+	assert_that(Input.is_key_pressed(KEY_META)).is_false()
+	assert_that(Input.is_key_pressed(KEY_A)).is_false()
+
+	# In addition, we need to check whether we output two input events:
+	# first the key a + modifier shift is pressing (Shift+A)
+	var event := InputEventKey.new()
+	event.keycode = KEY_A
+	event.physical_keycode = KEY_A
+	event.unicode = KEY_A as int
+	event.pressed = true
+	event.shift_pressed = true
+	event.alt_pressed = false
+	event.ctrl_pressed = false
+	event.meta_pressed = false
+	verify(_scene_spy, 1)._input(event)
+
+	# second in addition  the key a + modifier shift is released (Shift+A)
+	event = InputEventKey.new()
+	event.keycode = KEY_A
+	event.physical_keycode = KEY_A
+	event.unicode = KEY_A as int
+	event.pressed = false
+	event.shift_pressed = true
+	event.alt_pressed = false
+	event.ctrl_pressed = false
+	event.meta_pressed = false
+	verify(_scene_spy, 1)._input(event)
+	verify_no_more_interactions(_scene_spy)
 
 
 func test_simulate_many_keys_press() -> void:
@@ -229,6 +467,7 @@ func test_simulate_keypressed_as_action() -> void:
 	# test a key event is not trigger the custom action event
 	# simulate press only space+ctrl
 	runner._reset_input_to_default()
+	# @deprecated
 	runner.simulate_key_pressed(KEY_SPACE, false, true)
 	# it is important do not wait for next frame here, otherwise the input action cache is cleared and can't be use to verify
 	assert_bool(Input.is_action_just_released("player_jump", true)).is_false()

--- a/addons/gdUnit4/test/core/InputEventTestScene.tscn
+++ b/addons/gdUnit4/test/core/InputEventTestScene.tscn
@@ -1,0 +1,19 @@
+[gd_scene load_steps=2 format=3 uid="uid://7fcklvxjr88k"]
+
+[sub_resource type="GDScript" id="GDScript_h62nu"]
+script/source = "extends Control
+
+
+func _input(event: InputEvent) -> void:
+	prints(\">>\", GdAssertMessages.input_event_as_text(event))
+	get_viewport().set_input_as_handled()
+"
+
+[node name="KeyTest" type="Control"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+script = SubResource("GDScript_h62nu")


### PR DESCRIPTION
# Why
After reviewing the test coverage of “simulate key” once again, I decide to revise it to improve it.

# What
Revision of simulation tests for keys with modifiers and correction of incorrect assumptions for creating key events. Adding more specific use cases
- pressing key combination SHIFT+A
- pressing key combination A+SHIFT
- releasing key combination SHIFT+A
- pressed key combination SHIFT+A
- pressing key A and using the modifier SHIFT
- releasing key A and using the modifier SHIFT
- pressed key A and using the modifier SHIFT

Evaluate the built events by using an SPY to verify the input events are built like the Godot engine by using the `addons\gdUnit4\test\core\InputEventTestScene.tscn`

- Fixes wrong setting key input event modifiers
- Set `simulate_key_pressed`, `simulate_key_press`, `simulate_key_release` as deprecated
- Improve the class documentation by adding an example
