### PR TITLE
GD-1102: Display the “Run/Debug Tests” context menu in the File System Inspector when a directory is selected

### DIFF
--- a/addons/gdUnit4/src/ui/menu/GdUnitEditorFileSystemContextMenuHandler.gd
+++ b/addons/gdUnit4/src/ui/menu/GdUnitEditorFileSystemContextMenuHandler.gd
@@ -23,21 +23,23 @@ func _init() -> void:
 
 
 func _popup_menu(paths: PackedStringArray) -> void:
-	# Filter for test suites only
-	var test_suites := Array(paths)\
-		.filter(func(file: String) -> bool:
-			return file.get_extension() in ["gd", "cs"])\
-		.filter(func(file: String) -> bool:
-			var script := GdUnitTestSuiteScanner.load_with_disabled_warnings(file)
-			return GdUnitTestSuiteScanner.is_test_suite(script))
+	# Filter for directories and test suite files
+	var valid_paths := Array(paths)\
+		.filter(func(path: String) -> bool:
+			if DirAccess.dir_exists_absolute(path):
+				return true
+			if path.get_extension() in ["gd", "cs"]:
+				var script := GdUnitTestSuiteScanner.load_with_disabled_warnings(path)
+				return GdUnitTestSuiteScanner.is_test_suite(script)
+			return false)
 
-	# If no test suites selected don't extend the context menu
-	if test_suites.is_empty():
+	# If no valid paths selected don't extend the context menu
+	if valid_paths.is_empty():
 		return
 
 	for menu_item in _context_menus:
 		if menu_item.shortcut():
-			add_menu_shortcut(menu_item.shortcut(), menu_item.execute.bindv(test_suites).unbind(1))
+			add_menu_shortcut(menu_item.shortcut(), menu_item.execute.bindv(valid_paths).unbind(1))
 			add_context_menu_item_from_shortcut(menu_item.name, menu_item.shortcut(), menu_item.icon)
 		else:
-			add_context_menu_item(menu_item.name, menu_item.execute.bindv(test_suites).unbind(1), menu_item.icon)
+			add_context_menu_item(menu_item.name, menu_item.execute.bindv(valid_paths).unbind(1), menu_item.icon)


### PR DESCRIPTION
# Why
There was a regression in the implementation of `GdUnitEditorFileSystemContextMenuHandler` that caused an error. The context menu does not display the “Run/Debug Tests” entries when a folder is selected.

# What
Improved the filter so that selected directories are accepted and the context menu is expanded. We are not adding tests here because we cannot use mocks for an editor plugin class. We first need to improve the GdUnitClassDoubler to be able to mock on plugin classes.

