### PR TITLE
TASK-1094: Add Godot 4.7-devX to ci workflows

### DIFF
--- a/.github/workflows/ci-pr-publish-report.yml
+++ b/.github/workflows/ci-pr-publish-report.yml
@@ -27,9 +27,9 @@ jobs:
         godot-version: ['4.5', '4.5.1', '4.6', '4.6.1', '4.6.2']
         godot-status: ['stable']
         godot-net: ['-net', '']
-        # include:
-        #  - godot-version: '4.6'
-        #    godot-status: 'rc1'
+        include:
+          - godot-version: '4.7'
+            godot-status: 'dev3'
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -39,9 +39,9 @@ jobs:
         godot-version: ['4.5', '4.5.1', '4.6', '4.6.1', '4.6.2']
         godot-status: ['stable']
         godot-net: ['.Net', '']
-        # include:
-        #  - godot-version: '4.6'
-        #    godot-status: 'rc1'
+        include:
+          - godot-version: '4.7'
+            godot-status: 'dev3'
 
     permissions:
       actions: write

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@
   <img src="https://img.shields.io/badge/Godot-v4.6-%23478cbf?logo=godot-engine&logoColor=cyian&color=green" alt="">
   <img src="https://img.shields.io/badge/Godot-v4.6.1-%23478cbf?logo=godot-engine&logoColor=cyian&color=green" alt="">
   <img src="https://img.shields.io/badge/Godot-v4.6.2-%23478cbf?logo=godot-engine&logoColor=cyian&color=green" alt="">
+  <img src="https://img.shields.io/badge/Godot-v4.7 dev3-%23478cbf?logo=godot-engine&logoColor=cyian&color=yellow" alt="">
 </p>
 
 <h1 align="center">Compatibility Overview</h1>
@@ -34,7 +35,7 @@
   </thead>
   <tbody>
     <tr>
-      <td>master (upcoming v6.2)</td><td>v4.5, v4.5.1, v4.6, v4.6.1, v4.6.2</td>
+      <td>master (upcoming v6.2)</td><td>v4.5, v4.5.1, v4.6, v4.6.1, v4.6.2, v6.7-dev3</td>
     </tr>
     <tr>
       <td>v6.1.x</td><td>v4.5, v4.5.1, v4.6, v4.6.1, v4.6.2</td>


### PR DESCRIPTION
# Why
Godot 4.7-dev has been released and we need to cover all the tests that work with this version.

# What
- Adding Godot 4.7-dev to ci-pr
- Adding Godot 4.7-dev to ci-pr-publish-report
