### PR TITLE
GD-1116: Make GdUnit4 resilient against project setting changes during test execution

### DIFF
--- a/addons/gdUnit4/src/core/GdUnitSettings.gd
+++ b/addons/gdUnit4/src/core/GdUnitSettings.gd
@@ -120,7 +120,6 @@ enum NAMING_CONVENTIONS {
 
 const _VALUE_SET_SEPARATOR = "\f" # ASCII Form-feed character (AKA page break)
 
-
 static func setup() -> void:
 	create_property_if_need(UPDATE_NOTIFICATION_ENABLED, true, "Show notification if new gdUnit4 version is found")
 	# test settings
@@ -474,18 +473,3 @@ static func migrate_property(old_property :String, new_property :String, default
 	set_help(new_property, value, help)
 	ProjectSettings.clear(old_property)
 	prints("Successfully migrated property '%s' -> '%s' value: %s" % [old_property, new_property, value])
-
-
-static func dump_to_tmp() -> void:
-	@warning_ignore("return_value_discarded")
-	ProjectSettings.save_custom("user://project_settings.godot")
-
-
-static func restore_dump_from_tmp() -> void:
-	# Only restore if the current project.godot differs from the backup to avoid
-	# triggering a "file newer on disk" dialog in the editor
-	var backup := FileAccess.get_file_as_bytes("user://project_settings.godot")
-	var current := FileAccess.get_file_as_bytes("res://project.godot")
-	if backup == current:
-		return
-	var _error := DirAccess.copy_absolute("user://project_settings.godot", "res://project.godot")

--- a/addons/gdUnit4/src/core/execution/GdUnitExecutionContext.gd
+++ b/addons/gdUnit4/src/core/execution/GdUnitExecutionContext.gd
@@ -24,6 +24,9 @@ var _flaky_test_check := GdUnitSettings.is_test_flaky_check_enabled()
 var _flaky_test_retries := GdUnitSettings.get_flaky_max_retries()
 
 
+var _settings_snapshot: GdUnitProjectSettingsSnapshot = null
+
+
 var error_monitor: GodotGdErrorMonitor = null:
 	get:
 		if _parent_context != null:
@@ -120,6 +123,18 @@ func get_test_case_name() -> StringName:
 	if _test_case_name.is_empty():
 		return test_case._test_case.display_name
 	return _test_case_name
+
+
+func save_project_settings() -> void:
+	if _settings_snapshot == null:
+		_settings_snapshot = GdUnitProjectSettingsSnapshot.new()
+	_settings_snapshot.save()
+
+
+func restore_project_settings() -> void:
+	if _settings_snapshot == null:
+		return
+	_settings_snapshot.restore()
 
 
 func error_monitor_start() -> void:

--- a/addons/gdUnit4/src/core/execution/GdUnitProjectSettingsSnapshot.gd
+++ b/addons/gdUnit4/src/core/execution/GdUnitProjectSettingsSnapshot.gd
@@ -1,0 +1,36 @@
+## Captures and restores all in-memory [ProjectSettings] values around a single
+## stage of test execution.[br]
+## Each [GdUnitExecutionContext] owns one instance. Suite-level and test-level
+## isolation are achieved by the two separate contexts rather than by stacking:[br]
+## [codeblock]
+##   GdUnitTestSuiteExecutionStage  -> save()   (before before())
+##     GdUnitTestCaseExecutionStage -> save()   (before before_test())
+##     GdUnitTestCaseExecutionStage -> restore() (after after_test())
+##   GdUnitTestSuiteExecutionStage  -> restore() (after after())
+## [/codeblock]
+class_name GdUnitProjectSettingsSnapshot
+extends RefCounted
+
+
+var _snapshot: Dictionary = {}
+
+
+func save() -> void:
+	_snapshot.clear()
+	for property: Dictionary in ProjectSettings.get_property_list():
+		var name: String = property["name"]
+		if ProjectSettings.has_setting(name):
+			var value: Variant = ProjectSettings.get_setting(name)
+			@warning_ignore("unsafe_method_access")
+			_snapshot[name] = value.duplicate() if (value is Dictionary or value is Array) else value
+
+
+func restore() -> void:
+	for name: String in _snapshot:
+		if not ProjectSettings.has_setting(name):
+			continue
+		var current: Variant = ProjectSettings.get_setting(name)
+		var original: Variant = _snapshot[name]
+		if current != original:
+			ProjectSettings.set_setting(name, original)
+	_snapshot.clear()

--- a/addons/gdUnit4/src/core/execution/stages/GdUnitTestCaseExecutionStage.gd
+++ b/addons/gdUnit4/src/core/execution/stages/GdUnitTestCaseExecutionStage.gd
@@ -16,6 +16,7 @@ var _stage_fuzzer_test: IGdUnitExecutionStage = GdUnitTestCaseFuzzedExecutionSta
 func _execute(context :GdUnitExecutionContext) -> void:
 	var test_case := context.test_case
 
+	context.save_project_settings()
 	context.error_monitor_start()
 
 	if test_case.is_fuzzed():
@@ -25,6 +26,7 @@ func _execute(context :GdUnitExecutionContext) -> void:
 
 	await context.gc()
 	context.error_monitor_stop()
+	context.restore_project_settings()
 
 	# finally free the test instance
 	if is_instance_valid(context.test_case):

--- a/addons/gdUnit4/src/core/execution/stages/GdUnitTestSuiteExecutionStage.gd
+++ b/addons/gdUnit4/src/core/execution/stages/GdUnitTestSuiteExecutionStage.gd
@@ -21,6 +21,7 @@ func _execute(context :GdUnitExecutionContext) -> void:
 	else:
 		@warning_ignore("return_value_discarded")
 		GdUnitMemoryObserver.guard_instance(context.test_suite.__awaiter)
+		context.save_project_settings()
 		await _stage_before.execute(context)
 		for test_case_index in context.test_suite.get_child_count():
 			# iterate only over test cases
@@ -39,6 +40,7 @@ func _execute(context :GdUnitExecutionContext) -> void:
 				# and replace it by a clone without function state
 				context.test_suite = await clone_test_suite(context.test_suite)
 		await _stage_after.execute(context)
+		context.restore_project_settings()
 		GdUnitMemoryObserver.unguard_instance(context.test_suite.__awaiter)
 
 	await (Engine.get_main_loop() as SceneTree).process_frame

--- a/addons/gdUnit4/test/GdUnitTestSuiteTest.gd
+++ b/addons/gdUnit4/test/GdUnitTestSuiteTest.gd
@@ -7,9 +7,7 @@ const __source = 'res://addons/gdUnit4/src/GdUnitTestSuite.gd'
 
 var _events :Array[GdUnitEvent] = []
 var _retry_count := 0
-var _flaky_settings: bool
 var _test_unknown_argument_in_test_case_is_called := false
-
 
 
 func collect_report(event :GdUnitEvent) -> void:
@@ -19,7 +17,6 @@ func collect_report(event :GdUnitEvent) -> void:
 func before() -> void:
 	# register to receive test reports
 	GdUnitSignals.instance().gdunit_event.connect(collect_report)
-	_flaky_settings = ProjectSettings.get_setting(GdUnitSettings.TEST_FLAKY_CHECK, false)
 	ProjectSettings.set_setting(GdUnitSettings.TEST_FLAKY_CHECK, true)
 
 
@@ -29,8 +26,6 @@ func after() -> void:
 		.override_failure_message("Expecting 'test_unknown_argument_in_test_case' is skipped!")\
 		.is_false()
 	GdUnitSignals.instance().gdunit_event.disconnect(collect_report)
-	# Restore original project settings
-	ProjectSettings.set_setting(GdUnitSettings.TEST_FLAKY_CHECK, _flaky_settings)
 
 
 func test_assert_that_types() -> void:

--- a/addons/gdUnit4/test/asserts/GdUnitArrayAssertImplTest.gd
+++ b/addons/gdUnit4/test/asserts/GdUnitArrayAssertImplTest.gd
@@ -4,16 +4,8 @@ extends GdUnitTestSuite
 # TestSuite generated from
 const __source = 'res://addons/gdUnit4/src/asserts/GdUnitArrayAssertImpl.gd'
 
-var _saved_report_assert_warnings :Variant
-
-
 func before() -> void:
-	_saved_report_assert_warnings = ProjectSettings.get_setting(GdUnitSettings.REPORT_ASSERT_WARNINGS)
 	ProjectSettings.set_setting(GdUnitSettings.REPORT_ASSERT_WARNINGS, false)
-
-
-func after() -> void:
-	ProjectSettings.set_setting(GdUnitSettings.REPORT_ASSERT_WARNINGS, _saved_report_assert_warnings)
 
 
 func test_is_null() -> void:

--- a/addons/gdUnit4/test/asserts/GdUnitGodotErrorAssertImplTest.gd
+++ b/addons/gdUnit4/test/asserts/GdUnitGodotErrorAssertImplTest.gd
@@ -7,22 +7,11 @@ extends GdUnitTestSuite
 # TestSuite generated from
 const __source = 'res://addons/gdUnit4/src/asserts/GdUnitGodotErrorAssertImpl.gd'
 
-var _save_is_report_push_errors :bool
-var _save_is_report_script_errors :bool
-
-
 # skip see https://github.com/godotengine/godot/issues/80292
 func before() -> void:
-	_save_is_report_push_errors = GdUnitSettings.is_report_push_errors()
-	_save_is_report_script_errors = GdUnitSettings.is_report_script_errors()
 	# disable default error reporting for testing
 	ProjectSettings.set_setting(GdUnitSettings.REPORT_PUSH_ERRORS, false)
 	ProjectSettings.set_setting(GdUnitSettings.REPORT_SCRIPT_ERRORS, false)
-
-
-func after() -> void:
-	ProjectSettings.set_setting(GdUnitSettings.REPORT_PUSH_ERRORS, _save_is_report_push_errors)
-	ProjectSettings.set_setting(GdUnitSettings.REPORT_SCRIPT_ERRORS, _save_is_report_script_errors)
 
 
 func after_test() -> void:

--- a/addons/gdUnit4/test/core/GdUnitSettingsTest.gd
+++ b/addons/gdUnit4/test/core/GdUnitSettingsTest.gd
@@ -23,14 +23,6 @@ const TEST_PROPERTY_F = CATEGORY_B + "/c/prop_f"
 const TEST_PROPERTY_G = CATEGORY_B + "/a/prop_g"
 
 
-func before() -> void:
-	GdUnitSettings.dump_to_tmp()
-
-
-func after() -> void:
-	GdUnitSettings.restore_dump_from_tmp()
-
-
 func before_test() -> void:
 	GdUnitSettings.create_property_if_need(TEST_PROPERTY_A, true, "helptext TEST_PROPERTY_A.")
 	GdUnitSettings.create_property_if_need(TEST_PROPERTY_B, false, "helptext TEST_PROPERTY_B.")

--- a/addons/gdUnit4/test/core/execution/GdUnitExecutionContextTest.gd
+++ b/addons/gdUnit4/test/core/execution/GdUnitExecutionContextTest.gd
@@ -5,17 +5,8 @@ extends GdUnitTestSuite
 @warning_ignore('return_value_discarded')
 
 
-var _flaky_settings: bool
-
 func before() -> void:
-	# register to receive test reports
-	_flaky_settings = ProjectSettings.get_setting(GdUnitSettings.TEST_FLAKY_CHECK, false)
 	ProjectSettings.set_setting(GdUnitSettings.TEST_FLAKY_CHECK, false)
-
-
-func after() -> void:
-	# Restore original project settings
-	ProjectSettings.set_setting(GdUnitSettings.TEST_FLAKY_CHECK, _flaky_settings)
 
 
 func test_collect_report_statistics_with_errors() -> void:

--- a/addons/gdUnit4/test/core/execution/GdUnitProjectSettingsSnapshotTest.gd
+++ b/addons/gdUnit4/test/core/execution/GdUnitProjectSettingsSnapshotTest.gd
@@ -1,0 +1,65 @@
+# GdUnit generated TestSuite
+class_name GdUnitProjectSettingsSnapshotTest
+extends GdUnitTestSuite
+
+
+const __source = "res://addons/gdUnit4/src/core/execution/GdUnitProjectSettingsSnapshot.gd"
+
+const IGNORE := GdUnitSettings.GdScriptWarningMode.IGNORE
+const WARN := GdUnitSettings.GdScriptWarningMode.WARN
+const ERROR := GdUnitSettings.GdScriptWarningMode.ERROR
+const EXCLUDE := GdUnitSettings.GdScriptWarningDirectoryMode.EXCLUDE
+const INCLUDE := GdUnitSettings.GdScriptWarningDirectoryMode.INCLUDE
+
+
+#region save / restore
+
+func test_restore_restores_scalar_setting() -> void:
+	# Setup
+	var snapshot := GdUnitProjectSettingsSnapshot.new()
+	ProjectSettings.set_setting(GdUnitSettings.GDSCRIPT_WARNINGS_INFERRED_DECLARATION, IGNORE)
+	snapshot.save()
+	# Act
+	ProjectSettings.set_setting(GdUnitSettings.GDSCRIPT_WARNINGS_INFERRED_DECLARATION, ERROR)
+	snapshot.restore()
+	# Verify
+	assert_int(ProjectSettings.get_setting(GdUnitSettings.GDSCRIPT_WARNINGS_INFERRED_DECLARATION))\
+		.is_equal(IGNORE)
+
+
+func test_restore_restores_dictionary_setting() -> void:
+	# Setup
+	var snapshot := GdUnitProjectSettingsSnapshot.new()
+	var original_rules: Dictionary = {"res://addons": EXCLUDE}
+	ProjectSettings.set_setting(GdUnitSettings.GDSCRIPT_WARNINGS_DIRECTORY_RULES, original_rules.duplicate())
+	snapshot.save()
+	# Act
+	ProjectSettings.set_setting(GdUnitSettings.GDSCRIPT_WARNINGS_DIRECTORY_RULES, {"res://modified": INCLUDE})
+	snapshot.restore()
+	# Verify
+	assert_dict(ProjectSettings.get_setting(GdUnitSettings.GDSCRIPT_WARNINGS_DIRECTORY_RULES))\
+		.is_equal(original_rules)
+
+
+func test_restore_does_not_change_unmodified_settings() -> void:
+	# Setup
+	var snapshot := GdUnitProjectSettingsSnapshot.new()
+	ProjectSettings.set_setting(GdUnitSettings.GDSCRIPT_WARNINGS_INFERRED_DECLARATION, IGNORE)
+	snapshot.save()
+	# Act
+	snapshot.restore()
+	# Verify
+	assert_int(ProjectSettings.get_setting(GdUnitSettings.GDSCRIPT_WARNINGS_INFERRED_DECLARATION))\
+		.is_equal(IGNORE)
+
+
+func test_restore_without_save_does_nothing() -> void:
+	# Setup
+	var snapshot := GdUnitProjectSettingsSnapshot.new()
+	# Act
+	snapshot.restore()
+	snapshot.restore()
+	# Verify — no error, no crash
+	assert_bool(true).is_true()
+
+#endregion

--- a/addons/gdUnit4/test/core/execution/GdUnitTestSuiteExecutorTest.gd
+++ b/addons/gdUnit4/test/core/execution/GdUnitTestSuiteExecutorTest.gd
@@ -22,18 +22,14 @@ const WARNINGS = true
 const NO_WARNING = false
 
 var _collected_events: Array[GdUnitEvent] = []
-var _saved_flack_check: bool
-
 func before() -> void:
 	GdUnitSignals.instance().gdunit_event_debug.connect(_on_gdunit_event_debug)
 	# we run without flaky check
-	_saved_flack_check = GdUnitSettings.get_setting(GdUnitSettings.TEST_FLAKY_CHECK, false)
 	ProjectSettings.set_setting(GdUnitSettings.TEST_FLAKY_CHECK, false)
 
 
 func after() -> void:
 	GdUnitSignals.instance().gdunit_event_debug.disconnect(_on_gdunit_event_debug)
-	ProjectSettings.set_setting(GdUnitSettings.TEST_FLAKY_CHECK, _saved_flack_check)
 
 
 func after_test() -> void:

--- a/addons/gdUnit4/test/core/flaky_test.gd
+++ b/addons/gdUnit4/test/core/flaky_test.gd
@@ -15,8 +15,6 @@ var test_retries := {
 	"test_fuzzed_flaky_fail" = 0
 }
 
-var _max_retries := 0
-var _flaky_check_enabled: bool
 var _run_with_reries := 5
 
 
@@ -28,16 +26,11 @@ class ValueSetFuzzer extends Fuzzer:
 
 
 func before(_do_skip := true, _skip_reason := "Do only activate for internal testing!") -> void:
-	_max_retries = GdUnitSettings.get_flaky_max_retries()
-	_flaky_check_enabled = GdUnitSettings.is_test_flaky_check_enabled()
 	ProjectSettings.set_setting(GdUnitSettings.TEST_FLAKY_CHECK, true)
 	ProjectSettings.set_setting(GdUnitSettings.TEST_FLAKY_MAX_RETRIES, _run_with_reries)
 
 
 func after() -> void:
-	ProjectSettings.set_setting(GdUnitSettings.TEST_FLAKY_CHECK, _flaky_check_enabled)
-	ProjectSettings.set_setting(GdUnitSettings.TEST_FLAKY_MAX_RETRIES, _max_retries)
-
 	var retry_count: int = test_retries["test_flaky_success"]
 	assert_int(retry_count)\
 		.override_failure_message("Expecting 3 retries to succeed for test 'test_flaky_success'\n but was %d" % retry_count)\

--- a/addons/gdUnit4/test/mocker/GdUnitMockerTest.gd
+++ b/addons/gdUnit4/test/mocker/GdUnitMockerTest.gd
@@ -5,17 +5,9 @@ extends GdUnitTestSuite
 
 var resource_path := "res://addons/gdUnit4/test/mocker/resources/"
 
-var _saved_report_error_settings :Variant
-
-
 func before() -> void:
 	# disable error pushing for testing
-	_saved_report_error_settings = ProjectSettings.get_setting(GdUnitSettings.REPORT_PUSH_ERRORS)
 	ProjectSettings.set_setting(GdUnitSettings.REPORT_PUSH_ERRORS, false)
-
-
-func after() -> void:
-	ProjectSettings.set_setting(GdUnitSettings.REPORT_PUSH_ERRORS, _saved_report_error_settings)
 
 
 func test_mock_instance_id_is_unique() -> void:

--- a/addons/gdUnit4/test/monitor/GodotGdErrorMonitorTest.gd
+++ b/addons/gdUnit4/test/monitor/GodotGdErrorMonitorTest.gd
@@ -5,21 +5,10 @@ class_name GodotGdErrorMonitorTest
 extends GdUnitTestSuite
 
 
-var _save_is_report_push_errors :bool
-var _save_is_report_script_errors :bool
-
-
 func before() -> void:
-	_save_is_report_push_errors = GdUnitSettings.is_report_push_errors()
-	_save_is_report_script_errors = GdUnitSettings.is_report_script_errors()
 	# disable default error reporting for testing
 	ProjectSettings.set_setting(GdUnitSettings.REPORT_PUSH_ERRORS, false)
 	ProjectSettings.set_setting(GdUnitSettings.REPORT_SCRIPT_ERRORS, false)
-
-
-func after() -> void:
-	ProjectSettings.set_setting(GdUnitSettings.REPORT_PUSH_ERRORS, _save_is_report_push_errors)
-	ProjectSettings.set_setting(GdUnitSettings.REPORT_SCRIPT_ERRORS, _save_is_report_script_errors)
 
 
 func test_monitor_push_error() -> void:
@@ -40,10 +29,10 @@ func test_monitor_push_error() -> void:
 	prints(reports[0].message())
 	assert_str(reports[0].message())\
 		.contains("Test GodotGdErrorMonitor 'push_error' reporting")\
-		.contains("at res://addons/gdUnit4/test/monitor/GodotGdErrorMonitorTest.gd:78")\
-		.contains("at res://addons/gdUnit4/test/monitor/GodotGdErrorMonitorTest.gd:73")\
-		.contains("at res://addons/gdUnit4/test/monitor/GodotGdErrorMonitorTest.gd:35")
-	assert_int(reports[0].line_number()).is_equal(35)
+		.contains("at res://addons/gdUnit4/test/monitor/GodotGdErrorMonitorTest.gd:67")\
+		.contains("at res://addons/gdUnit4/test/monitor/GodotGdErrorMonitorTest.gd:62")\
+		.contains("at res://addons/gdUnit4/test/monitor/GodotGdErrorMonitorTest.gd:24")
+	assert_int(reports[0].line_number()).is_equal(24)
 
 
 func test_monitor_push_waring() -> void:
@@ -59,8 +48,8 @@ func test_monitor_push_waring() -> void:
 	assert_array(reports).has_size(1)
 	assert_str(reports[0].message())\
 		.contains("Test GodotGdErrorMonitor 'push_warning' reporting")\
-		.contains("at res://addons/gdUnit4/test/monitor/GodotGdErrorMonitorTest.gd:55")
-	assert_int(reports[0].line_number()).is_equal(55)
+		.contains("at res://addons/gdUnit4/test/monitor/GodotGdErrorMonitorTest.gd:44")
+	assert_int(reports[0].line_number()).is_equal(44)
 
 
 func test_fail_by_push_error(_do_skip := true, _skip_reason := "disabled to not produce errors, enable only for direct testing") -> void:

--- a/documentation/doc/_faq/solutions.md
+++ b/documentation/doc/_faq/solutions.md
@@ -12,6 +12,7 @@ This section lists known problems and possible solutions/workarounds.
 
 - [Script/Resource Errors after the plugin is installed]({{site.baseurl}}/faq/solutions/#scriptresource-errors-after-the-plugin-is-installed)
 - [Modifying the Game Engine State 'mainLoop.Paused = true' during Tests]({{site.baseurl}}/faq/solutions/#modifying-the-game-engine-state-mainlooppaused--true-during-tests)
+- [Modifying ProjectSettings during Tests]({{site.baseurl}}/faq/solutions/#modifying-projectsettings-during-tests)
 - [Export Failures with GdUnit4 Plugin Installed]({{site.baseurl}}/faq/solutions/#export-failures-with-gdunit4-plugin-installed)
 - [How to Exclude Directories from Test Discovery]({{site.baseurl}}/faq/solutions/#how-to-exclude-directories-from-test-discovery)
 
@@ -83,6 +84,70 @@ public void GamePaused()
     // The following lines cause the GdUnit4 test window to remain open even after tests are complete
     mainLoop.Paused = true;
     AssertThat(mainLoop.Paused).IsTrue();
+}
+```
+
+{% endtab %}
+{% endtabs %}
+
+---
+
+### Modifying ProjectSettings during Tests
+
+When a test modifies `ProjectSettings` — for example changing a warning mode or a feature flag — those changes
+persist across tests within the same Godot session and can cause later tests to behave unexpectedly.
+
+<h4> Solution </h4>
+
+GdUnit4 automatically snapshots all `ProjectSettings` before each test suite and each individual test, and
+restores any changed values afterwards. There is no need to manually save and restore settings in `after` hooks:
+
+{% tabs projectsettings_isolation %}
+{% tab projectsettings_isolation GDScript %}
+
+```gdscript
+# unnecessary — the framework restores ProjectSettings automatically
+func before() -> void:
+    _saved = ProjectSettings.get_setting("debug/gdscript/warnings/inferred_declaration")
+    ProjectSettings.set_setting("debug/gdscript/warnings/inferred_declaration", 0)
+
+func after() -> void:
+    ProjectSettings.set_setting("debug/gdscript/warnings/inferred_declaration", _saved)
+```
+
+Simply set what the tests need — the original value is restored automatically:
+
+```gdscript
+func before() -> void:
+    ProjectSettings.set_setting("debug/gdscript/warnings/inferred_declaration", 0)
+```
+
+{% endtab %}
+{% tab projectsettings_isolation C# %}
+
+```csharp
+// unnecessary — the framework restores ProjectSettings automatically
+[Before]
+public void Setup()
+{
+    _saved = ProjectSettings.GetSetting("debug/gdscript/warnings/inferred_declaration");
+    ProjectSettings.SetSetting("debug/gdscript/warnings/inferred_declaration", 0);
+}
+
+[After]
+public void TearDown()
+{
+    ProjectSettings.SetSetting("debug/gdscript/warnings/inferred_declaration", _saved);
+}
+```
+
+Simply set what the tests need — the original value is restored automatically:
+
+```csharp
+[Before]
+public void Setup()
+{
+    ProjectSettings.SetSetting("debug/gdscript/warnings/inferred_declaration", 0);
 }
 ```
 

--- a/documentation/doc/_testing/hooks.md
+++ b/documentation/doc/_testing/hooks.md
@@ -39,6 +39,8 @@ For information about Session Hooks, see [Testing with Hooks]({{site.baseurl}}/a
 {% endtab %}
 {% endtabs %}
 
+> **ProjectSettings isolation is automatic.** GdUnit4 snapshots all `ProjectSettings` before each suite and each test case, and restores any changed values afterwards. Tests can modify `ProjectSettings` freely in any hook or test body — no manual save/restore is needed. See [Manually Saving and Restoring ProjectSettings](#6-manually-saving-and-restoring-projectsettings) and [FAQ: Modifying ProjectSettings during Tests]({{site.baseurl}}/faq/solutions/#modifying-projectsettings-during-tests).
+
 ## When to Use Each Hook
 
 Choosing the right hook level is crucial for test performance and maintainability:
@@ -344,6 +346,26 @@ func after_test():
 ### 5. Incorrect Hook Choice
 **Problem:** Using `before()` for data that each test modifies.  
 **Solution:** Follow the "When to Use Each Hook" guide above.
+
+### 6. Manually Saving and Restoring ProjectSettings
+**Problem:** Tests that change `ProjectSettings` (e.g. warning modes, feature flags) leak those changes to later tests, causing unpredictable failures.  
+**Solution:** GdUnit4 automatically snapshots all `ProjectSettings` before each suite and each test, and restores any changed values afterwards. There is no need to save the previous value and restore it in an `after` hook:
+
+```gdscript
+# unnecessary — the framework restores ProjectSettings automatically
+func before():
+    _saved = ProjectSettings.get_setting("some/setting")
+    ProjectSettings.set_setting("some/setting", true)
+
+func after():
+    ProjectSettings.set_setting("some/setting", _saved)
+```
+
+```gdscript
+# correct — just set what the tests need
+func before():
+    ProjectSettings.set_setting("some/setting", true)
+```
 
 ---
 


### PR DESCRIPTION
# Why
Tests that modify `ProjectSettings` (e.g. `GDSCRIPT_WARNINGS_INFERRED_DECLARATION`) leaked those changes to subsequent tests and to the Godot process, causing flaky CI failures on some Godot versions. The old file-based `dump_to_tmp()`/`restore_dump_from_tmp()` silently did nothing because tests only change in-memory settings and never write to disk.

# What
Introduce `GdUnitProjectSettingsSnapshot` — a lightweight class that captures all in-memory `ProjectSettings` before a test suite or test case runs and restores any changed values afterwards. One snapshot instance is held per `GdUnitExecutionContext` (lazy, suite-level and test-level each own their own). The snapshot/restore calls are wired into `GdUnitTestSuiteExecutionStage` and `GdUnitTestCaseExecutionStage` so isolation is transparent and automatic, requiring no boilerplate in individual tests. The old `dump_to_tmp()`/`restore_dump_from_tmp()` API is removed from `GdUnitSettings`.