### PR TITLE
GD-1133: Serialize and deserialize stack trace in GdUnitReport

### DIFF
--- a/addons/gdUnit4/src/core/GdUnitStackTrace.gd
+++ b/addons/gdUnit4/src/core/GdUnitStackTrace.gd
@@ -30,6 +30,25 @@ func print_stack_trace() -> String:
 	return output
 
 
+## Serializes the stack trace to a JSON string.
+func serialize() -> String:
+	var frames: Array[Dictionary] = []
+	for frame in _stack_trace:
+		frames.append({"source": frame._source, "line": frame._line, "function": frame._function})
+	return JSON.stringify(frames)
+
+
+## Reconstructs a [GdUnitStackTrace] from a JSON string produced by [method serialize].
+static func deserialize(json: String) -> GdUnitStackTrace:
+	var data: Variant = JSON.parse_string(json)
+	if not data is Array:
+		return GdUnitStackTrace.of([])
+	var frames: Array[GdUnitStackTraceElement] = []
+	for frame_data: Dictionary in data:
+		frames.append(GdUnitStackTraceElement.of(frame_data))
+	return GdUnitStackTrace.of(frames)
+
+
 ## Creates a [GdUnitStackTrace] from an existing array of [GdUnitStackTraceElement] frames.[br]
 ## Useful for constructing expected stack traces in assertions.
 static func of(stack_trace: Array[GdUnitStackTraceElement]) -> GdUnitStackTrace:

--- a/addons/gdUnit4/src/core/GdUnitStackTraceElement.gd
+++ b/addons/gdUnit4/src/core/GdUnitStackTraceElement.gd
@@ -19,6 +19,14 @@ func _init(source: String, line: int, function: String) -> void:
 	_function = function
 
 
+## Creates a [GdUnitStackTraceElement] from a dictionary with keys [code]source[/code], [code]line[/code], and [code]function[/code].
+static func of(data: Dictionary) -> GdUnitStackTraceElement:
+	var source: String = data["source"]
+	var line: int = data["line"]
+	var function: String = data["function"]
+	return GdUnitStackTraceElement.new(source, line, function)
+
+
 ## Returns a human-readable representation in the form [code]basename.function(file:line)[/code].
 func _to_string() -> String:
 	return "%s.%s(%s:%d)" % [_source.get_basename(), _function, _source.get_file(), _line]

--- a/addons/gdUnit4/src/core/report/GdUnitReport.gd
+++ b/addons/gdUnit4/src/core/report/GdUnitReport.gd
@@ -72,6 +72,12 @@ func is_orphan() -> bool:
 	return _type == ORPHAN
 
 
+func stack_trace() -> GdUnitStackTrace:
+	if _error == null:
+		return null
+	return _error._stack_trace
+
+
 func _to_string() -> String:
 	if _line_number == -1:
 		return "[color=green]line [/color][color=aqua]<n/a>:[/color] %s" % [_message]
@@ -79,15 +85,23 @@ func _to_string() -> String:
 
 
 func serialize() -> Dictionary:
-	return {
-		"type"        :_type,
-		"line_number" :_line_number,
-		"message"     :_message
+	var serialized := {
+		"type"        : _type,
+		"line_number" : _line_number,
+		"message"     : _message
 	}
+	var trace := stack_trace()
+	if trace != null:
+		serialized["stack_trace"] = trace.serialize()
+	return serialized
 
 
-func deserialize(serialized :Dictionary) -> GdUnitReport:
+func deserialize(serialized: Dictionary) -> GdUnitReport:
 	_type        = serialized["type"]
 	_line_number = serialized["line_number"]
 	_message     = serialized["message"]
+	if serialized.has("stack_trace"):
+		@warning_ignore("unsafe_cast")
+		var trace := GdUnitStackTrace.deserialize(serialized["stack_trace"] as String)
+		_error = GdUnitError.new(_message, _line_number, trace)
 	return self

--- a/addons/gdUnit4/test/asserts/GdUnitFailureAssertImplTest.gd
+++ b/addons/gdUnit4/test/asserts/GdUnitFailureAssertImplTest.gd
@@ -77,3 +77,41 @@ func test_assert_failure_on_assert_result() -> void:
 	var  instance := assert_failure(func() -> void: assert_result(null))
 	assert_object(last_assert()).is_instanceof(GdUnitResultAssert)
 	assert_object(instance).is_instanceof(GdUnitFailureAssert)
+
+
+#region has_stack_trace
+
+func _stack_fail_1() -> void:
+	assert_bool(true).is_false()
+
+
+func _stack_fail_2() -> void:
+	_stack_fail_1()
+
+
+func _stack_fail_3() -> void:
+	_stack_fail_2()
+
+
+func test_has_stack_trace_depth_1() -> void:
+	assert_failure(_stack_fail_1) \
+		.is_failed() \
+		.has_message("Expecting: 'false' but is 'true'") \
+		.has_stack_trace([
+			GdUnitStackTraceElement.new("res://addons/gdUnit4/test/asserts/GdUnitFailureAssertImplTest.gd", 85, "_stack_fail_1"),
+			GdUnitStackTraceElement.new("res://addons/gdUnit4/test/asserts/GdUnitFailureAssertImplTest.gd", 97, "test_has_stack_trace_depth_1"),
+		])
+
+
+func test_has_stack_trace_depth_3() -> void:
+	assert_failure(_stack_fail_3) \
+		.is_failed() \
+		.has_message("Expecting: 'false' but is 'true'") \
+		.has_stack_trace([
+			GdUnitStackTraceElement.new("res://addons/gdUnit4/test/asserts/GdUnitFailureAssertImplTest.gd", 85, "_stack_fail_1"),
+			GdUnitStackTraceElement.new("res://addons/gdUnit4/test/asserts/GdUnitFailureAssertImplTest.gd", 89, "_stack_fail_2"),
+			GdUnitStackTraceElement.new("res://addons/gdUnit4/test/asserts/GdUnitFailureAssertImplTest.gd", 93, "_stack_fail_3"),
+			GdUnitStackTraceElement.new("res://addons/gdUnit4/test/asserts/GdUnitFailureAssertImplTest.gd", 107, "test_has_stack_trace_depth_3"),
+		])
+
+#endregion

--- a/addons/gdUnit4/test/core/GdUnitStackTraceElementTest.gd
+++ b/addons/gdUnit4/test/core/GdUnitStackTraceElementTest.gd
@@ -1,0 +1,13 @@
+# GdUnit generated TestSuite
+extends GdUnitTestSuite
+@warning_ignore('unused_parameter')
+@warning_ignore('return_value_discarded')
+
+# TestSuite generated from
+const __source = 'res://addons/gdUnit4/src/core/GdUnitStackTraceElement.gd'
+
+
+func test_of_creates_element_from_dict() -> void:
+	var data := {"source": "res://test.gd", "line": 42, "function": "my_func"}
+	assert_that(GdUnitStackTraceElement.of(data)) \
+		.is_equal(GdUnitStackTraceElement.new("res://test.gd", 42, "my_func"))

--- a/addons/gdUnit4/test/core/GdUnitStackTraceElementTest.gd
+++ b/addons/gdUnit4/test/core/GdUnitStackTraceElementTest.gd
@@ -1,0 +1,13 @@
+# GdUnit generated TestSuite
+extends GdUnitTestSuite
+@warning_ignore('unused_parameter')
+@warning_ignore('return_value_discarded')
+
+# TestSuite generated from
+const __source = 'res://addons/gdUnit4/src/core/GdUnitStackTraceElement.gd'
+
+
+func test_of_creates_element_from_dict() -> void:
+	var data := {"source": "res://test.gd", "line": 42, "function": "my_func"}
+	assert_that(GdUnitStackTraceElement.of(data)) \
+		.is_equal(GdUnitStackTraceElement.new("res://test.gd", 42, "my_funsc"))

--- a/addons/gdUnit4/test/core/GdUnitStackTraceTest.gd
+++ b/addons/gdUnit4/test/core/GdUnitStackTraceTest.gd
@@ -137,3 +137,40 @@ func test_inner_class_frames_in_stack_trace() -> void:
 			""".dedent().indent("\t").trim_prefix("\n"))
 
 #endregion
+
+
+#region serialize / deserialize
+
+func test_serialize_empty_trace_returns_empty_json_array() -> void:
+	var trace := GdUnitStackTrace.of([])
+	assert_str(trace.serialize()).is_equal("[]")
+
+
+func test_serialize_returns_json_string() -> void:
+	var trace := GdUnitStackTrace.of([
+		GdUnitStackTraceElement.new("res://test.gd", 10, "func_a"),
+		GdUnitStackTraceElement.new("res://test.gd", 20, "func_b"),
+	])
+	var json := trace.serialize()
+	assert_str(json)\
+		.is_not_empty()\
+		.is_equal('[{"function":"func_a","line":10,"source":"res://test.gd"},{"function":"func_b","line":20,"source":"res://test.gd"}]')
+
+
+func test_deserialize_reconstructs_frames() -> void:
+	var json := '[{"source":"res://test.gd","line":10,"function":"func_a"},{"source":"res://test.gd","line":20,"function":"func_b"}]'
+	var trace := GdUnitStackTrace.deserialize(json)
+	assert_that(trace).is_equal(GdUnitStackTrace.of([
+		GdUnitStackTraceElement.new("res://test.gd", 10, "func_a"),
+		GdUnitStackTraceElement.new("res://test.gd", 20, "func_b"),
+	]))
+
+
+func test_serialize_deserialize_round_trip() -> void:
+	var original := GdUnitStackTrace.of([
+		GdUnitStackTraceElement.new("res://my_test.gd", 42, "check_value"),
+		GdUnitStackTraceElement.new("res://my_test.gd", 55, "run_suite"),
+	])
+	var restored := GdUnitStackTrace.deserialize(original.serialize())
+	assert_that(restored).is_equal(original)
+#endregion

--- a/addons/gdUnit4/test/core/report/GdUnitReportTest.gd
+++ b/addons/gdUnit4/test/core/report/GdUnitReportTest.gd
@@ -1,0 +1,94 @@
+# GdUnit generated TestSuite
+class_name GdUnitReportTest
+extends GdUnitTestSuite
+@warning_ignore('unused_parameter')
+@warning_ignore('return_value_discarded')
+
+# TestSuite generated from
+const __source = 'res://addons/gdUnit4/src/core/report/GdUnitReport.gd'
+
+
+#region _to_string
+
+func test_to_string_failure_with_line_number() -> void:
+	var report := GdUnitReport.new().create(GdUnitReport.FAILURE, 42, "test message")
+	assert_str(report.to_string()).is_equal("[color=green]line [/color][color=aqua]42:[/color] test message")
+
+
+func test_to_string_failure_with_unknown_line() -> void:
+	var report := GdUnitReport.new().create(GdUnitReport.FAILURE, -1, "test message")
+	assert_str(report.to_string()).is_equal("[color=green]line [/color][color=aqua]<n/a>:[/color] test message")
+
+#endregion
+
+
+#region stack_trace
+
+func test_stack_trace_is_null_when_no_error() -> void:
+	var report := GdUnitReport.new().create(GdUnitReport.FAILURE, 42, "test message")
+	assert_that(report.stack_trace()).is_null()
+
+
+func test_stack_trace_returns_trace_from_error() -> void:
+	var trace := GdUnitStackTrace.of([
+		GdUnitStackTraceElement.new("res://test.gd", 10, "func_a"),
+		GdUnitStackTraceElement.new("res://test.gd", 20, "func_b"),
+	])
+	var report := GdUnitReport.new().from_error(GdUnitReport.FAILURE, GdUnitError.new("test message", 10, trace))
+	assert_that(report.stack_trace()).is_equal(trace)
+
+#endregion
+
+
+#region serialize / deserialize
+
+func test_serialize_report_contains_all_base_fields() -> void:
+	var serialized := GdUnitReport.new().create(GdUnitReport.FAILURE, 42, "test message").serialize()
+	assert_dict(serialized) \
+		.contains_key_value("type", GdUnitReport.FAILURE) \
+		.contains_key_value("line_number", 42) \
+		.contains_key_value("message", "test message")
+
+
+func test_serialize_report_without_error_has_no_stack_trace_key() -> void:
+	var report := GdUnitReport.new().create(GdUnitReport.FAILURE, 42, "test message")
+	assert_bool(report.serialize().has("stack_trace")).is_false()
+
+
+func test_serialize_report_with_error_includes_stack_trace_key() -> void:
+	var trace := GdUnitStackTrace.of([
+		GdUnitStackTraceElement.new("res://test.gd", 10, "func_a"),
+	])
+	var serialized := GdUnitReport.new().from_error(GdUnitReport.FAILURE, GdUnitError.new("test message", 10, trace)).serialize()
+	assert_dict(serialized).contains_key_value("stack_trace", trace.serialize())
+
+
+func test_deserialize_without_stack_trace_produces_full_report() -> void:
+	var serialized := {"type": GdUnitReport.FAILURE, "line_number": 42, "message": "test message"}
+	assert_that(GdUnitReport.new().deserialize(serialized)).is_equal(GdUnitReport.new().create(GdUnitReport.FAILURE, 42, "test message"))
+
+
+func test_deserialize_reconstructs_full_report() -> void:
+	var trace := GdUnitStackTrace.of([
+		GdUnitStackTraceElement.new("res://my_test.gd", 10, "func_a"),
+		GdUnitStackTraceElement.new("res://my_test.gd", 20, "func_b"),
+	])
+	var expected := GdUnitReport.new().from_error(GdUnitReport.FAILURE, GdUnitError.new("test message", 10, trace))
+	var serialized := {
+		"type": GdUnitReport.FAILURE,
+		"line_number": 10,
+		"message": "test message",
+		"stack_trace": trace.serialize()
+	}
+	assert_that(GdUnitReport.new().deserialize(serialized)).is_equal(expected)
+
+
+func test_serialize_deserialize_round_trip_preserves_full_report() -> void:
+	var original := GdUnitReport.new().from_error(GdUnitReport.FAILURE,
+		GdUnitError.new("test message", 42, GdUnitStackTrace.of([
+			GdUnitStackTraceElement.new("res://my_test.gd", 42, "check_value"),
+			GdUnitStackTraceElement.new("res://my_test.gd", 55, "run_suite"),
+		])))
+	assert_that(GdUnitReport.new().deserialize(original.serialize())).is_equal(original)
+
+#endregion


### PR DESCRIPTION
# Why
The stack trace captured at assertion failure time was lost during TCP transport because `GdUnitReport.serialize()` / `deserialize()` never included it. As a result `_error` was always `null` on the receiving side and stack trace visualization had no data to display.

# What
- `GdUnitStackTraceElement`: add `static of(Dictionary)` factory used by the deserializer
- `GdUnitStackTrace`: add `serialize() -> String` (JSON) and `static deserialize(String)` so the trace owns its own wire format
- `GdUnitReport`: `serialize()` writes `"stack_trace"` JSON string when a trace is present; `deserialize()` reconstructs `GdUnitError` + `GdUnitStackTrace` from it — backward compatible (missing key leaves `_error` null as before)
- Tests: `GdUnitStackTraceElementTest`, `GdUnitStackTraceTest` serde region, `GdUnitReportTest` serde region, `GdUnitFailureAssertImplTest` `has_stack_trace` region