### PR TITLE
TASK-1133: Add GdUnit4 test writing guidelines to test/CLAUDE.md

### DIFF
--- a/addons/gdUnit4/test/CLAUDE.md
+++ b/addons/gdUnit4/test/CLAUDE.md
@@ -46,6 +46,74 @@ func test_has_size() -> void:
 #endregion
 ```
 
+**Always use the type-specific assert function:**
+
+Match the assert to the type of the value under test. Type-specific asserts unlock
+richer failure messages and type-appropriate matchers. Fall back to `assert_that` only
+for custom objects and variants that have no dedicated assert.
+
+| Value type | Use |
+| ---------- | --- |
+| `bool` | `assert_bool(value)` |
+| `int` | `assert_int(value)` |
+| `float` | `assert_float(value)` |
+| `String` | `assert_str(value)` |
+| `Array` | `assert_array(value)` |
+| `Dictionary` | `assert_dict(value)` |
+| Custom object / variant | `assert_that(value)` |
+
+Pick the assert based on the type of the value — whether that comes from an explicit
+annotation, `:=` inference, or the return type of the called function.
+
+```gdscript
+# Preferred — assert matches the inferred type of the value
+var is_alive := player.is_alive()       # bool  → assert_bool
+assert_bool(is_alive).is_true()
+
+var item_count := inventory.size()      # int   → assert_int
+assert_int(item_count).is_equal(5)
+
+var label := button.get_label()         # String → assert_str
+assert_str(label).is_equal("Start Game")
+
+var config := settings.to_dict()        # Dictionary → assert_dict
+assert_dict(config).contains_key_value("difficulty", "hard")
+
+var node := scene.find_child("Player")  # Node → assert_that
+assert_that(node).is_equal(expected_node)
+
+# Avoid — assert_that used where a type-specific assert exists
+assert_that(player.is_alive()).is_equal(true)
+assert_that(inventory.size()).is_equal(5)
+assert_that(button.get_label()).is_equal("Start Game")
+```
+
+**Fluent chain — break only when necessary:**
+
+Keep the chain on one line when it fits within the 140-character limit and uses a single
+validation call. Break with `\` continuation when the line would be too long, or when
+chaining more than one validation method.
+
+```gdscript
+# Preferred — fits on one line, single validation
+assert_bool(player.is_alive()).is_true()
+assert_str(player.name()).is_equal("Hero")
+
+# Preferred — break because the line would exceed 140 characters
+assert_str(player.get_full_description()) \
+    .is_equal("Hero the Brave, level 42, wielder of the Sword of Destiny")
+
+# Preferred — break because multiple validations are chained
+assert_str(player.name()) \
+    .is_not_empty() \
+    .starts_with("H") \
+    .is_equal("Hero")
+
+# Avoid — unnecessary break for a short single-validation chain
+assert_bool(player.is_alive()) \
+    .is_true()
+```
+
 **Core assert functions and chaining:**
 
 ```gdscript
@@ -69,7 +137,50 @@ assert_object(value).is_instanceof(MyClass)
 assert_that(value).is_null()
 assert_that(value).is_equal(expected)
 assert_that(value).is_instanceof(Node)
+```
 
+**Object equality — prefer whole-object comparison:**
+
+`assert_that(obj).is_equal(expected)` uses deep property comparison (`GdObjects.equals`), so
+always prefer it over asserting fields one by one. Field-by-field assertions are harder to
+read, require more maintenance, and produce worse failure messages.
+
+```gdscript
+# Preferred — compare the full result to an expected object in one assertion
+var result := Player.new("Hero", 100, Vector3(1, 2, 3))
+assert_that(result).is_equal(Player.new("Hero", 100, Vector3(1, 2, 3)))
+
+# Avoid — noisy, fragile, easy to miss a property
+assert_str(result.name).is_equal("Hero")
+assert_int(result.health).is_equal(100)
+assert_that(result.position).is_equal(Vector3(1, 2, 3))
+```
+
+Only fall back to field-by-field when you intentionally want to verify a single property
+in isolation, or when the expected object cannot be constructed easily.
+
+**Inline expected values — avoid unnecessary variables:**
+
+Put the expected value directly in the assertion unless the line would exceed the 140-character
+limit. An extra `var expected` adds noise without adding clarity.
+
+```gdscript
+# Preferred — expected value inline
+assert_str(player.name()).is_equal("Hero")
+assert_that(result).is_equal(Player.new("Hero", 100, Vector3(1, 2, 3)))
+
+# Accepted — variable needed to stay within the 140-character line limit
+var expected := Player.new(
+    "Hero", 100, Vector3(1, 2, 3), ["sword", "shield"], {"speed": 5.0}
+)
+assert_that(result).is_equal(expected)
+
+# Avoid — variable adds no value when the expression fits on one line
+var expected_name := "Hero"
+assert_str(player.name()).is_equal(expected_name)
+```
+
+```gdscript
 # Arrays
 assert_array(value).is_not_empty()
 assert_array(value).has_size(3).contains(1, 2)


### PR DESCRIPTION
# Why
Establish consistent test writing conventions so Claude Code and contributors follow the same patterns when writing GdUnit4 tests.

# What
- Type-specific assert dispatch table (`assert_bool` / `assert_int` / `assert_str` / `assert_dict` / `assert_array` / `assert_that`)
- Rule to infer the correct assert from the value type (explicit annotation, `:=` inference, or function return type)
- Fluent chain breaking: only when exceeding 140 chars or chaining more than one validation call
- Object equality: prefer `assert_that(result).is_equal(expected)` over field-by-field assertions
- Inline expected values: avoid `var expected` when the expression fits on one line within the line limit