### PR TITLE
TASK-1138: Display stack traces in GdUnit4 console test reporter

### DIFF
--- a/addons/gdUnit4/src/core/GdUnitStackTrace.gd
+++ b/addons/gdUnit4/src/core/GdUnitStackTrace.gd
@@ -31,7 +31,7 @@ func get_line_number() -> int:
 func print_stack_trace() -> String:
 	var output := ""
 	for frame in _stack_trace:
-		output += "\tat - %s:%d in function '%s'\n" % [frame._source, frame._line, frame._function]
+		output += "\tat '%s' in %s:%d\n" % [frame._function, frame._source, frame._line]
 	return output
 
 

--- a/addons/gdUnit4/src/core/writers/GdUnitCSIMessageWriter.gd
+++ b/addons/gdUnit4/src/core/writers/GdUnitCSIMessageWriter.gd
@@ -145,6 +145,14 @@ func _bbcode_tags_to_csi_codes(message: String) -> String:
 	return result
 
 
+## Internal implementation of print_stack_trace.[br]
+## [br]
+## [param stack_trace] The stack trace to print.[br]
+## [param _indent] The indentation level.
+func _print_stack_trace(stack_trace: GdUnitStackTrace, _indent: int) -> void:
+	_print_message(stack_trace.print_stack_trace(), Color.LIGHT_BLUE, _indent, 0)
+
+
 ## Implementation of basic message output with formatting.
 func _print_message(_message: String, _color: Color, _indent: int, _flags: int) -> void:
 	var text := _bbcode_tags_to_csi_codes(_message)

--- a/addons/gdUnit4/src/core/writers/GdUnitMessageWriter.gd
+++ b/addons/gdUnit4/src/core/writers/GdUnitMessageWriter.gd
@@ -1,5 +1,5 @@
 @tool
-class_name GdUnitMessageWriter
+@abstract class_name GdUnitMessageWriter
 extends RefCounted
 ## Base interface class for writing formatted messages to different outputs.[br]
 ## [br]
@@ -147,17 +147,19 @@ func prints_error(message: String) -> void:
 ## Prints a message with current formatting settings.[br]
 ## [br]
 ## [param message] The text to print.
-func print_message(message: String) -> void:
+func print_message(message: String) -> GdUnitMessageWriter:
 	_print_message(message, _current_color, _current_indent, _current_flags)
 	reset()
+	return self
 
 
 ## Prints a message with current formatting settings followed by a newline.[br]
 ## [br]
 ## [param message] The text to print.
-func println_message(message: String) -> void:
+func println_message(message: String) -> GdUnitMessageWriter:
 	_println_message(message, _current_color, _current_indent, _current_flags)
 	reset()
+	return self
 
 
 ## Prints a message at a specific column position with current formatting settings.[br]
@@ -169,46 +171,59 @@ func print_at(message: String, cursor_pos: int) -> void:
 	reset()
 
 
+## Prints a stack trace with the current indentation setting.[br]
+## [br]
+## [param stack_trace] The stack trace to print.
+func print_stack_trace(stack_trace: GdUnitStackTrace) -> void:
+	if stack_trace:
+		_print_stack_trace(stack_trace, _current_indent)
+
+
+## Internal implementation of print_stack_trace.[br]
+## [br]
+## To be overridden by concrete formatters.[br]
+## [br]
+## [param stack_trace] The stack trace to print.[br]
+## [param current_indent] The indentation level.
+@abstract func _print_stack_trace(stack_trace: GdUnitStackTrace, current_indent: int) -> void
+
+
 ## Internal implementation of print_message.[br]
 ## [br]
 ## To be overridden by concrete formatters.[br]
 ## [br]
-## [param message] The text to print.[br]
-## [param color] The color to use.[br]
-## [param indent] The indentation level.[br]
-## [param flags] The style flags to apply.
-func _print_message(_message: String, _color: Color, _indent: int, _flags: int) -> void:
-	pass
+## [param _message] The text to print.[br]
+## [param _color] The color to use.[br]
+## [param _indent] The indentation level.[br]
+## [param _flags] The style flags to apply.
+@abstract func _print_message(_message: String, _color: Color, _indent: int, _flags: int) -> void
 
 
 ## Internal implementation of println_message.[br]
 ## [br]
 ## To be overridden by concrete formatters.[br]
 ## [br]
-## [param message] The text to print.[br]
-## [param color] The color to use.[br]
-## [param indent] The indentation level.[br]
-## [param flags] The style flags to apply.
-func _println_message(_message: String, _color: Color, _indent: int, _flags: int) -> void:
-	pass
+## [param _message] The text to print.[br]
+## [param _color] The color to use.[br]
+## [param _indent] The indentation level.[br]
+## [param _flags] The style flags to apply.
+@abstract func _println_message(_message: String, _color: Color, _indent: int, _flags: int) -> void
 
 
 ## Internal implementation of print_at.[br]
 ## [br]
 ## To be overridden by concrete formatters.[br]
 ## [br]
-## [param message] The text to print.[br]
-## [param cursor_pos] The column position.[br]
-## [param color] The color to use.[br]
-## [param effect] The effect to apply.[br]
-## [param align] The text alignment.[br]
-## [param flags] The style flags to apply.
-func _print_at(_message: String, _cursor_pos: int, _color: Color, _effect: GdUnitMessageWriter.Effect, _align: Align, _flags: int) -> void:
-	pass
+## [param _message] The text to print.[br]
+## [param _cursor_pos] The column position.[br]
+## [param _color] The color to use.[br]
+## [param _effect] The effect to apply.[br]
+## [param _align] The text alignment.[br]
+## [param _flags] The style flags to apply.
+@abstract func _print_at(_message: String, _cursor_pos: int, _color: Color, _effect: GdUnitMessageWriter.Effect, _align: Align, _flags: int) -> void
 
 
 ## Clears all output content.[br]
 ## [br]
 ## To be overridden by concrete formatters.
-func clear() -> void:
-	pass
+@abstract func clear() -> void

--- a/addons/gdUnit4/src/core/writers/GdUnitRichTextMessageWriter.gd
+++ b/addons/gdUnit4/src/core/writers/GdUnitRichTextMessageWriter.gd
@@ -16,6 +16,7 @@ extends GdUnitMessageWriter
 
 ## The [RichTextLabel] instance to write formatted messages
 var _output: RichTextLabel
+var _report_formatter: GdUnitReportPanel
 
 ## Tracks current position in characters from line start
 var _current_pos := 0
@@ -26,6 +27,7 @@ var _current_pos := 0
 ## [param output] The [RichTextLabel] used for output.
 func _init(output: RichTextLabel) -> void:
 	_output = output
+	_report_formatter = GdUnitReportPanel.new()
 
 
 ## Applies text style flags by wrapping text in BBCode tags.[br]
@@ -45,6 +47,18 @@ func _apply_flags(message: String, flags: int) -> String:
 	if flags & UNDERLINE:
 		message = "[u]%s[/u]" % message
 	return message
+
+
+## Internal implementation of print_stack_trace.[br]
+## [br]
+## [param stack_trace] The stack trace to print.[br]
+## [param _indent] The indentation level.
+func _print_stack_trace(stack_trace: GdUnitStackTrace, _indent: int) -> void:
+	for i in _indent:
+		_output.push_indent(1)
+	_report_formatter.add_stack_trace(_output, stack_trace)
+	for i in _indent:
+		_output.pop()
 
 
 ## Writes a message with formatting.[br]

--- a/addons/gdUnit4/src/reporters/console/GdUnitConsoleTestReporter.gd
+++ b/addons/gdUnit4/src/reporters/console/GdUnitConsoleTestReporter.gd
@@ -131,9 +131,11 @@ func _print_failure_report(reports: Array[GdUnitReport]) -> void:
 				.color(Color.DARK_TURQUOISE) \
 				.style(GdUnitMessageWriter.BOLD | GdUnitMessageWriter.UNDERLINE) \
 				.println_message("Report:")
-			var text := str(report)
-			for line in text.split("\n", false):
-				_writer.indent(2).color(Color.DARK_TURQUOISE).println_message(line)
+			_writer.indent(2) \
+				.color(GdUnitEditorColorTheme.text_color) \
+				.println_message(report.message()) \
+				.indent(2) \
+				.print_stack_trace(report.stack_trace())
 
 	if not reports.is_empty():
 		println_message("")

--- a/addons/gdUnit4/src/ui/GdUnitConsole.gd
+++ b/addons/gdUnit4/src/ui/GdUnitConsole.gd
@@ -12,7 +12,6 @@ const TITLE = "gdUnit4 ${version} Console"
 var _test_reporter: GdUnitConsoleTestReporter
 
 
-@warning_ignore("return_value_discarded")
 func _ready() -> void:
 	GdUnitFonts.init_fonts(output)
 	GdUnit4Version.init_version_label(title)

--- a/addons/gdUnit4/src/ui/GdUnitConsole.tscn
+++ b/addons/gdUnit4/src/ui/GdUnitConsole.tscn
@@ -1,8 +1,8 @@
-[gd_scene load_steps=2 format=3 uid="uid://dm0wvfyeew7vd"]
+[gd_scene format=4 uid="uid://dm0wvfyeew7vd"]
 
 [ext_resource type="Script" path="res://addons/gdUnit4/src/ui/GdUnitConsole.gd" id="1"]
 
-[node name="Control" type="Control"]
+[node name="Control" type="Control" unique_id=1838139573]
 use_parent_material = true
 clip_contents = true
 custom_minimum_size = Vector2(0, 200)
@@ -16,7 +16,7 @@ size_flags_horizontal = 3
 size_flags_vertical = 3
 script = ExtResource("1")
 
-[node name="VBoxContainer" type="VBoxContainer" parent="."]
+[node name="VBoxContainer" type="VBoxContainer" parent="." unique_id=1582573516]
 use_parent_material = true
 clip_contents = true
 layout_mode = 1
@@ -28,31 +28,37 @@ grow_vertical = 2
 size_flags_horizontal = 3
 size_flags_vertical = 3
 
-[node name="Header" type="PanelContainer" parent="VBoxContainer"]
+[node name="Header" type="Control" parent="VBoxContainer" unique_id=1823073031]
 auto_translate_mode = 2
-custom_minimum_size = Vector2(0, 32)
+custom_minimum_size = Vector2(0, 36)
 layout_mode = 2
+size_flags_vertical = 0
 localize_numeral_system = false
-mouse_filter = 2
 
-[node name="header_title" type="RichTextLabel" parent="VBoxContainer/Header"]
+[node name="header_title" type="RichTextLabel" parent="VBoxContainer/Header" unique_id=20617532]
 auto_translate_mode = 2
-layout_mode = 2
+custom_minimum_size = Vector2(0, 36)
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
 size_flags_horizontal = 3
-size_flags_vertical = 3
 localize_numeral_system = false
-mouse_filter = 2
 bbcode_enabled = true
 scroll_active = false
 autowrap_mode = 0
 shortcut_keys_enabled = false
+horizontal_alignment = 1
+vertical_alignment = 1
 
-[node name="Console" type="ScrollContainer" parent="VBoxContainer"]
+[node name="Console" type="ScrollContainer" parent="VBoxContainer" unique_id=547060555]
 layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 3
 
-[node name="TextEdit" type="RichTextLabel" parent="VBoxContainer/Console"]
+[node name="TextEdit" type="RichTextLabel" parent="VBoxContainer/Console" unique_id=1121183605]
 use_parent_material = true
 layout_mode = 2
 size_flags_horizontal = 3

--- a/addons/gdUnit4/src/ui/parts/GdUnitReportPanel.gd
+++ b/addons/gdUnit4/src/ui/parts/GdUnitReportPanel.gd
@@ -23,13 +23,15 @@ func build_report(report: GdUnitReport) -> RichTextLabel:
 	message.push_color(GdUnitEditorColorTheme.text_color)
 	message.append_text(report.message())
 	message.pop()
+	message.newline()
 	add_stack_trace(message, report.stack_trace())
 	message.visible = true
 	return message
 
 
 func add_stack_trace(message: RichTextLabel, trace: GdUnitStackTrace) -> void:
-	message.newline()
+	if trace == null:
+		return
 	for frame in trace.get_frames():
 		message.push_indent(1)
 		message.push_meta(frame, RichTextLabel.META_UNDERLINE_ON_HOVER, frame._source)
@@ -49,7 +51,8 @@ func add_stack_trace(message: RichTextLabel, trace: GdUnitStackTrace) -> void:
 		message.pop() # hint
 		message.pop()
 		message.newline()
-	message.meta_clicked.connect(_on_meta_clicked)
+	if not message.meta_clicked.is_connected(_on_meta_clicked):
+		message.meta_clicked.connect(_on_meta_clicked)
 
 
 func _on_meta_clicked(meta: Variant) -> void:

--- a/addons/gdUnit4/test/core/GdUnitStackTraceTest.gd
+++ b/addons/gdUnit4/test/core/GdUnitStackTraceTest.gd
@@ -39,7 +39,7 @@ func test_captures_stack_depth_0() -> void:
 	var trace := GdUnitStackTrace.new()
 	assert_int(trace.get_line_number()).is_equal(39)
 	assert_str(trace.print_stack_trace())\
-		.is_equal("\tat - res://addons/gdUnit4/test/core/GdUnitStackTraceTest.gd:39 in function 'test_captures_stack_depth_0'\n")
+		.is_equal("\tat 'test_captures_stack_depth_0' in res://addons/gdUnit4/test/core/GdUnitStackTraceTest.gd:39\n")
 
 
 func test_captures_stack_depth_1() -> void:
@@ -47,8 +47,8 @@ func test_captures_stack_depth_1() -> void:
 	assert_int(trace.get_line_number()).is_equal(9)
 	assert_str(trace.print_stack_trace())\
 		.is_equal("""
-			at - res://addons/gdUnit4/test/core/GdUnitStackTraceTest.gd:9 in function 'capture_stack'
-			at - res://addons/gdUnit4/test/core/GdUnitStackTraceTest.gd:46 in function 'test_captures_stack_depth_1'
+			at 'capture_stack' in res://addons/gdUnit4/test/core/GdUnitStackTraceTest.gd:9
+			at 'test_captures_stack_depth_1' in res://addons/gdUnit4/test/core/GdUnitStackTraceTest.gd:46
 			""".dedent().indent("\t").trim_prefix("\n"))
 
 
@@ -57,9 +57,9 @@ func test_captures_stack_depth_2() -> void:
 	assert_int(trace.get_line_number()).is_equal(9)
 	assert_str(trace.print_stack_trace())\
 		.is_equal("""
-			at - res://addons/gdUnit4/test/core/GdUnitStackTraceTest.gd:9 in function 'capture_stack'
-			at - res://addons/gdUnit4/test/core/GdUnitStackTraceTest.gd:13 in function 'capture_stack_1'
-			at - res://addons/gdUnit4/test/core/GdUnitStackTraceTest.gd:56 in function 'test_captures_stack_depth_2'
+			at 'capture_stack' in res://addons/gdUnit4/test/core/GdUnitStackTraceTest.gd:9
+			at 'capture_stack_1' in res://addons/gdUnit4/test/core/GdUnitStackTraceTest.gd:13
+			at 'test_captures_stack_depth_2' in res://addons/gdUnit4/test/core/GdUnitStackTraceTest.gd:56
 			""".dedent().indent("\t").trim_prefix("\n"))
 
 
@@ -68,10 +68,10 @@ func test_captures_stack_depth_3() -> void:
 	assert_int(trace.get_line_number()).is_equal(9)
 	assert_str(trace.print_stack_trace())\
 		.is_equal("""
-			at - res://addons/gdUnit4/test/core/GdUnitStackTraceTest.gd:9 in function 'capture_stack'
-			at - res://addons/gdUnit4/test/core/GdUnitStackTraceTest.gd:13 in function 'capture_stack_1'
-			at - res://addons/gdUnit4/test/core/GdUnitStackTraceTest.gd:17 in function 'capture_stack_2'
-			at - res://addons/gdUnit4/test/core/GdUnitStackTraceTest.gd:67 in function 'test_captures_stack_depth_3'
+			at 'capture_stack' in res://addons/gdUnit4/test/core/GdUnitStackTraceTest.gd:9
+			at 'capture_stack_1' in res://addons/gdUnit4/test/core/GdUnitStackTraceTest.gd:13
+			at 'capture_stack_2' in res://addons/gdUnit4/test/core/GdUnitStackTraceTest.gd:17
+			at 'test_captures_stack_depth_3' in res://addons/gdUnit4/test/core/GdUnitStackTraceTest.gd:67
 			""".dedent().indent("\t").trim_prefix("\n"))
 
 
@@ -80,11 +80,11 @@ func test_captures_stack_depth_4() -> void:
 	assert_int(trace.get_line_number()).is_equal(9)
 	assert_str(trace.print_stack_trace())\
 		.is_equal("""
-			at - res://addons/gdUnit4/test/core/GdUnitStackTraceTest.gd:9 in function 'capture_stack'
-			at - res://addons/gdUnit4/test/core/GdUnitStackTraceTest.gd:13 in function 'capture_stack_1'
-			at - res://addons/gdUnit4/test/core/GdUnitStackTraceTest.gd:17 in function 'capture_stack_2'
-			at - res://addons/gdUnit4/test/core/GdUnitStackTraceTest.gd:21 in function 'capture_stack_3'
-			at - res://addons/gdUnit4/test/core/GdUnitStackTraceTest.gd:79 in function 'test_captures_stack_depth_4'
+			at 'capture_stack' in res://addons/gdUnit4/test/core/GdUnitStackTraceTest.gd:9
+			at 'capture_stack_1' in res://addons/gdUnit4/test/core/GdUnitStackTraceTest.gd:13
+			at 'capture_stack_2' in res://addons/gdUnit4/test/core/GdUnitStackTraceTest.gd:17
+			at 'capture_stack_3' in res://addons/gdUnit4/test/core/GdUnitStackTraceTest.gd:21
+			at 'test_captures_stack_depth_4' in res://addons/gdUnit4/test/core/GdUnitStackTraceTest.gd:79
 			""".dedent().indent("\t").trim_prefix("\n"))
 
 
@@ -93,12 +93,12 @@ func test_captures_stack_depth_5() -> void:
 	assert_int(trace.get_line_number()).is_equal(9)
 	assert_str(trace.print_stack_trace())\
 		.is_equal("""
-			at - res://addons/gdUnit4/test/core/GdUnitStackTraceTest.gd:9 in function 'capture_stack'
-			at - res://addons/gdUnit4/test/core/GdUnitStackTraceTest.gd:13 in function 'capture_stack_1'
-			at - res://addons/gdUnit4/test/core/GdUnitStackTraceTest.gd:17 in function 'capture_stack_2'
-			at - res://addons/gdUnit4/test/core/GdUnitStackTraceTest.gd:21 in function 'capture_stack_3'
-			at - res://addons/gdUnit4/test/core/GdUnitStackTraceTest.gd:25 in function 'capture_stack_4'
-			at - res://addons/gdUnit4/test/core/GdUnitStackTraceTest.gd:92 in function 'test_captures_stack_depth_5'
+			at 'capture_stack' in res://addons/gdUnit4/test/core/GdUnitStackTraceTest.gd:9
+			at 'capture_stack_1' in res://addons/gdUnit4/test/core/GdUnitStackTraceTest.gd:13
+			at 'capture_stack_2' in res://addons/gdUnit4/test/core/GdUnitStackTraceTest.gd:17
+			at 'capture_stack_3' in res://addons/gdUnit4/test/core/GdUnitStackTraceTest.gd:21
+			at 'capture_stack_4' in res://addons/gdUnit4/test/core/GdUnitStackTraceTest.gd:25
+			at 'test_captures_stack_depth_5' in res://addons/gdUnit4/test/core/GdUnitStackTraceTest.gd:92
 			""".dedent().indent("\t").trim_prefix("\n"))
 
 
@@ -132,8 +132,8 @@ func test_inner_class_frames_in_stack_trace() -> void:
 	assert_int(trace.get_line_number()).is_equal(31)
 	assert_str(trace.print_stack_trace())\
 		.is_equal("""
-			at - res://addons/gdUnit4/test/core/GdUnitStackTraceTest.gd:31 in function 'capture_stack'
-			at - res://addons/gdUnit4/test/core/GdUnitStackTraceTest.gd:131 in function 'test_inner_class_frames_in_stack_trace'
+			at 'capture_stack' in res://addons/gdUnit4/test/core/GdUnitStackTraceTest.gd:31
+			at 'test_inner_class_frames_in_stack_trace' in res://addons/gdUnit4/test/core/GdUnitStackTraceTest.gd:131
 			""".dedent().indent("\t").trim_prefix("\n"))
 
 #endregion

--- a/addons/gdUnit4/test/reporters/GdUnitConsoleTestReporterTest.gd
+++ b/addons/gdUnit4/test/reporters/GdUnitConsoleTestReporterTest.gd
@@ -3,7 +3,7 @@ class_name GdUnitConsoleTestReporterTest
 extends GdUnitTestSuite
 
 
-var reporter := GdUnitConsoleTestReporter.new(GdUnitMessageWriter.new())
+var reporter := GdUnitConsoleTestReporter.new(GdUnitCSIMessageWriter.new())
 
 
 func before_test() -> void:


### PR DESCRIPTION
# Why
Assertion failure stack traces captured via #1088 were available in
`GdUnitReport` but never rendered in the console, leaving developers with
only an error message and no indication of the failing call chain.

# What
- Added `print_stack_trace` interface to `GdUnitMessageWriter` (now
  abstract) and implemented it in both writers
- Console failure reporter prints message + stack trace as distinct blocks
- Stack trace format aligned with the report panel (`at 'func' in source:line`)

## Images
<img width="1422" height="632" alt="image" src="https://github.com/user-attachments/assets/5f780b5f-dc50-4bd4-bc41-1c3d8376c444" />
<img width="1090" height="639" alt="image" src="https://github.com/user-attachments/assets/0372c81c-de51-4713-bb05-577bd3b2ba7f" />



Closes #1138