### PR TITLE
GD-1103: The plugin must respect GDScript warning directory rules

### DIFF
--- a/addons/gdUnit4/plugin.gd
+++ b/addons/gdUnit4/plugin.gd
@@ -9,21 +9,9 @@ var _editor_code_context_menu: EditorContextMenuPlugin
 
 
 func _enter_tree() -> void:
-	var inferred_declaration: int = ProjectSettings.get_setting("debug/gdscript/warnings/inferred_declaration")
-
-	var is_gdunit_excluded_warnings: bool = false
-	if Engine.get_version_info().hex >= 0x40600:
-		var dirctrory_rules: Dictionary = ProjectSettings.get_setting("debug/gdscript/warnings/directory_rules")
-		if dirctrory_rules.has("res://addons/gdUnit4") and dirctrory_rules["res://addons/gdUnit4"] == 0:
-			is_gdunit_excluded_warnings = true
-	else:
-		is_gdunit_excluded_warnings = ProjectSettings.get_setting("debug/gdscript/warnings/exclude_addons")
-	if !is_gdunit_excluded_warnings and inferred_declaration != 0:
-		printerr("GdUnit4: 'inferred_declaration' is set to Warning/Error!")
-		if Engine.get_version_info().hex >= 0x40600:
-			printerr("GdUnit4 is not 'inferred_declaration' save, you have to excluded the addon (debug/gdscript/warnings/directory_rules)")
-		else:
-			printerr("GdUnit4 is not 'inferred_declaration' save, you have to excluded addons (debug/gdscript/warnings/exclude_addons)")
+	var inferred_declaration := GdUnitSettings.validate_is_inferred_declaration_enabled()
+	if inferred_declaration.is_error():
+		printerr(inferred_declaration.error_message())
 		printerr("Loading GdUnit4 Plugin failed.")
 		return
 

--- a/addons/gdUnit4/src/core/GdUnitSettings.gd
+++ b/addons/gdUnit4/src/core/GdUnitSettings.gd
@@ -40,6 +40,23 @@ const CATEGORY_LOGGING := "debug/file_logging/"
 const STDOUT_ENABLE_TO_FILE = CATEGORY_LOGGING + "enable_file_logging"
 const STDOUT_WITE_TO_FILE = CATEGORY_LOGGING + "log_path"
 
+# Godot GDScript warning settings
+const CATEGORY_GDSCRIPT_WARNINGS := "debug/gdscript/warnings/"
+const GDSCRIPT_WARNINGS_INFERRED_DECLARATION := CATEGORY_GDSCRIPT_WARNINGS + "inferred_declaration"
+const GDSCRIPT_WARNINGS_EXCLUDE_ADDONS := CATEGORY_GDSCRIPT_WARNINGS + "exclude_addons"
+const GDSCRIPT_WARNINGS_DIRECTORY_RULES := CATEGORY_GDSCRIPT_WARNINGS + "directory_rules"
+
+enum GdScriptWarningMode {
+	IGNORE = 0,
+	WARN = 1,
+	ERROR = 2,
+}
+
+enum GdScriptWarningDirectoryMode {
+	EXCLUDE = 0,
+	INCLUDE = 1,
+}
+
 
 # GdUnit Templates
 const TEMPLATES = MAIN_CATEGORY + "/templates"
@@ -324,6 +341,32 @@ static func is_log_enabled() -> bool:
 	return ProjectSettings.get_setting(STDOUT_ENABLE_TO_FILE)
 
 
+static func validate_is_inferred_declaration_enabled() -> GdUnitResult:
+	if ProjectSettings.get_setting(GDSCRIPT_WARNINGS_INFERRED_DECLARATION) == GdScriptWarningMode.IGNORE:
+		return GdUnitResult.success()
+
+	if Engine.get_version_info().hex >= 0x40600:
+		var directory_rules: Dictionary = ProjectSettings.get_setting(GDSCRIPT_WARNINGS_DIRECTORY_RULES)
+		# Find the most specific matching rule (longest path wins)
+		var best_match := ""
+		for path: String in directory_rules.keys():
+			if "res://addons/gdUnit4".begins_with(path) and path.length() > best_match.length():
+				best_match = path
+		var is_excluded :bool = not best_match.is_empty() and directory_rules[best_match] == GdScriptWarningDirectoryMode.EXCLUDE
+		if not is_excluded:
+			return GdUnitResult.error("""
+				GdUnit4: 'inferred_declaration' is set to Warning/Error!
+				GdUnit4 is not 'inferred_declaration' safe, you have to exclude the addon (debug/gdscript/warnings/directory_rules)
+				""".dedent().strip_edges())
+	else:
+		if not ProjectSettings.get_setting(GDSCRIPT_WARNINGS_EXCLUDE_ADDONS):
+			return GdUnitResult.error("""
+				GdUnit4: 'inferred_declaration' is set to Warning/Error!
+				GdUnit4 is not 'inferred_declaration' safe, you have to exclude addons (debug/gdscript/warnings/exclude_addons)
+				""".dedent().strip_edges())
+	return GdUnitResult.success()
+
+
 static func list_settings(category: String) -> Array[GdUnitProperty]:
 	var settings: Array[GdUnitProperty] = []
 	for property in ProjectSettings.get_property_list():
@@ -439,5 +482,10 @@ static func dump_to_tmp() -> void:
 
 
 static func restore_dump_from_tmp() -> void:
-	@warning_ignore("return_value_discarded")
-	DirAccess.copy_absolute("user://project_settings.godot", "res://project.godot")
+	# Only restore if the current project.godot differs from the backup to avoid
+	# triggering a "file newer on disk" dialog in the editor
+	var backup := FileAccess.get_file_as_bytes("user://project_settings.godot")
+	var current := FileAccess.get_file_as_bytes("res://project.godot")
+	if backup == current:
+		return
+	var _error := DirAccess.copy_absolute("user://project_settings.godot", "res://project.godot")

--- a/addons/gdUnit4/test/core/GdUnitSettingsTest.gd
+++ b/addons/gdUnit4/test/core/GdUnitSettingsTest.gd
@@ -5,6 +5,12 @@ extends GdUnitTestSuite
 # TestSuite generated from
 const __source = 'res://addons/gdUnit4/src/core/GdUnitSettings.gd'
 
+const IGNORE := GdUnitSettings.GdScriptWarningMode.IGNORE
+const WARN := GdUnitSettings.GdScriptWarningMode.WARN
+const ERROR := GdUnitSettings.GdScriptWarningMode.ERROR
+const EXCLUDE := GdUnitSettings.GdScriptWarningDirectoryMode.EXCLUDE
+const INCLUDE := GdUnitSettings.GdScriptWarningDirectoryMode.INCLUDE
+
 const MAIN_CATEGORY = "unit_test"
 const CATEGORY_A = MAIN_CATEGORY + "/category_a"
 const CATEGORY_B = MAIN_CATEGORY + "/category_b"
@@ -131,6 +137,107 @@ func test_migrate_property_change_value() -> void:
 	assert_str(new_property.help()).is_equal(old_property.help())
 	# cleanup
 	ProjectSettings.clear(new_property_X)
+
+
+func test_validate_is_inferred_declaration_enabled_when_disabled() -> void:
+	ProjectSettings.set_setting(GdUnitSettings.GDSCRIPT_WARNINGS_INFERRED_DECLARATION, IGNORE)
+	assert_result(GdUnitSettings.validate_is_inferred_declaration_enabled())\
+		.is_success()
+
+
+func test_validate_is_inferred_declaration_enabled_when_warning_and_addon_excluded() -> void:
+	ProjectSettings.set_setting(GdUnitSettings.GDSCRIPT_WARNINGS_INFERRED_DECLARATION, WARN)
+	if Engine.get_version_info().hex >= 0x40600:
+		ProjectSettings.set_setting(GdUnitSettings.GDSCRIPT_WARNINGS_DIRECTORY_RULES, {"res://addons/gdUnit4": EXCLUDE})
+	else:
+		ProjectSettings.set_setting(GdUnitSettings.GDSCRIPT_WARNINGS_EXCLUDE_ADDONS, true)
+	assert_result(GdUnitSettings.validate_is_inferred_declaration_enabled())\
+		.is_success()
+
+
+func test_validate_is_inferred_declaration_enabled_when_warning_and_parent_dir_excluded() -> void:
+	ProjectSettings.set_setting(GdUnitSettings.GDSCRIPT_WARNINGS_INFERRED_DECLARATION, WARN)
+	if Engine.get_version_info().hex >= 0x40600:
+		# Godot's default: all plugins are excluded, covers gdUnit4 via parent path
+		ProjectSettings.set_setting(GdUnitSettings.GDSCRIPT_WARNINGS_DIRECTORY_RULES, {"res://addons": EXCLUDE})
+	else:
+		ProjectSettings.set_setting(GdUnitSettings.GDSCRIPT_WARNINGS_EXCLUDE_ADDONS, true)
+	assert_result(GdUnitSettings.validate_is_inferred_declaration_enabled())\
+		.is_success()
+
+
+func test_validate_is_inferred_declaration_enabled_when_warning_and_addon_excluded_but_parent_included() -> void:
+	ProjectSettings.set_setting(GdUnitSettings.GDSCRIPT_WARNINGS_INFERRED_DECLARATION, WARN)
+	if Engine.get_version_info().hex >= 0x40600:
+		# parent addons dir is included (warnings active) but gdUnit4 is specifically excluded
+		ProjectSettings.set_setting(GdUnitSettings.GDSCRIPT_WARNINGS_DIRECTORY_RULES, {"res://addons": INCLUDE, "res://addons/gdUnit4": EXCLUDE})
+	else:
+		ProjectSettings.set_setting(GdUnitSettings.GDSCRIPT_WARNINGS_EXCLUDE_ADDONS, true)
+	assert_result(GdUnitSettings.validate_is_inferred_declaration_enabled())\
+		.is_success()
+
+
+func test_validate_is_inferred_declaration_enabled_when_warning_and_only_parent_included() -> void:
+	ProjectSettings.set_setting(GdUnitSettings.GDSCRIPT_WARNINGS_INFERRED_DECLARATION, WARN)
+	var expected_message: String
+	if Engine.get_version_info().hex >= 0x40600:
+		# only "res://addons" is included (warnings active), gdUnit4 has no explicit exclusion
+		ProjectSettings.set_setting(GdUnitSettings.GDSCRIPT_WARNINGS_DIRECTORY_RULES, {"res://addons": INCLUDE})
+		expected_message = """
+			GdUnit4: 'inferred_declaration' is set to Warning/Error!
+			GdUnit4 is not 'inferred_declaration' safe, you have to exclude the addon (debug/gdscript/warnings/directory_rules)
+			""".dedent().strip_edges()
+	else:
+		ProjectSettings.set_setting(GdUnitSettings.GDSCRIPT_WARNINGS_EXCLUDE_ADDONS, false)
+		expected_message = """
+			GdUnit4: 'inferred_declaration' is set to Warning/Error!
+			GdUnit4 is not 'inferred_declaration' safe, you have to exclude addons (debug/gdscript/warnings/exclude_addons)
+			""".dedent().strip_edges()
+	assert_result(GdUnitSettings.validate_is_inferred_declaration_enabled())\
+		.is_error()\
+		.contains_message(expected_message)
+
+
+func test_validate_is_inferred_declaration_enabled_when_warning_and_addon_not_excluded() -> void:
+	ProjectSettings.set_setting(GdUnitSettings.GDSCRIPT_WARNINGS_INFERRED_DECLARATION, WARN)
+	var expected_message: String
+	if Engine.get_version_info().hex >= 0x40600:
+		# default + gdUnit4 explicitly re-included: addon is not excluded from warnings
+		ProjectSettings.set_setting(GdUnitSettings.GDSCRIPT_WARNINGS_DIRECTORY_RULES, {"res://addons": EXCLUDE, "res://addons/gdUnit4": INCLUDE})
+		expected_message = """
+			GdUnit4: 'inferred_declaration' is set to Warning/Error!
+			GdUnit4 is not 'inferred_declaration' safe, you have to exclude the addon (debug/gdscript/warnings/directory_rules)
+			""".dedent().strip_edges()
+	else:
+		ProjectSettings.set_setting(GdUnitSettings.GDSCRIPT_WARNINGS_EXCLUDE_ADDONS, false)
+		expected_message = """
+			GdUnit4: 'inferred_declaration' is set to Warning/Error!
+			GdUnit4 is not 'inferred_declaration' safe, you have to exclude addons (debug/gdscript/warnings/exclude_addons)
+			""".dedent().strip_edges()
+	assert_result(GdUnitSettings.validate_is_inferred_declaration_enabled())\
+		.is_error()\
+		.contains_message(expected_message)
+
+
+func test_validate_is_inferred_declaration_enabled_when_error_and_addon_not_excluded() -> void:
+	ProjectSettings.set_setting(GdUnitSettings.GDSCRIPT_WARNINGS_INFERRED_DECLARATION, ERROR)
+	var expected_message: String
+	if Engine.get_version_info().hex >= 0x40600:
+		# default + gdUnit4 explicitly re-included: addon is not excluded from warnings
+		ProjectSettings.set_setting(GdUnitSettings.GDSCRIPT_WARNINGS_DIRECTORY_RULES, {"res://addons": EXCLUDE, "res://addons/gdUnit4": INCLUDE})
+		expected_message = """
+			GdUnit4: 'inferred_declaration' is set to Warning/Error!
+			GdUnit4 is not 'inferred_declaration' safe, you have to exclude the addon (debug/gdscript/warnings/directory_rules)
+			""".dedent().strip_edges()
+	else:
+		ProjectSettings.set_setting(GdUnitSettings.GDSCRIPT_WARNINGS_EXCLUDE_ADDONS, false)
+		expected_message = """
+			GdUnit4: 'inferred_declaration' is set to Warning/Error!
+			GdUnit4 is not 'inferred_declaration' safe, you have to exclude addons (debug/gdscript/warnings/exclude_addons)
+			""".dedent().strip_edges()
+	assert_result(GdUnitSettings.validate_is_inferred_declaration_enabled())\
+		.is_error()\
+		.contains_message(expected_message)
 
 
 const TEST_ROOT_FOLDER := "gdunit4/settings/test/test_root_folder"


### PR DESCRIPTION
# Why
The plugin was incorrectly blocking initialization when `inferred_declaration` was set to warn/error
and the default Godot exclusion rule `{"res://addons": 0}` was in place. The check only looked for
an exact match on `"res://addons/gdUnit4"` and missed parent directory exclusions that implicitly
cover the addon.

# What
- Moved the `inferred_declaration` warning check from `plugin.gd` into `GdUnitSettings.validate_is_inferred_declaration_enabled() -> GdUnitResult`
- Fixed the `directory_rules` exclusion check to use longest-path-wins matching so parent directory rules (e.g. `"res://addons"`) are correctly recognized
- Fixed `restore_dump_from_tmp()` to compare file contents instead to preventing spurious "file newer on disk" dialogs
- Added test coverage for all relevant `directory_rules` combinations


