### PR TITLE
DOC-1106: Improve contributor onboarding in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,44 +37,49 @@ review and discuss code changes.
    - Ensure that the continuous integration (CI) process passes successfully.
 6. Submit the pull request!
 
-## Project Setup (For contributions)
+## Project Setup (for contributions)
 
-This project includes optional C# support. If you plan to work with C# parts of the codebase, ensure your environment is correctly configured for it.
-Otherwise you can use the standard Godot version.
+Most contributions can be made using the standard (non-Mono) Godot version.  
+C# support is only required when working on the C# API.
 
 ### Prerequisites
 
 You should be comfortable with:
 
-- Basic Godot usage (Scenes, nodes, scripts, etc...)
+- Basic Godot usage (scenes, nodes, scripts, etc...)
 - Reading and writing simple GDScript
 - Basic Git workflow
 
 ### Required Versions
 
-- Godot 4.6.x **Mono build**
-- .NET SDK version specified in [global.json](./global.json)
+- Godot 4.6.x (standard version)
 
-### Install .NET SDK
+For C# API contributions, additional setup is required.  
+[See Optional C# Setup](#optional-c-setup).
 
-The **required** .NET SDK version is pinned via [global.json](./global.json).
+### Optional C# Setup
+
+Only required if you want to contribute to the C# API.
+
+- Use Godot 4.6.x **Mono build**
+- Install the .NET SDK version specified in [global.json](./global.json)
 
 [.NET installation instructions](https://learn.microsoft.com/en-us/dotnet/core/install/)
 
-### Verify the Installation
-
-Open a terminal from the project root:
+#### Verify your setup:
 
 Check the SDK(s) is installed on your system:  
 `dotnet --list-sdks`
 
 Build the C# project:  
-`dotnet build`  
+`dotnet build`
 
 The terminal should print "Build succeeded".
 If Godot shows a generic error such as:  
 `Build error: Failed to build project. Check MSBuild panel for details.`  
 This can occur due to CI rules. Check the terminal output for details and ensure your changes comply with them.
+
+For more details, refer to the GdUnit4Net repository.
 
 ### Setup GDScript Linting
 
@@ -82,7 +87,8 @@ GDScript linting uses `gdtoolkit` (`gdlint`).
 
 [Install GDlint](https://github.com/Scony/godot-gdscript-toolkit)
 
-Run `gdlint` on the project root to check your changes.
+You can optionally run `gdlint` locally to check your changes before submitting a PR.  
+Linting is enforced by CI.
 
 ### Project Structure
 
@@ -97,6 +103,7 @@ For a high-level overview of the repository, see:
 - C# knowledge is helpful but not required for GDScript-only contributions
 - The goal is to apply linting across the entire project, but currently only part of the source tree is fully lint-clean
 - Please follow existing project rules and CI expectations for the files you modify
+- Do not commit local `project.godot` changes caused by opening the project with a different Godot setup
 
 ## License
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,8 +41,12 @@ review and discuss code changes.
 
 A pull request should:
 
-- Be linked to a single issue
-- Clearly explain the "Why" and "What" of the change
+- Be linked to a single issue ![Alt text](./assets/link-issue.png)
+- The PR description must contain sections:
+  # Why  
+  clean description why we need this changeset
+  # What
+  describe exactly what you have changed and what the effects are
 - Stay focused and minimal in scope
 - Include related documentation updates when applicable
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -114,7 +114,11 @@ For a high-level overview of the repository, see:
 - [llms.txt](./llms.txt)
 - [llms-full.txt](./llms-full.txt)
 
-These files provide a structured overview of the codebase to help contributors understand the project layout and navigate it more easily.
+To help AI tools like ChatGPT or Claude provide more accurate answers about our project, we offer optimized formats:
+Why? Standard websites contain too much "noise" (menus, layouts) for AI. Our files provide clean, structured content for maximum precision and lower token usage.
+Why the name? The naming follows the emerging standard for Large Language Models (LLMs). Similar to robots.txt for search engines, the llms prefix signals that these files are specifically designed for AI consumption.
+In short: We eliminate the clutter so the AI can find the right answers faster.
+
 
 ### Notes for contributors
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,18 +37,22 @@ review and discuss code changes.
    - Ensure that the continuous integration (CI) process passes successfully.
 6. Submit the pull request!
 
-### Pull Request Rules
+# Pull Request Rules
 
-A pull request should:
+To ensure a smooth review process, every Pull Request (PR) must meet the following criteria:
 
-- Be linked to a single issue ![Alt text](./assets/link-issue.png)
-- The PR description must contain sections:
-  # Why  
-  clean description why we need this changeset
-  # What
-  describe exactly what you have changed and what the effects are
-- Stay focused and minimal in scope
-- Include related documentation updates when applicable
+1. Naming & Linking
+   - PR Title: Must start with the issue number followed by a concise summary:
+     e.g., GD-1234: Add support for multithreaded test execution
+   - Branch Naming: Start with the issue number (e.g., GD-1234 or GD-1234-feature-name).
+     Link Issue: Every PR must be linked to a single corresponding issue.
+2. Content & Style
+   - Grammar: Both the title and description must be written in the present tense (e.g., "Add feature" instead of "Added feature").
+   - Required Sections: The PR description must include:
+     - **# Why** - A clear explanation of the need for this change.
+     - **# What** - A detailed description of the changes and their effects.
+   - Scope: Keep changes minimal and focused. Include documentation updates where applicable.
+
 
 ### AI Usage
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -124,7 +124,8 @@ For a high-level overview of the repository, see:
 
 To help AI tools like ChatGPT or Claude provide more accurate answers about our project, we offer optimized formats:
 Why? Standard websites contain too much "noise" (menus, layouts) for AI. Our files provide clean, structured content for maximum precision and lower token usage.
-Why the name? The naming follows the emerging standard for Large Language Models (LLMs). Similar to robots.txt for search engines, the llms prefix signals that these files are specifically designed for AI consumption.
+Why the name? The naming follows the emerging standard for Large Language Models (LLMs). Similar to robots.txt for search engines, the llms prefix signals that these
+files are specifically designed for AI consumption.
 In short: We eliminate the clutter so the AI can find the right answers faster.
 
 ### Notes for contributors
@@ -134,7 +135,8 @@ In short: We eliminate the clutter so the AI can find the right answers faster.
 - The goal is to apply linting across the entire project, but currently only part of the source tree is fully lint-clean
 - Please follow existing project rules and CI expectations for the files you modify
 - Never commit changes to `project.godot` unless we need to update the C# API dependencies
-- Follow the repository configuration and formatting rules defined in files such as [.gdlintrc](./.gdlintrc), [.editorconfig](./.editorconfig), [.markdownlint.jsonc](./.github/actions/formatting_checks/.markdownlint.jsonc), and [.yamllint.yml](./.github/actions/formatting_checks/.yamllint.yml)
+- Follow the repository configuration and formatting rules defined in files such as [.gdlintrc](./.gdlintrc), [.editorconfig](./.editorconfig),
+  [.markdownlint.jsonc](./.github/actions/formatting_checks/.markdownlint.jsonc), and [.yamllint.yml](./.github/actions/formatting_checks/.yamllint.yml)
 
 ## License
 
@@ -148,4 +150,3 @@ To maintain code consistency, please adhere to the following coding style guides
 
 - <a href='https://docs.godotengine.org/en/stable/tutorials/scripting/gdscript/gdscript_styleguide.html' target="_blank">Godot's GDScript Conventions</a>
 - <a href='https://docs.microsoft.com/en-us/dotnet/csharp/fundamentals/coding-style/coding-conventions' target="_blank">C# Coding Conventions</h>
-

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -124,8 +124,8 @@ For a high-level overview of the repository, see:
 
 To help AI tools like ChatGPT or Claude provide more accurate answers about our project, we offer optimized formats:
 Why? Standard websites contain too much "noise" (menus, layouts) for AI. Our files provide clean, structured content for maximum precision and lower token usage.
-Why the name? The naming follows the emerging standard for Large Language Models (LLMs). Similar to robots.txt for search engines, the llms prefix signals that these
-files are specifically designed for AI consumption.
+Why the name? The naming follows the emerging standard for Large Language Models (LLMs). Similar to robots.txt for search engines, the llms prefix signals
+that these files are specifically designed for AI consumption.
 In short: We eliminate the clutter so the AI can find the right answers faster.
 
 ### Notes for contributors

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,7 +26,7 @@ review and discuss code changes.
 2. Fork the repository and create a branch from the `master` branch.
    - Use the issue number as the branch name, e.g., GD-111.
 3. If you have made changes to the code that should be tested, please include appropriate tests.
-4. If you have modified any APIs, ensure that the documentation is updated accordingly.
+4. If you have implemented new features or modified any APIs, ensure that the documentation is updated accordingly.
 5. Create a pull request and provide information in the "Why" and "What" sections:
    - Link the pull request to the corresponding issue.<br>
    ![Alt text](./assets/link-issue.png)
@@ -37,7 +37,24 @@ review and discuss code changes.
    - Ensure that the continuous integration (CI) process passes successfully.
 6. Submit the pull request!
 
-## Project Setup (for contributions)
+### Pull Request Rules
+
+A pull request should:
+
+- Be linked to a single issue
+- Clearly explain the "Why" and "What" of the change
+- Stay focused and minimal in scope
+- Include related documentation updates when applicable
+
+### AI Usage
+
+The use of AI is permitted, but you remain fully responsible for your contributions.
+
+- Follow the project-specific rules defined in the claude files: [CLAUDE.md](./CLAUDE.md).
+- Never commit AI-generated code without understanding it yourself
+- Avoid unnecessary class or function documentation when names are already self-explanatory
+
+## Project Setup
 
 Most contributions can be made using the standard (non-Mono) Godot version.  
 C# support is only required when working on the C# API.
@@ -52,21 +69,21 @@ You should be comfortable with:
 
 ### Required Versions
 
-- Godot 4.6.x (standard version)
+Refer to [README.MD](./README.md) to use a correct version of Godot.
 
-For C# API contributions, additional setup is required.  
+To contribute to the C# API, additional settings are required.  
 [See Optional C# Setup](#optional-c-setup).
 
 ### Optional C# Setup
 
 Only required if you want to contribute to the C# API.
 
-- Use Godot 4.6.x **Mono build**
+- Use a correct Godot **Mono build version** specified in [README.MD](./README.md)
 - Install the .NET SDK version specified in [global.json](./global.json)
 
 [.NET installation instructions](https://learn.microsoft.com/en-us/dotnet/core/install/)
 
-#### Verify your setup:
+#### Verify your setup
 
 Check the SDK(s) is installed on your system:  
 `dotnet --list-sdks`
@@ -97,13 +114,16 @@ For a high-level overview of the repository, see:
 - [llms.txt](./llms.txt)
 - [llms-full.txt](./llms-full.txt)
 
+These files provide a structured overview of the codebase to help contributors understand the project layout and navigate it more easily.
+
 ### Notes for contributors
 
 - Basic understanding of object-oriented concepts (interfaces, inheritance) is recommended
 - C# knowledge is helpful but not required for GDScript-only contributions
 - The goal is to apply linting across the entire project, but currently only part of the source tree is fully lint-clean
 - Please follow existing project rules and CI expectations for the files you modify
-- Do not commit local `project.godot` changes caused by opening the project with a different Godot setup
+- Never commit changes to `project.godot` unless we need to update the C# API dependencies
+- Follow the repository configuration and formatting rules defined in files such as [.gdlintrc](./.gdlintrc), [.editorconfig](./.editorconfig), [.markdownlint.jsonc](./.github/actions/formatting_checks/.markdownlint.jsonc), and [.yamllint.yml](./.github/actions/formatting_checks/.yamllint.yml)
 
 ## License
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,7 +37,7 @@ review and discuss code changes.
    - Ensure that the continuous integration (CI) process passes successfully.
 6. Submit the pull request!
 
-# Pull Request Rules
+## Pull Request Rules
 
 To ensure a smooth review process, every Pull Request (PR) must meet the following criteria:
 
@@ -52,7 +52,6 @@ To ensure a smooth review process, every Pull Request (PR) must meet the followi
      - **# Why** - A clear explanation of the need for this change.
      - **# What** - A detailed description of the changes and their effects.
    - Scope: Keep changes minimal and focused. Include documentation updates where applicable.
-
 
 ### AI Usage
 
@@ -82,7 +81,6 @@ All contributions must be compatible with the Godot versions currently supported
 - **Target Versions:** Please refer to the [Compatibility Overview](./README.md#compatibility-overview) for the list of supported Godot versions on the master branch.
 - **Verification:** You are responsible for ensuring that your changes are fully functional across these versions.
 - **Testing:** We recommend testing your changeset locally in the oldest and newest supported versions listed to avoid compatibility regressions.
-
 
 ### C# Setup - (Optional)
 
@@ -128,7 +126,6 @@ To help AI tools like ChatGPT or Claude provide more accurate answers about our 
 Why? Standard websites contain too much "noise" (menus, layouts) for AI. Our files provide clean, structured content for maximum precision and lower token usage.
 Why the name? The naming follows the emerging standard for Large Language Models (LLMs). Similar to robots.txt for search engines, the llms prefix signals that these files are specifically designed for AI consumption.
 In short: We eliminate the clutter so the AI can find the right answers faster.
-
 
 ### Notes for contributors
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,18 +75,20 @@ You should be comfortable with:
 - Reading and writing simple GDScript
 - Basic Git workflow
 
-### Required Versions
+### Compatibility & Supported Versions
 
-Refer to [README.MD](./README.md) to use a correct version of Godot.
+All contributions must be compatible with the Godot versions currently supported by this project:
 
-To contribute to the C# API, additional settings are required.  
-[See Optional C# Setup](#optional-c-setup).
+- **Target Versions:** Please refer to the [Compatibility Overview](./README.md#compatibility-overview) for the list of supported Godot versions on the master branch.
+- **Verification:** You are responsible for ensuring that your changes are fully functional across these versions.
+- **Testing:** We recommend testing your changeset locally in the oldest and newest supported versions listed to avoid compatibility regressions.
 
-### Optional C# Setup
 
-Only required if you want to contribute to the C# API.
+### C# Setup - (Optional)
 
-- Use a correct Godot **Mono build version** specified in [README.MD](./README.md)
+To contribute to the C# API, additional settings are required.
+
+- Use a correct Godot **Mono build version** specified in [README.MD](./README.md#compatibility-overview)d)
 - Install the .NET SDK version specified in [global.json](./global.json)
 
 [.NET installation instructions](https://learn.microsoft.com/en-us/dotnet/core/install/)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,6 +37,67 @@ review and discuss code changes.
    - Ensure that the continuous integration (CI) process passes successfully.
 6. Submit the pull request!
 
+## Project Setup (For contributions)
+
+This project includes optional C# support. If you plan to work with C# parts of the codebase, ensure your environment is correctly configured for it.
+Otherwise you can use the standard Godot version.
+
+### Prerequisites
+
+You should be comfortable with:
+
+- Basic Godot usage (Scenes, nodes, scripts, etc...)
+- Reading and writing simple GDScript
+- Basic Git workflow
+
+### Required Versions
+
+- Godot 4.6.x **Mono build**
+- .NET SDK version specified in [global.json](./global.json)
+
+### Install .NET SDK
+
+The **required** .NET SDK version is pinned via [global.json](./global.json).
+
+[.NET installation instructions](https://learn.microsoft.com/en-us/dotnet/core/install/)
+
+### Verify the Installation
+
+Open a terminal from the project root:
+
+Check the SDK(s) is installed on your system:  
+`dotnet --list-sdks`
+
+Build the C# project:  
+`dotnet build`  
+
+The terminal should print "Build succeeded".
+If Godot shows a generic error such as:  
+`Build error: Failed to build project. Check MSBuild panel for details.`  
+This can occur due to CI rules. Check the terminal output for details and ensure your changes comply with them.
+
+### Setup GDScript Linting
+
+GDScript linting uses `gdtoolkit` (`gdlint`).
+
+[Install GDlint](https://github.com/Scony/godot-gdscript-toolkit)
+
+Run `gdlint` on the project root to check your changes.
+
+### Project Structure
+
+For a high-level overview of the repository, see:
+
+- [llms.txt](./llms.txt)
+- [llms-full.txt](./llms-full.txt)
+
+### Notes for contributors
+
+- Basic understanding of object-oriented concepts (interfaces, inheritance) is recommended
+- C# knowledge is helpful but not required for GDScript-only contributions
+- The goal is to apply linting across the entire project, but currently only part of the source tree is fully lint-clean
+- Please follow existing project rules and CI expectations for the files you modify
+
 ## License
 
 By contributing to this project, you agree that your contributions will be licensed under the same
@@ -49,3 +110,4 @@ To maintain code consistency, please adhere to the following coding style guides
 
 - <a href='https://docs.godotengine.org/en/stable/tutorials/scripting/gdscript/gdscript_styleguide.html' target="_blank">Godot's GDScript Conventions</a>
 - <a href='https://docs.microsoft.com/en-us/dotnet/csharp/fundamentals/coding-style/coding-conventions' target="_blank">C# Coding Conventions</h>
+


### PR DESCRIPTION
# Why

The current CONTRIBUTING.md lacks some project-specific onboarding information.

While onboarding, it was not clear:
- Where to find a high-level overview of the project structure
- What level of C# knowledge is expected
- How GDScript linting is applied and what is expected from contributors

This can slow down onboarding and create unnecessary confusion for new contributors.

# What

- Add references to llms.txt and llms-full.txt for project structure overview
- Clarify contributor expectations regarding GDScript vs C# contributions
- Add a GDScript linting section (gdtoolkit / gdlint)
- Clarify that linting is a project-wide goal but currently only partially enforced