### PR TITLE
Add Claude Code agent instructions and aligned-test hook

### DIFF
--- a/.claude/run-aligned-tests.sh
+++ b/.claude/run-aligned-tests.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# PostToolUse hook: run the aligned GdUnit4 test when a src/ file is edited.
+# Mapping: addons/gdUnit4/src/X/Y.gd -> addons/gdUnit4/test/X/YTest.gd
+
+data=$(cat)
+
+# Use Python (always available) to extract file_path from JSON stdin
+file_path=$(python -c "
+import sys, json
+try:
+    d = json.loads(sys.stdin.read())
+    print(d.get('tool_input', {}).get('file_path', ''))
+except Exception:
+    pass
+" <<< "$data" 2>/dev/null)
+[ -z "$file_path" ] && exit 0
+
+# Normalize Windows backslashes
+file_path="${file_path//\\//}"
+
+# Only activate for source files under addons/gdUnit4/src/
+[[ "$file_path" =~ addons/gdUnit4/src/(.+)\.gd$ ]] || exit 0
+
+rel="${BASH_REMATCH[1]}"
+test_rel="addons/gdUnit4/test/${rel}Test.gd"
+
+# Skip if aligned test doesn't exist yet
+[ -f "$test_rel" ] || exit 0
+
+# Require GODOT_BIN
+if [ -z "${GODOT_BIN:-}" ]; then
+    python -c "import json; print(json.dumps({'systemMessage': '⚠ GODOT_BIN not set — skipping auto-test for $test_rel'}))"
+    exit 0
+fi
+
+res_path="res://$test_rel"
+
+if output=$(bash addons/gdUnit4/runtest.sh -a "$res_path" 2>&1); then
+    python -c "import json; print(json.dumps({'systemMessage': '✅ Tests passed: $res_path'}))"
+else
+    python -c "
+import json, sys
+output = sys.argv[1][-3000:]
+print(json.dumps({
+    'systemMessage': '❌ Tests FAILED: $res_path',
+    'hookSpecificOutput': {
+        'hookEventName': 'PostToolUse',
+        'additionalContext': 'Aligned tests FAILED for $res_path:\n' + output
+    }
+}))
+" "$output"
+fi

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,40 @@
+{
+  "env": {
+    "GODOT_BIN": "D:/development/Godot_v4.5-stable_mono_win64/Godot_v4.5-stable_mono_win64.exe"
+  },
+  "permissions": {
+    "allow": [
+      "Bash(PATH=\"/c/Program Files/Git/cmd:$PATH\" git diff:*)",
+      "Bash(gh issue:*)",
+      "WebFetch(domain:docs.godotengine.org)",
+      "Read(//mnt/d/development/workspace/**)",
+      "Bash(gdlint:*)",
+      "Bash(xargs basename:*)",
+      "Bash(markdownlint-cli2 --config .github/actions/formatting_checks/.markdownlint.jsonc \"CLAUDE.md\")",
+      "Bash(markdownlint-cli2.cmd --config .github/actions/formatting_checks/.markdownlint.jsonc \"CLAUDE.md\")",
+      "Bash(markdownlint-cli2.cmd --config .github/actions/formatting_checks/.markdownlint.jsonc \"CLAUDE.md\" \"addons/gdUnit4/src/asserts/CLAUDE.md\")",
+      "Skill(update-config)",
+      "Bash(ls:*)",
+      "WebSearch",
+      "Bash(gh api:*)",
+      "Bash(gh search:*)",
+      "Bash(bash addons/gdUnit4/runtest.sh:*)",
+      "Bash(markdownlint-cli2.cmd --config .github/actions/formatting_checks/.markdownlint.jsonc \"CLAUDE.md\" \"addons/gdUnit4/src/asserts/CLAUDE.md\" \"addons/gdUnit4/test/CLAUDE.md\")"
+    ]
+  },
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \".claude/run-aligned-tests.sh\"",
+            "timeout": 180,
+            "statusMessage": "Running aligned tests..."
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -40,4 +40,4 @@ reports/
 documentation/_site/
 
 # Claude Code local settings
-.claude/settings.local.json
+# .claude/settings.local.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,8 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 GdUnit4 is a Godot 4 embedded unit testing framework (Godot plugin) supporting GDScript and C#.
 The plugin lives entirely under `addons/gdUnit4/` and is self-tested — the framework uses itself to run its own test suite.
 
-Supported Godot versions: 4.3–4.6. C# targets net9.0 with .NET SDK 9.0.308 (pinned in `global.json`).
+Supported Godot versions: (read the **Compatibility Overview** table in `README.md`
+and find the row whose GdUnit4 version contains `master`). C# targets net9.0 with .NET SDK 9.0.308 (pinned in `global.json`).
 
 ## Commands
 
@@ -118,7 +119,45 @@ Enforced by gdlint with these key limits (`.gdlintrc`):
 - Max public methods: 40
 - Function argument count: 11
 
+After every GDScript change, lint the modified file with gdlint before considering the task done:
+
+```bash
+gdlint path/to/changed_file.gd
+```
+
+Before running gdlint, verify it is installed:
+
+```bash
+gdlint --version
+```
+
+If gdlint is not installed, **stop and tell the user** to install it:
+
+```text
+gdlint is not installed. Please install it with:
+  pip install gdtoolkit==4.5.0
+```
+
+Do not skip linting or proceed without it.
+
 **C#:** StyleCop.Analyzers enforced. `TreatWarningsAsErrors = true`. Nullable reference types enabled. C# language version 13.0.
+
+## Godot API Compatibility
+
+Before using any Godot API function, class, or feature, read the **Compatibility Overview** table in `README.md`
+and find the row whose GdUnit4 version contains `master`. That row lists the exact Godot versions that must be supported.
+
+All Godot API usage must be compatible with **every** version listed in that row. If an API is not available in
+all of them, it cannot be used without a version guard. When uncertain, check the
+[Godot class reference changelog](https://docs.godotengine.org/en/stable/classes/) or the Godot GitHub commit history.
+
+## Testing Requirements
+
+Every code change must be accompanied by new or updated tests. Tests live under `addons/gdUnit4/test/` and mirror
+the `src/` structure (e.g. `src/core/Foo.gd` → `test/core/FooTest.gd`).
+
+See `addons/gdUnit4/test/CLAUDE.md` for the full GdUnit4 fluent assertion syntax, test suite skeleton,
+section grouping conventions, mocking, scene runner, and auto-free usage.
 
 ## Documentation
 
@@ -181,9 +220,24 @@ markdownlint-cli2 --config .github/actions/formatting_checks/.markdownlint.jsonc
 dotnet format gdUnit4.csproj --verify-no-changes --verbosity diagnostic
 ```
 
+### Commit Messages
+
+The subject line must start with the issue/branch number (e.g. `GD-1234`) followed by a short
+meaningful title describing what the commit is about. The body must include these two sections:
+
+```markdown
+GD-1234: Short meaningful title
+
+# Why
+<explain the motivation or problem being solved>
+
+# What
+<describe the changes made>
+```
+
 ### PR Description
 
-PR descriptions must include these two sections:
+The PR title must start with the issue/branch number (e.g. `GD-1234`) followed by a short meaningful title. The description must include these two sections:
 
 ```markdown
 # Why
@@ -192,3 +246,17 @@ PR descriptions must include these two sections:
 # What
 <describe the changes made>
 ```
+
+## Task Progress Display
+
+For any multi-step task (more than one distinct action), always start the response by
+printing a numbered plan with checkboxes, then update each item to ✅ as it completes:
+
+```text
+- [ ] Step 1 — description
+- [ ] Step 2 — description
+- [ ] Step 3 — description
+```
+
+Reprint the list (with completed items marked ✅) before each major step so the
+developer can see live progress. Keep step descriptions short (one line each).

--- a/addons/gdUnit4/src/asserts/CLAUDE.md
+++ b/addons/gdUnit4/src/asserts/CLAUDE.md
@@ -1,0 +1,137 @@
+# Implementing a New Assert Type
+
+Every assert type follows a strict two-layer pattern. Five touch points must be updated — do them in this order.
+
+## 1. Abstract interface — `src/GdUnit<Type>Assert.gd`
+
+Read `src/GdUnitAssert.gd` to get the exact base interface — re-declare every `@abstract` method
+from it with the return type changed to `GdUnit<Type>Assert`, then append type-specific methods below.
+Do **not** hardcode the method list; derive it from the current file.
+
+## 2. Implementation — `src/asserts/GdUnit<Type>AssertImpl.gd`
+
+All logic delegates to a `GdUnitAssertImpl` instance. The mandatory skeleton:
+
+```gdscript
+extends GdUnit<Type>Assert
+
+var _base: GdUnitAssertImpl
+
+func _init(current: Variant) -> void:
+    _base = GdUnitAssertImpl.new(current)
+    GdUnitThreadManager.get_current_context().set_assert(self)
+    if not _validate_value_type(current):
+        @warning_ignore("return_value_discarded")
+        report_error("GdUnit<Type>Assert error, the type <%s> is not supported." % GdObjects.typeof_as_string(current))
+
+func _notification(event: int) -> void:       # required — cleans up _base
+    if event == NOTIFICATION_PREDELETE:
+        if _base != null:
+            _base.notification(event)
+            _base = null
+
+func _validate_value_type(value: Variant) -> bool:
+    return value == null or value is MyGodotType
+
+func current_value() -> Variant:
+    return _base.current_value()
+
+func report_success() -> GdUnit<Type>Assert:
+    @warning_ignore("return_value_discarded")
+    _base.report_success()
+    return self
+
+func report_error(error: String) -> GdUnit<Type>Assert:
+    @warning_ignore("return_value_discarded")
+    _base.report_error(error)
+    return self
+
+func failure_message() -> String:
+    return _base.failure_message()
+
+func override_failure_message(message: String) -> GdUnit<Type>Assert:
+    @warning_ignore("return_value_discarded")
+    _base.override_failure_message(message)
+    return self
+
+func append_failure_message(message: String) -> GdUnit<Type>Assert:
+    @warning_ignore("return_value_discarded")
+    _base.append_failure_message(message)
+    return self
+
+func is_null() -> GdUnit<Type>Assert:
+    @warning_ignore("return_value_discarded")
+    _base.is_null()
+    return self
+
+func is_not_null() -> GdUnit<Type>Assert:
+    @warning_ignore("return_value_discarded")
+    _base.is_not_null()
+    return self
+
+func is_equal(expected: Variant) -> GdUnit<Type>Assert:
+    @warning_ignore("return_value_discarded")
+    _base.is_equal(expected)   # or custom comparison + report_error/report_success
+    return self
+
+func is_not_equal(expected: Variant) -> GdUnit<Type>Assert:
+    @warning_ignore("return_value_discarded")
+    _base.is_not_equal(expected)
+    return self
+```
+
+Key rules:
+
+- Every method returns `self` for chaining.
+- Call `report_error(message)` on failure, `report_success()` on pass — never raise directly.
+- `GdObjects.equals()` handles deep comparison for most types. For objects whose `==` is
+  reference-only (e.g. `Image`), implement comparison manually via their API.
+- Custom error message helpers belong in `GdAssertMessages.gd` as `static func` methods.
+  Use `_error()` / `_colored_value()` for consistent colouring.
+
+## 3. Preload — `src/asserts/GdUnitAssertions.gd`
+
+Add one line inside `_init()` alongside the other preloads:
+
+```gdscript
+GdUnitAssertions.__lazy_load("res://addons/gdUnit4/src/asserts/GdUnit<Type>AssertImpl.gd")
+```
+
+## 4. Registration — `src/GdUnitTestSuite.gd`
+
+Add the public factory method near the other `assert_*` functions:
+
+```gdscript
+func assert_mytype(current: Variant) -> GdUnit<Type>Assert:
+    return __lazy_load("res://addons/gdUnit4/src/asserts/GdUnit<Type>AssertImpl.gd").new(current)
+```
+
+Update `assert_that()` to dispatch the new type (add a `match` branch or an `if` inside `TYPE_OBJECT`):
+
+```gdscript
+TYPE_OBJECT:
+    if current is MyGodotType:
+        return assert_mytype(current)
+    return assert_object(current)
+```
+
+## 5. Test suite — `test/asserts/GdUnit<Type>AssertImplTest.gd`
+
+```gdscript
+class_name GdUnit<Type>AssertImplTest
+extends GdUnitTestSuite
+
+
+const __source = 'res://addons/gdUnit4/src/asserts/GdUnit<Type>AssertImpl.gd'
+```
+
+Minimum test coverage: supported types, unsupported types (type-check error message),
+`is_null`, `is_not_null`, `is_equal` (pass + each failure variant), `is_not_equal`,
+every type-specific method, `assert_that` dispatch, method chaining.
+
+**Lint scope:** `test/asserts/` is **not** checked by CI gdlint. Only `src/asserts/` is.
+Always lint `src/asserts/` after changes:
+
+```bash
+gdlint addons/gdUnit4/src/asserts/
+```

--- a/addons/gdUnit4/test/CLAUDE.md
+++ b/addons/gdUnit4/test/CLAUDE.md
@@ -1,0 +1,119 @@
+# Testing Requirements
+
+Every code change must be accompanied by new or updated tests. Tests live under `addons/gdUnit4/test/` and mirror
+the `src/` structure (e.g. `src/core/Foo.gd` → `test/core/FooTest.gd`).
+
+## GdUnit4 Fluent Syntax
+
+All GDScript tests must use the GdUnit4 fluent assertion API. Do **not** use plain `assert()`.
+
+**Test suite skeleton:**
+
+```gdscript
+class_name MyFeatureTest
+extends GdUnitTestSuite
+
+
+const __source = "res://addons/gdUnit4/src/path/to/MyFeature.gd"
+
+
+# optional lifecycle hooks
+func before_test() -> void:
+    pass
+
+func after_test() -> void:
+    pass
+```
+
+**Test section grouping — use `#region` / `#endregion`:**
+
+Group related test functions into named regions instead of comment dividers.
+Every region must have a matching `#endregion`:
+
+```gdscript
+#region is_equal
+func test_is_equal_same_value() -> void:
+    assert_int(1).is_equal(1)
+
+func test_is_equal_different_value_fails() -> void:
+    assert_failure(func() -> void: assert_int(1).is_equal(2)) \
+        .is_failed()
+#endregion
+
+#region has_size
+func test_has_size() -> void:
+    assert_array([1, 2, 3]).has_size(3)
+#endregion
+```
+
+**Core assert functions and chaining:**
+
+```gdscript
+# Primitives
+assert_bool(value).is_true()
+assert_bool(value).is_false()
+
+assert_int(value).is_equal(42)
+assert_int(value).is_not_equal(0)
+assert_int(value).is_greater(10).is_less(100)
+
+assert_float(value).is_equal_approx(3.14, 0.001)
+
+assert_str(value).is_equal("expected")
+assert_str(value).is_not_null().has_length(5).starts_with("ab").ends_with("cd").contains("bc")
+assert_str(value).is_empty()
+
+# Objects / variants
+assert_object(value).is_not_null()
+assert_object(value).is_instanceof(MyClass)
+assert_that(value).is_null()
+assert_that(value).is_equal(expected)
+assert_that(value).is_instanceof(Node)
+
+# Arrays
+assert_array(value).is_not_empty()
+assert_array(value).has_size(3).contains(1, 2)
+assert_array(value).contains_exactly(1, 2, 3)
+
+# Dictionaries
+assert_dict(value).is_not_empty()
+assert_dict(value).contains_key("foo")
+assert_dict(value).contains_key_value("foo", "bar")
+assert_dict(value).has_size(3).contains_key_value("foo", "bar")
+```
+
+**Testing expected failures:**
+
+```gdscript
+assert_failure(func() -> void: assert_str("abc").is_equal("xyz")) \
+    .is_failed() \
+    .has_message("Expecting:\n 'xyz'\n but was\n 'abc'")
+
+assert_failure(func() -> void: assert_str("abc").is_null()) \
+    .is_failed() \
+    .starts_with_message("Expecting: '<null>'")
+```
+
+**Mocking and spying:**
+
+```gdscript
+var mock :Variant = mock(MyClass)
+when(mock.my_method(any_int())).thenReturn(42)
+verify(mock).my_method(42)
+verify(mock, times(2)).my_method(any_int())
+```
+
+**Scene runner:**
+
+```gdscript
+var runner := scene_runner("res://my_scene.tscn")
+await runner.simulate_frames(10)
+assert_signal(runner).is_emitted("my_signal")
+runner.simulate_key_pressed(KEY_ENTER)
+```
+
+**Auto-free resources:**
+
+```gdscript
+var node := auto_free(MyNode.new())   # freed after test automatically
+```


### PR DESCRIPTION
# Why
The agent lacked enough context to implement new assert types correctly,
enforce Godot API compatibility, and run tests automatically after edits —
leading to repeated back-and-forth to catch missing steps.

# What
- Extend CLAUDE.md with Godot API compatibility rules, mandatory gdlint after every GDScript change, testing requirements, and task progress display convention
- Add addons/gdUnit4/src/asserts/CLAUDE.md: two-layer assert pattern guide covering all five touch points (interface, impl, preload, registration, test)
- Add addons/gdUnit4/test/CLAUDE.md: GdUnit4 fluent assertion syntax reference with suite skeleton, region conventions, mocking, scene runner, and auto-free usage
- Add .claude/run-aligned-tests.sh: PostToolUse hook that maps edited src/ files to their aligned test suite and runs it automatically
- Configure .claude/settings.local.json: hook command, GODOT_BIN env, and Bash(bash addons/gdUnit4/runtest.sh:*) wildcard permission
- Untrack .claude/settings.local.json from .gitignore so agent config is committed with the repository

