### PR TITLE
DOC-1130: Document await requirement and fix missing awaits in signal examples

### DIFF
--- a/documentation/_includes/signal_await_advice.html
+++ b/documentation/_includes/signal_await_advice.html
@@ -1,0 +1,9 @@
+{% capture signal_await_advice %}
+Always use <code>await</code> with <code>is_emitted()</code> and <code>is_not_emitted()</code>.
+Both are coroutines — <code>await</code> suspends execution until the signal fires or times out.
+Without it, or if any caller in the chain omits it, the test <strong>silently passes</strong>.
+See <a
+  href="https://docs.godotengine.org/en/stable/tutorials/scripting/gdscript/gdscript_basics.html#awaiting-signals-or-coroutines"
+>Awaiting signals or coroutines</a> in the Godot docs.
+{% endcapture %}
+{% include advice.html content=signal_await_advice %}

--- a/documentation/doc/_advanced_testing/signals.md
+++ b/documentation/doc/_advanced_testing/signals.md
@@ -17,9 +17,7 @@ The `assert_signal()` an Assertion Tool to verify for emitted signals until a ce
 the assertion fails with a timeout error.<br>
 For more details show [assert_signal]({{site.baseurl}}/testing/assert-signal/#signal-assertions)
 
-Since **v6.1**, `is_emitted()` and `is_not_emitted()` accept signal arguments as **variadic parameters**
-instead of an array, and `signal_name` accepts either a **`Signal` reference** (type-safe, recommended)
-or a **`String`**.
+{% include signal_await_advice.html %}
 
 Here's an example of using `assert_signal()`:
 
@@ -166,22 +164,24 @@ public partial class SignalAssertTest
 The `monitor_signals()` tool allows you to monitor the emission of signals from a specific object.
 It sets up a signal monitoring system for the specified object, which enables you to capture and analyze the signals emitted during the execution of your test.
 
+{% include signal_await_advice.html %}
+
 {% tabs monitor_signals-overview %}
 {% tab monitor_signals-overview GdScript %}
 ```gd
-    func monitor_signals(source :Object, _auto_free := true) -> Object:
+func monitor_signals(source: Object, _auto_free := true) -> Object:
 ```
 {% endtab %}
 {% tab monitor_signals-overview C# %}
 In C#, the monitor is integrated into the AssertSignal and is generated implicitly the first time an assertion is used on an emitter.
 To visualize this better, you can use StartMonitoring. From this point on, all emitted signals are recorded.
 ```cs
-    /// <summary>
-    /// Starts the monitoring of emitted signals during the test runtime.
-    /// It should be called first if you want to collect all emitted signals after the emitter has been created.
-    /// </summary>
-    /// <returns></returns>
-    public ISignalAssert StartMonitoring();
+/// <summary>
+/// Starts the monitoring of emitted signals during the test runtime.
+/// It should be called first if you want to collect all emitted signals after the emitter has been created.
+/// </summary>
+/// <returns></returns>
+public ISignalAssert StartMonitoring();
 ```
 {% endtab %}
 {% endtabs %}

--- a/documentation/doc/_testing/assert-signal.md
+++ b/documentation/doc/_testing/assert-signal.md
@@ -6,9 +6,16 @@ parent: Asserts
 
 # Signal Assertions
 
-An Assertion Tool to verify for emitted signals until a certain time. When the timeout is reached, the assertion fails with a timeout error.
-The default timeout of 2s can be overridden by wait_until(\<time in ms\>)<br>
-To watch for signals emitted during the test execution you have to use in addition the [monitor_signal]({{site.baseurl}}/advanced_testing/signals/#monitor-signals) tool.
+`assert_signal()` verifies that a signal is emitted — or is **not** emitted — within a time window.
+If the condition is not met before the timeout expires, the assertion fails with a timeout error.
+The default timeout is 2000 ms and can be adjusted with
+[wait_until]({{site.baseurl}}/testing/assert-signal/#wait_until).
+
+To capture signals emitted during test execution, pair `assert_signal()` with
+[monitor_signals]({{site.baseurl}}/advanced_testing/signals/#monitor-signals)
+before the action under test runs.
+
+{% include signal_await_advice.html %}
 
 {% tabs assert-signal-overview %}
 {% tab assert-signal-overview GdScript %}
@@ -177,6 +184,10 @@ await AssertSignal(instance).IsNotEmitted(SignalName.SignalA, 10).WithTimeout(50
 {% endtab %}
 {% endtabs %}
 
+{% include advice.html
+content="Omitting signal_args requires the signal to be emitted with no arguments. If the signal carries arguments, provide them or use argument matchers."
+%}
+
 ## Matching Signal Arguments
 
 Signal arguments can be verified using **exact values** or **argument matchers** for flexible matching.
@@ -277,7 +288,7 @@ assert_signal(instance).is_signal_exists(my_signal)
 assert_signal(instance).is_signal_exists("my_signal")
 
 # Chain with other assertions
-assert_signal(instance) \
+await assert_signal(instance) \
     .is_signal_exists(my_signal) \
     .is_emitted(my_signal, 42)
 ```
@@ -318,7 +329,7 @@ func assert_signal(instance: Object>).wait_until(timeout: int) -> GdUnitSignalAs
 signal signal_a()
 
 # Do wait until 5s the instance has emitted the signal `signal_a`[br]
-assert_signal(instance).wait_until(5000).is_emitted(signal_a)
+await assert_signal(instance).wait_until(5000).is_emitted(signal_a)
 ```
 {% endtab %}
 {% tab assert-signal-wait_until C# %}


### PR DESCRIPTION
# Why
Without `await`, `is_emitted()` and `is_not_emitted()` run synchronously and return
immediately — the assertion exits before any signal can fire, causing a silent false pass.
This Godot coroutine behavior was not documented, leaving users confused about why their
tests passed when they expected a timeout failure.

# What
- `documentation/_includes/signal_await_advice.html` — new reusable advice callout explaining
  that `await` is required, the coroutine semantics behind it, call-chain propagation, and a
  link to the Godot docs on awaiting coroutines
- `doc/_testing/assert-signal.md` — rewrote page intro; added advice callout; fixed missing
  `await` in `wait_until` and `is_signal_exists` chained GdScript examples
- `doc/_advanced_testing/signals.md` — added advice callout to Verify Signals section and
  Monitor Signals section

Closes #1130