### PR TITLE
TASK-1126: Exclude AI agent files from asset library

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -8,6 +8,10 @@
 /addons/gdUnit4/test   export-ignore
 /documentation         export-ignore
 
+# Exclude AI agent files from asset library exports
+/addons/gdUnit4/**/CLAUDE.md   export-ignore
+/addons/gdUnit4/**/.claude     export-ignore
+
 
 # Ensure Unix line endings for text files
 * text=auto eol=lf


### PR DESCRIPTION
# Why
Claude agent files (CLAUDE.md, .claude/) were added to the repository to enforce project structure and coding rules, but were unintentionally included in the Godot Asset Library export because they reside inside addons/gdUnit4/.

# What
Add export-ignore rules in .gitattributes for CLAUDE.md and .claude/ entries inside addons/gdUnit4/ so they are stripped from asset library downloads.

Closes #1126