### PR TITLE
Update ci/pr to Godot 4.6

### DIFF
--- a/.github/workflows/ci-dev.yml
+++ b/.github/workflows/ci-dev.yml
@@ -22,7 +22,7 @@ jobs:
       fail-fast: false
       max-parallel: 10
       matrix:
-        godot-version: ['4.5', '4.5.1']
+        godot-version: ['4.5', '4.5.1', '4.6']
         godot-status: ['stable']
         godot-net: ['.Net', '']
 

--- a/.github/workflows/ci-pr-publish-report.yml
+++ b/.github/workflows/ci-pr-publish-report.yml
@@ -24,12 +24,12 @@ jobs:
       fail-fast: false
       max-parallel: 10
       matrix:
-        godot-version: ['4.5', '4.5.1']
+        godot-version: ['4.5', '4.5.1', '4.6']
         godot-status: ['stable']
         godot-net: ['-net', '']
-        include:
-          - godot-version: '4.6'
-            godot-status: 'rc1'
+        # include:
+        #  - godot-version: '4.6'
+        #    godot-status: 'rc1'
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -36,12 +36,12 @@ jobs:
       max-parallel: 10
       matrix:
         # If changes are made here, they must be transferred to `.github\workflows\ci-pr-publish-report.yml`
-        godot-version: ['4.5', '4.5.1']
+        godot-version: ['4.5', '4.5.1', '4.6']
         godot-status: ['stable']
         godot-net: ['.Net', '']
-        include:
-          - godot-version: '4.6'
-            godot-status: 'rc1'
+        # include:
+        #  - godot-version: '4.6'
+        #    godot-status: 'rc1'
 
     permissions:
       actions: write

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
   <img src="https://img.shields.io/badge/Godot-v4.4-%23478cbf?logo=godot-engine&logoColor=cyian&color=green" alt="">
   <img src="https://img.shields.io/badge/Godot-v4.4.1-%23478cbf?logo=godot-engine&logoColor=cyian&color=green" alt="">
   <img src="https://img.shields.io/badge/Godot-v4.5-%23478cbf?logo=godot-engine&logoColor=cyian&color=green" alt="">
-    <img src="https://img.shields.io/badge/Godot-v4.6-%23478cbf?logo=godot-engine&logoColor=cyian&color=yellow" alt="">
+  <img src="https://img.shields.io/badge/Godot-v4.6-%23478cbf?logo=godot-engine&logoColor=cyian&color=green" alt="">
 </p>
 
 <h1 align="center">Compatibility Overview</h1>
@@ -26,7 +26,7 @@
   </thead>
   <tbody>
     <tr>
-      <td>master (upcoming v6.1)</td><td>v4.6.rc1</td>
+      <td>master (upcoming v6.1)</td><td>v4.6</td>
     </tr>
     <tr>
       <td>v6.x+</td><td>v4.5, v4.5.1</td>


### PR DESCRIPTION
# Why
Godot 4.6 is released

