### PR TITLE
TASK-1090: Add Godot 4.6.2 to ci workflows

### DIFF
--- a/.github/workflows/ci-dev.yml
+++ b/.github/workflows/ci-dev.yml
@@ -22,7 +22,7 @@ jobs:
       fail-fast: false
       max-parallel: 10
       matrix:
-        godot-version: ['4.5', '4.5.1', '4.6', '4.6.1']
+        godot-version: ['4.5', '4.5.1', '4.6', '4.6.1', '4.6.2']
         godot-status: ['stable']
         godot-net: ['.Net', '']
 

--- a/.github/workflows/ci-pr-publish-report.yml
+++ b/.github/workflows/ci-pr-publish-report.yml
@@ -24,7 +24,7 @@ jobs:
       fail-fast: false
       max-parallel: 10
       matrix:
-        godot-version: ['4.5', '4.5.1', '4.6', '4.6.1']
+        godot-version: ['4.5', '4.5.1', '4.6', '4.6.1', '4.6.2']
         godot-status: ['stable']
         godot-net: ['-net', '']
         # include:

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -36,7 +36,7 @@ jobs:
       max-parallel: 10
       matrix:
         # If changes are made here, they must be transferred to `.github\workflows\ci-pr-publish-report.yml`
-        godot-version: ['4.5', '4.5.1', '4.6', '4.6.1']
+        godot-version: ['4.5', '4.5.1', '4.6', '4.6.1', '4.6.2']
         godot-status: ['stable']
         godot-net: ['.Net', '']
         # include:

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@
   <img src="https://img.shields.io/badge/Godot-v4.5-%23478cbf?logo=godot-engine&logoColor=cyian&color=green" alt="">
   <img src="https://img.shields.io/badge/Godot-v4.6-%23478cbf?logo=godot-engine&logoColor=cyian&color=green" alt="">
   <img src="https://img.shields.io/badge/Godot-v4.6.1-%23478cbf?logo=godot-engine&logoColor=cyian&color=green" alt="">
+  <img src="https://img.shields.io/badge/Godot-v4.6.2-%23478cbf?logo=godot-engine&logoColor=cyian&color=green" alt="">
 </p>
 
 <h1 align="center">Compatibility Overview</h1>
@@ -33,10 +34,10 @@
   </thead>
   <tbody>
     <tr>
-      <td>master (upcoming v6.2)</td><td>v4.5, v4.5.1, v4.6, v4.6.1</td>
+      <td>master (upcoming v6.2)</td><td>v4.5, v4.5.1, v4.6, v4.6.1, v4.6.2</td>
     </tr>
     <tr>
-      <td>v6.1.x</td><td>v4.5, v4.5.1, v4.6</td>
+      <td>v6.1.x</td><td>v4.5, v4.5.1, v4.6, v4.6.1, v4.6.2</td>
     </tr>
     <tr>
       <td>v6.0.x+</td><td>v4.5, v4.5.1</td>


### PR DESCRIPTION
# Why
Godot v4.6.2 has been released and we need to cover all the tests that work with this version.

# What
- Adding Godot 4.6.2 to ci-pr
- Adding Godot 4.6.2 to ci-dev
- Adding Godot 4.6.2 to ci-pr-publish-report
