### PR TITLE
Add Godot 4.7-beta5 to CI

### DIFF
--- a/.github/workflows/ci-pr-publish-report.yml
+++ b/.github/workflows/ci-pr-publish-report.yml
@@ -29,7 +29,7 @@ jobs:
         godot-net: ['-net', '']
         include:
           - godot-version: '4.7'
-            godot-status: 'beta4'
+            godot-status: 'beta5'
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -41,7 +41,7 @@ jobs:
         godot-net: ['.Net', '']
         include:
           - godot-version: '4.7'
-            godot-status: 'beta4'
+            godot-status: 'beta5'
 
     permissions:
       actions: write

--- a/README.md
+++ b/README.md
@@ -14,14 +14,14 @@
 
 <h1 align="center">Supported Godot Versions</h1>
 <p align="center">
-  <img src="https://img.shields.io/badge/Godot-v4.3-%23478cbf?logo=godot-engine&logoColor=cyian&color=green" alt="">
-  <img src="https://img.shields.io/badge/Godot-v4.4-%23478cbf?logo=godot-engine&logoColor=cyian&color=green" alt="">
-  <img src="https://img.shields.io/badge/Godot-v4.4.1-%23478cbf?logo=godot-engine&logoColor=cyian&color=green" alt="">
-  <img src="https://img.shields.io/badge/Godot-v4.5-%23478cbf?logo=godot-engine&logoColor=cyian&color=green" alt="">
-  <img src="https://img.shields.io/badge/Godot-v4.6-%23478cbf?logo=godot-engine&logoColor=cyian&color=green" alt="">
-  <img src="https://img.shields.io/badge/Godot-v4.6.1-%23478cbf?logo=godot-engine&logoColor=cyian&color=green" alt="">
-  <img src="https://img.shields.io/badge/Godot-v4.6.2-%23478cbf?logo=godot-engine&logoColor=cyian&color=green" alt="">
-  <img src="https://img.shields.io/badge/Godot-v4.7 beta4-%23478cbf?logo=godot-engine&logoColor=cyian&color=yellow" alt="">
+  <img src="https://img.shields.io/badge/v4.3-%23478cbf?logo=godot-engine&logoColor=cyian&color=green" alt="">
+  <img src="https://img.shields.io/badge/v4.4-%23478cbf?logo=godot-engine&logoColor=cyian&color=green" alt="">
+  <img src="https://img.shields.io/badge/v4.4.1-%23478cbf?logo=godot-engine&logoColor=cyian&color=green" alt="">
+  <img src="https://img.shields.io/badge/v4.5-%23478cbf?logo=godot-engine&logoColor=cyian&color=green" alt="">
+  <img src="https://img.shields.io/badge/v4.6-%23478cbf?logo=godot-engine&logoColor=cyian&color=green" alt="">
+  <img src="https://img.shields.io/badge/v4.6.1-%23478cbf?logo=godot-engine&logoColor=cyian&color=green" alt="">
+  <img src="https://img.shields.io/badge/v4.6.2-%23478cbf?logo=godot-engine&logoColor=cyian&color=green" alt="">
+  <img src="https://img.shields.io/badge/v4.7.beta5-%23478cbf?logo=godot-engine&logoColor=cyian&color=yellow" alt="">
 </p>
 
 <h1 align="center">Compatibility Overview</h1>
@@ -35,7 +35,7 @@
   </thead>
   <tbody>
     <tr>
-      <td>master (upcoming v6.2)</td><td>v4.5, v4.5.1, v4.6, v4.6.1, v4.6.2, v4.7-beta4</td>
+      <td>master (upcoming v6.2)</td><td>v4.5, v4.5.1, v4.6, v4.6.1, v4.6.2, v4.7-beta5</td>
     </tr>
     <tr>
       <td>v6.1.x</td><td>v4.5, v4.5.1, v4.6, v4.6.1, v4.6.2</td>

--- a/addons/gdUnit4/src/core/execution/stages/GdUnitTestSuiteAfterStage.gd
+++ b/addons/gdUnit4/src/core/execution/stages/GdUnitTestSuiteAfterStage.gd
@@ -12,9 +12,6 @@ func _execute(context :GdUnitExecutionContext) -> void:
 
 	@warning_ignore("redundant_await")
 	await test_suite.after()
-	# TODO Godot 4.7.beta: This is current an workaround to fix sig11 crash on orphan tests
-	# is releated to https://github.com/godot-gdunit-labs/gdUnit4/issues/1154
-	await (Engine.get_main_loop() as SceneTree).process_frame
 	await context.gc(GdUnitExecutionContext.GC_ORPHANS_CHECK.SUITE_HOOK_AFTER)
 
 	var reports := context.collect_reports(false)

--- a/addons/gdUnit4/test/core/execution/GdUnitExecutionContextTest.gd
+++ b/addons/gdUnit4/test/core/execution/GdUnitExecutionContextTest.gd
@@ -36,7 +36,6 @@ func test_collect_report_statistics_with_errors() -> void:
 			ctx_test_call.gc(GdUnitExecutionContext.GC_ORPHANS_CHECK.TEST_CASE)
 
 			var test_hook_err2 := ctx_test_hook.add_report(GdUnitReport.new().create(GdUnitReport.FAILURE, 4, "after_test error"))
-			await get_tree().process_frame
 			ctx_test_hook.gc(GdUnitExecutionContext.GC_ORPHANS_CHECK.TEST_HOOK_AFTER)
 
 			# verify
@@ -103,7 +102,6 @@ func test_collect_report_statistics_with_errors_on_suite_hooks() -> void:
 			var ctx_test_call := GdUnitExecutionContext.of(ctx_test_hook)
 			ctx_test_call.gc(GdUnitExecutionContext.GC_ORPHANS_CHECK.TEST_CASE)
 
-			await get_tree().process_frame
 			ctx_test_hook.gc(GdUnitExecutionContext.GC_ORPHANS_CHECK.TEST_HOOK_AFTER)
 
 			# verify
@@ -170,7 +168,6 @@ func test_collect_report_statistics_only_errors_on_test_hooks() -> void:
 			var ctx_test_call := GdUnitExecutionContext.of(ctx_test_hook)
 			ctx_test_call.gc(GdUnitExecutionContext.GC_ORPHANS_CHECK.TEST_CASE)
 
-			await get_tree().process_frame
 			ctx_test_hook.gc(GdUnitExecutionContext.GC_ORPHANS_CHECK.TEST_HOOK_AFTER)
 
 			# verify
@@ -234,7 +231,7 @@ func test_collect_report_statistics_all_tests_skipped() -> void:
 				var ctx_test_call := GdUnitExecutionContext.of(ctx_test_hook)
 				ctx_test_call.gc(GdUnitExecutionContext.GC_ORPHANS_CHECK.TEST_CASE)
 				var expected_report := ctx_test_call.add_report(GdUnitReport.new().create(GdUnitReport.SKIPPED, index*5, "skipped test %d" % index))
-				await get_tree().process_frame
+
 				ctx_test_hook.gc(GdUnitExecutionContext.GC_ORPHANS_CHECK.TEST_HOOK_AFTER)
 				# verify
 				ctx_test.gc()
@@ -302,7 +299,7 @@ func test_simmulate_flaky_test(retry_count: int, is_flaky: bool, is_failed: bool
 				if retry < 2:
 					expected_reports.append(ctx_test_call.add_report(GdUnitReport.new().create(GdUnitReport.FAILURE, 42, "error")))
 					expected_reports.append(ctx_test_call.add_report(GdUnitReport.new().create(GdUnitReport.FAILURE, 43, "error")))
-				await get_tree().process_frame
+
 				ctx_test_hook.gc(GdUnitExecutionContext.GC_ORPHANS_CHECK.TEST_HOOK_AFTER)
 
 			ctx_test.gc()
@@ -328,7 +325,6 @@ func test_simmulate_flaky_test(retry_count: int, is_flaky: bool, is_failed: bool
 			assert_bool(statistics[GdUnitEvent.FLAKY]).override_failure_message("Shold be marked as %s" %  "flaky" if is_flaky else "").is_equal(is_flaky)
 			assert_bool(statistics[GdUnitEvent.FAILED]).override_failure_message("Expect be failing: %s" % is_failed).is_equal(is_failed)
 
-		await get_tree().process_frame
 		ctx_suite.gc(GdUnitExecutionContext.GC_ORPHANS_CHECK.SUITE_HOOK_AFTER)
 		var suite_reports := ctx_suite.collect_reports(false)
 		assert_array(suite_reports).is_empty()


### PR DESCRIPTION
# Why
The new RC Godot-4.7-beta5 is out, and we can rollback the custom hacks to prevent the plugin crashing.

# What
- Remove the as workaround added obsolete extra awaits since the bug https://github.com/godotengine/godot/issues/119654 is fixed now.
- Adding Godot 4.7-beta5 to the CI workflows
