### PR TITLE
GD-1103: Fix plugin load gate rejecting Godot 4.6 default directory_rules

### DIFF
--- a/addons/gdUnit4/plugin.gd
+++ b/addons/gdUnit4/plugin.gd
@@ -9,21 +9,9 @@ var _editor_code_context_menu: EditorContextMenuPlugin
 
 
 func _enter_tree() -> void:
-	var inferred_declaration: int = ProjectSettings.get_setting("debug/gdscript/warnings/inferred_declaration")
-
-	var is_gdunit_excluded_warnings: bool = false
-	if Engine.get_version_info().hex >= 0x40600:
-		var dirctrory_rules: Dictionary = ProjectSettings.get_setting("debug/gdscript/warnings/directory_rules")
-		if dirctrory_rules.has("res://addons/gdUnit4") and dirctrory_rules["res://addons/gdUnit4"] == 0:
-			is_gdunit_excluded_warnings = true
-	else:
-		is_gdunit_excluded_warnings = ProjectSettings.get_setting("debug/gdscript/warnings/exclude_addons")
-	if !is_gdunit_excluded_warnings and inferred_declaration != 0:
+	if GdUnitPluginGate.should_block_plugin_load():
 		printerr("GdUnit4: 'inferred_declaration' is set to Warning/Error!")
-		if Engine.get_version_info().hex >= 0x40600:
-			printerr("GdUnit4 is not 'inferred_declaration' save, you have to excluded the addon (debug/gdscript/warnings/directory_rules)")
-		else:
-			printerr("GdUnit4 is not 'inferred_declaration' save, you have to excluded addons (debug/gdscript/warnings/exclude_addons)")
+		printerr(GdUnitPluginGate.build_block_help_message())
 		printerr("Loading GdUnit4 Plugin failed.")
 		return
 

--- a/addons/gdUnit4/src/core/GdUnitPluginGate.gd
+++ b/addons/gdUnit4/src/core/GdUnitPluginGate.gd
@@ -1,26 +1,37 @@
 class_name GdUnitPluginGate
 extends RefCounted
 
-## Encapsulates the plugin-load gate that aborts `_enter_tree` when gdUnit4's
-## own files would produce `inferred_declaration` parse errors. Extracted from
-## plugin.gd so the decision can be unit-tested without instantiating the
-## EditorPlugin.
+## Decides whether plugin.gd should abort in `_enter_tree` because gdUnit4's
+## files would hit `inferred_declaration` parse errors. Extracted from plugin.gd
+## so the logic can be tested without an EditorPlugin instance.
 ##
-## This file currently preserves the original exact-key `directory_rules`
-## check from GD-1004 / PR #1043 verbatim (with the `dirctrory_rules` typo
-## fixed). A follow-up commit replaces the internals of
-## `is_addon_warnings_suppressed()` with a sorted-prefix walk that mirrors
-## Godot's own rule evaluation in
-## `GDScriptParser::evaluate_warning_directory_rules_for_script_path`.
+## On Godot 4.6+ this walks `directory_rules` by descending slash count and
+## picks the most-specific prefix rule covering `res://addons/gdUnit4/`,
+## mirroring `GDScriptParser::evaluate_warning_directory_rules_for_script_path`
+## (see `modules/gdscript/gdscript_parser.cpp:141-147` for `RuleSort` and
+## `:312-328` for the evaluator). On <4.6 it reads `exclude_addons`, the only
+## suppression knob those versions have. We do NOT read `exclude_addons` on
+## 4.6+: the engine deprecated it and migrates its value into `directory_rules`
+## on first parser init (see `gdscript_parser.cpp:113-123`).
+
+# The path we check against directory_rules to decide if gdUnit4's own files
+# would be warning-suppressed. Trailing slash matches the engine's
+# post-normalization form (see gdscript_parser.cpp:127-139).
+const GDUNIT_ADDON_PATH := "res://addons/gdUnit4/"
 
 const SETTING_INFERRED_DECLARATION := "debug/gdscript/warnings/inferred_declaration"
 const SETTING_DIRECTORY_RULES := "debug/gdscript/warnings/directory_rules"
 const SETTING_EXCLUDE_ADDONS := "debug/gdscript/warnings/exclude_addons"
 
+# Mirror of GDScriptParser::WarningDirectoryRule::Decision in
+# `modules/gdscript/gdscript_parser.h`. Stable under Godot's compatibility
+# policy because the PropertyInfo hint in `gdscript.cpp:2840` exposes
+# `Exclude,Include` in this exact order to users.
+const DECISION_EXCLUDE := 0
 
-## Returns true when `_enter_tree` should print the configuration error and
-## abort plugin load. True only when `inferred_declaration` is set to Warn or
-## Error AND the gdUnit4 addon path is not already excluded from warnings.
+
+## Returns true when `_enter_tree` should abort plugin load: `inferred_declaration`
+## is Warn or Error AND the gdUnit4 addon path is not warning-suppressed.
 static func should_block_plugin_load() -> bool:
 	var inferred_declaration: int = int(ProjectSettings.get_setting(
 			SETTING_INFERRED_DECLARATION, 0))
@@ -29,26 +40,64 @@ static func should_block_plugin_load() -> bool:
 	return not is_addon_warnings_suppressed()
 
 
-## Returns true when the plugin believes Godot's warning rules would suppress
-## warnings for `res://addons/gdUnit4/`. On Godot 4.6+ this reads
-## `directory_rules`; on earlier versions it reads the deprecated
-## `exclude_addons` setting (still valid for <4.6).
+## Returns true if Godot would suppress warnings for scripts under
+## `res://addons/gdUnit4/`. On 4.6+ this walks `directory_rules` mirroring
+## the engine. On <4.6 this reads `exclude_addons`.
 static func is_addon_warnings_suppressed() -> bool:
 	if Engine.get_version_info().hex >= 0x40600:
-		var directory_rules: Dictionary = ProjectSettings.get_setting(
-				SETTING_DIRECTORY_RULES, {})
-		return (directory_rules.has("res://addons/gdUnit4")
-				and directory_rules["res://addons/gdUnit4"] == 0)
+		return _is_suppressed_by_directory_rules()
+	# Godot <4.6: exclude_addons is the only suppression knob.
 	return bool(ProjectSettings.get_setting(SETTING_EXCLUDE_ADDONS, true))
 
 
-## User-facing help message printed alongside the block. Version-split to
-## match the setting `is_addon_warnings_suppressed()` reads above.
+## User-facing help message printed alongside the block. Lists the valid
+## fixes for the running Godot version. On 4.6+ it does NOT recommend
+## `exclude_addons`, which is deprecated (see gdscript_parser.cpp:113-123).
 static func build_block_help_message() -> String:
 	if Engine.get_version_info().hex >= 0x40600:
-		return ("GdUnit4 is not 'inferred_declaration' save, "
-				+ "you have to excluded the addon "
-				+ "(debug/gdscript/warnings/directory_rules)")
-	return ("GdUnit4 is not 'inferred_declaration' save, "
-			+ "you have to excluded addons "
-			+ "(debug/gdscript/warnings/exclude_addons)")
+		return ("GdUnit4 needs its addon path excluded from warnings. "
+				+ "Fix in project.godot [debug]: keep the default "
+				+ "directory_rules={\"res://addons\": 0} (already excludes "
+				+ "gdUnit4 via prefix match), or add "
+				+ "\"res://addons/gdUnit4\": 0 to directory_rules. When "
+				+ "overriding directory_rules in project.godot, preserve "
+				+ "\"res://addons\": 0 or other addons lose warning "
+				+ "suppression too.")
+	return ("GdUnit4 needs its addon path excluded from warnings. "
+			+ "Fix in project.godot [debug]: set "
+			+ "debug/gdscript/warnings/exclude_addons=true.")
+
+
+# Mirrors the rule pipeline in `GDScriptParser::update_project_settings()`
+# (`gdscript_parser.cpp:127-147`) and
+# `GDScriptParser::evaluate_warning_directory_rules_for_script_path`
+# (`gdscript_parser.cpp:312-328`).
+#
+# Sort-key note: the engine sorts normalized rules by
+# `directory_path.count("/")` descending, and we do the same. For a single
+# target path (the gdUnit4 case), matching rules always form a prefix chain,
+# so slash count and length order coincide; the distinction only matters when
+# evaluating multiple target paths. We use slash count to match the engine
+# literally so this comment stays honest if the helper is reused.
+static func _is_suppressed_by_directory_rules() -> bool:
+	var rules: Dictionary = ProjectSettings.get_setting(
+			SETTING_DIRECTORY_RULES, {})
+	if rules.is_empty():
+		return false
+	# Normalize each key the way the engine does (gdscript_parser.cpp:127-139):
+	# simplify_path() collapses redundant slashes and . / .. segments, then we
+	# append a trailing slash so prefix matching aligns to directory boundaries.
+	var normalized_rules: Array[Dictionary] = []
+	for key: Variant in rules.keys():
+		var dir: String = str(key).simplify_path()
+		if not dir.ends_with("/"):
+			dir += "/"
+		normalized_rules.append({"dir": dir, "decision": int(rules[key])})
+	# Sort by slash count, descending (gdscript_parser.cpp:141-147 RuleSort).
+	normalized_rules.sort_custom(func(a: Dictionary, b: Dictionary) -> bool:
+		return (a["dir"] as String).count("/") > (b["dir"] as String).count("/"))
+	# First prefix match wins (gdscript_parser.cpp:312-328).
+	for rule: Dictionary in normalized_rules:
+		if GDUNIT_ADDON_PATH.begins_with(rule["dir"] as String):
+			return (rule["decision"] as int) == DECISION_EXCLUDE
+	return false

--- a/addons/gdUnit4/src/core/GdUnitPluginGate.gd
+++ b/addons/gdUnit4/src/core/GdUnitPluginGate.gd
@@ -1,0 +1,54 @@
+class_name GdUnitPluginGate
+extends RefCounted
+
+## Encapsulates the plugin-load gate that aborts `_enter_tree` when gdUnit4's
+## own files would produce `inferred_declaration` parse errors. Extracted from
+## plugin.gd so the decision can be unit-tested without instantiating the
+## EditorPlugin.
+##
+## This file currently preserves the original exact-key `directory_rules`
+## check from GD-1004 / PR #1043 verbatim (with the `dirctrory_rules` typo
+## fixed). A follow-up commit replaces the internals of
+## `is_addon_warnings_suppressed()` with a sorted-prefix walk that mirrors
+## Godot's own rule evaluation in
+## `GDScriptParser::evaluate_warning_directory_rules_for_script_path`.
+
+const SETTING_INFERRED_DECLARATION := "debug/gdscript/warnings/inferred_declaration"
+const SETTING_DIRECTORY_RULES := "debug/gdscript/warnings/directory_rules"
+const SETTING_EXCLUDE_ADDONS := "debug/gdscript/warnings/exclude_addons"
+
+
+## Returns true when `_enter_tree` should print the configuration error and
+## abort plugin load. True only when `inferred_declaration` is set to Warn or
+## Error AND the gdUnit4 addon path is not already excluded from warnings.
+static func should_block_plugin_load() -> bool:
+	var inferred_declaration: int = int(ProjectSettings.get_setting(
+			SETTING_INFERRED_DECLARATION, 0))
+	if inferred_declaration == 0:
+		return false
+	return not is_addon_warnings_suppressed()
+
+
+## Returns true when the plugin believes Godot's warning rules would suppress
+## warnings for `res://addons/gdUnit4/`. On Godot 4.6+ this reads
+## `directory_rules`; on earlier versions it reads the deprecated
+## `exclude_addons` setting (still valid for <4.6).
+static func is_addon_warnings_suppressed() -> bool:
+	if Engine.get_version_info().hex >= 0x40600:
+		var directory_rules: Dictionary = ProjectSettings.get_setting(
+				SETTING_DIRECTORY_RULES, {})
+		return (directory_rules.has("res://addons/gdUnit4")
+				and directory_rules["res://addons/gdUnit4"] == 0)
+	return bool(ProjectSettings.get_setting(SETTING_EXCLUDE_ADDONS, true))
+
+
+## User-facing help message printed alongside the block. Version-split to
+## match the setting `is_addon_warnings_suppressed()` reads above.
+static func build_block_help_message() -> String:
+	if Engine.get_version_info().hex >= 0x40600:
+		return ("GdUnit4 is not 'inferred_declaration' save, "
+				+ "you have to excluded the addon "
+				+ "(debug/gdscript/warnings/directory_rules)")
+	return ("GdUnit4 is not 'inferred_declaration' save, "
+			+ "you have to excluded addons "
+			+ "(debug/gdscript/warnings/exclude_addons)")

--- a/addons/gdUnit4/test/core/GdUnitPluginGateTest.gd
+++ b/addons/gdUnit4/test/core/GdUnitPluginGateTest.gd
@@ -1,0 +1,99 @@
+class_name GdUnitPluginGateTest
+extends GdUnitTestSuite
+
+# Tests for GdUnitPluginGate (extracted from plugin.gd _enter_tree).
+# Source under test: res://addons/gdUnit4/src/core/GdUnitPluginGate.gd
+
+const SETTING_INFERRED := "debug/gdscript/warnings/inferred_declaration"
+const SETTING_RULES := "debug/gdscript/warnings/directory_rules"
+
+var _had_inferred: bool
+var _original_inferred: Variant
+var _had_rules: bool
+var _original_rules: Variant
+
+
+## Suite-level skip: the `directory_rules` branch under test only applies
+## to Godot 4.6+. On earlier versions the helper falls through to
+## `exclude_addons`, which this suite does not exercise. The framework
+## reports these runs as skipped (not silently passing).
+func before(
+		_do_skip: bool = Engine.get_version_info().hex < 0x40600,
+		_skip_reason: String = "GdUnitPluginGate directory_rules branch requires Godot 4.6+"
+) -> void:
+	pass
+
+
+func before_test() -> void:
+	_had_inferred = ProjectSettings.has_setting(SETTING_INFERRED)
+	if _had_inferred:
+		_original_inferred = ProjectSettings.get_setting(SETTING_INFERRED)
+	_had_rules = ProjectSettings.has_setting(SETTING_RULES)
+	if _had_rules:
+		_original_rules = ProjectSettings.get_setting(SETTING_RULES)
+
+
+func after_test() -> void:
+	# Only clear settings that existed before the test. Clearing a setting
+	# that was never present errors out, which would fail under CI's
+	# warnings-as-errors.
+	if _had_inferred:
+		ProjectSettings.set_setting(SETTING_INFERRED, _original_inferred)
+	elif ProjectSettings.has_setting(SETTING_INFERRED):
+		ProjectSettings.clear(SETTING_INFERRED)
+	if _had_rules:
+		ProjectSettings.set_setting(SETTING_RULES, _original_rules)
+	elif ProjectSettings.has_setting(SETTING_RULES):
+		ProjectSettings.clear(SETTING_RULES)
+
+
+## Covers the plugin-load gate decision across the full configuration
+## matrix. Each row is `(inferred_declaration level, directory_rules value,
+## expected block outcome)`. Engine source references for the semantics
+## under test: `modules/gdscript/gdscript_parser.cpp:127-139` (rule
+## normalization), `:141-147` (`RuleSort`), and `:312-328`
+## (`evaluate_warning_directory_rules_for_script_path`).
+func test_should_block_plugin_load(
+		inferred: int,
+		rules: Dictionary,
+		expected: bool,
+		_test_parameters := [
+			# inferred_declaration=0 short-circuits regardless of rules
+			[0, {}, false],
+			# engine-registered default — every fresh 4.6 project
+			[1, {"res://addons": 0}, false],
+			# explicit gdUnit4-only rule
+			[1, {"res://addons/gdUnit4": 0}, false],
+			# both the default and an explicit rule present
+			[1, {"res://addons": 0, "res://addons/gdUnit4": 0}, false],
+			# trailing-slash key on the gdUnit4 rule
+			[1, {"res://addons/gdUnit4/": 0}, false],
+			# malformed key with redundant slashes — engine simplifies, so do we
+			[1, {"res://addons//gdUnit4": 0}, false],
+			# malformed key with `.` segment — engine simplifies, so do we
+			[1, {"res://./addons": 0}, false],
+			# specific INCLUDE overrides broader EXCLUDE — sort-order coverage
+			[1, {"res://addons": 0, "res://addons/gdUnit4": 1}, true],
+			# empty rules dict — no suppression anywhere
+			[1, {}, true],
+			# user explicitly enabled warnings for the addons tree
+			[1, {"res://addons": 1}, true],
+			# user explicitly enabled warnings for gdUnit4 specifically
+			[1, {"res://addons/gdUnit4": 1}, true],
+			# rule that doesn't prefix res://addons/gdUnit4/ has no effect
+			[1, {"res://src/game": 0}, true],
+		]
+) -> void:
+	ProjectSettings.set_setting(SETTING_INFERRED, inferred)
+	ProjectSettings.set_setting(SETTING_RULES, rules)
+	assert_bool(GdUnitPluginGate.should_block_plugin_load()).is_equal(expected)
+
+
+## The help message must not recommend `exclude_addons` on 4.6+ — the
+## setting is wrapped in `#ifndef DISABLE_DEPRECATED` at
+## `gdscript_parser.cpp:113-123` and `update_project_settings()` clears it
+## from ProjectSettings after migrating its value into `directory_rules`.
+func test_help_message_omits_exclude_addons_on_46_plus() -> void:
+	var msg: String = GdUnitPluginGate.build_block_help_message()
+	assert_str(msg).contains("directory_rules")
+	assert_str(msg).not_contains("exclude_addons")


### PR DESCRIPTION
# Why
On Godot 4.6+, gdUnit4 refuses to load when `inferred_declaration` is Warn/Error and `directory_rules` is left at Godot's default `{"res://addons": 0}`. Every fresh 4.6 project ships with that config. The gate in `plugin.gd:_enter_tree` does an exact-key `Dictionary.has()` check, but the engine evaluates rules as prefixes, so the default already covers `res://addons/gdUnit4/`. The plugin bails out anyway. Full diagnosis in #1103. Regression from #1043 (GD-1004).

# What
- Extract the gate into `GdUnitPluginGate` (`src/core/`) so it can be unit-tested without an EditorPlugin instance (also fixes the `dirctrory_rules` typo)
- Replace the exact-key check with a sorted-prefix walk that mirrors `GDScriptParser::update_project_settings` (`gdscript_parser.cpp:127-147`) and `evaluate_warning_directory_rules_for_script_path` (`:312-328`). Rule keys are normalized with `simplify_path()` and sorted by slash count descending, matching `RuleSort`; first prefix match decides the outcome
- Drop the `exclude_addons` read on 4.6+: the engine deprecated it and migrates its value into `directory_rules` on first parser init (`:113-123`). The <4.6 branch still reads it
- Rewrite the user-facing error message to name the two valid 4.6+ fixes and note that overriding `directory_rules` in project.godot replaces (not merges with) the default
- Add `GdUnitPluginGateTest` with a parameterized table covering the configuration matrix: sort-order precedence, malformed keys, and the engine-default happy path
