### PR TITLE
GD-1100: Fix signal 11 crash by disposing resources on remote runner quit

### DIFF
--- a/addons/gdUnit4/src/core/GdUnitTools.gd
+++ b/addons/gdUnit4/src/core/GdUnitTools.gd
@@ -116,6 +116,7 @@ static func release_timers() -> void:
 
 # the finally cleaup unfreed resources and singletons
 static func dispose_all(use_call_deferred :bool = false) -> void:
+	prints("Run dispose test resources")
 	release_timers()
 	GdUnitSingleton.dispose(use_call_deferred)
 	GdUnitSignals.dispose()

--- a/addons/gdUnit4/src/core/runners/GdUnitTestCIRunner.gd
+++ b/addons/gdUnit4/src/core/runners/GdUnitTestCIRunner.gd
@@ -20,8 +20,6 @@ extends "res://addons/gdUnit4/src/core/runners/GdUnitTestSessionRunner.gd"
 ## runtest -a <directory> -i <testsuite:test_name>
 ## [/codeblock]
 
-const GdUnitTools := preload("res://addons/gdUnit4/src/core/GdUnitTools.gd")
-
 var _console := GdUnitCSIMessageWriter.new()
 var _console_reporter: GdUnitConsoleTestReporter
 var _headless_mode_ignore := false
@@ -113,8 +111,6 @@ func _ready() -> void:
 
 func _notification(what: int) -> void:
 	super(what)
-	if what == NOTIFICATION_PREDELETE:
-		prints("Finallize .. done")
 
 
 func init_runner() -> void:
@@ -131,10 +127,8 @@ func get_exit_code() -> int:
 ## [br]
 ## [param code] The exit code to return.
 func quit(code: int) -> void:
-	_state = EXIT
-	GdUnitTools.dispose_all()
-	await GdUnitMemoryObserver.gc_on_guarded_instances()
 	await super(code)
+	get_tree().quit(code)
 
 
 ## Prints info message to console.[br]

--- a/addons/gdUnit4/src/core/runners/GdUnitTestRunner.gd
+++ b/addons/gdUnit4/src/core/runners/GdUnitTestRunner.gd
@@ -1,4 +1,3 @@
-@tool
 extends "res://addons/gdUnit4/src/core/runners/GdUnitTestSessionRunner.gd"
 ## Runner implementation used by the editor UI.[br]
 ## [br]
@@ -37,16 +36,6 @@ func _ready() -> void:
 	if result.is_error():
 		push_error(result.error_message())
 		return
-
-
-## Cleanup and quit the runner.[br]
-## [br]
-## [param code] The exit code to return.
-func quit(code: int) -> void:
-	if code != RETURN_SUCCESS:
-		_state = EXIT
-	await GdUnitMemoryObserver.gc_on_guarded_instances()
-	await super.quit(code)
 
 
 ## Called when the TCP connection to the GdUnit server fails.[br]

--- a/addons/gdUnit4/src/core/runners/GdUnitTestSessionRunner.gd
+++ b/addons/gdUnit4/src/core/runners/GdUnitTestSessionRunner.gd
@@ -13,6 +13,8 @@ extends Node
 ## - [b]GdUnitCLRunner[/b]: A command line interface runner, writes test reports to file[br]
 ## The test runner runs checked default in fail-fast mode, it stops checked first test failure.
 
+const GdUnitTools := preload("res://addons/gdUnit4/src/core/GdUnitTools.gd")
+
 ## Overall test run status codes used by the runners
 const RETURN_SUCCESS = 0
 const RETURN_ERROR = 100
@@ -70,6 +72,7 @@ var max_report_history: int = GdUnitConstants.DEFAULT_REPORT_HISTORY_COUNT:
 
 # holds the current test session context
 var _test_session: GdUnitTestSession
+var _is_editor_debug_run: bool
 
 ## Runner state machine
 enum {
@@ -81,7 +84,8 @@ enum {
 }
 
 func _init() -> void:
-	if OS.get_cmdline_args().size() == 1:
+	_is_editor_debug_run = OS.get_cmdline_args().has("--scene")
+	if _is_editor_debug_run:
 		DisplayServer.window_set_title("GdUnit4 Runner (Debug Mode)")
 	else:
 		DisplayServer.window_set_title("GdUnit4 Runner (Release Mode)")
@@ -158,9 +162,15 @@ func get_exit_code() -> int:
 
 ## Quits the test runner with given exit code.
 func quit(code: int) -> void:
+	await GdUnitMemoryObserver.gc_on_guarded_instances()
+
+	if !_is_editor_debug_run:
+		# Only dispose all resources when we not run embedded in the editor
+		GdUnitTools.dispose_all()
+		await get_tree().process_frame
+
 	await get_tree().process_frame
 	await get_tree().physics_frame
-	get_tree().quit(code)
 
 
 func prints_warning(message: String) -> void:


### PR DESCRIPTION
# Why
When the editor launches a test run via **Run** (non-debug mode), the tests execute in a separate Godot process spawned via `OS.create_process`. On quit, `GdUnitTools.dispose_all()` was never called for this process, leaving resources unreleased and causing a signal 11 (segfault) crash after the test session ended.

# What
- `GdUnitTestSessionRunner`: add `_is_editor_debug_run` flag (detected via `--scene` in OS command-line args) to distinguish editor debug runs from remote/CI runs. Move `GdUnitTools` preload here from `GdUnitTestCIRunner`. Enhance `quit()` to call `gc_on_guarded_instances()` and `dispose_all()` for all non-editor-debug runs.
- `GdUnitTestRunner`: remove `@tool` annotation (caused a crash when opening the scene in the editor). Remove the `quit()` override — the base class now handles full cleanup for both remote-process and editor-debug cases.
- `GdUnitTestCIRunner`: remove `GdUnitTools` preload (moved to base). Simplify `quit()` — cleanup delegated to base, subclass only calls `get_tree().quit()`.

Closes #1100