### PR TITLE
GD-1084: Fix gdUnit inspector becoming unresponsive after stopping test run via editor stop button

### DIFF
--- a/addons/gdUnit4/src/core/command/GdUnitCommandHandler.gd
+++ b/addons/gdUnit4/src/core/command/GdUnitCommandHandler.gd
@@ -48,7 +48,7 @@ func _notification(what: int) -> void:
 
 
 func _do_process() -> void:
-	# Do stop test execution when the user has stoped the main scene manually
+	# Do stop test execution when the user has stoped the test runner manually by hit the Godot editor stop button
 	if test_session_command._is_debug and test_session_command.is_running() and not EditorInterface.is_playing_scene():
 		if GdUnitSettings.is_verbose_assert_warnings():
 			print_debug("Test Runner scene was stopped manually, force stopping the current test run!")

--- a/addons/gdUnit4/src/core/command/GdUnitCommandTestSession.gd
+++ b/addons/gdUnit4/src/core/command/GdUnitCommandTestSession.gd
@@ -35,15 +35,13 @@ func stop() -> void:
 
 	if _is_debug and EditorInterface.is_playing_scene():
 		EditorInterface.stop_playing_scene()
-		# We need finaly to send the test session close event because the current run is hard aborted.
-		GdUnitSignals.instance().gdunit_event.emit(GdUnitSessionClose.new())
 	elif OS.is_process_running(_current_runner_process_id):
 		var result := OS.kill(_current_runner_process_id)
 		if result != OK:
 			push_error("ERROR checked stopping GdUnit Test Runner. error code: %s" % result)
 		_current_runner_process_id = -1
-		# We need finaly to send the test session close event because the current run is hard aborted.
-		GdUnitSignals.instance().gdunit_event.emit(GdUnitSessionClose.new())
+	# We need finaly to send the test session close event because the current run is hard aborted.
+	GdUnitSignals.instance().gdunit_event.emit(GdUnitSessionClose.new())
 
 
 ## Forces the running scene to unpause when the debugger hits a breakpoint.[br]

--- a/addons/gdUnit4/src/ui/GdUnitInspector.gd
+++ b/addons/gdUnit4/src/ui/GdUnitInspector.gd
@@ -29,6 +29,6 @@ func _ready() -> void:
 
 func _process(delta: float) -> void:
 	_wait_time += delta
-	if _wait_time > 5.0:
+	if _wait_time > 2.0:
 		_wait_time = 0
 		_command_handler._do_process()


### PR DESCRIPTION
# Why
When aborting a test run using the regular Editor stop button (not the gdUnit inspector stop button), the gdUnit tab becomes unresponsive. The stop command was called but the `GdUnitSessionClose` signal was not emitted because the if conditions did not match in this scenario.

# What
Moved the `GdUnitSessionClose` signal emit outside/after the if/elif block in `GdUnitCommandTestSession.stop()` so it is always emitted regardless of which stop path is taken. Also reduced the `_do_process` poll interval in `GdUnitInspector` from 5s to 2s for faster detection.

