### PR TITLE
TASK-1154: Add Godot 4.7-beta4 support and fix orphan-check crash

### DIFF
--- a/.github/workflows/ci-pr-publish-report.yml
+++ b/.github/workflows/ci-pr-publish-report.yml
@@ -29,7 +29,7 @@ jobs:
         godot-net: ['-net', '']
         include:
           - godot-version: '4.7'
-            godot-status: 'beta1'
+            godot-status: 'beta4'
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -41,7 +41,7 @@ jobs:
         godot-net: ['.Net', '']
         include:
           - godot-version: '4.7'
-            godot-status: 'beta1'
+            godot-status: 'beta4'
 
     permissions:
       actions: write

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
   <img src="https://img.shields.io/badge/Godot-v4.6-%23478cbf?logo=godot-engine&logoColor=cyian&color=green" alt="">
   <img src="https://img.shields.io/badge/Godot-v4.6.1-%23478cbf?logo=godot-engine&logoColor=cyian&color=green" alt="">
   <img src="https://img.shields.io/badge/Godot-v4.6.2-%23478cbf?logo=godot-engine&logoColor=cyian&color=green" alt="">
-  <img src="https://img.shields.io/badge/Godot-v4.7 beta1-%23478cbf?logo=godot-engine&logoColor=cyian&color=yellow" alt="">
+  <img src="https://img.shields.io/badge/Godot-v4.7 beta4-%23478cbf?logo=godot-engine&logoColor=cyian&color=yellow" alt="">
 </p>
 
 <h1 align="center">Compatibility Overview</h1>
@@ -35,7 +35,7 @@
   </thead>
   <tbody>
     <tr>
-      <td>master (upcoming v6.2)</td><td>v4.5, v4.5.1, v4.6, v4.6.1, v4.6.2, v4.7-beta1</td>
+      <td>master (upcoming v6.2)</td><td>v4.5, v4.5.1, v4.6, v4.6.1, v4.6.2, v4.7-beta4</td>
     </tr>
     <tr>
       <td>v6.1.x</td><td>v4.5, v4.5.1, v4.6, v4.6.1, v4.6.2</td>

--- a/addons/gdUnit4/src/asserts/GdAssertMessages.gd
+++ b/addons/gdUnit4/src/asserts/GdAssertMessages.gd
@@ -188,11 +188,16 @@ static func _index_report_as_table(index_reports :Array) -> String:
 
 static func orphan_warning(orphans_count: int) -> String:
 	return """
-		%s: Found %s possible orphan nodes.
-			Add %s to the end of the test to collect details.""".dedent().trim_prefix("\n") % [
+		%s Found %s possible orphan nodes.
+			To collect detailed information, insert this block at the end of your test.
+			%s""".dedent().trim_prefix("\n") % [
 		_warning("WARNING:"),
 		_nerror(orphans_count),
-		_colored("collect_orphan_node_details()", _value_color)
+		_colored("""
+			[code]
+				await get_tree().process_frame
+				collect_orphan_node_details()
+			[/code]""".dedent().trim_prefix("\n"), GdUnitEditorColorTheme.value_color)
 	]
 
 static func orphan_detected_on_suite_setup(orphans: Array[GdUnitOrphanNodeInfo]) -> String:

--- a/addons/gdUnit4/src/core/GdUnitTestSuiteScanner.gd
+++ b/addons/gdUnit4/src/core/GdUnitTestSuiteScanner.gd
@@ -237,7 +237,7 @@ static func is_test_suite(script: Script) -> bool:
 
 static func _is_script_format_supported(resource_path: String) -> bool:
 	var ext := resource_path.get_extension()
-	return ext == "gd" or ext == "cs"
+	return ext == "gd" or (ext == "cs" and ClassDB.class_exists("CSharpScript"))
 
 
 static func parse_test_suite_name(script: Script) -> String:

--- a/addons/gdUnit4/src/core/_TestCase.gd
+++ b/addons/gdUnit4/src/core/_TestCase.gd
@@ -93,8 +93,13 @@ func _execute_test_case(name: String, test_parameter: Array) -> void:
 	# save the function state like GDScriptFunctionState to dispose at test timeout to prevent orphan state
 	_func_state = get_parent().callv(name, test_parameter)
 	await _func_state
-	# needs at least on await otherwise it breaks the awaiting chain
-	await (Engine.get_main_loop() as SceneTree).process_frame
+	# Give the engine time to free resources otherwies we do orphan false detection
+	await get_tree().process_frame
+	# We need to call deferred the signal `completed` otherwise the current thread is blocked
+	test_completed.call_deferred()
+
+
+func test_completed() -> void:
 	completed.emit()
 
 
@@ -131,7 +136,7 @@ func do_interrupt() -> void:
 		else:
 			execution_context.add_report(GdUnitReport.new()\
 				.create(GdUnitReport.INTERUPTED, line_number(), GdAssertMessages.test_timeout(_attribute.timeout)))
-	completed.emit()
+	test_completed.call_deferred()
 
 
 func do_terminate() -> void:
@@ -141,7 +146,7 @@ func do_terminate() -> void:
 	var execution_context := GdUnitThreadManager.get_current_context().get_execution_context()
 	execution_context.add_report(GdUnitReport.new()\
 		.create(GdUnitReport.TERMINATED, line_number(), GdAssertMessages.test_session_terminated()))
-	completed.emit()
+	test_completed.call_deferred()
 
 
 func _set_failure_handler() -> void:

--- a/addons/gdUnit4/src/core/execution/stages/GdUnitTestSuiteAfterStage.gd
+++ b/addons/gdUnit4/src/core/execution/stages/GdUnitTestSuiteAfterStage.gd
@@ -12,6 +12,8 @@ func _execute(context :GdUnitExecutionContext) -> void:
 
 	@warning_ignore("redundant_await")
 	await test_suite.after()
+	# TODO This is current an workaround to fix sig11 crash on orphan tests
+	await (Engine.get_main_loop() as SceneTree).process_frame
 	await context.gc(GdUnitExecutionContext.GC_ORPHANS_CHECK.SUITE_HOOK_AFTER)
 
 	var reports := context.collect_reports(false)

--- a/addons/gdUnit4/src/core/execution/stages/GdUnitTestSuiteAfterStage.gd
+++ b/addons/gdUnit4/src/core/execution/stages/GdUnitTestSuiteAfterStage.gd
@@ -12,7 +12,8 @@ func _execute(context :GdUnitExecutionContext) -> void:
 
 	@warning_ignore("redundant_await")
 	await test_suite.after()
-	# TODO This is current an workaround to fix sig11 crash on orphan tests
+	# TODO Godot 4.7.beta: This is current an workaround to fix sig11 crash on orphan tests
+	# is releated to https://github.com/godot-gdunit-labs/gdUnit4/issues/1154
 	await (Engine.get_main_loop() as SceneTree).process_frame
 	await context.gc(GdUnitExecutionContext.GC_ORPHANS_CHECK.SUITE_HOOK_AFTER)
 

--- a/addons/gdUnit4/src/core/execution/stages/fuzzed/GdUnitTestCaseFuzzedTestStage.gd
+++ b/addons/gdUnit4/src/core/execution/stages/fuzzed/GdUnitTestCaseFuzzedTestStage.gd
@@ -34,8 +34,6 @@ func _execute(context :GdUnitExecutionContext) -> void:
 				.create(GdUnitReport.FAILURE, report.line_number(), GdAssertMessages.fuzzer_interuped(iteration, report.message())))
 			break
 
-	# TODO Do we really need to sync again here? Otherwise, an orphaned node will be incorrectly detected.
-	await test_suite.get_tree().process_frame
 	await context.gc(GdUnitExecutionContext.GC_ORPHANS_CHECK.TEST_CASE)
 
 	# unguard on fuzzers

--- a/addons/gdUnit4/src/core/execution/stages/fuzzed/GdUnitTestCaseFuzzedTestStage.gd
+++ b/addons/gdUnit4/src/core/execution/stages/fuzzed/GdUnitTestCaseFuzzedTestStage.gd
@@ -33,6 +33,9 @@ func _execute(context :GdUnitExecutionContext) -> void:
 			reports.append(GdUnitReport.new() \
 				.create(GdUnitReport.FAILURE, report.line_number(), GdAssertMessages.fuzzer_interuped(iteration, report.message())))
 			break
+
+	# TODO Do we really need to sync again here? Otherwise, an orphaned node will be incorrectly detected.
+	await test_suite.get_tree().process_frame
 	await context.gc(GdUnitExecutionContext.GC_ORPHANS_CHECK.TEST_CASE)
 
 	# unguard on fuzzers

--- a/addons/gdUnit4/src/monitor/GdUnitOrphanNodesMonitor.gd
+++ b/addons/gdUnit4/src/monitor/GdUnitOrphanNodesMonitor.gd
@@ -79,16 +79,22 @@ func orphans_count() -> int:
 func collect() -> void:
 	if not _orphan_detection_enabled:
 		return
-	for orphan_id in _get_orphan_node_ids():
+
+	var orphan_ids := _get_orphan_node_ids()
+	if orphan_ids.is_empty():
+		return
+
+	var script_backtraces := Engine.capture_script_backtraces(true)
+	for orphan_id in orphan_ids:
 		var orphan_to_find := instance_from_id(orphan_id)
-		_collect_orphan_info(orphan_to_find)
+		_collect_orphan_info(orphan_to_find, script_backtraces)
 
 
-func _collect_orphan_info(orphan_to_find: Object) -> void:
+func _collect_orphan_info(orphan_to_find: Object, script_backtraces: Array[ScriptBacktrace]) -> void:
 	if orphan_to_find == null:
 		return
 
-	var orphan_node := _find_orphan_on_backtraces(orphan_to_find)
+	var orphan_node := _find_orphan_on_backtraces(orphan_to_find, script_backtraces)
 	if orphan_node:
 		_collected_orphan_infos.append(orphan_node)
 		return
@@ -164,8 +170,8 @@ func _is_frame_file_excluded(frame_file: String) -> bool:
 	return false
 
 
-func _find_orphan_on_backtraces(orphan_to_find: Object) -> GdUnitOrphanNodeInfo:
-	for script_backtrace in Engine.capture_script_backtraces(true):
+func _find_orphan_on_backtraces(orphan_to_find: Object, script_backtraces: Array[ScriptBacktrace]) -> GdUnitOrphanNodeInfo:
+	for script_backtrace in script_backtraces:
 		for frame in script_backtrace.get_frame_count():
 			var frame_file := script_backtrace.get_frame_file(frame)
 			if _is_frame_file_excluded(frame_file):

--- a/addons/gdUnit4/test/core/execution/GdUnitExecutionContextTest.gd
+++ b/addons/gdUnit4/test/core/execution/GdUnitExecutionContextTest.gd
@@ -36,6 +36,7 @@ func test_collect_report_statistics_with_errors() -> void:
 			ctx_test_call.gc(GdUnitExecutionContext.GC_ORPHANS_CHECK.TEST_CASE)
 
 			var test_hook_err2 := ctx_test_hook.add_report(GdUnitReport.new().create(GdUnitReport.FAILURE, 4, "after_test error"))
+			await get_tree().process_frame
 			ctx_test_hook.gc(GdUnitExecutionContext.GC_ORPHANS_CHECK.TEST_HOOK_AFTER)
 
 			# verify
@@ -102,6 +103,7 @@ func test_collect_report_statistics_with_errors_on_suite_hooks() -> void:
 			var ctx_test_call := GdUnitExecutionContext.of(ctx_test_hook)
 			ctx_test_call.gc(GdUnitExecutionContext.GC_ORPHANS_CHECK.TEST_CASE)
 
+			await get_tree().process_frame
 			ctx_test_hook.gc(GdUnitExecutionContext.GC_ORPHANS_CHECK.TEST_HOOK_AFTER)
 
 			# verify
@@ -168,6 +170,7 @@ func test_collect_report_statistics_only_errors_on_test_hooks() -> void:
 			var ctx_test_call := GdUnitExecutionContext.of(ctx_test_hook)
 			ctx_test_call.gc(GdUnitExecutionContext.GC_ORPHANS_CHECK.TEST_CASE)
 
+			await get_tree().process_frame
 			ctx_test_hook.gc(GdUnitExecutionContext.GC_ORPHANS_CHECK.TEST_HOOK_AFTER)
 
 			# verify
@@ -231,6 +234,7 @@ func test_collect_report_statistics_all_tests_skipped() -> void:
 				var ctx_test_call := GdUnitExecutionContext.of(ctx_test_hook)
 				ctx_test_call.gc(GdUnitExecutionContext.GC_ORPHANS_CHECK.TEST_CASE)
 				var expected_report := ctx_test_call.add_report(GdUnitReport.new().create(GdUnitReport.SKIPPED, index*5, "skipped test %d" % index))
+				await get_tree().process_frame
 				ctx_test_hook.gc(GdUnitExecutionContext.GC_ORPHANS_CHECK.TEST_HOOK_AFTER)
 				# verify
 				ctx_test.gc()
@@ -298,6 +302,7 @@ func test_simmulate_flaky_test(retry_count: int, is_flaky: bool, is_failed: bool
 				if retry < 2:
 					expected_reports.append(ctx_test_call.add_report(GdUnitReport.new().create(GdUnitReport.FAILURE, 42, "error")))
 					expected_reports.append(ctx_test_call.add_report(GdUnitReport.new().create(GdUnitReport.FAILURE, 43, "error")))
+				await get_tree().process_frame
 				ctx_test_hook.gc(GdUnitExecutionContext.GC_ORPHANS_CHECK.TEST_HOOK_AFTER)
 
 			ctx_test.gc()
@@ -323,6 +328,7 @@ func test_simmulate_flaky_test(retry_count: int, is_flaky: bool, is_failed: bool
 			assert_bool(statistics[GdUnitEvent.FLAKY]).override_failure_message("Shold be marked as %s" %  "flaky" if is_flaky else "").is_equal(is_flaky)
 			assert_bool(statistics[GdUnitEvent.FAILED]).override_failure_message("Expect be failing: %s" % is_failed).is_equal(is_failed)
 
+		await get_tree().process_frame
 		ctx_suite.gc(GdUnitExecutionContext.GC_ORPHANS_CHECK.SUITE_HOOK_AFTER)
 		var suite_reports := ctx_suite.collect_reports(false)
 		assert_array(suite_reports).is_empty()

--- a/addons/gdUnit4/test/core/execution/GdUnitTestSuiteExecutorTest.gd
+++ b/addons/gdUnit4/test/core/execution/GdUnitTestSuiteExecutorTest.gd
@@ -56,7 +56,7 @@ func run_tests(tests :Array[GdUnitTestCase], settings := {}) -> Array[GdUnitEven
 			ProjectSettings.set_setting(key, settings[key])
 
 		# sync to main thread
-		await (Engine.get_main_loop() as SceneTree).process_frame
+		await get_tree().process_frame
 		# execute all tests
 		await executor.run_and_wait(tests)
 
@@ -105,14 +105,15 @@ func assert_event_states(events :Array[GdUnitEvent]) -> GdUnitArrayAssert:
 func assert_event_reports(events: Array[GdUnitEvent], expected_reports: Array) -> void:
 	var _events: Array[GdUnitEvent] = events
 	for event_index in _events.size():
-		var current: Array[GdUnitReport] = _events[event_index].reports()
+		var event := _events[event_index]
+		var current: Array[GdUnitReport] = event.reports()
 		var expected: Array = expected_reports[event_index] if expected_reports.size() > event_index else []
 		if expected.is_empty():
 			for m in current.size():
 				assert_str(flating_message(current[m].message() as String)).is_empty()
 		for m in expected.size():
 			if m < current.size():
-				assert_str(flating_message(current[m].message() as String)).starts_with(str(expected[m]))
+				assert_str(flating_message(current[m].message() as String)).append_failure_message(event.test_name()).starts_with(str(expected[m]))
 			else:
 				assert_str("<N/A>").is_equal(expected[m])
 
@@ -603,7 +604,7 @@ func test_execute_error_on_test_timeout() -> void:
 
 # This test checks if all test stages are called at each test iteration.
 func test_execute_fuzzed_metrics() -> void:
-	var tests := GdUnitTestResourceLoader.load_tests("res://addons/gdUnit4/test/core/resources/testsuites/TestSuiteFuzzedMetricsTest.resource")
+	var tests := GdUnitTestResourceLoader.load_tests("res://addons/gdUnit4/test/core/resources/testsuites/TestSuiteFuzzedMetricsTest.gd")
 	var all_tests: Array[GdUnitTestCase] = Array(tests.values(), TYPE_OBJECT, "RefCounted", GdUnitTestCase)
 
 	# simulate test suite execution
@@ -624,7 +625,7 @@ func test_execute_fuzzed_metrics() -> void:
 
 # This test checks if all test stages are called at each test iteration.
 func test_execute_parameterized_metrics() -> void:
-	var tests := GdUnitTestResourceLoader.load_tests("res://addons/gdUnit4/test/core/resources/testsuites/TestSuiteParameterizedMetricsTest.resource")
+	var tests := GdUnitTestResourceLoader.load_tests("res://addons/gdUnit4/test/core/resources/testsuites/TestSuiteParameterizedMetricsTest.gd")
 	var all_tests: Array[GdUnitTestCase] = Array(tests.values(), TYPE_OBJECT, "RefCounted", GdUnitTestCase)
 
 	# simulate test suite execution

--- a/addons/gdUnit4/test/core/execution/resources/orphans/TestSuiteFailAndOrpahnsDetected.gd
+++ b/addons/gdUnit4/test/core/execution/resources/orphans/TestSuiteFailAndOrpahnsDetected.gd
@@ -26,6 +26,7 @@ func test_case1() -> void:
 	var n12 := Node.new()
 	var n13 := Node.new()
 	_orphans.append_array([n11, n12, n13])
+	await get_tree().process_frame
 	collect_orphan_node_details()
 
 
@@ -38,6 +39,7 @@ func test_case2() -> void:
 	var n24 := Node.new()
 	_orphans.append_array([n21, n22, n23, n24])
 	fail("faild on test_case2()")
+	await get_tree().process_frame
 	collect_orphan_node_details()
 
 

--- a/addons/gdUnit4/test/core/resources/testsuites/TestSuiteFuzzedMetricsTest.gd
+++ b/addons/gdUnit4/test/core/resources/testsuites/TestSuiteFuzzedMetricsTest.gd
@@ -8,21 +8,21 @@ class TestCaseStatistics:
 	var _testcase_after_called := 0
 	var _test_called := 0
 	var _expected_calls :int
-	
+
 	func _init(expected_calls :int) -> void:
 		_expected_calls = expected_calls
-	
+
 	func count_test_before_test() -> void:
 		_testcase_before_called +=1
-	
+
 	func count_test_after_test() -> void:
 		_testcase_after_called +=1
-	
+
 	func count_test() -> void:
 		_test_called += 1
 
 
-var _metrics := {
+var _metrics: Dictionary[String, TestCaseStatistics] = {
 	"test_execute_3times" : TestCaseStatistics.new(3),
 	"test_execute_5times" : TestCaseStatistics.new(5)
 }
@@ -46,7 +46,7 @@ func after() -> void:
 	assert_that(_after_called)\
 		.override_failure_message("Expecting 'after' is called only one times")\
 		.is_equal(1)
-	
+
 	for test_case :String in _metrics.keys():
 		var statistics: TestCaseStatistics = _metrics[test_case]
 		assert_int(statistics._testcase_before_called)\
@@ -70,13 +70,9 @@ func after_test() -> void:
 	_metrics[__active_test_case].count_test_after_test()
 
 
-@warning_ignore('unused_parameter')
-func test_execute_3times(fuzzer := Fuzzers.rangei(0, 1000), fuzzer_iterations := 3) -> void:
+func test_execute_3times(_fuzzer := Fuzzers.rangei(0, 1000), _fuzzer_iterations := 3) -> void:
 	_metrics[__active_test_case].count_test()
-	pass
 
 
-@warning_ignore('unused_parameter')
-func test_execute_5times(fuzzer := Fuzzers.rangei(0, 1000), fuzzer_iterations := 5) -> void:
+func test_execute_5times(_fuzzer := Fuzzers.rangei(0, 1000), _fuzzer_iterations := 5) -> void:
 	_metrics[__active_test_case].count_test()
-	pass

--- a/addons/gdUnit4/test/core/resources/testsuites/TestSuiteParameterizedMetricsTest.gd
+++ b/addons/gdUnit4/test/core/resources/testsuites/TestSuiteParameterizedMetricsTest.gd
@@ -1,29 +1,26 @@
 extends GdUnitTestSuite
 
-@warning_ignore('unused_parameter')
-@warning_ignore('return_value_discarded')
-
 
 class TestCaseStatistics:
 	var _testcase_before_called := 0
 	var _testcase_after_called := 0
 	var _test_called := 0
 	var _expected_calls :int
-	
+
 	func _init(expected_calls :int) -> void:
 		_expected_calls = expected_calls
-	
+
 	func count_test_before_test() -> void:
 		_testcase_before_called +=1
-	
+
 	func count_test_after_test() -> void:
 		_testcase_after_called +=1
-	
+
 	func count_test() -> void:
 		_test_called += 1
 
 
-var _metrics := {
+var _metrics: Dictionary[String, TestCaseStatistics] = {
 	"test_parameterized_2times" : TestCaseStatistics.new(2),
 	"test_parameterized_5times" : TestCaseStatistics.new(5)
 }
@@ -44,7 +41,7 @@ func after() -> void:
 	assert_that(_after_called)\
 		.override_failure_message("Expecting 'after' is called only one times")\
 		.is_equal(1)
-	
+
 	for test_case :String in _metrics.keys():
 		var statistics: TestCaseStatistics = _metrics[test_case]
 		assert_int(statistics._testcase_before_called)\
@@ -66,20 +63,18 @@ func after_test() -> void:
 	_metrics[__active_test_case].count_test_after_test()
 
 
-@warning_ignore('unused_parameter')
-func test_parameterized_2times(a: int, expected :bool, test_parameters := [
+func test_parameterized_2times(_value: int, _expected: bool, _test_parameters := [
 	[0, false],
 	[1, true]]) -> void:
-	
+
 	_metrics[__active_test_case].count_test()
 
 
-@warning_ignore('unused_parameter')
-func test_parameterized_5times(a: int, expected :bool, test_parameters := [
+func test_parameterized_5times(_value: int, _expected: bool, _test_parameters := [
 	[0, false],
 	[1, true],
 	[0, false],
 	[1, true],
 	[1, true]]) -> void:
-	
+
 	_metrics[__active_test_case].count_test()

--- a/addons/gdUnit4/test/ui/parts/GdUnitInspectorTreeMainPanelTest.gd
+++ b/addons/gdUnit4/test/ui/parts/GdUnitInspectorTreeMainPanelTest.gd
@@ -813,7 +813,7 @@ func load_non_cached(resource_path: String) -> GDScript:
 	return ResourceLoader.load(resource_path, "GDScript", ResourceLoader.CACHE_MODE_IGNORE)
 
 
-func cs_load_non_cached(resource_path: String) -> GDScript:
+func cs_load_non_cached(resource_path: String) -> Script:
 	return ResourceLoader.load(resource_path, "CSharpScript", ResourceLoader.CACHE_MODE_IGNORE)
 
 


### PR DESCRIPTION
# Why
Godot 4.7-beta4 introduced a regression that crashes the test runner (SIGSEGV / signal 11)
when GdUnit4 collects orphan node backtraces during the suite `after` teardown stage.
Related to https://github.com/godotengine/godot/issues/119654.

# What
- Update CI workflows and README to target Godot 4.7-beta4
- Pre-capture all script backtraces once in `GdUnitOrphanNodesMonitor` before iterating
  orphans, eliminating repeated `Engine.capture_script_backtraces()` calls
- Add `await process_frame` workaround in `GdUnitTestSuiteAfterStage` after `after()`
  to prevent the crash during orphan detection
- Add `test_completed()` helper in `_TestCase` and emit `completed` via `call_deferred()`
  in `_execute_test_case`, `do_interrupt`, and `do_terminate` to avoid blocking the current thread
- Guard C# script scanning with `ClassDB.class_exists("CSharpScript")` in `GdUnitTestSuiteScanner`
- Improve orphan warning message in `GdAssertMessages` with a code snippet example
- Rename test suite resources (`.resource` → `.gd`) and fix typed dictionary declarations

Closes #1154