### PR TITLE
TASK-1148: Error monitor should provide stacktrace on error detection

### DIFF
--- a/addons/gdUnit4/src/monitor/ErrorLogEntry.gd
+++ b/addons/gdUnit4/src/monitor/ErrorLogEntry.gd
@@ -15,27 +15,27 @@ const GdUnitTools := preload("res://addons/gdUnit4/src/core/GdUnitTools.gd")
 var _type: TYPE
 var _line: int
 var _message: String
-var _details: String
+var _stack_trace: GdUnitStackTrace
 
 
-func _init(type: TYPE, line: int, message: String, details: String) -> void:
+func _init(type: TYPE, line: int, message: String, stack_trace: GdUnitStackTrace) -> void:
 	_type = type
 	_line = line
 	_message = message
-	_details = details
+	_stack_trace = stack_trace
 
 
 func _to_string() -> String:
 	return _message
 
 
-static func of_push_warning(line: int, message: String, stack_trace: PackedStringArray) -> ErrorLogEntry:
-	return ErrorLogEntry.new(TYPE.PUSH_WARNING, line, message, "\n".join(stack_trace))
+static func of_push_warning(line: int, message: String, stack_trace: GdUnitStackTrace) -> ErrorLogEntry:
+	return ErrorLogEntry.new(TYPE.PUSH_WARNING, line, message, stack_trace)
 
 
-static func of_push_error(line: int, message: String, stack_trace: PackedStringArray) -> ErrorLogEntry:
-	return ErrorLogEntry.new(TYPE.PUSH_ERROR, line, message, "\n".join(stack_trace))
+static func of_push_error(line: int, message: String, stack_trace: GdUnitStackTrace) -> ErrorLogEntry:
+	return ErrorLogEntry.new(TYPE.PUSH_ERROR, line, message, stack_trace)
 
 
-static func of_script_error(line: int, message: String, stack_trace: PackedStringArray) -> ErrorLogEntry:
-	return ErrorLogEntry.new(TYPE.SCRIPT_ERROR, line, message, "\n".join(stack_trace))
+static func of_script_error(line: int, message: String, stack_trace: GdUnitStackTrace) -> ErrorLogEntry:
+	return ErrorLogEntry.new(TYPE.SCRIPT_ERROR, line, message, stack_trace)

--- a/addons/gdUnit4/src/monitor/GodotGdErrorMonitor.gd
+++ b/addons/gdUnit4/src/monitor/GodotGdErrorMonitor.gd
@@ -7,7 +7,6 @@ var _logger: GdUnitLogger
 
 class GdUnitLogger extends Logger:
 	var _entries: Array[ErrorLogEntry] = []
-	var _line_number: int
 	var _is_report_push_errors: bool
 	var _is_report_script_errors: bool
 
@@ -38,21 +37,21 @@ class GdUnitLogger extends Logger:
 		error_type: int,
 		script_backtraces: Array[ScriptBacktrace]
 		) -> void:
+
+		var stack_trace := _to_stack_trace(script_backtraces)
+
 		match error_type:
 			ErrorType.ERROR_TYPE_WARNING:
 				if _is_report_push_errors:
-					var stack_trace := _build_stack_trace(script_backtraces)
-					_entries.append(ErrorLogEntry.of_push_warning(_line_number, message, stack_trace))
+					_entries.append(ErrorLogEntry.of_push_warning(stack_trace.get_line_number(), message, stack_trace))
 
 			ErrorType.ERROR_TYPE_ERROR:
 				if _is_report_push_errors:
-					var stack_trace := _build_stack_trace(script_backtraces)
-					_entries.append(ErrorLogEntry.of_push_error(_line_number, message, stack_trace))
+					_entries.append(ErrorLogEntry.of_push_error(stack_trace.get_line_number(), message, stack_trace))
 
 			ErrorType.ERROR_TYPE_SCRIPT:
 				if _is_report_script_errors:
-					var stack_trace := _build_stack_trace(script_backtraces)
-					_entries.append(ErrorLogEntry.of_script_error(_line_number, message, stack_trace))
+					_entries.append(ErrorLogEntry.of_script_error(stack_trace.get_line_number(), message, stack_trace))
 
 			ErrorType.ERROR_TYPE_SHADER:
 				pass
@@ -62,19 +61,23 @@ class GdUnitLogger extends Logger:
 	func _log_message(_message: String, _error: bool) -> void:
 		pass
 
-	func _build_stack_trace(script_backtraces: Array[ScriptBacktrace]) -> PackedStringArray:
+
+	func _to_stack_trace(script_backtraces: Array[ScriptBacktrace]) -> GdUnitStackTrace:
+		var test_stack_trace: Array[GdUnitStackTraceElement] = []
+
 		for sb in script_backtraces:
 			for frame in sb.get_frame_count():
-				# Find start of test stack
-				if sb.get_frame_file(frame) == "res://addons/gdUnit4/src/core/_TestCase.gd":
-					var stack_trace := PackedStringArray()
-					for test_case_frame in range(0, frame):
-						_line_number = sb.get_frame_line(test_case_frame)
-						stack_trace.append("	at %s:%s" % [sb.get_frame_file(test_case_frame), sb.get_frame_line(test_case_frame)])
-					return stack_trace
-		# if no stack trace collected, we in an await function call
-		var sb := script_backtraces[0]
-		return ["	at %s:%s" % [sb.get_frame_file(0), sb.get_frame_line(0)]]
+				var source := sb.get_frame_file(frame)
+
+				if (source.begins_with("res://addons/gdUnit4/src/")
+					or source.begins_with("user://tmp/mock/")
+					or source.begins_with("user://tmp/spy/")):
+					continue
+
+				var function := sb.get_frame_function(frame)
+				var line := sb.get_frame_line(frame)
+				test_stack_trace.append(GdUnitStackTraceElement.new(source, line, function))
+		return GdUnitStackTrace.of(test_stack_trace)
 
 
 func _init() -> void:
@@ -107,15 +110,14 @@ func to_reports() -> Array[GdUnitReport]:
 
 
 static func _to_report(errorLog: ErrorLogEntry) -> GdUnitReport:
+
 	var failure := """
 		%s
-		%s %s
-		%s""".dedent().trim_prefix("\n") % [
+		  %s""".dedent().trim_prefix("\n") % [
 		GdAssertMessages._error("Godot Runtime Error !"),
-		GdAssertMessages._error("Error:"),
-		GdAssertMessages._colored_value(errorLog._message),
-		GdAssertMessages._colored(errorLog._details, GdUnitEditorColorTheme.state_failure)]
-	return GdUnitReport.new().create(GdUnitReport.ABORT, errorLog._line, failure)
+		GdAssertMessages._colored_value(errorLog._message)]
+	var error := GdUnitError.new(failure, errorLog._line, errorLog._stack_trace)
+	return GdUnitReport.new().from_error(GdUnitReport.ABORT, error)
 
 
 func clear_logs() -> void:

--- a/addons/gdUnit4/test/monitor/GodotGdErrorMonitorTest.gd
+++ b/addons/gdUnit4/test/monitor/GodotGdErrorMonitorTest.gd
@@ -21,18 +21,21 @@ func test_monitor_push_error() -> void:
 
 	# push error
 	monitor.start()
-	forcet_push_error()
+	force_push_error()
 	monitor.stop()
 
 	var reports := monitor.to_reports()
 	assert_array(reports).has_size(1)
-	prints(reports[0].message())
-	assert_str(reports[0].message())\
-		.contains("Test GodotGdErrorMonitor 'push_error' reporting")\
-		.contains("at res://addons/gdUnit4/test/monitor/GodotGdErrorMonitorTest.gd:67")\
-		.contains("at res://addons/gdUnit4/test/monitor/GodotGdErrorMonitorTest.gd:62")\
-		.contains("at res://addons/gdUnit4/test/monitor/GodotGdErrorMonitorTest.gd:24")
-	assert_int(reports[0].line_number()).is_equal(24)
+	var report := reports[0]
+	assert_str(report.message()) \
+		.contains("Test GodotGdErrorMonitor 'push_error' reporting")
+	assert_object(report.stack_trace()) \
+		.is_equal(GdUnitStackTrace.new([
+			GdUnitStackTraceElement.new("res://addons/gdUnit4/test/monitor/GodotGdErrorMonitorTest.gd", 74, "force_push_error2"),
+			GdUnitStackTraceElement.new("res://addons/gdUnit4/test/monitor/GodotGdErrorMonitorTest.gd", 69, "force_push_error"),
+			GdUnitStackTraceElement.new("res://addons/gdUnit4/test/monitor/GodotGdErrorMonitorTest.gd", 24, "test_monitor_push_error")
+		]))
+	assert_int(report.line_number()).is_equal(74)
 
 
 func test_monitor_push_waring() -> void:
@@ -46,10 +49,14 @@ func test_monitor_push_waring() -> void:
 
 	var reports := monitor.to_reports()
 	assert_array(reports).has_size(1)
-	assert_str(reports[0].message())\
-		.contains("Test GodotGdErrorMonitor 'push_warning' reporting")\
-		.contains("at res://addons/gdUnit4/test/monitor/GodotGdErrorMonitorTest.gd:44")
-	assert_int(reports[0].line_number()).is_equal(44)
+	var report := reports[0]
+	assert_str(report.message())\
+		.contains("Test GodotGdErrorMonitor 'push_warning' reporting")
+	assert_object(report.stack_trace()) \
+		.is_equal(GdUnitStackTrace.new([
+			GdUnitStackTraceElement.new("res://addons/gdUnit4/test/monitor/GodotGdErrorMonitorTest.gd", 47, "test_monitor_push_waring")
+		]))
+	assert_int(report.line_number()).is_equal(47)
 
 
 func test_fail_by_push_error(_do_skip := true, _skip_reason := "disabled to not produce errors, enable only for direct testing") -> void:
@@ -57,11 +64,11 @@ func test_fail_by_push_error(_do_skip := true, _skip_reason := "disabled to not 
 	push_error("test error")
 
 
-func forcet_push_error() -> void:
+func force_push_error() -> void:
 	@warning_ignore("redundant_await")
-	await forcet_push_error2()
+	await force_push_error2()
 
 
-func forcet_push_error2() -> void:
+func force_push_error2() -> void:
 	#await get_tree().process_frame
 	push_error("Test GodotGdErrorMonitor 'push_error' reporting")


### PR DESCRIPTION
# Why
The error monitor converted stack backtraces to plain strings on capture, making it impossible for report generators to use the structured frame data

# What
- Replace `_details: String` in `ErrorLogEntry` with `_stack_trace: GdUnitStackTrace`
- Rewrite `_build_stack_trace` → `_to_stack_trace` to return a structured `GdUnitStackTrace`
  instead of a `PackedStringArray`

Closes #1148