### PR TITLE
GD-1096 Respect backslashes in function body

### DIFF
--- a/addons/gdUnit4/src/core/parse/GdScriptParser.gd
+++ b/addons/gdUnit4/src/core/parse/GdScriptParser.gd
@@ -37,6 +37,7 @@ var TOKEN_BRACKET_SQUARE_OPEN := Token.new("[")
 var TOKEN_BRACKET_SQUARE_CLOSE := Token.new("]")
 var TOKEN_BRACKET_CURLY_OPEN := Token.new("{")
 var TOKEN_BRACKET_CURLY_CLOSE := Token.new("}")
+var TOKEN_BACKSLASH := Token.new("\\")
 
 
 var OPERATOR_ADD := Operator.new("+")
@@ -49,6 +50,7 @@ var TOKENS :Array[Token] = [
 	TOKEN_SPACE,
 	TOKEN_TABULATOR,
 	TOKEN_NEW_LINE,
+	TOKEN_BACKSLASH,
 	TOKEN_COMMENT,
 	TOKEN_BRACKET_ROUND_OPEN,
 	TOKEN_BRACKET_ROUND_CLOSE,

--- a/addons/gdUnit4/test/mocker/GdUnitMockBuilderTest.gd
+++ b/addons/gdUnit4/test/mocker/GdUnitMockBuilderTest.gd
@@ -39,3 +39,12 @@ func test_mock_on_class_with_custom_class_name() -> void:
 	assert_that(script.get_instance_base_type()).is_equal("Resource")
 	# finally check the mocked script is valid
 	assert_int(script.reload()).is_equal(OK)
+
+
+func test_mock_on_script_with_multilines() -> void:
+	var instance :Object = (load("res://addons/gdUnit4/test/mocker/resources/ClassWithMultilineBlocks.gd") as GDScript).new()
+	var script := GdUnitMockBuilder.mock_on_script(instance, instance.get_script(), [], false);
+	assert_str(script.resource_name).starts_with("MockClassWithMultilineBlocks")
+	assert_that(script.get_instance_base_type()).is_equal("RefCounted")
+	# finally check the mocked script is valid
+	assert_int(script.reload()).is_equal(OK)

--- a/addons/gdUnit4/test/mocker/resources/ClassWithMultilineBlocks.gd
+++ b/addons/gdUnit4/test/mocker/resources/ClassWithMultilineBlocks.gd
@@ -1,0 +1,29 @@
+extends RefCounted
+
+
+func no_arg_multiline(
+) -> void:
+	pass
+
+
+func single_arg_multiline(
+	_arg1: int
+) -> void:
+	pass
+
+
+func multi_arg_multiline(
+	_arg1: int,
+	_arg2: String,
+	_arg3: String
+) -> void:
+	pass
+
+
+## See https://github.com/godot-gdunit-labs/gdUnit4/issues/1096
+func multi_arg_with_backslashes_multiline(\
+	_arg1: int,\
+	_arg2: String,\
+	_arg3: String\
+) -> void:
+	pass


### PR DESCRIPTION
# Why
If a user attempts to simulate a class with functions that contain multi-line arguments in combination with backslashes, the script analysis fails.

# What
Allows the script parser to process backslashes by adding the missing parser token.
