### PR TITLE
TASK-1133: Render assertion stack traces in the Inspector report panel

### DIFF
--- a/addons/gdUnit4/src/core/GdUnitStackTrace.gd
+++ b/addons/gdUnit4/src/core/GdUnitStackTrace.gd
@@ -15,6 +15,11 @@ func _to_string() -> String:
 	return "\n".join(_stack_trace)
 
 
+## Returns all frames in the stack trace, ordered innermost first.
+func get_frames() -> Array[GdUnitStackTraceElement]:
+	return _stack_trace
+
+
 ## Returns the line number of the topmost frame, or [code]-1[/code] if the stack trace is empty.
 func get_line_number() -> int:
 	if _stack_trace.is_empty():

--- a/addons/gdUnit4/src/reporters/console/GdUnitConsoleTestReporter.gd
+++ b/addons/gdUnit4/src/reporters/console/GdUnitConsoleTestReporter.gd
@@ -19,9 +19,6 @@ var _writer: GdUnitMessageWriter
 var _reporter: GdUnitTestReporter = GdUnitTestReporter.new()
 var _status_indent := 86
 var _detailed: bool
-var _text_color: Color = Color.ANTIQUE_WHITE
-var _function_color: Color = Color.ANTIQUE_WHITE
-var _engine_type_color: Color = Color.ANTIQUE_WHITE
 
 
 func _init(writer: GdUnitMessageWriter, detailed := false) -> void:
@@ -30,15 +27,6 @@ func _init(writer: GdUnitMessageWriter, detailed := false) -> void:
 	_detailed = detailed
 	if _detailed:
 		_status_indent = 20
-	init_colors()
-
-
-func init_colors() -> void:
-	if Engine.is_editor_hint():
-		var settings := EditorInterface.get_editor_settings()
-		_text_color = settings.get_setting("text_editor/theme/highlighting/text_color")
-		_function_color = settings.get_setting("text_editor/theme/highlighting/function_color")
-		_engine_type_color = settings.get_setting("text_editor/theme/highlighting/engine_type_color")
 
 
 func clear() -> void:
@@ -61,13 +49,13 @@ func on_gdunit_event(event: GdUnitEvent) -> void:
 		GdUnitEvent.TESTSUITE_BEFORE:
 			_reporter.init_statistics()
 			print_message("Run Test Suite: ", Color.DARK_TURQUOISE)
-			println_message(event.resource_path(), _engine_type_color)
+			println_message(event.resource_path(), GdUnitEditorColorTheme.engine_type_color)
 
 		GdUnitEvent.TESTSUITE_AFTER:
 			if not event.reports().is_empty():
-				_writer.indent(1).color(_engine_type_color).print_message(event._suite_name)
+				_writer.indent(1).color(GdUnitEditorColorTheme.engine_type_color).print_message(event._suite_name)
 				print_message(" > ")
-				print_message("finalize()", _function_color)
+				print_message("finalize()", GdUnitEditorColorTheme.function_definition_color)
 				_print_failure_report(event.reports())
 			_print_statistics(_reporter.build_test_suite_statisitcs(event))
 			_print_status(event)
@@ -96,13 +84,13 @@ func on_gdunit_event(event: GdUnitEvent) -> void:
 func _print_test_path(test: GdUnitTestCase, uid: GdUnitGUID) -> void:
 	if test == null:
 		prints_warning("Can't print full test info, the test by uid: '%s' was not discovered." % uid)
-		_writer.indent(1).color(_engine_type_color).print_message("Test ID: %s" % uid)
+		_writer.indent(1).color(GdUnitEditorColorTheme.engine_type_color).print_message("Test ID: %s" % uid)
 		return
 
 	var suite_name := test.source_file if _detailed else test.suite_name
-	_writer.indent(1).color(_engine_type_color).print_message(suite_name)
+	_writer.indent(1).color(GdUnitEditorColorTheme.engine_type_color).print_message(suite_name)
 	print_message(" > ")
-	print_message(test.display_name, _function_color)
+	print_message(test.display_name, GdUnitEditorColorTheme.function_definition_color)
 
 
 func _print_status(event: GdUnitEvent) -> void:
@@ -187,11 +175,11 @@ func build_executed_test_case_msg(total_count: int, p_skipped_count: int) -> Str
 	return "Executed test cases : (%d/%d), %d skipped" % [total_count - p_skipped_count, total_count, p_skipped_count]
 
 
-func print_message(message: String, color: Color = _text_color) -> void:
+func print_message(message: String, color: Color = GdUnitEditorColorTheme.text_color) -> void:
 	_writer.color(color).print_message(message)
 
 
-func println_message(message: String, color: Color = _text_color) -> void:
+func println_message(message: String, color: Color = GdUnitEditorColorTheme.text_color) -> void:
 	_writer.color(color).println_message(message)
 
 

--- a/addons/gdUnit4/src/ui/GdUnitConsole.gd
+++ b/addons/gdUnit4/src/ui/GdUnitConsole.gd
@@ -24,8 +24,6 @@ func _ready() -> void:
 
 
 func _notification(what: int) -> void:
-	if what == EditorSettings.NOTIFICATION_EDITOR_SETTINGS_CHANGED:
-		_test_reporter.init_colors()
 	if what == NOTIFICATION_PREDELETE:
 		var instance := GdUnitSignals.instance()
 		if instance.gdunit_event.is_connected(_on_gdunit_event):

--- a/addons/gdUnit4/src/ui/GdUnitInspector.gd
+++ b/addons/gdUnit4/src/ui/GdUnitInspector.gd
@@ -1,6 +1,6 @@
 @tool
 class_name GdUnitInspecor
-extends Panel
+extends PanelContainer
 
 
 var _command_handler := GdUnitCommandHandler.instance()
@@ -25,6 +25,8 @@ func _ready() -> void:
 	# propagete the test_counters_changed signal to the progress bar
 	@warning_ignore("unsafe_property_access", "unsafe_method_access")
 	%MainPanel.test_counters_changed.connect(%ProgressBar._on_test_counter_changed)
+	# Register for editor theme updates
+	add_child(GdUnitEditorColorTheme.new(), true, Node.INTERNAL_MODE_BACK)
 
 
 func _process(delta: float) -> void:

--- a/addons/gdUnit4/src/ui/GdUnitInspector.tscn
+++ b/addons/gdUnit4/src/ui/GdUnitInspector.tscn
@@ -1,62 +1,59 @@
-[gd_scene load_steps=8 format=3 uid="uid://mpo5o6d4uybu"]
+[gd_scene format=3 uid="uid://mpo5o6d4uybu"]
 
 [ext_resource type="PackedScene" path="res://addons/gdUnit4/src/ui/parts/InspectorToolBar.tscn" id="1"]
+[ext_resource type="Script" path="res://addons/gdUnit4/src/ui/GdUnitInspector.gd" id="1_j37cs"]
 [ext_resource type="PackedScene" path="res://addons/gdUnit4/src/ui/parts/InspectorProgressBar.tscn" id="2"]
 [ext_resource type="PackedScene" path="res://addons/gdUnit4/src/ui/parts/InspectorStatusBar.tscn" id="3"]
 [ext_resource type="PackedScene" path="res://addons/gdUnit4/src/ui/parts/InspectorMonitor.tscn" id="4"]
-[ext_resource type="Script" path="res://addons/gdUnit4/src/ui/GdUnitInspector.gd" id="5"]
 [ext_resource type="PackedScene" path="res://addons/gdUnit4/src/ui/parts/InspectorTreePanel.tscn" id="7"]
 [ext_resource type="PackedScene" path="res://addons/gdUnit4/src/network/GdUnitServer.tscn" id="7_721no"]
 
-[node name="GdUnit" type="Panel"]
-use_parent_material = true
+[node name="GdUnit" type="PanelContainer" unique_id=1659901582]
 clip_contents = true
 anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
-size_flags_horizontal = 11
+grow_horizontal = 2
+grow_vertical = 2
+size_flags_horizontal = 3
 size_flags_vertical = 3
 focus_mode = 2
-script = ExtResource("5")
+script = ExtResource("1_j37cs")
 
-[node name="VBoxContainer" type="VBoxContainer" parent="."]
-use_parent_material = true
+[node name="VBoxContainer" type="VBoxContainer" parent="." unique_id=1550259230]
 clip_contents = true
-layout_mode = 0
-anchor_right = 1.0
-anchor_bottom = 1.0
+layout_mode = 2
 size_flags_vertical = 11
 theme_override_constants/separation = 0
 
-[node name="Header" type="VBoxContainer" parent="VBoxContainer"]
+[node name="Header" type="VBoxContainer" parent="VBoxContainer" unique_id=876343251]
 use_parent_material = true
 clip_contents = true
 layout_mode = 2
-size_flags_horizontal = 9
 size_flags_vertical = 0
 
-[node name="ToolBar" parent="VBoxContainer/Header" instance=ExtResource("1")]
+[node name="ToolBar" parent="VBoxContainer/Header" unique_id=185399834 instance=ExtResource("1")]
 layout_mode = 2
-size_flags_vertical = 1
 
-[node name="ProgressBar" parent="VBoxContainer/Header" instance=ExtResource("2")]
+[node name="ProgressBar" parent="VBoxContainer/Header" unique_id=360281822 instance=ExtResource("2")]
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 5
 max_value = 0.0
 
-[node name="StatusBar" parent="VBoxContainer/Header" instance=ExtResource("3")]
+[node name="StatusBar" parent="VBoxContainer/Header" unique_id=625414847 instance=ExtResource("3")]
 layout_mode = 2
 size_flags_horizontal = 11
 
-[node name="MainPanel" parent="VBoxContainer" instance=ExtResource("7")]
+[node name="MainPanel" parent="VBoxContainer" unique_id=1133307707 instance=ExtResource("7")]
 unique_name_in_owner = true
+clip_contents = true
 layout_mode = 2
 
-[node name="Monitor" parent="VBoxContainer" instance=ExtResource("4")]
+[node name="Monitor" parent="VBoxContainer" unique_id=1419900107 instance=ExtResource("4")]
 layout_mode = 2
 
-[node name="event_server" parent="." instance=ExtResource("7_721no")]
+[node name="event_server" parent="." unique_id=756999253 instance=ExtResource("7_721no")]
 
 [connection signal="select_error_next" from="VBoxContainer/Header/StatusBar" to="VBoxContainer/MainPanel" method="_on_select_next_item_by_state" binds= [7]]
 [connection signal="select_error_prevous" from="VBoxContainer/Header/StatusBar" to="VBoxContainer/MainPanel" method="_on_select_previous_item_by_state" binds= [7]]

--- a/addons/gdUnit4/src/ui/parts/GdUnitReportPanel.gd
+++ b/addons/gdUnit4/src/ui/parts/GdUnitReportPanel.gd
@@ -1,0 +1,56 @@
+@tool
+class_name GdUnitReportPanel
+extends Panel
+
+@onready var report_list: Node = %report_list
+@onready var message_template: RichTextLabel = %message
+
+
+func clear() -> void:
+	for child in report_list.get_children():
+		report_list.remove_child(child)
+		child.queue_free()
+
+
+func show_report(reports: Array[GdUnitReport]) -> void:
+	clear()
+	for report in reports:
+		report_list.add_child(build_report(report))
+
+
+func build_report(report: GdUnitReport) -> RichTextLabel:
+	var message: RichTextLabel = message_template.duplicate()
+	message.push_color(GdUnitEditorColorTheme.text_color)
+	message.append_text(report.message())
+	message.pop()
+	add_stack_trace(message, report.stack_trace())
+	message.visible = true
+	return message
+
+
+func add_stack_trace(message: RichTextLabel, trace: GdUnitStackTrace) -> void:
+	message.newline()
+	for frame in trace.get_frames():
+		message.push_indent(1)
+		message.push_meta(frame, RichTextLabel.META_UNDERLINE_ON_HOVER, frame._source)
+		message.push_color(GdUnitEditorColorTheme.text_color)
+		message.append_text("at ")
+		message.push_color(GdUnitEditorColorTheme.function_definition_color)
+		message.append_text(frame._function)
+		message.pop()
+		message.append_text(" in ")
+		message.pop()
+
+		message.push_color(GdUnitEditorColorTheme.engine_type_color)
+		message.append_text(frame._source.get_file())
+		message.append_text(" : ")
+		message.append_text(str(frame._line))
+		message.pop()
+		message.pop() # hint
+		message.pop()
+		message.newline()
+	message.meta_clicked.connect(_on_meta_clicked)
+
+
+func _on_meta_clicked(meta: Variant) -> void:
+	print_debug("TODO: implement jump to source", "_on_meta_clicked", meta)

--- a/addons/gdUnit4/src/ui/parts/GdUnitReportPanel.tscn
+++ b/addons/gdUnit4/src/ui/parts/GdUnitReportPanel.tscn
@@ -1,0 +1,47 @@
+[gd_scene format=3 uid="uid://dga8nhaxnyr53"]
+
+[ext_resource type="Script" path="res://addons/gdUnit4/src/ui/parts/GdUnitReportPanel.gd" id="1_w8qy0"]
+
+[node name="report" type="Panel" unique_id=1075065511]
+clip_contents = true
+custom_minimum_size = Vector2(120, 80)
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
+script = ExtResource("1_w8qy0")
+
+[node name="message" type="RichTextLabel" parent="." unique_id=1680360176]
+unique_name_in_owner = true
+auto_translate_mode = 2
+visible = false
+layout_mode = 0
+size_flags_horizontal = 3
+size_flags_vertical = 3
+focus_mode = 2
+mouse_filter = 1
+bbcode_enabled = true
+fit_content = true
+autowrap_mode = 0
+selection_enabled = true
+
+[node name="ScrollContainer" type="ScrollContainer" parent="." unique_id=385317760]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+size_flags_vertical = 3
+
+[node name="report_list" type="VBoxContainer" parent="ScrollContainer" unique_id=1467163528]
+unique_name_in_owner = true
+clip_contents = true
+custom_minimum_size = Vector2(120, 0)
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 2
+theme_override_constants/separation = 2

--- a/addons/gdUnit4/src/ui/parts/InspectorTreeMainPanel.gd
+++ b/addons/gdUnit4/src/ui/parts/InspectorTreeMainPanel.gd
@@ -1,15 +1,14 @@
 @tool
-extends VSplitContainer
+extends PanelContainer
 
 ## Will be emitted when the test index counter is changed
 signal test_counters_changed(index: int, total: int, state: GdUnitInspectorTreeConstants.STATE)
 signal tree_item_selected(item: TreeItem)
 
 
-@onready var _tree: Tree = $Panel/Tree
-@onready var _report_list: Node = $report/ScrollContainer/list
-@onready var _report_template: RichTextLabel = $report/report_template
-@onready var _context_menu: GdUnitInspectorContextMenu = $contextMenu
+@onready var _tree: Tree = %Tree
+@onready var _report_panel: GdUnitReportPanel = %report
+@onready var _context_menu: GdUnitInspectorContextMenu = %contextMenu
 @onready var _discover_hint: Control = %discover_hint
 @onready var _spinner: Button = %spinner
 
@@ -235,7 +234,7 @@ func init_tree() -> void:
 
 
 func cleanup_tree() -> void:
-	clear_reports()
+	_report_panel.clear()
 	if not _tree_root:
 		return
 	_free_recursive()
@@ -732,26 +731,6 @@ func select_first_orphan() -> void:
 					return
 
 
-func clear_reports() -> void:
-	for child in _report_list.get_children():
-		_report_list.remove_child(child)
-		child.queue_free()
-
-
-func show_failed_report(selected_item: TreeItem) -> void:
-	clear_reports()
-	if selected_item == null or not selected_item.has_meta(META_GDUNIT_REPORT):
-		return
-	# add new reports
-	for report in get_item_reports(selected_item):
-		var reportNode: RichTextLabel = _report_template.duplicate()
-		_report_list.add_child(reportNode)
-		reportNode.push_color(Color.DARK_TURQUOISE)
-		reportNode.append_text(report.to_string())
-		reportNode.pop()
-		reportNode.visible = true
-
-
 func update_test_suite(event: GdUnitEvent) -> void:
 	var item := _find_tree_item_by_test_suite(_tree_root, event.resource_path(), event.suite_name())
 	if not item:
@@ -1055,6 +1034,8 @@ func on_test_case_discover_modified(test_case: GdUnitTestCase) -> void:
 
 
 func get_item_reports(item: TreeItem) -> Array[GdUnitReport]:
+	if item == null or not item.has_meta(META_GDUNIT_REPORT):
+		return []
 	return item.get_meta(META_GDUNIT_REPORT)
 
 
@@ -1112,7 +1093,7 @@ func collect_test_cases(item: TreeItem, tests: Array[GdUnitTestCase] = []) -> Ar
 func test_session_start() -> void:
 	_context_menu.disable_items()
 	reset_tree_state(_tree_root)
-	clear_reports()
+	_report_panel.clear()
 
 
 func test_session_stop() -> void:
@@ -1136,7 +1117,8 @@ func _on_tree_item_mouse_selected(mouse_position: Vector2, mouse_button_index: i
 
 func _on_Tree_item_selected() -> void:
 	_current_selected_item = _tree.get_selected()
-	show_failed_report(_current_selected_item)
+	var reports := get_item_reports(_current_selected_item)
+	_report_panel.show_report(reports)
 	tree_item_selected.emit(_current_selected_item)
 
 

--- a/addons/gdUnit4/src/ui/parts/InspectorTreePanel.tscn
+++ b/addons/gdUnit4/src/ui/parts/InspectorTreePanel.tscn
@@ -2,6 +2,7 @@
 
 [ext_resource type="Script" path="res://addons/gdUnit4/src/ui/parts/InspectorTreeMainPanel.gd" id="1"]
 [ext_resource type="PackedScene" path="res://addons/gdUnit4/src/ui/menu/GdUnitInspectorContextMenu.tscn" id="2_o6s0p"]
+[ext_resource type="PackedScene" path="res://addons/gdUnit4/src/ui/parts/GdUnitReportPanel.tscn" id="3_miuuy"]
 
 [sub_resource type="DPITexture" id="DPITexture_miuuy"]
 _source = "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"16\" height=\"16\"><path fill=\"#e0e0e0\" d=\"M4 12a1 1 0 0 0 1.555.832l6-4a1 1 0 0 0 0-1.664l-6-4A1 1 0 0 0 4 4z\"/></svg>
@@ -143,38 +144,51 @@ frame_6/duration = 0.2
 frame_7/texture = SubResource("DPITexture_pi1kv")
 frame_7/duration = 0.2
 
-[node name="MainPanel" type="VSplitContainer" unique_id=1044515559]
-use_parent_material = true
-clip_contents = true
+[node name="MainPanel" type="PanelContainer" unique_id=509541406]
+custom_minimum_size = Vector2(120, 400)
 anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
-offset_right = -924.0
+offset_right = -1032.0
+offset_bottom = -248.0
 grow_horizontal = 2
 grow_vertical = 2
 size_flags_horizontal = 3
 size_flags_vertical = 3
-split_offsets = PackedInt32Array(200)
-split_offset = 200
 script = ExtResource("1")
 
 [node name="contextMenu" parent="." unique_id=73764904 instance=ExtResource("2_o6s0p")]
+unique_name_in_owner = true
 visible = false
 item_0/icon = SubResource("DPITexture_miuuy")
 item_1/icon = SubResource("DPITexture_ern2r")
-item_2/text = "Run Tests Until Fail"
 item_2/icon = SubResource("DPITexture_miuuy")
 item_4/icon = SubResource("DPITexture_qdci2")
 item_5/icon = SubResource("DPITexture_hed0i")
 
-[node name="Panel" type="PanelContainer" parent="." unique_id=641912870]
+[node name="split" type="VSplitContainer" parent="." unique_id=1044515559]
+clip_contents = true
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
+theme_override_constants/autohide = 0
+split_offsets = PackedInt32Array(80)
+split_offset = 80
+
+[node name="Panel" type="Panel" parent="split" unique_id=290722553]
 layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 3
 
-[node name="Tree" type="Tree" parent="Panel" unique_id=741772884]
+[node name="Tree" type="Tree" parent="split/Panel" unique_id=741772884]
+unique_name_in_owner = true
 use_parent_material = true
-layout_mode = 2
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
 size_flags_horizontal = 3
 size_flags_vertical = 3
 theme_override_constants/icon_max_width = 16
@@ -184,14 +198,14 @@ allow_rmb_select = true
 hide_root = true
 select_mode = 1
 
-[node name="discover_hint" type="HBoxContainer" parent="Panel" unique_id=555683311]
+[node name="discover_hint" type="HBoxContainer" parent="split/Panel" unique_id=555683311]
 unique_name_in_owner = true
 visible = false
 use_parent_material = true
-layout_mode = 2
+layout_mode = 0
 alignment = 1
 
-[node name="spinner" type="Button" parent="Panel/discover_hint" unique_id=200472082]
+[node name="spinner" type="Button" parent="split/Panel/discover_hint" unique_id=200472082]
 unique_name_in_owner = true
 clip_contents = true
 custom_minimum_size = Vector2(64, 64)
@@ -204,37 +218,10 @@ icon = SubResource("AnimatedTexture_eor1x")
 flat = true
 alignment = 2
 
-[node name="report" type="PanelContainer" parent="." unique_id=503703488]
-clip_contents = true
+[node name="report" parent="split" unique_id=1465857421 instance=ExtResource("3_miuuy")]
+unique_name_in_owner = true
 layout_mode = 2
-size_flags_horizontal = 11
-size_flags_vertical = 11
 
-[node name="report_template" type="RichTextLabel" parent="report" unique_id=817912164]
-auto_translate_mode = 2
-use_parent_material = true
-clip_contents = false
-layout_mode = 2
-size_flags_horizontal = 3
-localize_numeral_system = false
-focus_mode = 2
-bbcode_enabled = true
-fit_content = true
-selection_enabled = true
-
-[node name="ScrollContainer" type="ScrollContainer" parent="report" unique_id=1479075289]
-use_parent_material = true
-custom_minimum_size = Vector2(0, 80)
-layout_mode = 2
-size_flags_horizontal = 3
-size_flags_vertical = 11
-
-[node name="list" type="VBoxContainer" parent="report/ScrollContainer" unique_id=1104634565]
-clip_contents = true
-layout_mode = 2
-size_flags_horizontal = 3
-size_flags_vertical = 3
-
-[connection signal="item_activated" from="Panel/Tree" to="." method="_on_Tree_item_activated"]
-[connection signal="item_mouse_selected" from="Panel/Tree" to="." method="_on_tree_item_mouse_selected"]
-[connection signal="item_selected" from="Panel/Tree" to="." method="_on_Tree_item_selected"]
+[connection signal="item_activated" from="split/Panel/Tree" to="." method="_on_Tree_item_activated"]
+[connection signal="item_mouse_selected" from="split/Panel/Tree" to="." method="_on_tree_item_mouse_selected"]
+[connection signal="item_selected" from="split/Panel/Tree" to="." method="_on_Tree_item_selected"]

--- a/addons/gdUnit4/src/ui/utils/GdUnitEditorColorTheme.gd
+++ b/addons/gdUnit4/src/ui/utils/GdUnitEditorColorTheme.gd
@@ -1,0 +1,28 @@
+## Provides editor theme colors sourced from [EditorSettings].
+## Add this node to the scene tree so it auto-refreshes colors when the
+## editor theme changes ([constant EditorSettings.NOTIFICATION_EDITOR_SETTINGS_CHANGED]).
+@tool
+class_name GdUnitEditorColorTheme
+extends Node
+
+
+static var text_color := Color.ANTIQUE_WHITE
+static var function_definition_color := Color.ANTIQUE_WHITE
+static var engine_type_color := Color.ANTIQUE_WHITE
+
+
+func _ready() -> void:
+	init_colors()
+
+
+func _notification(what: int) -> void:
+	if what == EditorSettings.NOTIFICATION_EDITOR_SETTINGS_CHANGED:
+		init_colors()
+
+
+func init_colors() -> void:
+	if Engine.is_editor_hint():
+		var settings := EditorInterface.get_editor_settings()
+		text_color =  settings.get_setting("text_editor/theme/highlighting/text_color")
+		function_definition_color = settings.get_setting("text_editor/theme/highlighting/gdscript/function_definition_color")
+		engine_type_color = settings.get_setting("text_editor/theme/highlighting/engine_type_color")

--- a/addons/gdUnit4/test/ui/parts/GdUnitReportPanelTest.gd
+++ b/addons/gdUnit4/test/ui/parts/GdUnitReportPanelTest.gd
@@ -1,0 +1,96 @@
+class_name GdUnitReportPanelTest
+extends GdUnitTestSuite
+
+
+var _panel: GdUnitReportPanel
+
+
+func before_test() -> void:
+	@warning_ignore("unsafe_method_access")
+	_panel = load("res://addons/gdUnit4/src/ui/parts/GdUnitReportPanel.tscn").instantiate()
+	add_child(_panel)
+
+
+func after_test() -> void:
+	remove_child(_panel)
+	_panel.free()
+
+
+func _build_report(message: String) -> GdUnitReport:
+	return _build_report_with_frames(message, [])
+
+
+func _build_report_with_frames(message: String, frames: Array[GdUnitStackTraceElement]) -> GdUnitReport:
+	return GdUnitReport.new().from_error(
+		GdUnitReport.FAILURE,
+		GdUnitError.new(message, 1, GdUnitStackTrace.of(frames))
+	)
+
+
+#region clear
+func test_clear_removes_all_report_children() -> void:
+	_panel.show_report([_build_report("a"), _build_report("b")])
+	_panel.clear()
+	assert_int(_panel.report_list.get_child_count()).is_equal(0)
+#endregion
+
+
+#region show_report
+func test_show_report_with_empty_list() -> void:
+	_panel.show_report([])
+	assert_int(_panel.report_list.get_child_count()).is_equal(0)
+
+
+func test_show_report_adds_one_child_per_report() -> void:
+	var reports: Array[GdUnitReport] = [
+		_build_report("failure A"),
+		_build_report("failure B"),
+		_build_report("failure C"),
+	]
+	_panel.show_report(reports)
+	assert_int(_panel.report_list.get_child_count()).is_equal(3)
+
+
+func test_show_report_replaces_previous_reports() -> void:
+	_panel.show_report([_build_report("first"), _build_report("second")])
+	_panel.show_report([_build_report("only")])
+	assert_int(_panel.report_list.get_child_count()).is_equal(1)
+#endregion
+
+
+#region build_report
+func test_build_report_label_is_visible() -> void:
+	var label: RichTextLabel = auto_free(_panel.build_report(_build_report("test message")))
+	assert_bool(label.visible).is_true()
+
+
+func test_build_report_parsed_text_contains_message() -> void:
+	var label: RichTextLabel = auto_free(_panel.build_report(_build_report("expected failure text")))
+	assert_str(label.get_parsed_text()).contains("expected failure text")
+
+
+func test_build_report_with_stack_depth_of_1() -> void:
+	var frames: Array[GdUnitStackTraceElement] = [
+		GdUnitStackTraceElement.new("res://test/MyTest.gd", 42, "test_foo"),
+	]
+	var label: RichTextLabel = auto_free(_panel.build_report(_build_report_with_frames("assertion failed", frames)))
+	assert_str(label.get_parsed_text()).is_equal("""
+		assertion failed
+			at test_foo in MyTest.gd : 42
+		""".dedent().trim_prefix("\n"))
+
+
+func test_build_report_with_stack_depth_of_3() -> void:
+	var frames: Array[GdUnitStackTraceElement] = [
+		GdUnitStackTraceElement.new("res://test/MyTest.gd", 42, "test_foo"),
+		GdUnitStackTraceElement.new("res://suite/TestSuiteA.gd", 10, "before_test"),
+		GdUnitStackTraceElement.new("res://runner/TestRunner.gd", 5, "run"),
+	]
+	var label: RichTextLabel = auto_free(_panel.build_report(_build_report_with_frames("assertion failed", frames)))
+	assert_str(label.get_parsed_text()).is_equal("""
+		assertion failed
+			at test_foo in MyTest.gd : 42
+			at before_test in TestSuiteA.gd : 10
+			at run in TestRunner.gd : 5
+		""".dedent().trim_prefix("\n"))
+#endregion


### PR DESCRIPTION
# Why
Stack trace capture for failed assertions was introduced in #1088 and made available
via GdUnitReport in #1136, but the data was never surfaced in the GdUnit Inspector UI.
Test failures only showed the assertion message, leaving developers to navigate manually
when failures occurred inside shared helpers or parameterized tests.

# What
- Added `GdUnitReportPanel` scene that renders failure messages and clickable stack
  frames in the Inspector's report area
- Introduced `GdUnitEditorColorTheme` — a static-var `Node`-based utility that provides
  editor syntax-highlight colors and auto-refreshes on `NOTIFICATION_EDITOR_SETTINGS_CHANGED`,
  eliminating the duplicated `init_colors()` from `GdUnitConsoleTestReporter`
- Added `GdUnitStackTrace.get_frames()` to expose individual frames for rendering
- Registered `GdUnitEditorColorTheme` as an internal child of `GdUnitInspector` so
  static colors refresh automatically whenever the editor theme changes
- Replaced the inline report widgets in `InspectorTreePanel.tscn` with the new
  instanced `GdUnitReportPanel`
- Added `GdUnitReportPanelTest` covering `clear`, `show_report`, and `build_report`
  with exact-text assertions for stack depth 1 and 3
  
 # Before - without stacktrace
<img width="1165" height="517" alt="image" src="https://github.com/user-attachments/assets/24b024e7-59ab-4e34-8f31-53fbecf48f8a" />


# After - with stacktrace
<img width="1242" height="777" alt="image" src="https://github.com/user-attachments/assets/095800da-8098-4ef8-b2e1-b87cec20510e" />


Closes #1133