### PR TITLE
Bump GdUnit4 to version v6.2

### DIFF
--- a/addons/gdUnit4/plugin.cfg
+++ b/addons/gdUnit4/plugin.cfg
@@ -3,5 +3,5 @@
 name="gdUnit4"
 description="Unit Testing Framework for Godot Scripts"
 author="Mike Schulze"
-version="6.1.3"
+version="6.2.0-rc0"
 script="plugin.gd"

--- a/gdUnit4.csproj
+++ b/gdUnit4.csproj
@@ -11,7 +11,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
     <!-- ProjectReference Include="..\gdUnit4Net\api\gdUnit4Api.csproj" /-->
-    <PackageReference Include="gdUnit4.api" Version="5.1.0-rc3" />
+    <PackageReference Include="gdUnit4.api" Version="5.1.0-rc4" />
     <PackageReference Include="gdUnit4.test.adapter" Version="3.0.0" />
     <PackageReference Include="gdUnit4.analyzers" Version="1.0.0">
       <PrivateAssets>none</PrivateAssets>

--- a/global.json
+++ b/global.json
@@ -5,6 +5,6 @@
     "allowPrerelease": false
   },
   "msbuild-sdks": {
-    "Godot.NET.Sdk": "4.5.1"
+    "Godot.NET.Sdk": "4.6.2"
   }
 }


### PR DESCRIPTION
# Why
We want to prepare the v6.2 release candidate

# What
- increase version to `6.2.0-rc0`
- update C# dependencies to latest `gdUnit4.api` version
- update Godot Net SDK to 4.6.2
