### PR TITLE
GD-1069: Fixing compile errors and warnings

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -23,8 +23,9 @@ body:
       label: The used GdUnit4 version
       description: Which GdUnit4 version are you using?
       options:
-        - 6.1.0 (Pre Release/Master branch)
-        - 6.0.3 (Latest Release)
+        - 6.1.1 (Pre Release/Master branch)
+        - 6.1.0 (Latest Release)
+        - 6.0.3
         - 6.0.2
         - 6.0.1
         - 6.0.0

--- a/addons/gdUnit4/plugin.cfg
+++ b/addons/gdUnit4/plugin.cfg
@@ -3,5 +3,5 @@
 name="gdUnit4"
 description="Unit Testing Framework for Godot Scripts"
 author="Mike Schulze"
-version="6.1.0"
+version="6.1.1"
 script="plugin.gd"

--- a/addons/gdUnit4/src/asserts/GdAssertMessages.gd
+++ b/addons/gdUnit4/src/asserts/GdAssertMessages.gd
@@ -46,7 +46,7 @@ static func input_event_as_text(event :InputEvent) -> String:
 				location: %s
 				echo: %s""" % [
 					key_event.keycode,
-					event.as_text_keycode(),
+					key_event.as_text_keycode(),
 					key_event.pressed,
 					key_event.physical_keycode,
 					key_event.location,

--- a/addons/gdUnit4/src/asserts/GdUnitSignalAssertImpl.gd
+++ b/addons/gdUnit4/src/asserts/GdUnitSignalAssertImpl.gd
@@ -91,10 +91,11 @@ func is_not_equal(_expected: Variant) -> GdUnitSignalAssert:
 
 
 # Verifies the signal exists checked the emitter
-func is_signal_exists(signal_name: Variant) -> GdUnitSignalAssert:
-	if not (signal_name is String or signal_name is Signal):
-		return report_error("Invalid signal_name: expected String or Signal, but is '%s'" % type_string(typeof(signal_name)))
-	signal_name = (signal_name as Signal).get_name() if signal_name is Signal else signal_name
+func is_signal_exists(signal_or_name: Variant) -> GdUnitSignalAssert:
+	if not (signal_or_name is String or signal_or_name is Signal):
+		return report_error("Invalid signal_name: expected String or Signal, but is '%s'" % type_string(typeof(signal_or_name)))
+
+	var signal_name := _to_signal_name(signal_or_name)
 
 	if not _emitter.has_signal(signal_name):
 		@warning_ignore("return_value_discarded")
@@ -105,6 +106,7 @@ func is_signal_exists(signal_name: Variant) -> GdUnitSignalAssert:
 # Verifies that given signal is emitted until waiting time
 func is_emitted(signal_name: Variant, ...signal_args: Array) -> GdUnitSignalAssert:
 	_line_number = GdUnitAssertions.get_line_number()
+	@warning_ignore("unsafe_call_argument")
 	return await _wail_until_signal(
 		signal_name,
 		_wrap_arguments.callv(signal_args),
@@ -114,6 +116,7 @@ func is_emitted(signal_name: Variant, ...signal_args: Array) -> GdUnitSignalAsse
 # Verifies that given signal is NOT emitted until waiting time
 func is_not_emitted(signal_name: Variant, ...signal_args: Array) -> GdUnitSignalAssert:
 	_line_number = GdUnitAssertions.get_line_number()
+	@warning_ignore("unsafe_call_argument")
 	return await _wail_until_signal(
 		signal_name,
 		_wrap_arguments.callv(signal_args),
@@ -127,12 +130,13 @@ func _wrap_arguments(...args: Array) -> Array:
 	return args
 
 
-func _wail_until_signal(signal_value: Variant, expected_args: Array, expect_not_emitted: bool) -> GdUnitSignalAssert:
+func _wail_until_signal(signal_or_name: Variant, expected_args: Array, expect_not_emitted: bool) -> GdUnitSignalAssert:
 	if _emitter == null:
 		return report_error("Can't wait for signal checked a NULL object.")
-	if not (signal_value is String or signal_value is Signal):
-		return report_error("Invalid signal_name: expected String or Signal, but is '%s'" % type_string(typeof(signal_value)))
-	var signal_name := (signal_value as Signal).get_name() if signal_value is Signal else signal_value
+	if not (signal_or_name is String or signal_or_name is Signal):
+		return report_error("Invalid signal_name: expected String or Signal, but is '%s'" % type_string(typeof(signal_or_name)))
+
+	var signal_name := _to_signal_name(signal_or_name)
 	# first verify the signal is defined
 	if not _emitter.has_signal(signal_name):
 		return report_error("Can't wait for non-existion signal '%s' checked object '%s'." % [signal_name,_emitter.get_class()])
@@ -161,3 +165,8 @@ func _wail_until_signal(signal_value: Variant, expected_args: Array, expect_not_
 	if is_instance_valid(_emitter):
 		_signal_collector.reset_received_signals(_emitter, signal_name, expected_args)
 	return self
+
+
+func _to_signal_name(signal_or_name: Variant) -> String:
+	@warning_ignore("unsafe_cast")
+	return (signal_or_name as Signal).get_name() if signal_or_name is Signal else signal_or_name

--- a/addons/gdUnit4/src/core/GdUnitRunnerConfig.gd
+++ b/addons/gdUnit4/src/core/GdUnitRunnerConfig.gd
@@ -43,8 +43,8 @@ func server_port() -> int:
 	return _config.get(SERVER_PORT, -1)
 
 
-func do_fail_fast(is_fail_fast: bool) -> GdUnitRunnerConfig:
-	_config[EXIT_FAIL_FAST] = is_fail_fast
+func do_fail_fast(fail_fast: bool) -> GdUnitRunnerConfig:
+	_config[EXIT_FAIL_FAST] = fail_fast
 	return self
 
 

--- a/addons/gdUnit4/src/core/command/GdUnitCommandFileSystemDebugTests.gd
+++ b/addons/gdUnit4/src/core/command/GdUnitCommandFileSystemDebugTests.gd
@@ -11,5 +11,7 @@ func _init(test_session_command: GdUnitCommandTestSession) -> void:
 
 
 func execute(...parameters: Array) -> void:
+	if parameters.is_empty():
+		return
 	var selected_paths: PackedStringArray = parameters[0]
 	execute_tests(selected_paths, true)

--- a/addons/gdUnit4/src/core/command/GdUnitCommandInspectorRerunTestsUntilFailure.gd
+++ b/addons/gdUnit4/src/core/command/GdUnitCommandInspectorRerunTestsUntilFailure.gd
@@ -29,7 +29,7 @@ func execute(..._parameters: Array) -> void:
 	var selected_item := inspector._tree.get_selected()
 	var tests_to_execute := inspector.collect_test_cases(selected_item)
 	var rerun_until_failure_count := GdUnitSettings.get_rerun_max_retries()
-	var saved_settings := ProjectSettings.get_setting(GdUnitSettings.TEST_FLAKY_CHECK)
+	var saved_settings: bool = ProjectSettings.get_setting(GdUnitSettings.TEST_FLAKY_CHECK)
 	ProjectSettings.set_setting(GdUnitSettings.TEST_FLAKY_CHECK, false)
 
 	GdUnitSignals.instance().gdunit_event.connect(_on_test_event)

--- a/addons/gdUnit4/src/core/execution/stages/GdUnitTestCaseAfterStage.gd
+++ b/addons/gdUnit4/src/core/execution/stages/GdUnitTestCaseAfterStage.gd
@@ -19,4 +19,4 @@ func _execute(context: GdUnitExecutionContext) -> void:
 		await test_suite.after_test()
 
 	await context.gc(GdUnitExecutionContext.GC_ORPHANS_CHECK.TEST_HOOK_AFTER)
-	await context.error_monitor_stop()
+	context.error_monitor_stop()

--- a/addons/gdUnit4/src/core/execution/stages/GdUnitTestCaseExecutionStage.gd
+++ b/addons/gdUnit4/src/core/execution/stages/GdUnitTestCaseExecutionStage.gd
@@ -24,7 +24,7 @@ func _execute(context :GdUnitExecutionContext) -> void:
 		await _stage_single_test.execute(context)
 
 	await context.gc()
-	await context.error_monitor_stop()
+	context.error_monitor_stop()
 
 	# finally free the test instance
 	if is_instance_valid(context.test_case):

--- a/addons/gdUnit4/src/monitor/ErrorLogEntry.gd
+++ b/addons/gdUnit4/src/monitor/ErrorLogEntry.gd
@@ -29,13 +29,13 @@ func _to_string() -> String:
 	return _message
 
 
-static func of_push_warning(file: String, line: int, message: String, stack_trace: PackedStringArray) -> ErrorLogEntry:
+static func of_push_warning(line: int, message: String, stack_trace: PackedStringArray) -> ErrorLogEntry:
 	return ErrorLogEntry.new(TYPE.PUSH_WARNING, line, message, "\n".join(stack_trace))
 
 
-static func of_push_error(file: String, line: int, message: String, stack_trace: PackedStringArray) -> ErrorLogEntry:
+static func of_push_error(line: int, message: String, stack_trace: PackedStringArray) -> ErrorLogEntry:
 	return ErrorLogEntry.new(TYPE.PUSH_ERROR, line, message, "\n".join(stack_trace))
 
 
-static func of_script_error(file: String, line: int, message: String, stack_trace: PackedStringArray) -> ErrorLogEntry:
+static func of_script_error(line: int, message: String, stack_trace: PackedStringArray) -> ErrorLogEntry:
 	return ErrorLogEntry.new(TYPE.SCRIPT_ERROR, line, message, "\n".join(stack_trace))

--- a/addons/gdUnit4/src/monitor/GodotGdErrorMonitor.gd
+++ b/addons/gdUnit4/src/monitor/GodotGdErrorMonitor.gd
@@ -2,7 +2,7 @@ class_name GodotGdErrorMonitor
 extends GdUnitMonitor
 
 var _report_enabled := false
-var _logger: Logger
+var _logger: GdUnitLogger
 
 
 class GdUnitLogger extends Logger:
@@ -14,26 +14,35 @@ class GdUnitLogger extends Logger:
 		return _entries
 
 
-	func _log_error(function: String, file: String, line: int, message: String, rationale: String, editor_notify: bool, error_type: int, script_backtraces: Array[ScriptBacktrace]) -> void:
+	func _log_error(
+		_function: String,
+		_file: String,
+		_line: int,
+		message: String,
+		_rationale: String,
+		_editor_notify: bool,
+		error_type: int,
+		script_backtraces: Array[ScriptBacktrace]
+		) -> void:
 		match error_type:
 			ErrorType.ERROR_TYPE_WARNING:
 				var stack_trace := _build_stack_trace(script_backtraces)
-				_entries.append(ErrorLogEntry.of_push_warning(file, _line_number, message, stack_trace))
+				_entries.append(ErrorLogEntry.of_push_warning(_line_number, message, stack_trace))
 
 			ErrorType.ERROR_TYPE_ERROR:
 				var stack_trace := _build_stack_trace(script_backtraces)
-				_entries.append(ErrorLogEntry.of_push_error(file, _line_number, message, stack_trace))
+				_entries.append(ErrorLogEntry.of_push_error(_line_number, message, stack_trace))
 
 			ErrorType.ERROR_TYPE_SCRIPT:
 				var stack_trace := _build_stack_trace(script_backtraces)
-				_entries.append(ErrorLogEntry.of_script_error(file, _line_number, message, stack_trace))
+				_entries.append(ErrorLogEntry.of_script_error(_line_number, message, stack_trace))
 
 			ErrorType.ERROR_TYPE_SHADER:
 				pass
 			_:
 				prints("Unknwon log type", message)
 
-	func _log_message(message: String, error: bool) -> void:
+	func _log_message(_message: String, _error: bool) -> void:
 		pass
 
 	func _build_stack_trace(script_backtraces: Array[ScriptBacktrace]) -> PackedStringArray:

--- a/addons/gdUnit4/src/network/GdUnitTcpServer.gd
+++ b/addons/gdUnit4/src/network/GdUnitTcpServer.gd
@@ -67,7 +67,7 @@ func _init(server_name := "GdUnit4 TCP Server") -> void:
 	GdUnitSignals.instance().gdunit_test_session_terminate.connect(func() -> void:
 		for connection in get_children():
 			if connection is TcpConnection:
-				connection.disconnect_from_server()
+				(connection as TcpConnection).disconnect_from_server()
 	)
 
 

--- a/addons/gdUnit4/src/ui/parts/InspectorTreeMainPanel.gd
+++ b/addons/gdUnit4/src/ui/parts/InspectorTreeMainPanel.gd
@@ -9,7 +9,7 @@ signal tree_item_selected(item: TreeItem)
 @onready var _tree: Tree = $Panel/Tree
 @onready var _report_list: Node = $report/ScrollContainer/list
 @onready var _report_template: RichTextLabel = $report/report_template
-@onready var _context_menu: PopupMenu = $contextMenu
+@onready var _context_menu: GdUnitInspectorContextMenu = $contextMenu
 @onready var _discover_hint: Control = %discover_hint
 @onready var _spinner: Button = %spinner
 

--- a/addons/gdUnit4/test/GdUnitAwaiterTest.gd
+++ b/addons/gdUnit4/test/GdUnitAwaiterTest.gd
@@ -16,7 +16,7 @@ func after_test() -> void:
 	for node in get_children():
 		if node is Timer:
 			remove_child(node)
-			node.stop()
+			(node as Timer).stop()
 			node.free()
 
 

--- a/addons/gdUnit4/test/GdUnitScanTestSuiteTest.gd
+++ b/addons/gdUnit4/test/GdUnitScanTestSuiteTest.gd
@@ -4,8 +4,8 @@ extends GdUnitTestSuite
 
 
 func test_example() -> void:
-	assert_that("This is an example message").has_length(26)
-	assert_that("This is an example message").starts_with("This is an ex")
+	assert_str("This is an example message").has_length(26)
+	assert_str("This is an example message").starts_with("This is an ex")
 
 
 func test_b() -> void:

--- a/addons/gdUnit4/test/asserts/GdUnitAssertImplTest.gd
+++ b/addons/gdUnit4/test/asserts/GdUnitAssertImplTest.gd
@@ -63,9 +63,9 @@ func test_get_line_number_multiline() -> void:
 		.has_message("Expecting:\n '42'\n but was\n '10'")
 
 
-@warning_ignore("unsafe_method_access")
 func test_get_line_number_verify() -> void:
 	var obj :Variant = mock(RefCounted)
+	@warning_ignore("unsafe_method_access")
 	assert_failure(func() -> void: verify(obj, 1).get_reference_count()) \
 		.is_failed() \
 		.has_line(69) \

--- a/addons/gdUnit4/test/asserts/GdUnitGodotErrorWithAssertTest.gd
+++ b/addons/gdUnit4/test/asserts/GdUnitGodotErrorWithAssertTest.gd
@@ -6,12 +6,12 @@ var _catched_events: Array[GdUnitEvent] = []
 
 func test_assert_method_with_enabled_global_error_report() -> void:
 	ProjectSettings.set_setting(GdUnitSettings.REPORT_SCRIPT_ERRORS, true)
-	await assert_error(do_a_fail).is_runtime_error('Assertion failed: test')
+	assert_error(do_a_fail).is_runtime_error('Assertion failed: test')
 
 
 func test_assert_method_with_disabled_global_error_report() -> void:
 	ProjectSettings.set_setting(GdUnitSettings.REPORT_SCRIPT_ERRORS, false)
-	await assert_error(do_a_fail).is_runtime_error('Assertion failed: test')
+	assert_error(do_a_fail).is_runtime_error('Assertion failed: test')
 
 
 func do_a_fail() -> void:

--- a/addons/gdUnit4/test/asserts/GdUnitPackedArrayAssertTest.gd
+++ b/addons/gdUnit4/test/asserts/GdUnitPackedArrayAssertTest.gd
@@ -1,3 +1,4 @@
+@warning_ignore_start("unsafe_method_access")
 # GdUnit generated TestSuite
 extends GdUnitTestSuite
 
@@ -5,8 +6,7 @@ extends GdUnitTestSuite
 const __source = 'res://addons/gdUnit4/src/asserts/GdUnitArrayAssertImpl.gd'
 
 
-@warning_ignore("unused_parameter")
-func test_is_array_assert(_test :String, array :Variant, test_parameters := [
+func test_is_array_assert(_test: String, array: Variant, _test_parameters := [
 	["Array", Array()],
 	["PackedByteArray", PackedByteArray()],
 	["PackedInt32Array", PackedInt32Array()],
@@ -22,8 +22,7 @@ func test_is_array_assert(_test :String, array :Variant, test_parameters := [
 	assert_object(assert_).is_instanceof(GdUnitArrayAssert)
 
 
-@warning_ignore("unused_parameter")
-func test_is_null(_test :String, value :Variant, test_parameters := [
+func test_is_null(_test: String, value: Variant, _test_parameters := [
 	["Array", Array()],
 	["PackedByteArray", PackedByteArray()],
 	["PackedInt32Array", PackedInt32Array()],
@@ -41,8 +40,7 @@ func test_is_null(_test :String, value :Variant, test_parameters := [
 		.has_message("Expecting: '<null>' but was '%s'" % GdDefaultValueDecoder.decode(value))
 
 
-@warning_ignore("unused_parameter")
-func test_is_not_null(_test :String, array :Variant, test_parameters := [
+func test_is_not_null(_test: String, array: Variant, _test_parameters := [
 	["Array", Array()],
 	["PackedByteArray", PackedByteArray()],
 	["PackedInt32Array", PackedInt32Array()],
@@ -61,8 +59,7 @@ func test_is_not_null(_test :String, array :Variant, test_parameters := [
 		.has_message("Expecting: not to be '<null>'")
 
 
-@warning_ignore("unused_parameter", "unsafe_method_access", "unsafe_call_argument")
-func test_is_equal(_test :String, array :Variant, test_parameters := [
+func test_is_equal(_test: String, array: Variant, _test_parameters := [
 	["Array", Array([1, 2, 3, 4, 5])],
 	["PackedByteArray", PackedByteArray([1, 2, 3, 4, 5])],
 	["PackedInt32Array", PackedInt32Array([1, 2, 3, 4, 5])],
@@ -94,8 +91,7 @@ func test_is_equal(_test :String, array :Variant, test_parameters := [
 			.replace("$value", str(array[2]) ) % [GdArrayTools.as_string(other, false), GdArrayTools.as_string(array, false)])
 
 
-@warning_ignore("unused_parameter", "unsafe_method_access")
-func test_is_not_equal(_test :String, array :Variant, test_parameters := [
+func test_is_not_equal(_test: String, array: Variant, _test_parameters := [
 	["Array", Array([1, 2, 3, 4, 5])],
 	["PackedByteArray", PackedByteArray([1, 2, 3, 4, 5])],
 	["PackedInt32Array", PackedInt32Array([1, 2, 3, 4, 5])],
@@ -123,8 +119,7 @@ func test_is_not_equal(_test :String, array :Variant, test_parameters := [
 			.trim_prefix("\n") % [GdDefaultValueDecoder.decode(array), GdDefaultValueDecoder.decode(array)])
 
 
-@warning_ignore("unused_parameter", "unsafe_method_access")
-func test_is_empty(_test :String, array :Variant, test_parameters := [
+func test_is_empty(_test: String, array: Variant, _test_parameters := [
 	["Array", Array([1, 2, 3, 4, 5])],
 	["PackedByteArray", PackedByteArray([1, 2, 3, 4, 5])],
 	["PackedInt32Array", PackedInt32Array([1, 2, 3, 4, 5])],
@@ -151,8 +146,7 @@ func test_is_empty(_test :String, array :Variant, test_parameters := [
 			.trim_prefix("\n") % GdDefaultValueDecoder.decode(array))
 
 
-@warning_ignore("unused_parameter", "unsafe_method_access")
-func test_is_not_empty(_test :String, array :Variant, test_parameters := [
+func test_is_not_empty(_test: String, array: Variant, _test_parameters := [
 	["Array", Array([1, 2, 3, 4, 5])],
 	["PackedByteArray", PackedByteArray([1, 2, 3, 4, 5])],
 	["PackedInt32Array", PackedInt32Array([1, 2, 3, 4, 5])],
@@ -174,8 +168,7 @@ func test_is_not_empty(_test :String, array :Variant, test_parameters := [
 		.has_message("Expecting:\n must not be empty")
 
 
-@warning_ignore("unused_parameter", "unsafe_method_access")
-func test_is_same(value :Variant, test_parameters := [
+func test_is_same(value: Variant, _test_parameters := [
 	[[0]],
 	[PackedByteArray([0])],
 	[PackedFloat32Array([0.0])],
@@ -201,8 +194,7 @@ func test_is_same(value :Variant, test_parameters := [
 			.trim_prefix("\n") % [v, v])
 
 
-@warning_ignore("unused_parameter", "unsafe_method_access")
-func test_is_not_same(value :Variant, test_parameters := [
+func test_is_not_same(value: Variant, _test_parameters := [
 	[[0]],
 	[PackedByteArray([0])],
 	[PackedFloat32Array([0.0])],
@@ -221,8 +213,7 @@ func test_is_not_same(value :Variant, test_parameters := [
 		.has_message("Expecting not same:\n '%s'" % GdDefaultValueDecoder.decode(value))
 
 
-@warning_ignore("unused_parameter", "unsafe_method_access")
-func test_has_size(_test :String, array :Variant, test_parameters := [
+func test_has_size(_test: String, array: Variant, _test_parameters := [
 	["Array", Array([1, 2, 3, 4, 5])],
 	["PackedByteArray", PackedByteArray([1, 2, 3, 4, 5])],
 	["PackedInt32Array", PackedInt32Array([1, 2, 3, 4, 5])],
@@ -248,8 +239,7 @@ func test_has_size(_test :String, array :Variant, test_parameters := [
 			.trim_prefix("\n"))
 
 
-@warning_ignore("unused_parameter")
-func test_contains(_test :String, array :Variant, test_parameters := [
+func test_contains(_test: String, array: Variant, _test_parameters := [
 	["Array", Array([1, 2, 3, 4, 5])],
 	["PackedByteArray", PackedByteArray([1, 2, 3, 4, 5])],
 	["PackedInt32Array", PackedInt32Array([1, 2, 3, 4, 5])],
@@ -281,8 +271,7 @@ func test_contains(_test :String, array :Variant, test_parameters := [
 		)
 
 
-@warning_ignore("unused_parameter", "unsafe_method_access")
-func test_contains_exactly(_test :String, array :Variant, test_parameters := [
+func test_contains_exactly(_test: String, array: Variant, _test_parameters := [
 	["Array", Array([1, 2, 3, 4, 5])],
 	["PackedByteArray", PackedByteArray([1, 2, 3, 4, 5])],
 	["PackedInt32Array", PackedInt32Array([1, 2, 3, 4, 5])],
@@ -317,8 +306,8 @@ func test_contains_exactly(_test :String, array :Variant, test_parameters := [
 			.replace("$contains", GdDefaultValueDecoder.decode(shuffled))
 		)
 
-@warning_ignore("unused_parameter")
-func test_override_failure_message(_test :String, array :Variant, test_parameters := [
+
+func test_override_failure_message(_test: String, array: Variant, _test_parameters := [
 	["Array", Array()],
 	["PackedByteArray", PackedByteArray()],
 	["PackedInt32Array", PackedInt32Array()],

--- a/addons/gdUnit4/test/asserts/GdUnitSignalAssertImplTest.gd
+++ b/addons/gdUnit4/test/asserts/GdUnitSignalAssertImplTest.gd
@@ -269,8 +269,8 @@ class MyEmitter extends Node:
 @warning_ignore("unsafe_method_access")
 func test_monitor_signals() -> void:
 	# start to watch on the emitter to collect all emitted signals
-	var emitter_a := monitor_signals(MyEmitter.new())
-	var emitter_b := monitor_signals(MyEmitter.new())
+	var emitter_a: MyEmitter = monitor_signals(MyEmitter.new())
+	var emitter_b: MyEmitter = monitor_signals(MyEmitter.new())
 
 	# verify the signals are not emitted initial
 	await assert_signal(emitter_a).wait_until(50).is_not_emitted('my_signal_a')

--- a/addons/gdUnit4/test/cmd/CmdCommandHandlerTest.gd
+++ b/addons/gdUnit4/test/cmd/CmdCommandHandlerTest.gd
@@ -1,3 +1,4 @@
+@warning_ignore_start("unsafe_method_access")
 # GdUnit generated TestSuite
 class_name CmdCommandHandlerTest
 extends GdUnitTestSuite
@@ -137,7 +138,6 @@ func test_execute_commands_no_cb_registered() -> void:
 	assert_result(cmd_handler.execute([CmdCommand.new("-a")])).is_success()
 
 
-@warning_ignore("unsafe_method_access")
 func test_execute_commands_with_cb_registered() -> void:
 	var cmd_handler: = CmdCommandHandler.new(_cmd_options)
 	var cmd_spy: TestCommands = spy(_cmd_instance)
@@ -147,6 +147,7 @@ func test_execute_commands_with_cb_registered() -> void:
 	cmd_handler.register_cb("-a", cmd_spy.cmd_no_arg)
 
 	assert_result(cmd_handler.execute([CmdCommand.new("-a")])).is_success()
+
 	verify(cmd_spy).cmd_no_arg()
 	verify_no_more_interactions(cmd_spy)
 

--- a/addons/gdUnit4/test/core/GdArrayToolsTest.gd
+++ b/addons/gdUnit4/test/core/GdArrayToolsTest.gd
@@ -1,15 +1,13 @@
 # GdUnit generated TestSuite
 class_name GdArrayToolsTest
 extends GdUnitTestSuite
-@warning_ignore('unused_parameter')
-@warning_ignore('return_value_discarded')
+
 
 # TestSuite generated from
 const __source = 'res://addons/gdUnit4/src/core/GdArrayTools.gd'
 
 
-@warning_ignore('unused_parameter')
-func test_as_string(_test :String, value :Variant, expected :String, test_parameters := [
+func test_as_string(_test: String, value: Variant, expected: String, _test_parameters := [
 	['Array', Array([1, 2]), '[1, 2]'],
 	['Array', Array([1.0, 2.212]), '[1.000000, 2.212000]'],
 	['Array', Array([true, false]), '[true, false]'],
@@ -48,8 +46,7 @@ func test_as_string_simple_format() -> void:
 	assert_that(GdArrayTools.as_string(value, false)).is_equal('[a, b]')
 
 
-@warning_ignore("unused_parameter")
-func test_is_array_type(_test :String, value :Variant, expected :bool, test_parameters := [
+func test_is_array_type(_test: String, value: Variant, expected: bool, _test_parameters := [
 	['bool', true, false],
 	['int', 42, false],
 	['float', 1.21, false],
@@ -88,17 +85,15 @@ func test_is_array_type(_test :String, value :Variant, expected :bool, test_para
 	assert_that(GdArrayTools.is_array_type(value)).is_equal(expected)
 
 
-@warning_ignore("unsafe_method_access")
 func test_is_type_array() -> void:
 	for type :int in [TYPE_NIL, TYPE_MAX]:
 		if type in [TYPE_ARRAY, TYPE_PACKED_COLOR_ARRAY]:
-			assert_that(GdArrayTools.is_type_array(type)).is_true()
+			assert_bool(GdArrayTools.is_type_array(type)).is_true()
 		else:
-			assert_that(GdArrayTools.is_type_array(type)).is_false()
+			assert_bool(GdArrayTools.is_type_array(type)).is_false()
 
 
-@warning_ignore("unused_parameter")
-func test_filter_value(value :Variant, expected_type :int, test_parameters := [
+func test_filter_value(value: Variant, expected_type: int, _test_parameters := [
 	[[1, 2, 3, 1], TYPE_ARRAY],
 	[Array([1, 2, 3, 1]) as Array[int], TYPE_ARRAY],
 	[PackedByteArray([1, 2, 3, 1]), TYPE_PACKED_BYTE_ARRAY],

--- a/addons/gdUnit4/test/core/GdObjectsTest.gd
+++ b/addons/gdUnit4/test/core/GdObjectsTest.gd
@@ -320,7 +320,7 @@ func test_extract_class_name_from_instance() -> void:
 	assert_result(extract_class_name(Person.new())).is_equal("Person")
 	assert_result(extract_class_name(ClassWithNameA.new())).is_equal("ClassWithNameA")
 	assert_result(extract_class_name(ClassWithNameB.new())).is_equal("ClassWithNameB")
-	var classWithoutNameA := load("res://addons/gdUnit4/test/mocker/resources/ClassWithoutNameA.gd")
+	var classWithoutNameA: GDScript = load("res://addons/gdUnit4/test/mocker/resources/ClassWithoutNameA.gd")
 	assert_result(extract_class_name(classWithoutNameA.new())).is_equal("ClassWithoutNameA")
 	assert_result(extract_class_name(CustomNodeTestClass.new())).is_equal("CustomNodeTestClass")
 	assert_result(extract_class_name(CustomResourceTestClass.new())).is_equal("CustomResourceTestClass")
@@ -445,7 +445,7 @@ func test_is_instance_scene() -> void:
 	assert_bool(GdObjects.is_instance_scene(auto_free(Control.new()))).is_false()
 
 	# now check checked a loaded scene
-	var resource := load("res://addons/gdUnit4/test/mocker/resources/scenes/TestScene.tscn")
+	var resource: PackedScene = load("res://addons/gdUnit4/test/mocker/resources/scenes/TestScene.tscn")
 	assert_bool(GdObjects.is_instance_scene(resource)).is_false()
 	# checked a instance of a scene
 	assert_bool(GdObjects.is_instance_scene(auto_free(resource.instantiate()))).is_true()
@@ -521,6 +521,7 @@ class ObjectWithSceneReferece:
 
 
 func test_is_equal_on_scene_embedded_script() -> void:
+	@warning_ignore("unsafe_method_access")
 	var node: Node = auto_free(load("res://addons/gdUnit4/test/core/resources/scenes/SceneWithEmbeddedScript.tscn").instantiate())
 
 	GdObjects.equals(ObjectWithSceneReferece.new(node), ObjectWithSceneReferece.new(node), false)

--- a/addons/gdUnit4/test/core/GdUnitSceneRunnerInputEventTest.gd
+++ b/addons/gdUnit4/test/core/GdUnitSceneRunnerInputEventTest.gd
@@ -1,4 +1,4 @@
-@warning_ignore_start("redundant_await")
+@warning_ignore_start("redundant_await", "unsafe_method_access")
 # GdUnit generated TestSuite
 extends GdUnitTestSuite
 
@@ -26,19 +26,19 @@ func before_test() -> void:
 # asserts to action strings
 func assert_initial_action_state() -> void:
 	for action in InputMap.get_actions():
-		assert_that(Input.is_action_pressed(action, true)).is_false()
+		assert_bool(Input.is_action_pressed(action, true)).is_false()
 
 
 # asserts to KeyList Enums
 func assert_inital_key_state() -> void:
 	# scacode 4194304-4194415
 	for key in range(KEY_SPECIAL, KEY_LAUNCHF):
-		assert_that(Input.is_key_pressed(key)).is_false()
-		assert_that(Input.is_physical_key_pressed(key)).is_false()
+		assert_bool(Input.is_key_pressed(key)).is_false()
+		assert_bool(Input.is_physical_key_pressed(key)).is_false()
 	# keycode 32-255
 	for key in range(KEY_SPACE, KEY_SECTION):
-		assert_that(Input.is_key_pressed(key)).is_false()
-		assert_that(Input.is_physical_key_pressed(key)).is_false()
+		assert_bool(Input.is_key_pressed(key)).is_false()
+		assert_bool(Input.is_physical_key_pressed(key)).is_false()
 
 
 #asserts to Mouse ButtonList Enums
@@ -54,7 +54,7 @@ func assert_inital_mouse_state() -> void:
 		MOUSE_BUTTON_WHEEL_LEFT,
 		MOUSE_BUTTON_WHEEL_RIGHT,
 		]:
-		assert_that(Input.is_mouse_button_pressed(button))\
+		assert_bool(Input.is_mouse_button_pressed(button))\
 			.override_failure_message("Expecting mouse button %s is not pressed state!" % 1)\
 			.is_false()
 	assert_that(Input.get_mouse_button_mask())\
@@ -72,32 +72,32 @@ func test_reset_to_inital_state_on_release() -> void:
 	runner.simulate_key_press(KEY_0)
 	runner.simulate_key_press(KEY_X)
 	await await_idle_frame()
-	assert_that(Input.is_action_pressed("ui_up")).is_true()
-	assert_that(Input.is_mouse_button_pressed(MOUSE_BUTTON_LEFT)).is_true()
-	assert_that(Input.is_mouse_button_pressed(MOUSE_BUTTON_RIGHT)).is_true()
-	assert_that(Input.is_mouse_button_pressed(MOUSE_BUTTON_MIDDLE)).is_true()
-	assert_that(Input.is_key_pressed(KEY_0)).is_true()
-	assert_that(Input.is_key_pressed(KEY_X)).is_true()
+	assert_bool(Input.is_action_pressed("ui_up")).is_true()
+	assert_bool(Input.is_mouse_button_pressed(MOUSE_BUTTON_LEFT)).is_true()
+	assert_bool(Input.is_mouse_button_pressed(MOUSE_BUTTON_RIGHT)).is_true()
+	assert_bool(Input.is_mouse_button_pressed(MOUSE_BUTTON_MIDDLE)).is_true()
+	assert_bool(Input.is_key_pressed(KEY_0)).is_true()
+	assert_bool(Input.is_key_pressed(KEY_X)).is_true()
 	# unreference the scene runner to enforce reset to initial Input state
 	runner._notification(NOTIFICATION_PREDELETE)
 	await await_idle_frame()
-	assert_that(Input.is_action_pressed("ui_up")).is_false()
-	assert_that(Input.is_mouse_button_pressed(MOUSE_BUTTON_LEFT)).is_false()
-	assert_that(Input.is_mouse_button_pressed(MOUSE_BUTTON_RIGHT)).is_false()
-	assert_that(Input.is_mouse_button_pressed(MOUSE_BUTTON_MIDDLE)).is_false()
-	assert_that(Input.is_key_pressed(KEY_0)).is_false()
-	assert_that(Input.is_key_pressed(KEY_X)).is_false()
+	assert_bool(Input.is_action_pressed("ui_up")).is_false()
+	assert_bool(Input.is_mouse_button_pressed(MOUSE_BUTTON_LEFT)).is_false()
+	assert_bool(Input.is_mouse_button_pressed(MOUSE_BUTTON_RIGHT)).is_false()
+	assert_bool(Input.is_mouse_button_pressed(MOUSE_BUTTON_MIDDLE)).is_false()
+	assert_bool(Input.is_key_pressed(KEY_0)).is_false()
+	assert_bool(Input.is_key_pressed(KEY_X)).is_false()
 
 
 func test_simulate_action_press() -> void:
 	# iterate over some example actions
 	var actions_to_simmulate :Array[String] = ["ui_up", "ui_down", "ui_left", "ui_right"]
 	for action in actions_to_simmulate:
-		assert_that(InputMap.has_action(action)).is_true()
+		assert_bool(InputMap.has_action(action)).is_true()
 		_runner.simulate_action_press(action)
 		await _runner.await_input_processed()
 
-		assert_that(Input.is_action_pressed(action))\
+		assert_bool(Input.is_action_pressed(action))\
 			.override_failure_message("Expect the action '%s' is pressed" % action).is_true()
 		assert_float(Input.get_action_strength(action))\
 			.is_equal_approx(1.0, 0.1)
@@ -106,7 +106,7 @@ func test_simulate_action_press() -> void:
 
 	# other actions are not pressed
 	for action :String in ["ui_accept", "ui_select", "ui_cancel"]:
-		assert_that(Input.is_action_pressed(action))\
+		assert_bool(Input.is_action_pressed(action))\
 			.override_failure_message("Expect the action '%s' is NOT pressed" % action).is_false()
 
 
@@ -114,16 +114,16 @@ func test_simulate_action_release() -> void:
 	# iterate over some example actions
 	var actions_to_simmulate :Array[String] = ["ui_up", "ui_down", "ui_left", "ui_right"]
 	for action in actions_to_simmulate:
-		assert_that(InputMap.has_action(action)).is_true()
+		assert_bool(InputMap.has_action(action)).is_true()
 		_runner.simulate_action_press(action)
 		await await_idle_frame()
 		_runner.simulate_action_release(action)
 
-		assert_that(Input.is_action_just_released(action))\
+		assert_bool(Input.is_action_just_released(action))\
 			.override_failure_message("Expect the action '%s' is released" % action).is_true()
 	# other actions are not pressed
 	for action :String in ["ui_accept", "ui_select", "ui_cancel"]:
-		assert_that(Input.is_action_pressed(action))\
+		assert_bool(Input.is_action_pressed(action))\
 			.override_failure_message("Expect the action '%s' is NOT pressed" % action).is_false()
 
 
@@ -139,17 +139,17 @@ func test_simulate_key_press() -> void:
 		event.unicode = key
 		event.pressed = true
 		verify(_scene_spy, 1)._input(event)
-		assert_that(Input.is_key_pressed(key)).is_true()
+		assert_bool(Input.is_key_pressed(key)).is_true()
 	# verify all this keys are still handled as pressed
-	assert_that(Input.is_key_pressed(KEY_A)).is_true()
-	assert_that(Input.is_key_pressed(KEY_D)).is_true()
-	assert_that(Input.is_key_pressed(KEY_X)).is_true()
-	assert_that(Input.is_key_pressed(KEY_0)).is_true()
+	assert_bool(Input.is_key_pressed(KEY_A)).is_true()
+	assert_bool(Input.is_key_pressed(KEY_D)).is_true()
+	assert_bool(Input.is_key_pressed(KEY_X)).is_true()
+	assert_bool(Input.is_key_pressed(KEY_0)).is_true()
 	# other keys are not pressed
-	assert_that(Input.is_key_pressed(KEY_B)).is_false()
-	assert_that(Input.is_key_pressed(KEY_G)).is_false()
-	assert_that(Input.is_key_pressed(KEY_Z)).is_false()
-	assert_that(Input.is_key_pressed(KEY_1)).is_false()
+	assert_bool(Input.is_key_pressed(KEY_B)).is_false()
+	assert_bool(Input.is_key_pressed(KEY_G)).is_false()
+	assert_bool(Input.is_key_pressed(KEY_Z)).is_false()
+	assert_bool(Input.is_key_pressed(KEY_1)).is_false()
 
 
 # Simulates pressing shift+A
@@ -161,11 +161,11 @@ func test_simulate_key_press_SHIFT_and_A() -> void:
 	await _runner.await_input_processed()
 
 	# We expect key A is pressed and also the modifier shift key
-	assert_that(Input.is_key_pressed(KEY_A)).is_true()
-	assert_that(Input.is_key_pressed(KEY_SHIFT)).is_true()
-	assert_that(Input.is_key_pressed(KEY_ALT)).is_false()
-	assert_that(Input.is_key_pressed(KEY_CTRL)).is_false()
-	assert_that(Input.is_key_pressed(KEY_META)).is_false()
+	assert_bool(Input.is_key_pressed(KEY_A)).is_true()
+	assert_bool(Input.is_key_pressed(KEY_SHIFT)).is_true()
+	assert_bool(Input.is_key_pressed(KEY_ALT)).is_false()
+	assert_bool(Input.is_key_pressed(KEY_CTRL)).is_false()
+	assert_bool(Input.is_key_pressed(KEY_META)).is_false()
 
 	# In addition we need to verify we emit two input events:
 	# first the shift key is pressing (Shift)
@@ -203,11 +203,11 @@ func test_simulate_key_press_A_and_SHIFT() -> void:
 	await _runner.await_input_processed()
 
 	# We expect key A is pressed and also the modifier shift key
-	assert_that(Input.is_key_pressed(KEY_A)).is_true()
-	assert_that(Input.is_key_pressed(KEY_SHIFT)).is_true()
-	assert_that(Input.is_key_pressed(KEY_ALT)).is_false()
-	assert_that(Input.is_key_pressed(KEY_CTRL)).is_false()
-	assert_that(Input.is_key_pressed(KEY_META)).is_false()
+	assert_bool(Input.is_key_pressed(KEY_A)).is_true()
+	assert_bool(Input.is_key_pressed(KEY_SHIFT)).is_true()
+	assert_bool(Input.is_key_pressed(KEY_ALT)).is_false()
+	assert_bool(Input.is_key_pressed(KEY_CTRL)).is_false()
+	assert_bool(Input.is_key_pressed(KEY_META)).is_false()
 
 	# In addition we need to verify we emit two input events:
 	# first the shift a is pressing (A)
@@ -245,11 +245,11 @@ func test_simulate_key_released_SHIFT_and_A() -> void:
 	await _runner.await_input_processed()
 
 	# We expect key A is NOT pressed (it was released) and no modifier keys
-	assert_that(Input.is_key_pressed(KEY_A)).is_false()
-	assert_that(Input.is_key_pressed(KEY_SHIFT)).is_false()
-	assert_that(Input.is_key_pressed(KEY_ALT)).is_false()
-	assert_that(Input.is_key_pressed(KEY_CTRL)).is_false()
-	assert_that(Input.is_key_pressed(KEY_META)).is_false()
+	assert_bool(Input.is_key_pressed(KEY_A)).is_false()
+	assert_bool(Input.is_key_pressed(KEY_SHIFT)).is_false()
+	assert_bool(Input.is_key_pressed(KEY_ALT)).is_false()
+	assert_bool(Input.is_key_pressed(KEY_CTRL)).is_false()
+	assert_bool(Input.is_key_pressed(KEY_META)).is_false()
 
 	# In addition we need to verify we emit two input events:
 	# first the shift+a key is released (Shift+A)
@@ -286,11 +286,11 @@ func test_simulate_key_pressed_SHIFT_and_A() -> void:
 	await _runner.simulate_key_pressed(KEY_A)
 
 	# We expect key A is NOT pressed (it was press and released) and no modifier keys
-	assert_that(Input.is_key_pressed(KEY_A)).is_false()
-	assert_that(Input.is_key_pressed(KEY_SHIFT)).is_false()
-	assert_that(Input.is_key_pressed(KEY_ALT)).is_false()
-	assert_that(Input.is_key_pressed(KEY_CTRL)).is_false()
-	assert_that(Input.is_key_pressed(KEY_META)).is_false()
+	assert_bool(Input.is_key_pressed(KEY_A)).is_false()
+	assert_bool(Input.is_key_pressed(KEY_SHIFT)).is_false()
+	assert_bool(Input.is_key_pressed(KEY_ALT)).is_false()
+	assert_bool(Input.is_key_pressed(KEY_CTRL)).is_false()
+	assert_bool(Input.is_key_pressed(KEY_META)).is_false()
 
 	# In addition, we need to check whether we output two input events:
 	# first the shift key is pressing (Shift+A)
@@ -326,11 +326,11 @@ func test_simulate_key_press_A_with_shift_modifier() -> void:
 	await _runner.await_input_processed()
 
 	# We expect key A is pressing only and no modifier keys
-	assert_that(Input.is_key_pressed(KEY_A)).is_true()
-	assert_that(Input.is_key_pressed(KEY_SHIFT)).is_false()
-	assert_that(Input.is_key_pressed(KEY_ALT)).is_false()
-	assert_that(Input.is_key_pressed(KEY_CTRL)).is_false()
-	assert_that(Input.is_key_pressed(KEY_META)).is_false()
+	assert_bool(Input.is_key_pressed(KEY_A)).is_true()
+	assert_bool(Input.is_key_pressed(KEY_SHIFT)).is_false()
+	assert_bool(Input.is_key_pressed(KEY_ALT)).is_false()
+	assert_bool(Input.is_key_pressed(KEY_CTRL)).is_false()
+	assert_bool(Input.is_key_pressed(KEY_META)).is_false()
 
 	# In addition we need to verify we emit one input events:
 	# the key A + modifier shift is pressing (Shift+A)
@@ -356,11 +356,11 @@ func test_simulate_key_released_A_with_shift_modifier() -> void:
 	await _runner.await_input_processed()
 
 	# We expect key A is NOT pressing and also no modifier keys
-	assert_that(Input.is_key_pressed(KEY_A)).is_false()
-	assert_that(Input.is_key_pressed(KEY_SHIFT)).is_false()
-	assert_that(Input.is_key_pressed(KEY_ALT)).is_false()
-	assert_that(Input.is_key_pressed(KEY_CTRL)).is_false()
-	assert_that(Input.is_key_pressed(KEY_META)).is_false()
+	assert_bool(Input.is_key_pressed(KEY_A)).is_false()
+	assert_bool(Input.is_key_pressed(KEY_SHIFT)).is_false()
+	assert_bool(Input.is_key_pressed(KEY_ALT)).is_false()
+	assert_bool(Input.is_key_pressed(KEY_CTRL)).is_false()
+	assert_bool(Input.is_key_pressed(KEY_META)).is_false()
 
 	# In addition we need to verify we emit one input events:
 	# The key A and modifier shift is released (Shift+A)
@@ -384,11 +384,11 @@ func test_simulate_key_pressed_A_with_shift_modifier() -> void:
 	await _runner.simulate_key_pressed(KEY_A, true)
 
 	# We expect key A is NOT pressing (was press and released) and also no modifier keys
-	assert_that(Input.is_key_pressed(KEY_SHIFT)).is_false()
-	assert_that(Input.is_key_pressed(KEY_ALT)).is_false()
-	assert_that(Input.is_key_pressed(KEY_CTRL)).is_false()
-	assert_that(Input.is_key_pressed(KEY_META)).is_false()
-	assert_that(Input.is_key_pressed(KEY_A)).is_false()
+	assert_bool(Input.is_key_pressed(KEY_SHIFT)).is_false()
+	assert_bool(Input.is_key_pressed(KEY_ALT)).is_false()
+	assert_bool(Input.is_key_pressed(KEY_CTRL)).is_false()
+	assert_bool(Input.is_key_pressed(KEY_META)).is_false()
+	assert_bool(Input.is_key_pressed(KEY_A)).is_false()
 
 	# In addition, we need to check whether we output two input events:
 	# first the key a + modifier shift is pressing (Shift+A)
@@ -423,19 +423,19 @@ func test_simulate_many_keys_press() -> void:
 	_runner.simulate_key_press(KEY_Z)
 	await _runner.await_input_processed()
 
-	assert_that(Input.is_key_pressed(KEY_W)).is_true()
-	assert_that(Input.is_physical_key_pressed(KEY_W)).is_true()
-	assert_that(Input.is_key_pressed(KEY_Z)).is_true()
-	assert_that(Input.is_physical_key_pressed(KEY_Z)).is_true()
+	assert_bool(Input.is_key_pressed(KEY_W)).is_true()
+	assert_bool(Input.is_physical_key_pressed(KEY_W)).is_true()
+	assert_bool(Input.is_key_pressed(KEY_Z)).is_true()
+	assert_bool(Input.is_physical_key_pressed(KEY_Z)).is_true()
 
 	#now release key w
 	_runner.simulate_key_release(KEY_W)
 	await _runner.await_input_processed()
 
-	assert_that(Input.is_key_pressed(KEY_W)).is_false()
-	assert_that(Input.is_physical_key_pressed(KEY_W)).is_false()
-	assert_that(Input.is_key_pressed(KEY_Z)).is_true()
-	assert_that(Input.is_physical_key_pressed(KEY_Z)).is_true()
+	assert_bool(Input.is_key_pressed(KEY_W)).is_false()
+	assert_bool(Input.is_physical_key_pressed(KEY_W)).is_false()
+	assert_bool(Input.is_key_pressed(KEY_Z)).is_true()
+	assert_bool(Input.is_physical_key_pressed(KEY_Z)).is_true()
 
 
 @warning_ignore("unsafe_property_access")
@@ -540,7 +540,7 @@ func test_simulate_set_mouse_pos_with_modifiers() -> void:
 			event.button_index = mouse_button as MouseButton
 			event.button_mask = GdUnitSceneRunnerImpl.MAP_MOUSE_BUTTON_MASKS.get(mouse_button)
 			verify(_scene_spy, 1)._input(event)
-			assert_that(Input.is_mouse_button_pressed(mouse_button)).is_true()
+			assert_bool(Input.is_mouse_button_pressed(mouse_button)).is_true()
 			# finally release it
 			_runner.simulate_mouse_button_release(mouse_button)
 			await _runner.await_input_processed()
@@ -615,7 +615,7 @@ func test_simulate_mouse_button_press_left() -> void:
 	event.button_index = MOUSE_BUTTON_LEFT
 	event.button_mask = GdUnitSceneRunnerImpl.MAP_MOUSE_BUTTON_MASKS.get(MOUSE_BUTTON_LEFT)
 	verify(_scene_spy, 1)._input(event)
-	assert_that(Input.is_mouse_button_pressed(MOUSE_BUTTON_LEFT)).is_true()
+	assert_bool(Input.is_mouse_button_pressed(MOUSE_BUTTON_LEFT)).is_true()
 
 
 func test_simulate_mouse_button_press_left_doubleclick() -> void:
@@ -632,7 +632,7 @@ func test_simulate_mouse_button_press_left_doubleclick() -> void:
 	event.button_index = MOUSE_BUTTON_LEFT
 	event.button_mask = GdUnitSceneRunnerImpl.MAP_MOUSE_BUTTON_MASKS.get(MOUSE_BUTTON_LEFT)
 	verify(_scene_spy, 1)._input(event)
-	assert_that(Input.is_mouse_button_pressed(MOUSE_BUTTON_LEFT)).is_true()
+	assert_bool(Input.is_mouse_button_pressed(MOUSE_BUTTON_LEFT)).is_true()
 
 
 func test_simulate_mouse_button_press_right() -> void:
@@ -648,7 +648,7 @@ func test_simulate_mouse_button_press_right() -> void:
 	event.button_index = MOUSE_BUTTON_RIGHT
 	event.button_mask = GdUnitSceneRunnerImpl.MAP_MOUSE_BUTTON_MASKS.get(MOUSE_BUTTON_RIGHT)
 	verify(_scene_spy, 1)._input(event)
-	assert_that(Input.is_mouse_button_pressed(MOUSE_BUTTON_RIGHT)).is_true()
+	assert_bool(Input.is_mouse_button_pressed(MOUSE_BUTTON_RIGHT)).is_true()
 
 
 func test_simulate_mouse_button_press_left_and_right() -> void:
@@ -675,8 +675,8 @@ func test_simulate_mouse_button_press_left_and_right() -> void:
 	event.button_index = MOUSE_BUTTON_RIGHT
 	event.button_mask = MOUSE_BUTTON_MASK_LEFT|MOUSE_BUTTON_MASK_RIGHT
 	verify(_scene_spy, 1)._input(event)
-	assert_that(Input.is_mouse_button_pressed(MOUSE_BUTTON_LEFT)).is_true()
-	assert_that(Input.is_mouse_button_pressed(MOUSE_BUTTON_RIGHT)).is_true()
+	assert_bool(Input.is_mouse_button_pressed(MOUSE_BUTTON_LEFT)).is_true()
+	assert_bool(Input.is_mouse_button_pressed(MOUSE_BUTTON_RIGHT)).is_true()
 	assert_that(Input.get_mouse_button_mask()).is_equal(MOUSE_BUTTON_MASK_LEFT|MOUSE_BUTTON_MASK_RIGHT)
 
 
@@ -705,8 +705,8 @@ func test_simulate_mouse_button_press_left_and_right_and_release() -> void:
 	event.button_index = MOUSE_BUTTON_RIGHT
 	event.button_mask = MOUSE_BUTTON_MASK_LEFT|MOUSE_BUTTON_MASK_RIGHT
 	verify(_scene_spy, 1)._input(event)
-	assert_that(Input.is_mouse_button_pressed(MOUSE_BUTTON_LEFT)).is_true()
-	assert_that(Input.is_mouse_button_pressed(MOUSE_BUTTON_RIGHT)).is_true()
+	assert_bool(Input.is_mouse_button_pressed(MOUSE_BUTTON_LEFT)).is_true()
+	assert_bool(Input.is_mouse_button_pressed(MOUSE_BUTTON_RIGHT)).is_true()
 	assert_that(Input.get_mouse_button_mask()).is_equal(MOUSE_BUTTON_MASK_LEFT|MOUSE_BUTTON_MASK_RIGHT)
 
 	# now release the right button
@@ -721,8 +721,8 @@ func test_simulate_mouse_button_press_left_and_right_and_release() -> void:
 	event.button_index = MOUSE_BUTTON_RIGHT
 	event.button_mask = MOUSE_BUTTON_MASK_LEFT
 	verify(_scene_spy, 1)._input(event)
-	assert_that(Input.is_mouse_button_pressed(MOUSE_BUTTON_LEFT)).is_true()
-	assert_that(Input.is_mouse_button_pressed(MOUSE_BUTTON_RIGHT)).is_false()
+	assert_bool(Input.is_mouse_button_pressed(MOUSE_BUTTON_LEFT)).is_true()
+	assert_bool(Input.is_mouse_button_pressed(MOUSE_BUTTON_RIGHT)).is_false()
 	assert_that(Input.get_mouse_button_mask()).is_equal(MOUSE_BUTTON_MASK_LEFT)
 
 	# finally relase left button
@@ -737,8 +737,8 @@ func test_simulate_mouse_button_press_left_and_right_and_release() -> void:
 	event.button_index = MOUSE_BUTTON_LEFT
 	event.button_mask = 0
 	verify(_scene_spy, 1)._input(event)
-	assert_that(Input.is_mouse_button_pressed(MOUSE_BUTTON_LEFT)).is_false()
-	assert_that(Input.is_mouse_button_pressed(MOUSE_BUTTON_RIGHT)).is_false()
+	assert_bool(Input.is_mouse_button_pressed(MOUSE_BUTTON_LEFT)).is_false()
+	assert_bool(Input.is_mouse_button_pressed(MOUSE_BUTTON_RIGHT)).is_false()
 	assert_that(Input.get_mouse_button_mask()).is_equal(0)
 
 
@@ -765,7 +765,7 @@ func test_simulate_mouse_button_pressed() -> void:
 		event.button_index = mouse_button as MouseButton
 		event.button_mask = 0
 		verify(_scene_spy, 1)._input(event)
-		assert_that(Input.is_mouse_button_pressed(mouse_button)).is_false()
+		assert_bool(Input.is_mouse_button_pressed(mouse_button)).is_false()
 		verify(_scene_spy, 2)._input(any_class(InputEventMouseButton))
 		reset(_scene_spy)
 
@@ -795,7 +795,7 @@ func test_simulate_mouse_button_pressed_doubleclick() -> void:
 		event.button_index = mouse_button as MouseButton
 		event.button_mask = 0
 		verify(_scene_spy, 1)._input(event)
-		assert_that(Input.is_mouse_button_pressed(mouse_button)).is_false()
+		assert_bool(Input.is_mouse_button_pressed(mouse_button)).is_false()
 		verify(_scene_spy, 2)._input(any_class(InputEventMouseButton))
 		reset(_scene_spy)
 
@@ -814,7 +814,7 @@ func test_simulate_mouse_button_press_and_release() -> void:
 		event.button_index = mouse_button as MouseButton
 		event.button_mask = GdUnitSceneRunnerImpl.MAP_MOUSE_BUTTON_MASKS.get(mouse_button)
 		verify(_scene_spy, 1)._input(event)
-		assert_that(Input.is_mouse_button_pressed(mouse_button)).is_true()
+		assert_bool(Input.is_mouse_button_pressed(mouse_button)).is_true()
 
 		# now simulate mouse button release
 		gmp = _runner.get_global_mouse_position()
@@ -828,7 +828,7 @@ func test_simulate_mouse_button_press_and_release() -> void:
 		event.button_index = mouse_button as MouseButton
 		#event.button_mask = 0
 		verify(_scene_spy, 1)._input(event)
-		assert_that(Input.is_mouse_button_pressed(mouse_button)).is_false()
+		assert_bool(Input.is_mouse_button_pressed(mouse_button)).is_false()
 
 
 #####################################################################################################################
@@ -1049,7 +1049,7 @@ func test_text_input_processing() -> void:
 
 	# Focus the text input and clear any existing content
 	lineEdit.grab_focus()
-	assert_that(lineEdit.has_focus()).is_true()
+	assert_bool(lineEdit.has_focus()).is_true()
 	lineEdit.text = ""
 
 	# Type individual characters

--- a/addons/gdUnit4/test/core/GdUnitSceneRunnerTest.gd
+++ b/addons/gdUnit4/test/core/GdUnitSceneRunnerTest.gd
@@ -1,5 +1,5 @@
 # GdUnit generated TestSuite
-@warning_ignore_start("redundant_await")
+@warning_ignore_start("redundant_await", "unsafe_method_access")
 class_name GdUnitSceneRunnerTest
 extends GdUnitTestSuite
 
@@ -9,6 +9,7 @@ const __source = 'res://addons/gdUnit4/src/core/GdUnitSceneRunnerImpl.gd'
 
 # loads the test runner and register for auto freeing after test
 func load_test_scene() -> Node:
+	@warning_ignore("unsafe_method_access")
 	return auto_free(load("res://addons/gdUnit4/test/mocker/resources/scenes/TestScene.tscn").instantiate())
 
 
@@ -205,7 +206,7 @@ func test_await_signal_without_time_factor() -> void:
 		# should be interrupted is will never change to Color.KHAKI
 		await assert_failure_await(func x() -> void: await runner.await_signal( "panel_color_change", [box1, Color.KHAKI], 300))
 	).has_message("await_signal_on(panel_color_change, [%s, %s]) timed out after 300ms" % [str(box1), str(Color.KHAKI)])\
-		.has_line(206)
+		.has_line(207)
 
 
 func test_await_signal_with_time_factor() -> void:
@@ -222,7 +223,7 @@ func test_await_signal_with_time_factor() -> void:
 		# should be interrupted is will never change to Color.KHAKI
 		await assert_failure_await(func x() -> void: await runner.await_signal("panel_color_change", [box1, Color.KHAKI], 30))
 	).has_message("await_signal_on(panel_color_change, [%s, %s]) timed out after 30ms" % [str(box1), str(Color.KHAKI)])\
-		.has_line(223)
+		.has_line(224)
 
 
 func test_simulate_until_signal() -> void:

--- a/addons/gdUnit4/test/core/GdUnitToolsTest.gd
+++ b/addons/gdUnit4/test/core/GdUnitToolsTest.gd
@@ -17,20 +17,20 @@ class InnerTestRefCountedClass extends RefCounted:
 
 func test_free_instance() -> void:
 	# on valid instances
-	assert_that(await GdUnitTools.free_instance(RefCounted.new())).is_true()
-	assert_that(await GdUnitTools.free_instance(Node.new())).is_true()
-	assert_that(await GdUnitTools.free_instance(JavaClass.new())).is_true()
-	assert_that(await GdUnitTools.free_instance(InnerTestNodeClass.new())).is_true()
-	assert_that(await GdUnitTools.free_instance(InnerTestRefCountedClass.new())).is_true()
+	assert_bool(await GdUnitTools.free_instance(RefCounted.new())).is_true()
+	assert_bool(await GdUnitTools.free_instance(Node.new())).is_true()
+	assert_bool(await GdUnitTools.free_instance(JavaClass.new())).is_true()
+	assert_bool(await GdUnitTools.free_instance(InnerTestNodeClass.new())).is_true()
+	assert_bool(await GdUnitTools.free_instance(InnerTestRefCountedClass.new())).is_true()
 
 	# on invalid instances
-	assert_that(await GdUnitTools.free_instance(null)).is_false()
-	assert_that(await GdUnitTools.free_instance(RefCounted)).is_false()
+	assert_bool(await GdUnitTools.free_instance(null)).is_false()
+	assert_bool(await GdUnitTools.free_instance(RefCounted)).is_false()
 
 	# on already freed instances
 	var node := Node.new()
 	node.free()
-	assert_that(await GdUnitTools.free_instance(node)).is_false()
+	assert_bool(await GdUnitTools.free_instance(node)).is_false()
 
 
 func test_richtext_normalize() -> void:

--- a/addons/gdUnit4/test/core/command/GdUnitCommandHandlerTest.gd
+++ b/addons/gdUnit4/test/core/command/GdUnitCommandHandlerTest.gd
@@ -1,4 +1,4 @@
-
+@warning_ignore_start("unsafe_method_access")
 # GdUnit generated TestSuite
 extends GdUnitTestSuite
 

--- a/addons/gdUnit4/test/core/discovery/GdUnitGuidTest.gd
+++ b/addons/gdUnit4/test/core/discovery/GdUnitGuidTest.gd
@@ -11,7 +11,7 @@ const __source = 'res://addons/gdUnit4/src/core/discovery/GdUnitGUID.gd'
 func test_initialization() -> void:
 	# Test initialization with empty string
 	var guid_a := GdUnitGUID.new()
-	assert_that(guid_a._guid).is_not_empty()
+	assert_str(guid_a._guid).is_not_empty()
 
 	# Test initialization with existing GUID
 	var existing_guid := "12345678-abcd-efgh-ijkl-mnopqrstuvwx"

--- a/addons/gdUnit4/test/core/event/GdUnitTestEventSerdeTest.gd
+++ b/addons/gdUnit4/test/core/event/GdUnitTestEventSerdeTest.gd
@@ -7,7 +7,7 @@ func test_serde_suite_before() -> void:
 	var event := GdUnitEvent.new().suite_before("path", "test_suite_a", 22)
 	var serialized := event.serialize()
 	var deserialized := GdUnitEvent.new().deserialize(serialized)
-	assert_that(deserialized).is_instanceof(GdUnitEvent)
+	assert_object(deserialized).is_instanceof(GdUnitEvent)
 	assert_that(deserialized).is_equal(event)
 
 

--- a/addons/gdUnit4/test/core/execution/GdUnitTestSuiteExecutorTest.gd
+++ b/addons/gdUnit4/test/core/execution/GdUnitTestSuiteExecutorTest.gd
@@ -116,7 +116,7 @@ func assert_event_reports(events: Array[GdUnitEvent], expected_reports: Array) -
 				assert_str(flating_message(current[m].message() as String)).is_empty()
 		for m in expected.size():
 			if m < current.size():
-				assert_str(flating_message(current[m].message() as String)).starts_with(expected[m])
+				assert_str(flating_message(current[m].message() as String)).starts_with(str(expected[m]))
 			else:
 				assert_str("<N/A>").is_equal(expected[m])
 

--- a/addons/gdUnit4/test/core/execution/resources/orphans/TestSuiteFailAndOrpahnsDetected.gd
+++ b/addons/gdUnit4/test/core/execution/resources/orphans/TestSuiteFailAndOrpahnsDetected.gd
@@ -2,7 +2,7 @@
 extends GdUnitTestSuite
 
 
-var _orphans: Array = Array()
+var _orphans: Array[Node] = []
 @warning_ignore("untyped_declaration")
 var before_n1
 
@@ -44,6 +44,6 @@ func test_case2() -> void:
 # we manually freeing the orphans from the simulated testsuite to prevent memory leaks here
 func _notification(what: int) -> void:
 	if what == NOTIFICATION_PREDELETE:
-		for orphan :Variant in _orphans:
+		for orphan in _orphans:
 			orphan.free()
 		_orphans.clear()

--- a/addons/gdUnit4/test/core/parse/GdUnitExpressionRunnerTest.gd
+++ b/addons/gdUnit4/test/core/parse/GdUnitExpressionRunnerTest.gd
@@ -13,21 +13,21 @@ const TestFuzzers := preload("res://addons/gdUnit4/test/fuzzers/TestFuzzers.gd")
 func test_create_fuzzer_argument_default() -> void:
 	var fuzzer := GdUnitExpressionRunner.new().to_fuzzer(GDScript.new(), "Fuzzers.rangei(-10, 22)")
 	assert_that(fuzzer).is_not_null()
-	assert_that(fuzzer).is_instanceof(Fuzzer)
+	assert_object(fuzzer).is_instanceof(Fuzzer)
 	assert_int(fuzzer.next_value()).is_between(-10, 22)
 
 
 func test_create_fuzzer_argument_with_constants() -> void:
 	var fuzzer := GdUnitExpressionRunner.new().to_fuzzer(TestFuzzers, "Fuzzers.rangei(-10, MAX_VALUE)")
 	assert_that(fuzzer).is_not_null()
-	assert_that(fuzzer).is_instanceof(Fuzzer)
+	assert_object(fuzzer).is_instanceof(Fuzzer)
 	assert_int(fuzzer.next_value()).is_between(-10, 22)
 
 
 func test_create_fuzzer_argument_with_custom_function() -> void:
 	var fuzzer := GdUnitExpressionRunner.new().to_fuzzer(TestFuzzers, "get_fuzzer()")
 	assert_that(fuzzer).is_not_null()
-	assert_that(fuzzer).is_instanceof(Fuzzer)
+	assert_object(fuzzer).is_instanceof(Fuzzer)
 	assert_int(fuzzer.next_value()).is_between(TestFuzzers.MIN_VALUE, TestFuzzers.MAX_VALUE)
 
 
@@ -39,14 +39,14 @@ func test_create_fuzzer_do_fail() -> void:
 func test_create_nested_fuzzer_do_fail() -> void:
 	var fuzzer := GdUnitExpressionRunner.new().to_fuzzer(TestFuzzers, "NestedFuzzer.new()")
 	assert_that(fuzzer).is_not_null()
-	assert_that(fuzzer is Fuzzer).is_true()
+	assert_bool(fuzzer is Fuzzer).is_true()
 	assert_bool(fuzzer is TestFuzzers.NestedFuzzer).is_true()
 
 
 func test_create_external_fuzzer() -> void:
 	var fuzzer := GdUnitExpressionRunner.new().to_fuzzer(GDScript.new(), "TestExternalFuzzer.new()")
 	assert_that(fuzzer).is_not_null()
-	assert_that(fuzzer is Fuzzer).is_true()
+	assert_bool(fuzzer is Fuzzer).is_true()
 	assert_bool(fuzzer is TestExternalFuzzer).is_true()
 
 
@@ -54,12 +54,12 @@ func test_create_multipe_fuzzers() -> void:
 	var fuzzer_a := GdUnitExpressionRunner.new().to_fuzzer(TestFuzzers, "Fuzzers.rangei(-10, MAX_VALUE)")
 	var fuzzer_b := GdUnitExpressionRunner.new().to_fuzzer(GDScript.new(), "Fuzzers.rangei(10, 20)")
 	assert_that(fuzzer_a).is_not_null()
-	assert_that(fuzzer_a).is_instanceof(IntFuzzer)
+	assert_object(fuzzer_a).is_instanceof(IntFuzzer)
 	var a :IntFuzzer = fuzzer_a
 	assert_int(a._from).is_equal(-10)
 	assert_int(a._to).is_equal(TestFuzzers.MAX_VALUE)
 	assert_that(fuzzer_b).is_not_null()
-	assert_that(fuzzer_b).is_instanceof(IntFuzzer)
+	assert_object(fuzzer_b).is_instanceof(IntFuzzer)
 	var b :IntFuzzer = fuzzer_b
 	assert_int(b._from).is_equal(10)
 	assert_int(b._to).is_equal(20)
@@ -68,5 +68,5 @@ func test_create_multipe_fuzzers() -> void:
 func test_create_fuzzer_with_args() -> void:
 	var fuzzer := GdUnitExpressionRunner.new().to_fuzzer(TestFuzzers, "NestedFuzzerWithArgs.new(100, MAX_VALUE, Vector2.ONE)")
 	assert_that(fuzzer).is_not_null()
-	assert_that(fuzzer is Fuzzer).is_true()
+	assert_bool(fuzzer is Fuzzer).is_true()
 	assert_bool(fuzzer is TestFuzzers.NestedFuzzerWithArgs).is_true()

--- a/addons/gdUnit4/test/matchers/CustomArgumentMatcherTest.gd
+++ b/addons/gdUnit4/test/matchers/CustomArgumentMatcherTest.gd
@@ -1,3 +1,4 @@
+@warning_ignore_start("unsafe_method_access")
 extends GdUnitTestSuite
 
 
@@ -23,4 +24,3 @@ func test_custom_matcher() -> void:
 	verify(mocked_test_class, 3).set_value(CustomArgumentMatcher.new(1000))
 	# counts 2002 = 1 times
 	verify(mocked_test_class, 1).set_value(CustomArgumentMatcher.new(2000))
-

--- a/addons/gdUnit4/test/mocker/GdUnitMockerTest.gd
+++ b/addons/gdUnit4/test/mocker/GdUnitMockerTest.gd
@@ -1,3 +1,4 @@
+@warning_ignore_start("unsafe_method_access")
 class_name GdUnitMockerTest
 extends GdUnitTestSuite
 
@@ -21,7 +22,6 @@ func test_mock_instance_id_is_unique() -> void:
 	var m1: Variant = mock(RefCounted)
 	var m2: Variant = mock(RefCounted)
 	# test the internal instance id is unique
-	@warning_ignore("unsafe_method_access")
 	assert_object(m1).is_not_same(m2)
 
 
@@ -33,51 +33,44 @@ func test_is_mockable_godot_classes() -> void:
 		# unregistered classes in ClassDB
 		# protected classes (name starts with underscore)
 		var is_mockable :bool = not Engine.has_singleton(clazz_name) and ClassDB.can_instantiate(clazz_name) and clazz_name.find("_") != 0
-		@warning_ignore("unsafe_method_access")
-		assert_that(GdUnitMockBuilder.is_mockable(clazz_name)) \
+		assert_bool(GdUnitMockBuilder.is_mockable(clazz_name)) \
 			.override_failure_message("Class '%s' expect mockable %s" % [clazz_name, is_mockable]) \
 			.is_equal(is_mockable)
 
 
-@warning_ignore("unsafe_method_access")
 func test_is_mockable_by_class_type() -> void:
-	assert_that(GdUnitMockBuilder.is_mockable(Node)).is_true()
-	assert_that(GdUnitMockBuilder.is_mockable(CSGBox3D)).is_true()
+	assert_bool(GdUnitMockBuilder.is_mockable(Node)).is_true()
+	assert_bool(GdUnitMockBuilder.is_mockable(CSGBox3D)).is_true()
 
 
-@warning_ignore("unsafe_method_access")
 func test_is_mockable_custom_class_type() -> void:
-	assert_that(GdUnitMockBuilder.is_mockable(CustomResourceTestClass)).is_true()
-	assert_that(GdUnitMockBuilder.is_mockable(CustomNodeTestClass)).is_true()
+	assert_bool(GdUnitMockBuilder.is_mockable(CustomResourceTestClass)).is_true()
+	assert_bool(GdUnitMockBuilder.is_mockable(CustomNodeTestClass)).is_true()
 
 
-@warning_ignore("unsafe_method_access")
 func test_is_mockable_by_script_path() -> void:
-	assert_that(GdUnitMockBuilder.is_mockable(resource_path + "CustomResourceTestClass.gd")).is_true()
-	assert_that(GdUnitMockBuilder.is_mockable(resource_path + "CustomNodeTestClass.gd")).is_true()
+	assert_bool(GdUnitMockBuilder.is_mockable(resource_path + "CustomResourceTestClass.gd")).is_true()
+	assert_bool(GdUnitMockBuilder.is_mockable(resource_path + "CustomNodeTestClass.gd")).is_true()
 	# verify for non scripts
-	assert_that(GdUnitMockBuilder.is_mockable(resource_path + "capsuleshape2d.tres")).is_false()
+	assert_bool(GdUnitMockBuilder.is_mockable(resource_path + "capsuleshape2d.tres")).is_false()
 
 
-@warning_ignore("unsafe_method_access")
 func test_is_mockable__overriden_func_get_class() -> void:
 	# test with class type
-	assert_that(GdUnitMockBuilder.is_mockable(OverridenGetClassTestClass))\
+	assert_bool(GdUnitMockBuilder.is_mockable(OverridenGetClassTestClass))\
 		.override_failure_message("The class 'CustomResourceTestClass' should be mockable when 'func get_class()' is overriden")\
 		.is_true()
 	# test with resource path
-	assert_that(GdUnitMockBuilder.is_mockable(resource_path + "OverridenGetClassTestClass.gd"))\
+	assert_bool(GdUnitMockBuilder.is_mockable(resource_path + "OverridenGetClassTestClass.gd"))\
 		.override_failure_message("The class 'CustomResourceTestClass' should be mockable when 'func get_class()' is overriden")\
 		.is_true()
 
 
-@warning_ignore("unused_parameter")
-func test_mock_godot_class_fullcheck(fuzzer := GodotClassNameFuzzer.new(), fuzzer_iterations := 200) -> void:
+func test_mock_godot_class_fullcheck(fuzzer := GodotClassNameFuzzer.new(), _fuzzer_iterations := 200) -> void:
 	var clazz_name := fuzzer.next_value()
 	# try to create a mock
 	if GdUnitMockBuilder.is_mockable(clazz_name):
 		var m: Variant = mock(clazz_name, CALL_REAL_FUNC)
-		@warning_ignore("unsafe_method_access")
 		assert_that(m)\
 			.override_failure_message("The class %s should be mockable" % clazz_name)\
 			.is_not_null()
@@ -107,7 +100,6 @@ func test_mock_special_classes() -> void:
 	assert_that(m).is_not_null()
 
 
-@warning_ignore("unsafe_method_access")
 func test_mock_Node() -> void:
 	var mocked_node: Variant = mock(Node)
 	assert_that(mocked_node).is_not_null()
@@ -136,7 +128,6 @@ func test_mock_Node() -> void:
 	assert_that(mocked_node.get_child_count()).is_equal(24)
 
 
-@warning_ignore("unsafe_method_access")
 func test_mock_source_with_class_name_by_resource_path() -> void:
 	var resource_path_ := 'res://addons/gdUnit4/test/mocker/resources/GD-256/world.gd'
 	var m: Variant = mock(resource_path_)
@@ -146,7 +137,6 @@ func test_mock_source_with_class_name_by_resource_path() -> void:
 		.contains("extends '%s'" % resource_path_)
 
 
-@warning_ignore("unsafe_method_access")
 func test_mock_source_with_class_name_by_class() -> void:
 	var resource_path_ := 'res://addons/gdUnit4/test/mocker/resources/GD-256/world.gd'
 	var m: Variant = mock(Munderwood_Pathing_World)
@@ -156,7 +146,6 @@ func test_mock_source_with_class_name_by_class() -> void:
 		.contains("extends '%s'" % resource_path_)
 
 
-@warning_ignore("unsafe_method_access")
 func test_mock_extends_godot_class() -> void:
 	var m: Variant = mock(World3D)
 	var head :String = m.get_script().source_code.substr(0, 500)
@@ -172,7 +161,6 @@ func _emit_ready(...args: Array) -> void:
 	_test_signal_args = args
 
 
-@warning_ignore("unsafe_method_access")
 func test_mock_Node_func_vararg() -> void:
 	# setup
 	var mocked_node: Variant = mock(Node)
@@ -190,7 +178,6 @@ func test_mock_Node_func_vararg() -> void:
 	assert_that(mocked_node.rpc("test", "arg1", "argX", 42)).is_equal(ERR_CANT_CREATE)
 
 
-@warning_ignore("unsafe_method_access")
 func test_mock_Node_func_vararg_call_real_func() -> void:
 	# setup
 	var mocked_node: Variant = mock(Node, CALL_REAL_FUNC)
@@ -233,7 +220,6 @@ class ClassWithSignal:
 		return true
 
 
-@warning_ignore("unsafe_method_access")
 func _test_mock_verify_emit_signal() -> void:
 	var mocked_node: Variant = mock(ClassWithSignal, CALL_REAL_FUNC)
 	assert_that(mocked_node).is_not_null()
@@ -258,7 +244,6 @@ func _test_mock_verify_emit_signal() -> void:
 	verify(mocked_node, 1).emit_signal("test_signal_b", "bb", true)
 
 
-@warning_ignore("unsafe_method_access")
 func test_mock_custom_class_by_class_name() -> void:
 	var m: Variant = mock(CustomResourceTestClass)
 	assert_that(m).is_not_null()
@@ -281,7 +266,6 @@ func test_mock_custom_class_by_class_name() -> void:
 	assert_that(m.bar(2)).is_equal("arg_2")
 
 
-@warning_ignore("unsafe_method_access")
 func test_mock_custom_class_by_resource_path() -> void:
 	var m: Variant = mock("res://addons/gdUnit4/test/mocker/resources/CustomResourceTestClass.gd")
 	assert_that(m).is_not_null()
@@ -304,7 +288,6 @@ func test_mock_custom_class_by_resource_path() -> void:
 	assert_that(m.bar(2)).is_equal("arg_2")
 
 
-@warning_ignore("unsafe_method_access")
 func test_mock_custom_class_func_foo_use_real_func() -> void:
 	var m: Variant = mock(CustomResourceTestClass, CALL_REAL_FUNC)
 	assert_that(m).is_not_null()
@@ -316,7 +299,6 @@ func test_mock_custom_class_func_foo_use_real_func() -> void:
 	assert_that(m.foo()).is_equal("overridden value")
 
 
-@warning_ignore("unsafe_method_access")
 func test_mock_void_func_not_allowed() -> void:
 	var m: Variant = mock(CustomResourceTestClass)
 	assert_that(m).is_not_null()
@@ -324,12 +306,11 @@ func test_mock_void_func_not_allowed() -> void:
 	assert_that(m.foo_void()).is_null()
 
 	# try now mock return value for a void function. results into an error
-	await assert_error(func() -> void:
+	assert_error(func() -> void:
 		do_return("overridden value").on(m).foo_void()
 	).is_push_error("Mocking functions with return type void is not allowed!")
 
 
-@warning_ignore("unsafe_method_access")
 func test_mock_void_call_real_func_not_allowed() -> void:
 	var m: Variant = mock(CustomResourceTestClass, CALL_REAL_FUNC)
 	assert_that(m).is_not_null()
@@ -337,12 +318,11 @@ func test_mock_void_call_real_func_not_allowed() -> void:
 	assert_that(m.foo_void()).is_null()
 
 	# try now mock return value for a void function. results into an error
-	await assert_error(func() -> void:
+	assert_error(func() -> void:
 		do_return("overridden value").on(m).foo_void()
 	).is_push_error("Mocking functions with return type void is not allowed!")
 
 
-@warning_ignore("unsafe_method_access")
 func test_mock_custom_class_func_foo_call_times() -> void:
 	var m: Variant = mock(CustomResourceTestClass)
 	assert_that(m).is_not_null()
@@ -356,7 +336,6 @@ func test_mock_custom_class_func_foo_call_times() -> void:
 	verify(m, 4).foo()
 
 
-@warning_ignore("unsafe_method_access")
 func test_mock_custom_class_func_foo_call_times_real_func() -> void:
 	var m: Variant = mock(CustomResourceTestClass, CALL_REAL_FUNC)
 	assert_that(m).is_not_null()
@@ -370,7 +349,6 @@ func test_mock_custom_class_func_foo_call_times_real_func() -> void:
 	verify(m, 4).foo()
 
 
-@warning_ignore("unsafe_method_access")
 func test_mock_custom_class_func_foo_full_test() -> void:
 	var m: Variant = mock(CustomResourceTestClass)
 	assert_that(m).is_not_null()
@@ -383,7 +361,6 @@ func test_mock_custom_class_func_foo_full_test() -> void:
 	verify(m, 2).foo()
 
 
-@warning_ignore("unsafe_method_access")
 func test_mock_custom_class_func_foo_full_test_real_func() -> void:
 	var m: Variant = mock(CustomResourceTestClass, CALL_REAL_FUNC)
 	assert_that(m).is_not_null()
@@ -396,7 +373,6 @@ func test_mock_custom_class_func_foo_full_test_real_func() -> void:
 	verify(m, 2).foo()
 
 
-@warning_ignore("unsafe_method_access")
 func test_mock_custom_class_func_bar() -> void:
 	var m: Variant = mock(CustomResourceTestClass)
 	assert_that(m).is_not_null()
@@ -418,7 +394,6 @@ func test_mock_custom_class_func_bar() -> void:
 	verify(m, 0).bar(23)
 
 
-@warning_ignore("unsafe_method_access")
 func test_mock_custom_class_func_bar_real_func() -> void:
 	var m: Variant = mock(CustomResourceTestClass, CALL_REAL_FUNC)
 	assert_that(m).is_not_null()
@@ -444,7 +419,6 @@ func test_mock_custom_class_func_bar_real_func() -> void:
 	verify(m, 1).bar(10, 20, "other")
 
 
-@warning_ignore("unsafe_method_access")
 func test_mock_custom_class_func_return_type_enum() -> void:
 	var m: Variant = mock(ClassWithEnumReturnTypes)
 	assert_that(m).is_not_null()
@@ -466,7 +440,6 @@ func test_mock_custom_class_func_return_type_enum() -> void:
 	assert_that(m2.get_enum()).is_equal(ClassWithEnumReturnTypes.TEST_ENUM.BAR)
 
 
-@warning_ignore("unsafe_method_access")
 func test_mock_custom_class_func_return_type_internal_class_enum() -> void:
 	var m: Variant = mock(ClassWithEnumReturnTypes)
 	assert_that(m).is_not_null()
@@ -488,7 +461,6 @@ func test_mock_custom_class_func_return_type_internal_class_enum() -> void:
 	assert_that(m2.get_inner_class_enum()).is_equal(ClassWithEnumReturnTypes.InnerClass.TEST_ENUM.BAR)
 
 
-@warning_ignore("unsafe_method_access")
 func test_mock_custom_class_func_return_type_external_class_enum() -> void:
 	var m: Variant = mock(ClassWithEnumReturnTypes)
 	assert_that(m).is_not_null()
@@ -510,7 +482,6 @@ func test_mock_custom_class_func_return_type_external_class_enum() -> void:
 	assert_that(m2.get_external_class_enum()).is_equal(CustomEnums.TEST_ENUM.BAR)
 
 
-@warning_ignore("unsafe_method_access")
 func test_mock_custom_class_extends_Node() -> void:
 	var m: Variant = mock(CustomNodeTestClass)
 	assert_that(m).is_not_null()
@@ -528,7 +499,6 @@ func test_mock_custom_class_extends_Node() -> void:
 	verify(m, 2).get_children()
 
 
-@warning_ignore("unsafe_method_access")
 func test_mock_custom_class_extends_Node_real_func() -> void:
 	var m: Variant = mock(CustomNodeTestClass, CALL_REAL_FUNC)
 	assert_that(m).is_not_null()
@@ -550,7 +520,6 @@ func test_mock_custom_class_extends_Node_real_func() -> void:
 	verify(m, 2).get_children()
 
 
-@warning_ignore("unsafe_method_access")
 func test_mock_custom_class_extends_other_custom_class() -> void:
 	var m: Variant = mock(CustomClassExtendsCustomClass)
 	assert_that(mock).is_not_null()
@@ -580,7 +549,6 @@ func test_mock_custom_class_extends_other_custom_class() -> void:
 	assert_that(m.bar2()).is_equal("abc3")
 
 
-@warning_ignore("unsafe_method_access")
 func test_mock_custom_class_extends_other_custom_class_call_real_func() -> void:
 	var m: Variant = mock(CustomClassExtendsCustomClass, CALL_REAL_FUNC)
 	assert_that(m).is_not_null()
@@ -610,7 +578,6 @@ func test_mock_custom_class_extends_other_custom_class_call_real_func() -> void:
 	assert_that(m.bar2()).is_equal("abc3")
 
 
-@warning_ignore("unsafe_method_access")
 func test_mock_static_func() -> void:
 	var m: Variant = mock(CustomNodeTestClass)
 	assert_that(m).is_not_null()
@@ -630,7 +597,6 @@ func test_mock_static_func() -> void:
 	verify(m, 3).static_test_void()
 
 
-@warning_ignore("unsafe_method_access")
 func test_mock_static_func_real_func() -> void:
 	var m: Variant = mock(CustomNodeTestClass, CALL_REAL_FUNC)
 	assert_that(m).is_not_null()
@@ -650,7 +616,6 @@ func test_mock_static_func_real_func() -> void:
 	verify(m, 3).static_test_void()
 
 
-@warning_ignore("unsafe_method_access")
 func test_mock_custom_class_assert_has_no_side_affect() -> void:
 	var m: Variant = mock(CustomNodeTestClass)
 	assert_that(m).is_not_null()
@@ -670,7 +635,6 @@ func test_mock_custom_class_assert_has_no_side_affect() -> void:
 	node.free()
 
 
-@warning_ignore("unsafe_method_access")
 func test_mock_custom_class_assert_has_no_side_affect_real_func() -> void:
 	var m: Variant = mock(CustomNodeTestClass, CALL_REAL_FUNC)
 	assert_that(m).is_not_null()
@@ -690,7 +654,6 @@ func test_mock_custom_class_assert_has_no_side_affect_real_func() -> void:
 
 # This test verifies a function is calling other internally functions
 # to collect the access times and the override return value is working as expected
-@warning_ignore("unsafe_method_access")
 func _test_mock_advanced_func_path() -> void:
 	var m: Variant = mock(AdvancedTestClass, CALL_REAL_FUNC)
 	# initial nothing is called
@@ -730,7 +693,6 @@ func _test_mock_advanced_func_path() -> void:
 	verify(m, 1).c()
 
 
-@warning_ignore("unsafe_method_access")
 func _test_mock_godot_class_calls_sub_function() -> void:
 	var m: Variant = mock(MeshInstance3D, CALL_REAL_FUNC)
 	verify(m, 0)._mesh_changed()
@@ -739,7 +701,6 @@ func _test_mock_godot_class_calls_sub_function() -> void:
 	verify(m, 1)._mesh_changed()
 
 
-@warning_ignore("unsafe_method_access")
 func test_mock_class_with_inner_class() -> void:
 	var mock_advanced: Variant = mock(AdvancedTestClass)
 	assert_that(mock_advanced).is_not_null()
@@ -774,7 +735,6 @@ func test_mock_class_with_property_getter_and_setter() -> void:
 	assert_int(c.session_count()).is_equal(23)
 
 
-@warning_ignore("unsafe_method_access")
 func test_do_return() -> void:
 	var mocked_node: Variant = mock(Node)
 
@@ -802,7 +762,6 @@ func test_do_return() -> void:
 	assert_object(node1).is_instanceof(Area3D)
 
 
-@warning_ignore("unsafe_method_access")
 func test_matching_is_sorted() -> void:
 	var mocked_node: Variant = mock(Node)
 	do_return(null).on(mocked_node).get_child(any(), false)
@@ -824,7 +783,6 @@ func test_matching_is_sorted() -> void:
 	assert_object(first_arguments[4]).is_instanceof(GdUnitArgumentMatcher)
 
 
-@warning_ignore("unsafe_method_access")
 func test_do_return_with_matchers() -> void:
 	var mocked_node: Variant = mock(Node)
 	var childN :Node = auto_free(Node2D.new())
@@ -856,7 +814,6 @@ func test_do_return_with_matchers() -> void:
 	assert_that(mocked_node.get_child(10)).is_same(child10)
 
 
-@warning_ignore("unsafe_method_access")
 func test_example_verify() -> void:
 	var mocked_node: Variant = mock(Node)
 
@@ -876,7 +833,6 @@ func test_example_verify() -> void:
 	verify(mocked_node, 3).set_process(any_bool())
 
 
-@warning_ignore("unsafe_method_access")
 func test_verify_fail() -> void:
 	var mocked_node: Variant = mock(Node)
 
@@ -899,7 +855,6 @@ func test_verify_fail() -> void:
 		.has_message(expected_error)
 
 
-@warning_ignore("unsafe_method_access")
 func test_verify_func_interaction_wiht_PoolStringArray() -> void:
 	var mocked: Variant = mock(ClassWithPoolStringArrayFunc)
 
@@ -909,7 +864,6 @@ func test_verify_func_interaction_wiht_PoolStringArray() -> void:
 	verify_no_more_interactions(mocked)
 
 
-@warning_ignore("unsafe_method_access")
 func test_verify_func_interaction_wiht_PoolStringArray_fail() -> void:
 	var mocked: Variant = mock(ClassWithPoolStringArrayFunc)
 
@@ -944,7 +898,6 @@ func test_verify_func_interaction_wiht_PoolStringArray_fail() -> void:
 		.has_message(expected_error)
 
 
-@warning_ignore("unsafe_method_access")
 func test_reset() -> void:
 	var mocked_node: Variant = mock(Node)
 
@@ -969,7 +922,6 @@ func test_verify_no_interactions() -> void:
 	verify_no_interactions(mocked_node)
 
 
-@warning_ignore("unsafe_method_access")
 func test_verify_no_interactions_fails() -> void:
 	var mocked_node: Variant = mock(Node)
 
@@ -990,7 +942,6 @@ func test_verify_no_interactions_fails() -> void:
 		.has_message(expected_error)
 
 
-@warning_ignore("unsafe_method_access")
 func test_verify_no_more_interactions() -> void:
 	var mocked_node: Variant = mock(Node)
 
@@ -1008,7 +959,6 @@ func test_verify_no_more_interactions() -> void:
 	verify_no_more_interactions(mocked_node)
 
 
-@warning_ignore("unsafe_method_access")
 func test_verify_no_more_interactions_but_has() -> void:
 	var mocked_node: Variant = mock(Node)
 
@@ -1044,7 +994,6 @@ func test_verify_no_more_interactions_but_has() -> void:
 		.has_message(expected_error)
 
 
-@warning_ignore("unsafe_method_access")
 func test_mock_snake_case_named_class_by_resource_path() -> void:
 	var mock_a: Variant = mock("res://addons/gdUnit4/test/mocker/resources/snake_case.gd")
 	assert_object(mock_a).is_not_null()
@@ -1061,7 +1010,6 @@ func test_mock_snake_case_named_class_by_resource_path() -> void:
 	verify_no_more_interactions(mock_b)
 
 
-@warning_ignore("unsafe_method_access")
 func test_mock_snake_case_named_godot_class_by_name() -> void:
 	# try checked Godot class
 	var mocked_tcp_server: Variant = mock("TCPServer")
@@ -1074,7 +1022,6 @@ func test_mock_snake_case_named_godot_class_by_name() -> void:
 	verify_no_more_interactions(mocked_tcp_server)
 
 
-@warning_ignore("unsafe_method_access")
 func test_mock_snake_case_named_class_by_class() -> void:
 	var m: Variant = mock(snake_case_class_name)
 	assert_object(m).is_not_null()
@@ -1094,7 +1041,6 @@ func test_mock_snake_case_named_class_by_class() -> void:
 	verify_no_more_interactions(mocked_tcp_server)
 
 
-@warning_ignore("unsafe_method_access")
 func test_mock_func_with_default_build_in_type() -> void:
 	var m: Variant = mock(ClassWithDefaultBuildIntTypes)
 	assert_object(m).is_not_null()
@@ -1113,7 +1059,6 @@ func test_mock_func_with_default_build_in_type() -> void:
 	verify_no_more_interactions(m)
 
 
-@warning_ignore("unsafe_method_access")
 func test_mock_virtual_function_is_not_called_twice() -> void:
 	# this test verifies the special handling of virtual functions by Godot
 	# virtual functions are handeld in a special way
@@ -1147,7 +1092,6 @@ func test_mock_virtual_function_is_not_called_twice() -> void:
 	assert_that(m._x).is_equal("ui_accept")
 
 
-@warning_ignore("unsafe_method_access")
 func test_mock_scene_by_path() -> void:
 	var mocked_scene: Variant = mock("res://addons/gdUnit4/test/mocker/resources/scenes/TestScene.tscn")
 	assert_object(mocked_scene).is_not_null()
@@ -1157,7 +1101,6 @@ func test_mock_scene_by_path() -> void:
 	assert_bool(GdUnitMemoryObserver.is_marked_auto_free(mocked_scene)).is_true()
 
 
-@warning_ignore("unsafe_method_access")
 func test_mock_scene_by_resource() -> void:
 	var resource: Object = load("res://addons/gdUnit4/test/mocker/resources/scenes/TestScene.tscn")
 	var mocked_scene: Variant = mock(resource)
@@ -1168,7 +1111,6 @@ func test_mock_scene_by_resource() -> void:
 	assert_bool(GdUnitMemoryObserver.is_marked_auto_free(mocked_scene)).is_true()
 
 
-@warning_ignore("unsafe_method_access")
 func test_mock_scene_by_instance() -> void:
 	var resource := load("res://addons/gdUnit4/test/mocker/resources/scenes/TestScene.tscn")
 	var instance :Control = auto_free(resource.instantiate())
@@ -1182,7 +1124,6 @@ func test_mock_scene_by_path_fail_has_no_script_attached() -> void:
 	assert_object(mocked_scene).is_null()
 
 
-@warning_ignore("unsafe_method_access")
 func test_mock_scene_variables_is_set() -> void:
 	var mocked_scene: Variant = mock("res://addons/gdUnit4/test/mocker/resources/scenes/TestScene.tscn")
 	assert_object(mocked_scene).is_not_null()
@@ -1202,7 +1143,6 @@ func test_mock_scene_variables_is_set() -> void:
 	assert_str(mocked_scene._initial_color.to_html()).is_equal(Color.RED.to_html())
 
 
-@warning_ignore("unsafe_method_access")
 func test_mock_scene_execute_func_yielded() -> void:
 	var mocked_scene: Variant = mock("res://addons/gdUnit4/test/mocker/resources/scenes/TestScene.tscn")
 	assert_object(mocked_scene).is_not_null()
@@ -1257,5 +1197,4 @@ func test_mock_with_await_function() -> void:
 
 	await mocked_instance.await_function()
 
-	@warning_ignore("unsafe_method_access")
 	verify(mocked_instance, 1).await_function()

--- a/addons/gdUnit4/test/monitor/GodotGdErrorMonitorTest.gd
+++ b/addons/gdUnit4/test/monitor/GodotGdErrorMonitorTest.gd
@@ -40,8 +40,8 @@ func test_monitor_push_error() -> void:
 	prints(reports[0].message())
 	assert_str(reports[0].message())\
 		.contains("Test GodotGdErrorMonitor 'push_error' reporting")\
-		.contains("at res://addons/gdUnit4/test/monitor/GodotGdErrorMonitorTest.gd:77")\
-		.contains("at res://addons/gdUnit4/test/monitor/GodotGdErrorMonitorTest.gd:72")\
+		.contains("at res://addons/gdUnit4/test/monitor/GodotGdErrorMonitorTest.gd:78")\
+		.contains("at res://addons/gdUnit4/test/monitor/GodotGdErrorMonitorTest.gd:73")\
 		.contains("at res://addons/gdUnit4/test/monitor/GodotGdErrorMonitorTest.gd:35")
 	assert_int(reports[0].line_number()).is_equal(35)
 
@@ -69,6 +69,7 @@ func test_fail_by_push_error(_do_skip := true, _skip_reason := "disabled to not 
 
 
 func forcet_push_error() -> void:
+	@warning_ignore("redundant_await")
 	await forcet_push_error2()
 
 

--- a/addons/gdUnit4/test/spy/GdUnitSpyTest.gd
+++ b/addons/gdUnit4/test/spy/GdUnitSpyTest.gd
@@ -197,10 +197,10 @@ func test_spy_on_inner_class() -> void:
 
 
 func test_spy_on_singleton() -> void:
-	await assert_error(func () -> void:
-							var spy_node_ :Variant = spy(Input)
-							assert_object(spy_node_).is_null()
-							await await_idle_frame()).is_push_error("Spy on a Singleton is not allowed! 'Input'")
+	assert_error(func () -> void:
+		var spy_node_ :Variant = spy(Input)
+		assert_object(spy_node_).is_null()
+		await await_idle_frame()).is_push_error("Spy on a Singleton is not allowed! 'Input'")
 
 
 func test_example_verify() -> void:

--- a/addons/gdUnit4/test/ui/templates/TestSuiteTemplateTest.gd
+++ b/addons/gdUnit4/test/ui/templates/TestSuiteTemplateTest.gd
@@ -1,6 +1,5 @@
+@warning_ignore_start("unsafe_method_access")
 # GdUnit generated TestSuite
-#warning-ignore-all:unused_argument
-#warning-ignore-all:return_value_discarded
 class_name TestSuiteTemplateTest
 extends GdUnitTestSuite
 

--- a/gdUnit4.csproj
+++ b/gdUnit4.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Godot.NET.Sdk/4.5.1">
+<Project Sdk="Godot.NET.Sdk/4.6.0">
   <PropertyGroup>
     <TargetFramework>net9.0</TargetFramework>
     <LangVersion>13.0</LangVersion>
@@ -9,10 +9,10 @@
     <NoWarn>NU1605</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1"/>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
     <!-- ProjectReference Include="..\gdUnit4Net\api\gdUnit4Api.csproj" /-->
-    <PackageReference Include="gdUnit4.api" Version="5.1.0-rc3"/>
-    <PackageReference Include="gdUnit4.test.adapter" Version="3.0.0"/>
+    <PackageReference Include="gdUnit4.api" Version="5.1.0-rc3" />
+    <PackageReference Include="gdUnit4.test.adapter" Version="3.0.0" />
     <PackageReference Include="gdUnit4.analyzers" Version="1.0.0">
       <PrivateAssets>none</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/project.godot
+++ b/project.godot
@@ -16,7 +16,7 @@ compatibility/default_parent_skeleton_in_mesh_instance_3d=true
 
 config/name="gdUnit4"
 config/tags=PackedStringArray("addon", "godot4", "testing")
-config/features=PackedStringArray("4.5", "C#")
+config/features=PackedStringArray("4.6", "C#")
 run/flush_stdout_on_print=true
 config/icon="res://icon.png"
 
@@ -28,15 +28,14 @@ default_bus_layout=""
 
 file_logging/enable_file_logging=true
 settings/gdscript/always_track_call_stacks=true
+gdscript/warnings/directory_rules={
+"res://addons": 1
+}
 gdscript/warnings/untyped_declaration=2
 gdscript/warnings/unsafe_property_access=1
 gdscript/warnings/unsafe_method_access=1
 gdscript/warnings/unsafe_cast=1
 gdscript/warnings/unsafe_call_argument=1
-gdscript/warnings/directory_rules={
-"res://addons": 1,
-"res://addons/gdUnit4": 0
-}
 
 [dotnet]
 


### PR DESCRIPTION
# Why
With Godot 4.6 the default exclude of plugins from script error reporting has changed and it shows errors and warnings when installing GdUnit4 v6.1.0

# What
- Fixing all script errors and warnings to get a start and test execution without errors and warnings
- Bump to v6.1.1

