### PR TITLE
Add ci/pr for Godot 4.6.rc1

### DIFF
--- a/.github/workflows/ci-pr-publish-report.yml
+++ b/.github/workflows/ci-pr-publish-report.yml
@@ -29,7 +29,7 @@ jobs:
         godot-net: ['-net', '']
         include:
           - godot-version: '4.6'
-            godot-status: 'beta2'
+            godot-status: 'rc1'
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -41,7 +41,7 @@ jobs:
         godot-net: ['.Net', '']
         include:
           - godot-version: '4.6'
-            godot-status: 'beta2'
+            godot-status: 'rc1'
 
     permissions:
       actions: write


### PR DESCRIPTION
# Why
update godot rc version