### PR TITLE
GD-1051: Add variadic argument support to assert_signal and support String and Signal reference for signal_name argument

### DIFF
--- a/addons/gdUnit4/src/GdUnitSignalAssert.gd
+++ b/addons/gdUnit4/src/GdUnitSignalAssert.gd
@@ -27,20 +27,132 @@ extends GdUnitAssert
 @abstract func append_failure_message(message: String) -> GdUnitSignalAssert
 
 
-## Verifies that given signal is emitted until waiting time
-@abstract func is_emitted(name: String, args := []) -> GdUnitSignalAssert
+## Verifies that the specified signal is emitted with the expected arguments.[br]
+##
+## This assertion waits for a signal to be emitted from the object under test and
+## validates that it was emitted with the correct arguments. The function supports
+## both typed signals (Signal type) and string-based signal names for flexibility
+## in different testing scenarios.[br]
+## [br]
+## [b]Parameters:[/b][br]
+## [param signal_name]: The signal to monitor. Can be either:[br]
+##   • A [Signal] reference (recommended for type safety)[br]
+##   • A [String] with the signal name
+## [param signal_args]: Optional expected signal arguments.[br]
+##   When provided, verifies the signal was emitted with exactly these values.[br]
+## [br]
+## [b]Returns:[/b][br]
+## [GdUnitSignalAssert] - Returns self for method chaining.[br]
+## [br]
+## [b]Examples:[/b]
+## [codeblock]
+## signal signal_a(value: int)
+## signal signal_b(name: String, count: int)
+##
+## # Wait for signal emission without checking arguments
+## # Using Signal reference (type-safe)
+## await assert_signal(instance).is_emitted(signal_a)
+## # Using string name (dynamic)
+## await assert_signal(instance).is_emitted("signal_a")
+##
+## # Wait for signal emission with specific argument
+## await assert_signal(instance).is_emitted(signal_a, 10)
+##
+## # Wait for signal with multiple arguments
+## await assert_signal(instance).is_emitted(signal_b, "test", 42)
+##
+## # Wait max 500ms for signal with argument 10
+## await assert_signal(instance).wait_until(500).is_emitted(signal_a, 10)
+## [/codeblock]
+## [br]
+## [b]Note:[/b] This is an async operation - use [code]await[/code] when calling.[br]
+## The assertion fails if the signal is not emitted within the timeout period.
+@abstract func is_emitted(signal_name: Variant, ...signal_args: Array) -> GdUnitSignalAssert
 
 
-## Verifies that given signal is NOT emitted until waiting time
-@abstract func is_not_emitted(name: String, args := []) -> GdUnitSignalAssert
+## Verifies that the specified signal is NOT emitted with the expected arguments.[br]
+##
+## This assertion waits for a specified time period and validates that a signal
+## was not emitted with the given arguments. Useful for ensuring certain conditions
+## don't trigger unwanted signals or for verifying signal filtering logic.[br]
+## [br]
+## [b]Parameters:[/b][br]
+## [param signal_name]: The signal to monitor. Can be either:[br]
+##   • A [Signal] reference (recommended for type safety)[br]
+##   • A [String] with the signal name
+## [param signal_args]: Optional expected signal arguments.[br]
+##   When provided, verifies the signal was not emitted with these specific values.[br]
+##   If omitted, verifies the signal was not emitted at all.[br]
+## [br]
+## [b]Returns:[/b][br]
+## [GdUnitSignalAssert] - Returns self for method chaining.[br]
+## [br]
+## [b]Examples:[/b]
+## [codeblock]
+## signal signal_a(value: int)
+## signal signal_b(name: String, count: int)
+##
+## # Verify signal is not emitted at all (without checking arguments)
+## await assert_signal(instance).wait_until(500).is_not_emitted(signal_a)
+## await assert_signal(instance).wait_until(500).is_not_emitted("signal_a")
+##
+## # Verify signal is not emitted with specific argument
+## await assert_signal(instance).wait_until(500).is_not_emitted(signal_a, 10)
+##
+## # Verify signal is not emitted with multiple arguments
+## await assert_signal(instance).wait_until(500).is_not_emitted(signal_b, "test", 42)
+##
+## # Can be emitted with different arguments (this passes)
+## instance.emit_signal("signal_a", 20)  # Emits with 20, not 10
+## await assert_signal(instance).wait_until(500).is_not_emitted(signal_a, 10)
+## [/codeblock]
+## [br]
+## [b]Note:[/b] This is an async operation - use [code]await[/code] when calling.[br]
+## The assertion fails if the signal IS emitted with the specified arguments within the timeout period.
+@abstract func is_not_emitted(signal_name: Variant, ...signal_args: Array) -> GdUnitSignalAssert
 
 
-## Verifies the signal exists checked the emitter
-@abstract func is_signal_exists(name: String) -> GdUnitSignalAssert
+## Verifies that the specified signal exists on the emitter object.[br]
+##
+## This assertion checks if a signal is defined on the object under test,
+## regardless of whether it has been emitted. Useful for validating that
+## objects have the expected signals before testing their emission.[br]
+## [br]
+## [b]Parameters:[/b][br]
+## [param signal_name]: The signal to check. Can be either:[br]
+##   • A [Signal] reference (recommended for type safety)[br]
+##   • A [String] with the signal name
+## [br]
+## [b]Returns:[/b][br]
+## [GdUnitSignalAssert] - Returns self for method chaining.[br]
+## [br]
+## [b]Examples:[/b]
+## [codeblock]
+## signal my_signal(value: int)
+## signal another_signal()
+##
+## # Verify signal exists using Signal reference
+## assert_signal(instance).is_signal_exists(my_signal)
+##
+## # Verify signal exists using string name
+## assert_signal(instance).is_signal_exists("my_signal")
+##
+## # Chain with other assertions
+## assert_signal(instance) \
+##     .is_signal_exists(my_signal) \
+##     .is_emitted(my_signal, 42)
+##
+## [/codeblock]
+## [br]
+## [b]Note:[/b] This only checks signal definition, not emission.[br]
+## The assertion fails if the signal is not defined on the object.
+@abstract func is_signal_exists(signal_name: Variant) -> GdUnitSignalAssert
 
 
 ## Sets the assert signal timeout in ms, if the time over a failure is reported.[br]
-## e.g.[br]
+## Example:
+## [codeblock]
 ## do wait until 5s the instance has emitted the signal `signal_a`[br]
-## [code]assert_signal(instance).wait_until(5000).is_emitted("signal_a")[/code]
+## assert_signal(instance).wait_until(5000).is_emitted("signal_a")
+## [/codeblock]
 @abstract func wait_until(timeout: int) -> GdUnitSignalAssert

--- a/addons/gdUnit4/src/core/GdUnitSignalCollector.gd
+++ b/addons/gdUnit4/src/core/GdUnitSignalCollector.gd
@@ -107,7 +107,7 @@ func is_signal_collecting(emitter: Object, signal_name: String) -> bool:
 	return _collected_signals.has(emitter) and (_collected_signals[emitter] as Dictionary).has(signal_name)
 
 
-func match(emitter :Object, signal_name :String, args :Array) -> bool:
+func match(emitter: Object, signal_name: String, args: Array) -> bool:
 	#prints("match", signal_name,  _collected_signals[emitter][signal_name]);
 	if _collected_signals.is_empty() or not _collected_signals.has(emitter):
 		return false

--- a/documentation/doc/_testing/assert-signal.md
+++ b/documentation/doc/_testing/assert-signal.md
@@ -40,15 +40,43 @@ To watch for signals emitted during the test execution you have to use in additi
 
 ## is_emitted
 
-Waits until the given signal is emitted or the timeout occures and fails
+Verifies that the specified signal is emitted with the expected arguments.
+
+This assertion waits for a signal to be emitted from the object under test and
+validates that it was emitted with the correct arguments. The function supports
+both typed signals (Signal type) and string-based signal names for flexibility
+in different testing scenarios.
+
 {% tabs assert-signal-is_emitted %}
 {% tab assert-signal-is_emitted GdScript %}
-```gdsrcipt
-func assert_signal(<instance :Object>).is_emitted(<signal_name>, [args :Array]) -> GdUnitSignalAssert
+
+```gd
+## [b]Parameters:[/b]
+## [param signal_name]: The signal to monitor. Can be either:
+##   • A [Signal] reference (recommended for type safety)
+##   • A [String] with the signal name
+## [param signal_args]: Optional expected signal arguments.
+##   When provided, verifies the signal was emitted with exactly these values.
+func assert_signal(instance: Object).is_emitted(signal_name: Variant, ...signal_args: Array) -> GdUnitSignalAssert
 ```
 ```gd
-# waits until the signal "door_opened" is emitted by the instance or fails after default timeout of 2s
-await assert_signal(instance).is_emitted("door_opened")
+signal signal_a(value: int)
+signal signal_b(name: String, count: int)
+
+# Wait for signal emission without checking arguments
+# Using Signal reference (type-safe)
+await assert_signal(instance).is_emitted(signal_a)
+# Using string name (dynamic)
+await assert_signal(instance).is_emitted("signal_a")
+
+# Wait for signal emission with specific argument
+await assert_signal(instance).is_emitted(signal_a, 10)
+
+# Wait for signal with multiple arguments
+await assert_signal(instance).is_emitted(signal_b, "test", 42)
+
+# Wait max 500ms for signal with argument 10
+await assert_signal(instance).wait_until(500).is_emitted(signal_a, 10)
 ```
 {% endtab %}
 {% tab assert-signal-is_emitted C# %}
@@ -66,15 +94,42 @@ await AssertSignal(instance).IsEmitted("door_opened").WithTimeout(200);
 
 ## is_not_emitted
 
-Waits until the specified timeout to check if the signal was NOT emitted
+Verifies that the specified signal is NOT emitted with the expected arguments.
+
+This assertion waits for a specified time period and validates that a signal
+was not emitted with the given arguments. Useful for ensuring certain conditions
+don't trigger unwanted signals or for verifying signal filtering logic.
+
 {% tabs assert-signal-is_not_emitted %}
 {% tab assert-signal-is_not_emitted GdScript %}
-```gdsrcipt
-func assert_signal(<instance :Object>).is_not_emitted(<signal_name>, [args :Array]) -> GdUnitSignalAssert
+```gd
+## [b]Parameters:[/b]
+## [param signal_name]: The signal to monitor. Can be either:
+##   • A [Signal] reference (recommended for type safety)
+##   • A [String] with the signal name
+## [param signal_args]: Optional expected signal arguments.
+##   When provided, verifies the signal was not emitted with these specific values.
+##   If omitted, verifies the signal was not emitted at all.
+func assert_signal(instance: Object).is_not_emitted(signal_name: Variant, ...signal_args: Array) -> GdUnitSignalAssert
 ```
-```gdsrcipt
-# waits until 2s and verifies the signal "door_locked" is not emitted
-await assert_signal(instance).is_not_emitted("door_locked")
+
+```gd
+signal signal_a(value: int)
+signal signal_b(name: String, count: int)
+
+# Verify signal is not emitted at all (without checking arguments)
+await assert_signal(instance).wait_until(500).is_not_emitted(signal_a)
+await assert_signal(instance).wait_until(500).is_not_emitted("signal_a")
+
+# Verify signal is not emitted with specific argument
+await assert_signal(instance).wait_until(500).is_not_emitted(signal_a, 10)
+
+# Verify signal is not emitted with multiple arguments
+await assert_signal(instance).wait_until(500).is_not_emitted(signal_b, "test", 42)
+
+# Can be emitted with different arguments (this passes)
+instance.emit_signal("signal_a", 20)  # Emits with 20, not 10
+await assert_signal(instance).wait_until(500).is_not_emitted(signal_a, 10)
 ```
 {% endtab %}
 {% tab assert-signal-is_not_emitted C# %}
@@ -92,15 +147,36 @@ await AssertSignal(instance).IsNotEmitted("door_locked").WithTimeout(200);
 
 ## is_signal_exists
 
-Verifies if the signal exists on the emitter.
+Verifies that the specified signal exists on the emitter object.
+
+This assertion checks if a signal is defined on the object under test,
+regardless of whether it has been emitted. Useful for validating that
+objects have the expected signals before testing their emission.
+
 {% tabs assert-signal-is_signal_exists %}
 {% tab assert-signal-is_signal_exists GdScript %}
-```gdsrcipt
-func assert_signal(<instance :Object>).wait_until(<timeout>) -> GdUnitSignalAssert
+```gd
+## [b]Parameters:[/b]
+## [param signal_name]: The signal to check. Can be either:
+##   • A [Signal] reference (recommended for type safety)
+##   • A [String] with the signal name
+func assert_signal(instance: Object).is_signal_exists(signal_name: Variant) -> GdUnitSignalAssert
 ```
-```gdsrcipt
-# verify the signal 'visibility_changed' exists in the node
-assert_signal(node).is_signal_exists("visibility_changed");
+
+```gd
+signal my_signal(value: int)
+signal another_signal()
+
+# Verify signal exists using Signal reference
+assert_signal(instance).is_signal_exists(my_signal)
+
+# Verify signal exists using string name
+assert_signal(instance).is_signal_exists("my_signal")
+
+# Chain with other assertions
+assert_signal(instance) \
+    .is_signal_exists(my_signal) \
+    .is_emitted(my_signal, 42)
 ```
 {% endtab %}
 {% tab assert-signal-is_signal_exists C# %}
@@ -116,15 +192,17 @@ AssertSignal(node).IsSignalExists("visibility_changed");
 
 ## wait_until
 
-Sets the timeout in ms to wait.
+Sets the assert signal timeout in ms, if the time over a failure is reported.
 {% tabs assert-signal-wait_until %}
 {% tab assert-signal-wait_until GdScript %}
-```gdsrcipt
-func assert_signal(<instance :Object>).wait_until(<timeout>) -> GdUnitSignalAssert
+```gd
+func assert_signal(instance: Object>).wait_until(timeout: int) -> GdUnitSignalAssert
 ```
-```gdsrcipt
-# waits until 5s the signal "door_closed" is emitted or fail
-await assert_signal(instance).wait_until(5000).is_emitted("door_closed")
+```gd
+signal signal_a()
+
+# Do wait until 5s the instance has emitted the signal `signal_a`[br]
+assert_signal(instance).wait_until(5000).is_emitted(signal_a)
 ```
 {% endtab %}
 {% tab assert-signal-wait_until C# %}


### PR DESCRIPTION
# Why
The current API does not allow the use of variadic argument style and needs to define expected arguments as an array.

# What
- Adding support of variadic argument support to assert_signal
- Allow type Signal and String for signal name
- Update documentation v6.1 for assert_signal

