### PR TITLE
GD-1114: Fix editor crash when clicking a string setting in Project Settings

### DIFF
--- a/addons/gdUnit4/src/core/GdUnitSettings.gd
+++ b/addons/gdUnit4/src/core/GdUnitSettings.gd
@@ -106,7 +106,7 @@ const DEFAULT_SERVER_TIMEOUT :int = 30
 # test case runtime timeout in seconds
 const DEFAULT_TEST_TIMEOUT :int = 60*5
 # the folder to create new test-suites
-const DEFAULT_TEST_LOOKUP_FOLDER := "test"
+const DEFAULT_TEST_LOOKUP_FOLDER :String = "test"
 
 # help texts
 const HELP_TEST_LOOKUP_FOLDER := "Subfolder where test suites are located (or empty to use source folder directly)"
@@ -117,8 +117,8 @@ enum NAMING_CONVENTIONS {
 	PASCAL_CASE,
 }
 
+static var _property_help :Dictionary[String, String] = {}
 
-const _VALUE_SET_SEPARATOR = "\f" # ASCII Form-feed character (AKA page break)
 
 static func setup() -> void:
 	create_property_if_need(UPDATE_NOTIFICATION_ENABLED, true, "Show notification if new gdUnit4 version is found")
@@ -179,23 +179,36 @@ static func create_shortcut_properties_if_need() -> void:
 	create_property_if_need(SHORTCUT_FILESYSTEM_RUN_TEST_DEBUG, GdUnitShortcut.default_keys(GdUnitShortcut.ShortCut.RUN_TESTSUITE_DEBUG), "Run all test suites in the selected folder or file (Debug)")
 
 
-static func create_property_if_need(name :String, default :Variant, help :="", value_set := PackedStringArray()) -> void:
-	if not ProjectSettings.has_setting(name):
+static func create_property_if_need(
+		property_name: String,
+		default_value: Variant,
+		help_text := "",
+		value_set := PackedStringArray()) -> void:
+
+	if not ProjectSettings.has_setting(property_name):
 		#prints("GdUnit4: Set inital settings '%s' to '%s'." % [name, str(default)])
-		ProjectSettings.set_setting(name, default)
+		ProjectSettings.set_setting(property_name, default_value)
 
-	ProjectSettings.set_initial_value(name, default)
-	help = help if value_set.is_empty() else "%s%s%s" % [help, _VALUE_SET_SEPARATOR, value_set]
-	set_help(name, default, help)
+	ProjectSettings.set_initial_value(property_name, default_value)
+	set_property_info(property_name, default_value, value_set)
+	set_property_help(property_name, help_text)
 
 
-static func set_help(property_name :String, value :Variant, help :String) -> void:
-	ProjectSettings.add_property_info({
+static func set_property_info(property_name: String, value: Variant, value_set: PackedStringArray) -> void:
+	var info := {
 		"name": property_name,
 		"type": typeof(value),
-		"hint": PROPERTY_HINT_TYPE_STRING,
-		"hint_string": help
-	})
+		"hint": PROPERTY_HINT_NONE,
+		"hint_string": "",
+	}
+	if not value_set.is_empty():
+		info["hint"] = PROPERTY_HINT_ENUM
+		info["hint_string"] = ",".join(value_set)
+	ProjectSettings.add_property_info(info)
+
+
+static func set_property_help(property_name: String, help_text: String) -> void:
+	_property_help[property_name] = help_text
 
 
 static func get_setting(name :String, default :Variant) -> Variant:
@@ -375,25 +388,6 @@ static func list_settings(category: String) -> Array[GdUnitProperty]:
 	return settings
 
 
-static func extract_value_set_from_help(value :String) -> PackedStringArray:
-	var split_value := value.split(_VALUE_SET_SEPARATOR)
-	if not split_value.size() > 1:
-		return PackedStringArray()
-
-	var regex := RegEx.new()
-	@warning_ignore("return_value_discarded")
-	regex.compile("\\[(.+)\\]")
-	var matches := regex.search_all(split_value[1])
-	if matches.is_empty():
-		return PackedStringArray()
-	var values: String = matches[0].get_string(1)
-	return values.replacen(" ", "").replacen("\"", "").split(",", false)
-
-
-static func extract_help_text(value :String) -> String:
-	return value.split(_VALUE_SET_SEPARATOR)[0]
-
-
 static func update_property(property :GdUnitProperty) -> Variant:
 	var current_value :Variant = ProjectSettings.get_setting(property.name())
 	if current_value != property.value():
@@ -457,9 +451,10 @@ static func build_property(property_name: String, property: Dictionary) -> GdUni
 	var value: Variant = ProjectSettings.get_setting(property_name)
 	var value_type: int = property["type"]
 	var default: Variant = ProjectSettings.property_get_revert(property_name)
-	var help: String = property["hint_string"]
-	var value_set := extract_value_set_from_help(help)
-	return GdUnitProperty.new(property_name, value_type, value, default, extract_help_text(help), value_set)
+	var hint_string: String = property["hint_string"]
+	var value_set := PackedStringArray() if hint_string.is_empty() else hint_string.split(",")
+	var help_text :String = _property_help.get(property_name, "")
+	return GdUnitProperty.new(property_name, value_type, value, default, help_text, value_set)
 
 
 static func migrate_property(old_property :String, new_property :String, default_value :Variant, help :String, converter := Callable()) -> void:
@@ -470,6 +465,7 @@ static func migrate_property(old_property :String, new_property :String, default
 	var value :Variant = converter.call(property.value()) if converter.is_valid() else property.value()
 	ProjectSettings.set_setting(new_property, value)
 	ProjectSettings.set_initial_value(new_property, default_value)
-	set_help(new_property, value, help)
+	set_property_help(new_property, help)
+	set_property_info(new_property, value, [])
 	ProjectSettings.clear(old_property)
 	prints("Successfully migrated property '%s' -> '%s' value: %s" % [old_property, new_property, value])

--- a/addons/gdUnit4/test/core/GdUnitSettingsTest.gd
+++ b/addons/gdUnit4/test/core/GdUnitSettingsTest.gd
@@ -11,78 +11,139 @@ const ERROR := GdUnitSettings.GdScriptWarningMode.ERROR
 const EXCLUDE := GdUnitSettings.GdScriptWarningDirectoryMode.EXCLUDE
 const INCLUDE := GdUnitSettings.GdScriptWarningDirectoryMode.INCLUDE
 
-const MAIN_CATEGORY = "unit_test"
-const CATEGORY_A = MAIN_CATEGORY + "/category_a"
-const CATEGORY_B = MAIN_CATEGORY + "/category_b"
-const TEST_PROPERTY_A = CATEGORY_A + "/a/prop_a"
-const TEST_PROPERTY_B = CATEGORY_A + "/a/prop_b"
-const TEST_PROPERTY_C = CATEGORY_A + "/a/prop_c"
-const TEST_PROPERTY_D = CATEGORY_B + "/prop_d"
-const TEST_PROPERTY_E = CATEGORY_B + "/c/prop_e"
-const TEST_PROPERTY_F = CATEGORY_B + "/c/prop_f"
-const TEST_PROPERTY_G = CATEGORY_B + "/a/prop_g"
+
+static func get_godot_property_info(property_name: String) -> Dictionary:
+	for property: Dictionary in ProjectSettings.get_property_list():
+		if property["name"] == property_name:
+			return property
+	return {}
 
 
-func before_test() -> void:
-	GdUnitSettings.create_property_if_need(TEST_PROPERTY_A, true, "helptext TEST_PROPERTY_A.")
-	GdUnitSettings.create_property_if_need(TEST_PROPERTY_B, false, "helptext TEST_PROPERTY_B.")
-	GdUnitSettings.create_property_if_need(TEST_PROPERTY_C, 100, "helptext TEST_PROPERTY_C.")
-	GdUnitSettings.create_property_if_need(TEST_PROPERTY_D, true, "helptext TEST_PROPERTY_D.")
-	GdUnitSettings.create_property_if_need(TEST_PROPERTY_E, false, "helptext TEST_PROPERTY_E.")
-	GdUnitSettings.create_property_if_need(TEST_PROPERTY_F, "abc", "helptext TEST_PROPERTY_F.")
-	GdUnitSettings.create_property_if_need(TEST_PROPERTY_G, 200, "helptext TEST_PROPERTY_G.")
-
-
-func after_test() -> void:
-	ProjectSettings.clear(TEST_PROPERTY_A)
-	ProjectSettings.clear(TEST_PROPERTY_B)
-	ProjectSettings.clear(TEST_PROPERTY_C)
-	ProjectSettings.clear(TEST_PROPERTY_D)
-	ProjectSettings.clear(TEST_PROPERTY_E)
-	ProjectSettings.clear(TEST_PROPERTY_F)
-	ProjectSettings.clear(TEST_PROPERTY_G)
-
-
+#region list_settings
 func test_list_settings() -> void:
-	var settingsA := GdUnitSettings.list_settings(CATEGORY_A)
-	assert_array(settingsA).extractv(extr("name"), extr("type"), extr("value"), extr("default"), extr("help"))\
+	var report_errors := "unit_test/settings/report_errors"
+	var report_warnings := "unit_test/settings/report_warnings"
+	var max_retries := "unit_test/settings/max_retries"
+	var enable_logging := "unit_test/network/enable_logging"
+	var verbose_output := "unit_test/network/verbose_output"
+	var log_path := "unit_test/network/log_path"
+	var timeout_seconds := "unit_test/network/timeout_seconds"
+	GdUnitSettings.create_property_if_need(report_errors, true, "Report errors as failures")
+	GdUnitSettings.create_property_if_need(report_warnings, false, "Report warnings as failures")
+	GdUnitSettings.create_property_if_need(max_retries, 3, "Maximum retry count on test failure")
+	GdUnitSettings.create_property_if_need(enable_logging, true, "Enable test run logging")
+	GdUnitSettings.create_property_if_need(verbose_output, false, "Show verbose test output")
+	GdUnitSettings.create_property_if_need(log_path, "logs/", "Path to store log files")
+	GdUnitSettings.create_property_if_need(timeout_seconds, 30, "Connection timeout in seconds")
+
+	var settings_settings := GdUnitSettings.list_settings("unit_test/settings")
+	assert_array(settings_settings)\
+		.extractv(extr("name"), extr("type"), extr("value"), extr("default"), extr("help"), extr("value_set"))\
 		.contains_exactly_in_any_order([
-		tuple(TEST_PROPERTY_A, TYPE_BOOL, true, true, "helptext TEST_PROPERTY_A."),
-		tuple(TEST_PROPERTY_B, TYPE_BOOL,false, false, "helptext TEST_PROPERTY_B."),
-		tuple(TEST_PROPERTY_C, TYPE_INT, 100, 100, "helptext TEST_PROPERTY_C.")
-	])
-	var settingsB := GdUnitSettings.list_settings(CATEGORY_B)
-	assert_array(settingsB).extractv(extr("name"), extr("type"), extr("value"), extr("default"), extr("help"))\
+			tuple(report_errors, TYPE_BOOL, true, true, "Report errors as failures", PackedStringArray()),
+			tuple(report_warnings, TYPE_BOOL, false, false, "Report warnings as failures", PackedStringArray()),
+			tuple(max_retries, TYPE_INT, 3, 3, "Maximum retry count on test failure", PackedStringArray()),
+		])
+	var settings_network := GdUnitSettings.list_settings("unit_test/network")
+	assert_array(settings_network)\
+		.extractv(extr("name"), extr("type"), extr("value"), extr("default"), extr("help"), extr("value_set"))\
 		.contains_exactly_in_any_order([
-		tuple(TEST_PROPERTY_D, TYPE_BOOL, true, true, "helptext TEST_PROPERTY_D."),
-		tuple(TEST_PROPERTY_E, TYPE_BOOL, false, false, "helptext TEST_PROPERTY_E."),
-		tuple(TEST_PROPERTY_F, TYPE_STRING, "abc", "abc", "helptext TEST_PROPERTY_F."),
-		tuple(TEST_PROPERTY_G, TYPE_INT, 200, 200, "helptext TEST_PROPERTY_G.")
-	])
+			tuple(enable_logging, TYPE_BOOL, true, true, "Enable test run logging", PackedStringArray()),
+			tuple(verbose_output, TYPE_BOOL, false, false, "Show verbose test output", PackedStringArray()),
+			tuple(log_path, TYPE_STRING, "logs/", "logs/", "Path to store log files", PackedStringArray()),
+			tuple(timeout_seconds, TYPE_INT, 30, 30, "Connection timeout in seconds", PackedStringArray()),
+		])
+#endregion
 
 
-func test_enum_property() -> void:
-	var value_set :PackedStringArray = GdUnitSettings.NAMING_CONVENTIONS.keys()
-	GdUnitSettings.create_property_if_need("test/enum", GdUnitSettings.NAMING_CONVENTIONS.AUTO_DETECT, "help", value_set)
+#region property info
+func test_property_bool_info() -> void:
+	var property_name := "unit_test/property/update_notification_enabled"
+	GdUnitSettings.create_property_if_need(property_name, true, "Show notification when a new version is found")
 
-	var property := GdUnitSettings.get_property("test/enum")
-	assert_that(property.default()).is_equal(GdUnitSettings.NAMING_CONVENTIONS.AUTO_DETECT)
-	assert_that(property.value()).is_equal(GdUnitSettings.NAMING_CONVENTIONS.AUTO_DETECT)
-	assert_that(property.type()).is_equal(TYPE_INT)
-	assert_that(property.help()).is_equal('help')
-	assert_that(property.value_set()).is_equal(value_set)
+	var property := GdUnitSettings.get_property(property_name)
+	assert_bool(property.value()).is_true()
+	assert_bool(property.default()).is_true()
+	assert_int(property.type()).is_equal(TYPE_BOOL)
+	assert_array(property.value_set()).is_empty()
+	assert_str(property.help()).is_equal("Show notification when a new version is found")
+	# verify Godot property API
+	var info := get_godot_property_info(property_name)
+	assert_dict(info)\
+		.contains_key_value("type", TYPE_BOOL)\
+		.contains_key_value("hint", PROPERTY_HINT_NONE)\
+		.contains_key_value("hint_string", "")
+	assert_that(ProjectSettings.property_get_revert(property_name)).is_equal(true)
 
 
+func test_property_int_info() -> void:
+	var property_name := "unit_test/property/server_timeout_minutes"
+	GdUnitSettings.create_property_if_need(property_name, 30, "Server connection timeout in minutes")
+
+	var property := GdUnitSettings.get_property(property_name)
+	assert_int(property.value()).is_equal(30)
+	assert_int(property.default()).is_equal(30)
+	assert_int(property.type()).is_equal(TYPE_INT)
+	assert_array(property.value_set()).is_empty()
+	assert_str(property.help()).is_equal("Server connection timeout in minutes")
+	# verify Godot property API
+	var info := get_godot_property_info(property_name)
+	assert_dict(info)\
+		.contains_key_value("type", TYPE_INT)\
+		.contains_key_value("hint", PROPERTY_HINT_NONE)\
+		.contains_key_value("hint_string", "")
+	assert_that(ProjectSettings.property_get_revert(property_name)).is_equal(30)
+
+
+func test_property_string_info() -> void:
+	var property_name := "unit_test/property/test_lookup_folder"
+	GdUnitSettings.create_property_if_need(property_name, "test", "Subfolder where test suites are located")
+
+	var property := GdUnitSettings.get_property(property_name)
+	assert_str(property.value()).is_equal("test")
+	assert_str(property.default()).is_equal("test")
+	assert_int(property.type()).is_equal(TYPE_STRING)
+	assert_array(property.value_set()).is_empty()
+	assert_str(property.help()).is_equal("Subfolder where test suites are located")
+	# verify Godot property API
+	var info := get_godot_property_info(property_name)
+	assert_dict(info)\
+		.contains_key_value("type", TYPE_STRING)\
+		.contains_key_value("hint", PROPERTY_HINT_NONE)\
+		.contains_key_value("hint_string", "")
+	assert_that(ProjectSettings.property_get_revert(property_name)).is_equal("test")
+
+
+func test_property_enum_info() -> void:
+	var property_name := "unit_test/property/naming_convention"
+	var value_set: PackedStringArray = GdUnitSettings.NAMING_CONVENTIONS.keys()
+	GdUnitSettings.create_property_if_need(property_name, GdUnitSettings.NAMING_CONVENTIONS.AUTO_DETECT, "Naming convention for test suite generation", value_set)
+
+	var property := GdUnitSettings.get_property(property_name)
+	assert_int(property.value()).is_equal(GdUnitSettings.NAMING_CONVENTIONS.AUTO_DETECT)
+	assert_int(property.default()).is_equal(GdUnitSettings.NAMING_CONVENTIONS.AUTO_DETECT)
+	assert_int(property.type()).is_equal(TYPE_INT)
+	assert_array(property.value_set()).is_equal(value_set)
+	assert_str(property.help()).is_equal("Naming convention for test suite generation")
+	# verify Godot property API
+	var info := get_godot_property_info(property_name)
+	assert_dict(info)\
+		.contains_key_value("type", TYPE_INT)\
+		.contains_key_value("hint", PROPERTY_HINT_ENUM)\
+		.contains_key_value("hint_string", ",".join(value_set))
+	assert_that(ProjectSettings.property_get_revert(property_name)).is_equal(GdUnitSettings.NAMING_CONVENTIONS.AUTO_DETECT)
+#endregion
+
+
+#region migrate_property
 func test_migrate_property_change_key() -> void:
-	# setup old property
-	var old_property_X := "/category_patch/group_old/name"
-	var new_property_X := "/category_patch/group_new/name"
+	var old_property_X := "/category_patch/migrate_key/old_name"
+	var new_property_X := "/category_patch/migrate_key/new_name"
 	GdUnitSettings.create_property_if_need(old_property_X, "foo")
 	assert_str(GdUnitSettings.get_setting(old_property_X, null)).is_equal("foo")
 	assert_str(GdUnitSettings.get_setting(new_property_X, null)).is_null()
 	var old_property := GdUnitSettings.get_property(old_property_X)
 
-	# migrate
 	GdUnitSettings.migrate_property(old_property.name(),\
 		new_property_X,\
 		old_property.default(),\
@@ -98,20 +159,15 @@ func test_migrate_property_change_key() -> void:
 	assert_str(new_property.default()).is_equal(old_property.default())
 	assert_str(new_property.help()).is_equal(old_property.help())
 
-	# cleanup
-	ProjectSettings.clear(new_property_X)
-
 
 func test_migrate_property_change_value() -> void:
-	# setup old property
-	var old_property_X := "/category_patch/group_old/name"
-	var new_property_X := "/category_patch/group_new/name"
+	var old_property_X := "/category_patch/migrate_value/old_name"
+	var new_property_X := "/category_patch/migrate_value/new_name"
 	GdUnitSettings.create_property_if_need(old_property_X, "foo", "help to foo")
 	assert_str(GdUnitSettings.get_setting(old_property_X, null)).is_equal("foo")
 	assert_str(GdUnitSettings.get_setting(new_property_X, null)).is_null()
 	var old_property := GdUnitSettings.get_property(old_property_X)
 
-	# migrate property
 	GdUnitSettings.migrate_property(old_property.name(),\
 		new_property_X,\
 		old_property.default(),\
@@ -127,10 +183,10 @@ func test_migrate_property_change_value() -> void:
 	assert_int(new_property.type()).is_equal(old_property.type())
 	assert_str(new_property.default()).is_equal(old_property.default())
 	assert_str(new_property.help()).is_equal(old_property.help())
-	# cleanup
-	ProjectSettings.clear(new_property_X)
+#endregion
 
 
+#region validate_is_inferred_declaration_enabled
 func test_validate_is_inferred_declaration_enabled_when_disabled() -> void:
 	ProjectSettings.set_setting(GdUnitSettings.GDSCRIPT_WARNINGS_INFERRED_DECLARATION, IGNORE)
 	assert_result(GdUnitSettings.validate_is_inferred_declaration_enabled())\
@@ -230,25 +286,22 @@ func test_validate_is_inferred_declaration_enabled_when_error_and_addon_not_excl
 	assert_result(GdUnitSettings.validate_is_inferred_declaration_enabled())\
 		.is_error()\
 		.contains_message(expected_message)
+#endregion
 
 
-const TEST_ROOT_FOLDER := "gdunit4/settings/test/test_root_folder"
-const HELP_TEST_ROOT_FOLDER := "Sets the root folder where test-suites located/generated."
-
+#region migrate_properties
 func test_migrate_properties_v215() -> void:
-	# rebuild original settings
-	GdUnitSettings.create_property_if_need(TEST_ROOT_FOLDER, "test", HELP_TEST_ROOT_FOLDER)
-	ProjectSettings.set_setting(TEST_ROOT_FOLDER, "xxx")
+	var old_property := "gdunit4/settings/test/test_root_folder"
+	GdUnitSettings.create_property_if_need(old_property, "test", "Sets the root folder where test-suites located/generated.")
+	ProjectSettings.set_setting(old_property, "tests")
 
-	# migrate
 	GdUnitSettings.migrate_properties()
 
-	# verify
 	var property := GdUnitSettings.get_property(GdUnitSettings.TEST_LOOKUP_FOLDER)
-	assert_str(property.value()).is_equal("xxx")
+	assert_str(property.value()).is_equal("tests")
 	assert_array(property.value_set()).is_empty()
 	assert_int(property.type()).is_equal(TYPE_STRING)
 	assert_str(property.default()).is_equal(GdUnitSettings.DEFAULT_TEST_LOOKUP_FOLDER)
 	assert_str(property.help()).is_equal(GdUnitSettings.HELP_TEST_LOOKUP_FOLDER)
-	assert_that(GdUnitSettings.get_property(TEST_ROOT_FOLDER)).is_null()
-	ProjectSettings.clear(GdUnitSettings.TEST_LOOKUP_FOLDER)
+	assert_that(GdUnitSettings.get_property(old_property)).is_null()
+#endregion


### PR DESCRIPTION
# Why
Opening Project Settings and clicking on a string-typed gdUnit4 setting caused the Godot editor to crash. The root cause was registering plain string properties with PROPERTY_HINT_TYPE_STRING and a non-empty hint_string — a combination the editor cannot handle for string values. GdUnitSettings was exploiting that field to smuggle help text and the value-set together via a form-feed separator, which triggered the crash.

# What
- Replace PROPERTY_HINT_TYPE_STRING with PROPERTY_HINT_NONE for plain string/bool/int properties and PROPERTY_HINT_ENUM for enum properties
- Store help text out-of-band in a static _property_help dict instead of embedding it in hint_string
- Add set_property_info() and set_property_help() helpers; remove set_help(), extract_value_set_from_help(), and extract_help_text()
- Refactor GdUnitSettingsTest: self-contained tests, static get_godot_property_info() helper, chained assert_dict() for Godot API verification, and unique property paths per migrate test to avoid stash/restore gaps

