### PR TITLE
TASK-1134: Enable click-to-navigate on stack trace entries in the report panel

### DIFF
--- a/addons/gdUnit4/src/ui/ScriptEditorControls.gd
+++ b/addons/gdUnit4/src/ui/ScriptEditorControls.gd
@@ -77,13 +77,14 @@ static func close_open_editor_scripts() -> void:
 # The line and column on which to open the script can also be specified.
 # The script will be open with the user-configured editor for the script's language which may be an external editor.
 static func edit_script(script_path: String, line_number := -1) -> void:
-	var file_system := EditorInterface.get_resource_filesystem()
-	file_system.update_file(script_path)
-	var file_system_dock := EditorInterface.get_file_system_dock()
-	file_system_dock.navigate_to_path(script_path)
-	EditorInterface.select_file(script_path)
-	var script: GDScript = load(script_path)
-	EditorInterface.edit_script(script, line_number)
+	if Engine.is_editor_hint():
+		var file_system := EditorInterface.get_resource_filesystem()
+		file_system.update_file(script_path)
+		var file_system_dock := EditorInterface.get_file_system_dock()
+		file_system_dock.navigate_to_path(script_path)
+		EditorInterface.select_file(script_path)
+		var script: GDScript = load(script_path)
+		EditorInterface.edit_script(script, line_number)
 
 
 static func _menu_popup() -> PopupMenu:

--- a/addons/gdUnit4/src/ui/parts/GdUnitReportPanel.gd
+++ b/addons/gdUnit4/src/ui/parts/GdUnitReportPanel.gd
@@ -53,4 +53,5 @@ func add_stack_trace(message: RichTextLabel, trace: GdUnitStackTrace) -> void:
 
 
 func _on_meta_clicked(meta: Variant) -> void:
-	print_debug("TODO: implement jump to source", "_on_meta_clicked", meta)
+	var frame: GdUnitStackTraceElement = meta
+	ScriptEditorControls.edit_script(frame._source, frame._line)

--- a/addons/gdUnit4/test/ui/parts/GdUnitReportPanelTest.gd
+++ b/addons/gdUnit4/test/ui/parts/GdUnitReportPanelTest.gd
@@ -58,6 +58,44 @@ func test_show_report_replaces_previous_reports() -> void:
 #endregion
 
 
+#region _on_meta_clicked
+func test_meta_clicked_signal_is_connected_when_stack_trace_has_frames() -> void:
+	var frames: Array[GdUnitStackTraceElement] = [
+		GdUnitStackTraceElement.new("res://test/MyTest.gd", 42, "test_foo"),
+	]
+	var label: RichTextLabel = auto_free(_panel.build_report(_build_report_with_frames("test", frames)))
+	assert_bool(label.meta_clicked.is_connected(_panel._on_meta_clicked)).is_true()
+
+@warning_ignore_start("redundant_await")
+func test_on_meta_clicked_is_called_with_expected_frame_on_click() -> void:
+	# Use a real source path so ScriptEditorControls.edit_script can load() the script
+	var frame1 := GdUnitStackTraceElement.new(
+		"res://test/MyTest.gd", 42, "test_foo"
+	)
+	# Spy on the panel via the scene so that _on_meta_clicked calls are recorded
+	var panel_spy: GdUnitReportPanel = spy("res://addons/gdUnit4/src/ui/parts/GdUnitReportPanel.tscn")
+	var runner := scene_runner(panel_spy)
+
+	# show_report adds the label into the panel's scene tree, giving it a valid rect
+	panel_spy.show_report([_build_report_with_frames("test", [frame1])])
+	await runner.simulate_frames(2)
+
+	# Simulate left mouse click on frame1
+	var label: RichTextLabel = panel_spy.report_list.get_child(0)
+	var label_rect := label.get_global_rect()
+	# Line 0 is the report message; line 1 is the first stack trace entry
+	var click_pos := Vector2(label_rect.position.x + 50, label_rect.position.y + label.get_line_offset(1) + 5)
+	runner.set_mouse_position(click_pos)
+	await runner.simulate_mouse_button_pressed(MOUSE_BUTTON_LEFT)
+
+	# Verify _on_meta_clicked was invoked with the expected stack frame
+	@warning_ignore("unsafe_method_access")
+	verify(panel_spy)._on_meta_clicked(frame1)
+
+@warning_ignore_restore("redundant_await")
+#endregion
+
+
 #region build_report
 func test_build_report_label_is_visible() -> void:
 	var label: RichTextLabel = auto_free(_panel.build_report(_build_report("test message")))


### PR DESCRIPTION
# Why
After GD-1088 introduced stack trace support in the Inspector, each failing test displays its call stack in the report panel — but as static text.
Developers must manually locate and open each referenced script to find the relevant line, which adds friction when a failure spans several frames or multiple files.

# What
- Implemented `_on_meta_clicked` in `GdUnitReportPanel` to open the referenced script at the exact line number via `ScriptEditorControls.edit_script`
- Guarded `ScriptEditorControls.edit_script` with `Engine.is_editor_hint()` to prevent crashes in non-editor contexts
- Added tests verifying the `meta_clicked` signal is connected and that a  simulated mouse click invokes `_on_meta_clicked` with the expected `GdUnitStackTraceElement`

Closes #1134