### PR TITLE
GD-1152: Fix GdUnit inspector layout at custom display scale settings

### DIFF
--- a/addons/gdUnit4/src/ui/GdUnitInspector.tscn
+++ b/addons/gdUnit4/src/ui/GdUnitInspector.tscn
@@ -10,13 +10,12 @@
 
 [node name="GdUnit" type="Control" unique_id=272268338]
 clip_contents = true
-custom_minimum_size = Vector2(320, 400)
+custom_minimum_size = Vector2(360, 440)
 layout_mode = 3
-anchors_preset = 15
-anchor_right = 1.0
+anchors_preset = 9
 anchor_bottom = 1.0
-grow_horizontal = 2
 grow_vertical = 2
+size_flags_horizontal = 3
 size_flags_vertical = 3
 focus_mode = 2
 script = ExtResource("1_j37cs")
@@ -38,22 +37,19 @@ clip_contents = true
 layout_mode = 2
 
 [node name="ToolBar" parent="VBoxContainer/Header" unique_id=185399834 instance=ExtResource("1")]
-custom_minimum_size = Vector2(0, 32)
 layout_mode = 2
-size_flags_vertical = 2
+size_flags_vertical = 3
 
 [node name="ProgressBar" parent="VBoxContainer/Header" unique_id=360281822 instance=ExtResource("2")]
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 5
-size_flags_vertical = 4
+size_flags_vertical = 1
 max_value = 0.0
 
 [node name="StatusBar" parent="VBoxContainer/Header" unique_id=625414847 instance=ExtResource("3")]
-custom_minimum_size = Vector2(0, 96)
 layout_mode = 2
 size_flags_horizontal = 1
-size_flags_vertical = 10
 
 [node name="MainPanel" parent="VBoxContainer" unique_id=1133307707 instance=ExtResource("7")]
 unique_name_in_owner = true
@@ -61,7 +57,6 @@ clip_contents = true
 layout_mode = 2
 
 [node name="Monitor" parent="VBoxContainer" unique_id=1419900107 instance=ExtResource("4")]
-visible = false
 layout_mode = 2
 
 [node name="event_server" parent="." unique_id=756999253 instance=ExtResource("7_721no")]

--- a/addons/gdUnit4/src/ui/parts/GdUnitInspectorStatusBar.tscn
+++ b/addons/gdUnit4/src/ui/parts/GdUnitInspectorStatusBar.tscn
@@ -12,16 +12,6 @@
 
 [sub_resource type="StyleBoxEmpty" id="StyleBoxEmpty_0oden"]
 
-[sub_resource type="DPITexture" id="DPITexture_mb3ih"]
-_source = "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"16\" height=\"16\"><path fill=\"none\" stroke=\"#e0e0e0\" stroke-linecap=\"round\" stroke-linejoin=\"round\" stroke-width=\"2\" d=\"M8 5v7l4-4m-4 4L4 8\"/></svg>
-"
-saturation = 2.0
-color_map = {
-Color(1, 0.37254903, 0.37254903, 1): Color(1, 0.47, 0.42, 1),
-Color(0.37254903, 1, 0.5921569, 1): Color(0.45, 0.95, 0.5, 1),
-Color(1, 0.8666667, 0.39607844, 1): Color(0.83, 0.78, 0.62, 1)
-}
-
 [sub_resource type="StyleBoxEmpty" id="StyleBoxEmpty_ixycx"]
 
 [sub_resource type="StyleBoxEmpty" id="StyleBoxEmpty_c80wp"]
@@ -34,86 +24,74 @@ Color(1, 0.8666667, 0.39607844, 1): Color(0.83, 0.78, 0.62, 1)
 
 [sub_resource type="StyleBoxEmpty" id="StyleBoxEmpty_lpjla"]
 
-[node name="StatusBar" type="Control" unique_id=719212496]
-clip_contents = true
-layout_mode = 3
-anchors_preset = 15
+[node name="StatusBar" type="VBoxContainer" unique_id=214621769]
+anchors_preset = 10
 anchor_right = 1.0
-anchor_bottom = 1.0
+offset_bottom = 132.0
 grow_horizontal = 2
-grow_vertical = 2
 size_flags_horizontal = 3
 size_flags_vertical = 2
 script = ExtResource("3")
 
-[node name="VBoxContainer" type="VBoxContainer" parent="." unique_id=214621769]
-layout_mode = 1
-anchors_preset = 15
-anchor_right = 1.0
-anchor_bottom = 1.0
-grow_horizontal = 2
-grow_vertical = 2
-size_flags_vertical = 0
-
-[node name="tree_tools" type="HBoxContainer" parent="VBoxContainer" unique_id=1524945370]
+[node name="tree_tools" type="HBoxContainer" parent="." unique_id=1524945370]
 layout_mode = 2
 size_flags_vertical = 0
 
-[node name="Label" type="Label" parent="VBoxContainer/tree_tools" unique_id=226892195]
+[node name="Label" type="Label" parent="tree_tools" unique_id=226892195]
 layout_mode = 2
 size_flags_horizontal = 0
 text = "Statistics"
 
-[node name="tree_buttons" type="HBoxContainer" parent="VBoxContainer/tree_tools" unique_id=1600307316]
+[node name="tree_buttons" type="HBoxContainer" parent="tree_tools" unique_id=1600307316]
 layout_mode = 2
 size_flags_horizontal = 10
 size_flags_vertical = 4
 alignment = 2
 
-[node name="VSeparator" type="VSeparator" parent="VBoxContainer/tree_tools/tree_buttons" unique_id=1191926359]
+[node name="VSeparator" type="VSeparator" parent="tree_tools/tree_buttons" unique_id=1191926359]
 layout_mode = 2
 
-[node name="btn_tree_sync" type="Button" parent="VBoxContainer/tree_tools/tree_buttons" unique_id=2138788372]
+[node name="btn_tree_sync" type="Button" parent="tree_tools/tree_buttons" unique_id=2138788372]
 unique_name_in_owner = true
 layout_mode = 2
 tooltip_text = "Run discover tests."
 theme_override_styles/normal = SubResource("StyleBoxEmpty_mb3ih")
 
-[node name="btn_tree_sort" type="MenuButton" parent="VBoxContainer/tree_tools/tree_buttons" unique_id=1452127838]
+[node name="btn_tree_sort" type="MenuButton" parent="tree_tools/tree_buttons" unique_id=1452127838]
 unique_name_in_owner = true
 layout_mode = 2
 tooltip_text = "Sets tree sorting mode."
 theme_override_styles/normal = SubResource("StyleBoxEmpty_wo03e")
 flat = false
 
-[node name="btn_tree_mode" type="MenuButton" parent="VBoxContainer/tree_tools/tree_buttons" unique_id=1744382439]
+[node name="btn_tree_mode" type="MenuButton" parent="tree_tools/tree_buttons" unique_id=1744382439]
 unique_name_in_owner = true
 layout_mode = 2
 tooltip_text = "Sets tree presentation mode."
 theme_override_styles/normal = SubResource("StyleBoxEmpty_jh28t")
 flat = false
 
-[node name="HSeparator" type="HSeparator" parent="VBoxContainer" unique_id=1416084348]
+[node name="HSeparator" type="HSeparator" parent="." unique_id=1416084348]
 layout_mode = 2
 theme_override_constants/separation = 0
 
-[node name="status_bar" type="HFlowContainer" parent="VBoxContainer" unique_id=1576624226]
+[node name="status_bar" type="HFlowContainer" parent="." unique_id=1576624226]
 layout_direction = 2
 layout_mode = 2
 size_flags_vertical = 2
 
-[node name="error" type="VBoxContainer" parent="VBoxContainer/status_bar" unique_id=532464781]
+[node name="error" type="VBoxContainer" parent="status_bar" unique_id=532464781]
 custom_minimum_size = Vector2(0, 48)
 layout_mode = 2
 size_flags_horizontal = 8
 size_flags_vertical = 0
 theme_override_constants/separation = -2
 
-[node name="icon" type="HBoxContainer" parent="VBoxContainer/status_bar/error" unique_id=980338948]
+[node name="icon" type="HBoxContainer" parent="status_bar/error" unique_id=980338948]
 layout_mode = 2
 size_flags_horizontal = 8
 
-[node name="icon_errors" type="TextureRect" parent="VBoxContainer/status_bar/error/icon" unique_id=981061410]
+[node name="icon_errors" type="TextureRect" parent="status_bar/error/icon" unique_id=981061410]
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 8
@@ -121,20 +99,20 @@ size_flags_vertical = 4
 tooltip_text = "Error Tests"
 stretch_mode = 3
 
-[node name="btn_up" type="Button" parent="VBoxContainer/status_bar/error/icon" unique_id=128855365]
+[node name="btn_up" type="Button" parent="status_bar/error/icon" unique_id=128855365]
 layout_mode = 2
 size_flags_horizontal = 8
 size_flags_vertical = 4
 tooltip_text = "Jump to the previous error test"
 theme_override_styles/normal = SubResource("StyleBoxEmpty_uqb0l")
 
-[node name="counter" type="HBoxContainer" parent="VBoxContainer/status_bar/error" unique_id=320088753]
+[node name="counter" type="HBoxContainer" parent="status_bar/error" unique_id=320088753]
 auto_translate_mode = 2
 layout_mode = 2
 size_flags_horizontal = 8
 localize_numeral_system = false
 
-[node name="error_value" type="Label" parent="VBoxContainer/status_bar/error/counter" unique_id=1173069184]
+[node name="error_value" type="Label" parent="status_bar/error/counter" unique_id=1173069184]
 unique_name_in_owner = true
 use_parent_material = true
 custom_minimum_size = Vector2(32, 0)
@@ -146,28 +124,27 @@ justification_flags = 0
 visible_characters = 3
 visible_ratio = 3.0
 
-[node name="btn_down" type="Button" parent="VBoxContainer/status_bar/error/counter" unique_id=345916573]
+[node name="btn_down" type="Button" parent="status_bar/error/counter" unique_id=345916573]
 layout_mode = 2
 size_flags_horizontal = 8
 size_flags_vertical = 4
 tooltip_text = "Jump to the next error test"
 theme_override_styles/normal = SubResource("StyleBoxEmpty_0oden")
-icon = SubResource("DPITexture_mb3ih")
 
-[node name="VSeparator" type="VSeparator" parent="VBoxContainer/status_bar" unique_id=1337164698]
+[node name="VSeparator" type="VSeparator" parent="status_bar" unique_id=1337164698]
 layout_mode = 2
 
-[node name="failure" type="VBoxContainer" parent="VBoxContainer/status_bar" unique_id=668143074]
+[node name="failure" type="VBoxContainer" parent="status_bar" unique_id=668143074]
 custom_minimum_size = Vector2(0, 48)
 layout_mode = 2
 size_flags_horizontal = 8
 theme_override_constants/separation = -2
 
-[node name="icon" type="HBoxContainer" parent="VBoxContainer/status_bar/failure" unique_id=913689377]
+[node name="icon" type="HBoxContainer" parent="status_bar/failure" unique_id=913689377]
 layout_mode = 2
 size_flags_horizontal = 8
 
-[node name="icon_failures" type="TextureRect" parent="VBoxContainer/status_bar/failure/icon" unique_id=644665557]
+[node name="icon_failures" type="TextureRect" parent="status_bar/failure/icon" unique_id=644665557]
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 8
@@ -175,20 +152,20 @@ size_flags_vertical = 4
 tooltip_text = "Failed Tests"
 stretch_mode = 3
 
-[node name="btn_up" type="Button" parent="VBoxContainer/status_bar/failure/icon" unique_id=703086216]
+[node name="btn_up" type="Button" parent="status_bar/failure/icon" unique_id=703086216]
 layout_mode = 2
 size_flags_horizontal = 8
 size_flags_vertical = 4
 tooltip_text = "Jump to the previous failed test"
 theme_override_styles/normal = SubResource("StyleBoxEmpty_ixycx")
 
-[node name="counter" type="HBoxContainer" parent="VBoxContainer/status_bar/failure" unique_id=469489912]
+[node name="counter" type="HBoxContainer" parent="status_bar/failure" unique_id=469489912]
 auto_translate_mode = 2
 layout_mode = 2
 size_flags_horizontal = 8
 localize_numeral_system = false
 
-[node name="failure_value" type="Label" parent="VBoxContainer/status_bar/failure/counter" unique_id=2112775802]
+[node name="failure_value" type="Label" parent="status_bar/failure/counter" unique_id=2112775802]
 unique_name_in_owner = true
 use_parent_material = true
 custom_minimum_size = Vector2(32, 0)
@@ -200,27 +177,27 @@ justification_flags = 0
 visible_characters = 3
 visible_ratio = 3.0
 
-[node name="btn_down" type="Button" parent="VBoxContainer/status_bar/failure/counter" unique_id=354437479]
+[node name="btn_down" type="Button" parent="status_bar/failure/counter" unique_id=354437479]
 layout_mode = 2
 size_flags_horizontal = 8
 size_flags_vertical = 4
 tooltip_text = "Jump to the next failed test"
 theme_override_styles/normal = SubResource("StyleBoxEmpty_c80wp")
 
-[node name="VSeparator2" type="VSeparator" parent="VBoxContainer/status_bar" unique_id=1340956265]
+[node name="VSeparator2" type="VSeparator" parent="status_bar" unique_id=1340956265]
 layout_mode = 2
 
-[node name="flaky" type="VBoxContainer" parent="VBoxContainer/status_bar" unique_id=1045751754]
+[node name="flaky" type="VBoxContainer" parent="status_bar" unique_id=1045751754]
 custom_minimum_size = Vector2(0, 48)
 layout_mode = 2
 size_flags_horizontal = 8
 theme_override_constants/separation = -2
 
-[node name="icon" type="HBoxContainer" parent="VBoxContainer/status_bar/flaky" unique_id=1657218582]
+[node name="icon" type="HBoxContainer" parent="status_bar/flaky" unique_id=1657218582]
 layout_mode = 2
 size_flags_horizontal = 8
 
-[node name="icon_flaky" type="TextureRect" parent="VBoxContainer/status_bar/flaky/icon" unique_id=1642017900]
+[node name="icon_flaky" type="TextureRect" parent="status_bar/flaky/icon" unique_id=1642017900]
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 8
@@ -228,20 +205,20 @@ size_flags_vertical = 4
 tooltip_text = "Flaky Tests"
 stretch_mode = 3
 
-[node name="btn_up" type="Button" parent="VBoxContainer/status_bar/flaky/icon" unique_id=1696112932]
+[node name="btn_up" type="Button" parent="status_bar/flaky/icon" unique_id=1696112932]
 layout_mode = 2
 size_flags_horizontal = 8
 size_flags_vertical = 4
 tooltip_text = "Jump to the previous flaky test"
 theme_override_styles/normal = SubResource("StyleBoxEmpty_eis20")
 
-[node name="counter" type="HBoxContainer" parent="VBoxContainer/status_bar/flaky" unique_id=1112580380]
+[node name="counter" type="HBoxContainer" parent="status_bar/flaky" unique_id=1112580380]
 auto_translate_mode = 2
 layout_mode = 2
 size_flags_horizontal = 8
 localize_numeral_system = false
 
-[node name="flaky_value" type="Label" parent="VBoxContainer/status_bar/flaky/counter" unique_id=86782555]
+[node name="flaky_value" type="Label" parent="status_bar/flaky/counter" unique_id=86782555]
 unique_name_in_owner = true
 use_parent_material = true
 custom_minimum_size = Vector2(32, 0)
@@ -253,28 +230,28 @@ justification_flags = 0
 visible_characters = 3
 visible_ratio = 3.0
 
-[node name="btn_down" type="Button" parent="VBoxContainer/status_bar/flaky/counter" unique_id=349950180]
+[node name="btn_down" type="Button" parent="status_bar/flaky/counter" unique_id=349950180]
 layout_mode = 2
 size_flags_horizontal = 8
 size_flags_vertical = 4
 tooltip_text = "Jump to the next flaky test"
 theme_override_styles/normal = SubResource("StyleBoxEmpty_t2qd7")
 
-[node name="VSeparator3" type="VSeparator" parent="VBoxContainer/status_bar" unique_id=1506845836]
+[node name="VSeparator3" type="VSeparator" parent="status_bar" unique_id=1506845836]
 layout_mode = 2
 
-[node name="skipped" type="VBoxContainer" parent="VBoxContainer/status_bar" unique_id=1801359704]
+[node name="skipped" type="VBoxContainer" parent="status_bar" unique_id=1801359704]
 custom_minimum_size = Vector2(0, 48)
 layout_mode = 2
 size_flags_horizontal = 8
 theme_override_constants/separation = -2
 
-[node name="icon" type="HBoxContainer" parent="VBoxContainer/status_bar/skipped" unique_id=730330861]
+[node name="icon" type="HBoxContainer" parent="status_bar/skipped" unique_id=730330861]
 layout_mode = 2
 size_flags_horizontal = 8
 theme_override_constants/separation = 0
 
-[node name="icon_skipped" type="TextureRect" parent="VBoxContainer/status_bar/skipped/icon" unique_id=1023112448]
+[node name="icon_skipped" type="TextureRect" parent="status_bar/skipped/icon" unique_id=1023112448]
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 8
@@ -282,21 +259,21 @@ size_flags_vertical = 4
 tooltip_text = "Skipped Tests"
 stretch_mode = 3
 
-[node name="btn_up" type="Button" parent="VBoxContainer/status_bar/skipped/icon" unique_id=273208942]
+[node name="btn_up" type="Button" parent="status_bar/skipped/icon" unique_id=273208942]
 layout_mode = 2
 size_flags_horizontal = 8
 size_flags_vertical = 4
 tooltip_text = "Jump to the previous skipped test"
 theme_override_styles/normal = SubResource("StyleBoxEmpty_1mh1t")
 
-[node name="counter" type="HBoxContainer" parent="VBoxContainer/status_bar/skipped" unique_id=1082090192]
+[node name="counter" type="HBoxContainer" parent="status_bar/skipped" unique_id=1082090192]
 auto_translate_mode = 2
 layout_mode = 2
 size_flags_horizontal = 8
 localize_numeral_system = false
 theme_override_constants/separation = 0
 
-[node name="skipped_value" type="Label" parent="VBoxContainer/status_bar/skipped/counter" unique_id=500157525]
+[node name="skipped_value" type="Label" parent="status_bar/skipped/counter" unique_id=500157525]
 unique_name_in_owner = true
 use_parent_material = true
 custom_minimum_size = Vector2(32, 0)
@@ -308,19 +285,19 @@ justification_flags = 0
 visible_characters = 3
 visible_ratio = 3.0
 
-[node name="btn_down" type="Button" parent="VBoxContainer/status_bar/skipped/counter" unique_id=2025315587]
+[node name="btn_down" type="Button" parent="status_bar/skipped/counter" unique_id=2025315587]
 layout_mode = 2
 size_flags_horizontal = 8
 size_flags_vertical = 4
 tooltip_text = "Jump to the next skipped test"
 theme_override_styles/normal = SubResource("StyleBoxEmpty_lpjla")
 
-[connection signal="pressed" from="VBoxContainer/tree_tools/tree_buttons/btn_tree_sync" to="." method="_on_btn_tree_sync_pressed"]
-[connection signal="pressed" from="VBoxContainer/status_bar/error/icon/btn_up" to="." method="_on_btn_error_up_pressed"]
-[connection signal="pressed" from="VBoxContainer/status_bar/error/counter/btn_down" to="." method="_on_btn_error_down_pressed"]
-[connection signal="pressed" from="VBoxContainer/status_bar/failure/icon/btn_up" to="." method="_on_failure_up_pressed"]
-[connection signal="pressed" from="VBoxContainer/status_bar/failure/counter/btn_down" to="." method="_on_failure_down_pressed"]
-[connection signal="pressed" from="VBoxContainer/status_bar/flaky/icon/btn_up" to="." method="_on_btn_flaky_up_pressed"]
-[connection signal="pressed" from="VBoxContainer/status_bar/flaky/counter/btn_down" to="." method="_on_btn_flaky_down_pressed"]
-[connection signal="pressed" from="VBoxContainer/status_bar/skipped/icon/btn_up" to="." method="_on_btn_skipped_up_pressed"]
-[connection signal="pressed" from="VBoxContainer/status_bar/skipped/counter/btn_down" to="." method="_on_btn_skipped_down_pressed"]
+[connection signal="pressed" from="tree_tools/tree_buttons/btn_tree_sync" to="." method="_on_btn_tree_sync_pressed"]
+[connection signal="pressed" from="status_bar/error/icon/btn_up" to="." method="_on_btn_error_up_pressed"]
+[connection signal="pressed" from="status_bar/error/counter/btn_down" to="." method="_on_btn_error_down_pressed"]
+[connection signal="pressed" from="status_bar/failure/icon/btn_up" to="." method="_on_failure_up_pressed"]
+[connection signal="pressed" from="status_bar/failure/counter/btn_down" to="." method="_on_failure_down_pressed"]
+[connection signal="pressed" from="status_bar/flaky/icon/btn_up" to="." method="_on_btn_flaky_up_pressed"]
+[connection signal="pressed" from="status_bar/flaky/counter/btn_down" to="." method="_on_btn_flaky_down_pressed"]
+[connection signal="pressed" from="status_bar/skipped/icon/btn_up" to="." method="_on_btn_skipped_up_pressed"]
+[connection signal="pressed" from="status_bar/skipped/counter/btn_down" to="." method="_on_btn_skipped_down_pressed"]

--- a/addons/gdUnit4/src/ui/parts/GdUnitInspectorToolBar.tscn
+++ b/addons/gdUnit4/src/ui/parts/GdUnitInspectorToolBar.tscn
@@ -8,138 +8,130 @@
 
 [sub_resource type="StyleBoxEmpty" id="StyleBoxEmpty_p22nw"]
 
-[sub_resource type="InputEventKey" id="InputEventKey_c7rhl"]
+[sub_resource type="InputEventKey" id="InputEventKey_4j3on"]
 alt_pressed = true
 pressed = true
 keycode = 4194338
 physical_keycode = 4194338
 
-[sub_resource type="Shortcut" id="Shortcut_3erui"]
-events = [SubResource("InputEventKey_c7rhl")]
+[sub_resource type="Shortcut" id="Shortcut_5pa04"]
+events = [SubResource("InputEventKey_4j3on")]
 
 [sub_resource type="StyleBoxEmpty" id="StyleBoxEmpty_3lcek"]
 
-[sub_resource type="InputEventKey" id="InputEventKey_p22nw"]
+[sub_resource type="InputEventKey" id="InputEventKey_85ykl"]
 alt_pressed = true
 pressed = true
 keycode = 4194336
 physical_keycode = 4194336
 
-[sub_resource type="Shortcut" id="Shortcut_3lcek"]
-events = [SubResource("InputEventKey_p22nw")]
+[sub_resource type="Shortcut" id="Shortcut_fpubx"]
+events = [SubResource("InputEventKey_85ykl")]
 
 [sub_resource type="StyleBoxEmpty" id="StyleBoxEmpty_ndw0i"]
 
-[sub_resource type="InputEventKey" id="InputEventKey_ndw0i"]
+[sub_resource type="InputEventKey" id="InputEventKey_1iti7"]
 alt_pressed = true
 pressed = true
 keycode = 4194337
 physical_keycode = 4194337
 
-[sub_resource type="Shortcut" id="Shortcut_eoihf"]
-events = [SubResource("InputEventKey_ndw0i")]
+[sub_resource type="Shortcut" id="Shortcut_hpi24"]
+events = [SubResource("InputEventKey_1iti7")]
 
 [sub_resource type="StyleBoxEmpty" id="StyleBoxEmpty_eoihf"]
 
-[sub_resource type="InputEventKey" id="InputEventKey_6gwbs"]
+[sub_resource type="InputEventKey" id="InputEventKey_hb3do"]
 alt_pressed = true
 pressed = true
 keycode = 4194339
 physical_keycode = 4194339
 
-[sub_resource type="Shortcut" id="Shortcut_2i8uq"]
-events = [SubResource("InputEventKey_6gwbs")]
+[sub_resource type="Shortcut" id="Shortcut_lm2q6"]
+events = [SubResource("InputEventKey_hb3do")]
 
-[node name="ToolBar" type="Control" unique_id=952982667]
-layout_mode = 3
+[node name="ToolBar" type="HBoxContainer" unique_id=295615556]
 anchors_preset = 10
 anchor_right = 1.0
-offset_bottom = 24.0
+offset_bottom = 32.0
 grow_horizontal = 2
-size_flags_horizontal = 3
-size_flags_vertical = 3
 script = ExtResource("3")
 
-[node name="HBoxContainer" type="HBoxContainer" parent="." unique_id=295615556]
-layout_mode = 0
-offset_right = 315.0
-offset_bottom = 24.0
-
-[node name="tools" type="HBoxContainer" parent="HBoxContainer" unique_id=753222103]
+[node name="tools" type="HBoxContainer" parent="." unique_id=753222103]
 layout_mode = 2
 size_flags_horizontal = 0
 size_flags_vertical = 4
 
-[node name="help" type="Button" parent="HBoxContainer/tools" unique_id=1834372497]
+[node name="help" type="Button" parent="tools" unique_id=1834372497]
 unique_name_in_owner = true
 layout_mode = 2
 theme_override_styles/normal = SubResource("StyleBoxEmpty_c7rhl")
 
-[node name="tool" type="Button" parent="HBoxContainer/tools" unique_id=144277615]
+[node name="tool" type="Button" parent="tools" unique_id=144277615]
 unique_name_in_owner = true
 layout_mode = 2
 tooltip_text = "GdUnit Settings"
 theme_override_styles/normal = SubResource("StyleBoxEmpty_3erui")
 
-[node name="controls" type="HBoxContainer" parent="HBoxContainer" unique_id=108317981]
+[node name="controls" type="HBoxContainer" parent="." unique_id=108317981]
 layout_mode = 2
 size_flags_horizontal = 6
 size_flags_vertical = 4
 alignment = 1
 
-[node name="VSeparator3" type="VSeparator" parent="HBoxContainer/controls" unique_id=1244151035]
+[node name="VSeparator3" type="VSeparator" parent="controls" unique_id=1244151035]
 layout_mode = 2
 
-[node name="run_overall" type="Button" parent="HBoxContainer/controls" unique_id=95775836]
+[node name="run_overall" type="Button" parent="controls" unique_id=95775836]
 unique_name_in_owner = true
 use_parent_material = true
 layout_mode = 2
 tooltip_text = "Run overall tests"
 theme_override_styles/normal = SubResource("StyleBoxEmpty_p22nw")
-shortcut = SubResource("Shortcut_3erui")
+shortcut = SubResource("Shortcut_5pa04")
 metadata/GdUnitCommand = "Run Tests Overall"
 
-[node name="run" type="Button" parent="HBoxContainer/controls" unique_id=121281977]
+[node name="run" type="Button" parent="controls" unique_id=121281977]
 unique_name_in_owner = true
 use_parent_material = true
 layout_mode = 2
 tooltip_text = "Rerun unit tests"
 theme_override_styles/normal = SubResource("StyleBoxEmpty_3lcek")
 disabled = true
-shortcut = SubResource("Shortcut_3lcek")
+shortcut = SubResource("Shortcut_fpubx")
 metadata/GdUnitCommand = "Run Inspector Tests"
 
-[node name="debug" type="Button" parent="HBoxContainer/controls" unique_id=1188465777]
+[node name="debug" type="Button" parent="controls" unique_id=1188465777]
 unique_name_in_owner = true
 use_parent_material = true
 layout_mode = 2
 tooltip_text = "Rerun unit tests (Debug)"
 theme_override_styles/normal = SubResource("StyleBoxEmpty_ndw0i")
 disabled = true
-shortcut = SubResource("Shortcut_eoihf")
+shortcut = SubResource("Shortcut_hpi24")
 metadata/GdUnitCommand = "Debug Inspector Tests"
 
-[node name="stop" type="Button" parent="HBoxContainer/controls" unique_id=2086070257]
+[node name="stop" type="Button" parent="controls" unique_id=2086070257]
 unique_name_in_owner = true
 use_parent_material = true
 layout_mode = 2
 tooltip_text = "Stops runing unit tests"
 theme_override_styles/normal = SubResource("StyleBoxEmpty_eoihf")
 disabled = true
-shortcut = SubResource("Shortcut_2i8uq")
+shortcut = SubResource("Shortcut_lm2q6")
 metadata/GdUnitCommand = "Stop Test Session"
 
-[node name="VSeparator4" type="VSeparator" parent="HBoxContainer/controls" unique_id=1661024234]
+[node name="VSeparator4" type="VSeparator" parent="controls" unique_id=1661024234]
 layout_mode = 2
 
-[node name="CenterContainer" type="HBoxContainer" parent="HBoxContainer" unique_id=1521483443]
+[node name="CenterContainer" type="HBoxContainer" parent="." unique_id=1521483443]
 use_parent_material = true
 layout_mode = 2
 size_flags_horizontal = 10
 size_flags_vertical = 4
 alignment = 2
 
-[node name="version" type="Label" parent="HBoxContainer/CenterContainer" unique_id=558200171]
+[node name="version" type="Label" parent="CenterContainer" unique_id=558200171]
 unique_name_in_owner = true
 auto_translate_mode = 2
 use_parent_material = true
@@ -150,9 +142,9 @@ localize_numeral_system = false
 horizontal_alignment = 1
 justification_flags = 160
 
-[connection signal="pressed" from="HBoxContainer/tools/help" to="." method="_on_wiki_pressed"]
-[connection signal="pressed" from="HBoxContainer/tools/tool" to="." method="_on_btn_tool_pressed"]
-[connection signal="pressed" from="HBoxContainer/controls/run_overall" to="." method="_on_button_pressed" flags=18]
-[connection signal="pressed" from="HBoxContainer/controls/run" to="." method="_on_button_pressed" flags=18]
-[connection signal="pressed" from="HBoxContainer/controls/debug" to="." method="_on_button_pressed" flags=18]
-[connection signal="pressed" from="HBoxContainer/controls/stop" to="." method="_on_button_pressed" flags=18]
+[connection signal="pressed" from="tools/help" to="." method="_on_wiki_pressed"]
+[connection signal="pressed" from="tools/tool" to="." method="_on_btn_tool_pressed"]
+[connection signal="pressed" from="controls/run_overall" to="." method="_on_button_pressed" flags=18]
+[connection signal="pressed" from="controls/run" to="." method="_on_button_pressed" flags=18]
+[connection signal="pressed" from="controls/debug" to="." method="_on_button_pressed" flags=18]
+[connection signal="pressed" from="controls/stop" to="." method="_on_button_pressed" flags=18]


### PR DESCRIPTION
# Why
When users set the Godot editor's interface display scale to a non-default value (e.g. 150%), the GdUnit inspector panel renders incorrectly with a broken layout.

# What
- Replaced `Control` root nodes in `GdUnitInspector.tscn`, `GdUnitInspectorStatusBar.tscn`, and `GdUnitInspectorToolBar.tscn` with native layout containers (`VBoxContainer`, `HBoxContainer`)
- Removed intermediate wrapper containers, flattening the scene hierarchy
- Adjusted `size_flags_horizontal`/`size_flags_vertical` to expand+fill so subcomponents fill their parent rect correctly at any display scale

Closes #1152