### PR TITLE
TASK-1160: Add end-line parsing to GdFunctionDescriptor for code injection

### DIFF
--- a/addons/gdUnit4/src/core/parse/GdFunctionDescriptor.gd
+++ b/addons/gdUnit4/src/core/parse/GdFunctionDescriptor.gd
@@ -1,42 +1,29 @@
 class_name GdFunctionDescriptor
 extends RefCounted
 
-var _is_virtual :bool
-var _is_static :bool
-var _is_engine :bool
-var _is_coroutine :bool
-var _name :String
+var _is_virtual: bool
+var _is_static: bool
+var _is_engine: bool
+var _is_coroutine: bool
+var _name: String
 var _source_path: String
-var _line_number :int
-var _return_type :int
-var _return_class :String
-var _args : Array[GdFunctionArgument]
-var _varargs :Array[GdFunctionArgument]
+var _begin_line: int = -1
+var _end_line: int = -1
+var _return_type: int
+var _return_class: String
+var _args: Array[GdFunctionArgument]
+var _varargs: Array[GdFunctionArgument]
 
 
-
-static func create(p_name: String, p_source_path: String, p_source_line: int, p_return_type: int, p_args: Array[GdFunctionArgument] = []) -> GdFunctionDescriptor:
-	var fd := GdFunctionDescriptor.new(p_name, p_source_line, false, false, false, p_return_type, "", p_args)
-	fd.enrich_file_info(p_source_path, p_source_line)
-	return fd
-
-static func create_static(p_name: String, p_source_path: String, p_source_line: int, p_return_type: int, p_args: Array[GdFunctionArgument] = []) -> GdFunctionDescriptor:
-	var fd := GdFunctionDescriptor.new(p_name, p_source_line, false, true, false, p_return_type, "", p_args)
-	fd.enrich_file_info(p_source_path, p_source_line)
-	return fd
-
-
-func _init(p_name :String,
-	p_line_number :int,
-	p_is_virtual :bool,
-	p_is_static :bool,
-	p_is_engine :bool,
-	p_return_type :int,
-	p_return_class :String,
-	p_args : Array[GdFunctionArgument],
-	p_varargs :Array[GdFunctionArgument] = []) -> void:
+func _init(p_name: String,
+	p_is_virtual: bool,
+	p_is_static: bool,
+	p_is_engine: bool,
+	p_return_type: int,
+	p_return_class: String,
+	p_args: Array[GdFunctionArgument],
+	p_varargs: Array[GdFunctionArgument] = []) -> void:
 	_name = p_name
-	_line_number = p_line_number
 	_return_type = p_return_type
 	_return_class = p_return_class
 	_is_virtual = p_is_virtual
@@ -60,8 +47,12 @@ func source_path() -> String:
 	return _source_path
 
 
-func line_number() -> int:
-	return _line_number
+func begin_line() -> int:
+	return _begin_line
+
+
+func end_line() -> int:
+	return _end_line
 
 
 func is_virtual() -> bool:
@@ -125,9 +116,10 @@ func enrich_arguments(arguments: Array[Dictionary]) -> void:
 			set_argument_value(arg_name, arg_value)
 
 
-func enrich_file_info(p_source_path: String, p_line_number: int) -> void:
+func enrich_file_info(p_source_path: String, p_begin_line: int, p_end_line: int) -> void:
 	_source_path = p_source_path
-	_line_number = p_line_number
+	_begin_line = p_begin_line
+	_end_line = p_end_line
 
 
 func args() -> Array[GdFunctionArgument]:
@@ -152,11 +144,11 @@ func typed_args() -> String:
 func _to_string() -> String:
 	var fsignature := "virtual " if is_virtual() else ""
 	if _return_type == TYPE_NIL:
-		return fsignature + "[Line:%s] func %s(%s):" % [line_number(), name(), typed_args()]
-	var func_template := fsignature + "[Line:%s] func %s(%s) -> %s:"
+		return fsignature + "[Line:(%d,%d)] func %s(%s):" % [begin_line(), end_line(), name(), typed_args()]
+	var func_template := fsignature + "[Line:(%d,%d)] func %s(%s) -> %s:"
 	if is_static():
-		func_template= "[Line:%s] static func %s(%s) -> %s:"
-	return func_template % [line_number(), name(), typed_args(), return_type_as_string()]
+		func_template= "[Line:(%d,%d)] static func %s(%s) -> %s:"
+	return func_template % [begin_line(), end_line(), name(), typed_args(), return_type_as_string()]
 
 
 # extract function description given by Object.get_method_list()
@@ -172,7 +164,6 @@ static func extract_from(descriptor :Dictionary, is_engine_ := true) -> GdFuncti
 	var return_type_ := _extract_return_type(return_descriptor)
 	return GdFunctionDescriptor.new(
 		func_name,
-		-1,
 		is_virtual_,
 		is_static_,
 		is_engine_,
@@ -206,7 +197,7 @@ const enum_fix := [
 	"Control.LayoutMode"]
 
 
-static func _extract_return_type(return_info :Dictionary) -> int:
+static func _extract_return_type(return_info: Dictionary) -> int:
 	var type :int = return_info["type"]
 	var usage :int = return_info["usage"]
 	if usage & PROPERTY_USAGE_CLASS_IS_ENUM:
@@ -218,13 +209,13 @@ static func _extract_return_type(return_info :Dictionary) -> int:
 	return type
 
 
-static func _extract_args(descriptor :Dictionary) -> Array[GdFunctionArgument]:
-	var args_ :Array[GdFunctionArgument] = []
-	var arguments :Array = descriptor["args"]
-	var defaults :Array = descriptor["default_args"]
+static func _extract_args(descriptor: Dictionary) -> Array[GdFunctionArgument]:
+	var args_: Array[GdFunctionArgument] = []
+	var arguments: Array = descriptor["args"]
+	var defaults: Array = descriptor["default_args"]
 	# iterate backwards because the default values are stored from right to left
 	while not arguments.is_empty():
-		var arg :Dictionary = arguments.pop_back()
+		var arg: Dictionary = arguments.pop_back()
 		var arg_name := _argument_name(arg)
 		var arg_type := _argument_type(arg)
 		var arg_type_hint := _argument_hint(arg)
@@ -234,21 +225,21 @@ static func _extract_args(descriptor :Dictionary) -> Array[GdFunctionArgument]:
 	return args_
 
 
-static func _build_varargs(p_is_vararg :bool) -> Array[GdFunctionArgument]:
-	var varargs_ :Array[GdFunctionArgument] = []
+static func _build_varargs(p_is_vararg: bool) -> Array[GdFunctionArgument]:
+	var varargs_: Array[GdFunctionArgument] = []
 	if not p_is_vararg:
 		return varargs_
 	varargs_.push_back(GdFunctionArgument.new("varargs", GdObjects.TYPE_VARARG, ''))
 	return varargs_
 
 
-static func _argument_name(arg :Dictionary) -> String:
+static func _argument_name(arg: Dictionary) -> String:
 	return arg["name"]
 
 
-static func _argument_type(arg :Dictionary) -> int:
-	var type :int = arg["type"]
-	var usage :int = arg["usage"]
+static func _argument_type(arg: Dictionary) -> int:
+	var type: int = arg["type"]
+	var usage: int = arg["usage"]
 
 	if type == TYPE_OBJECT:
 		if arg["class_name"] == "Node":
@@ -262,9 +253,9 @@ static func _argument_type(arg :Dictionary) -> int:
 	return type
 
 
-static func _argument_hint(arg :Dictionary) -> int:
-	var hint :int = arg["hint"]
-	var hint_string :String = arg["hint_string"]
+static func _argument_hint(arg: Dictionary) -> int:
+	var hint: int = arg["hint"]
+	var hint_string: String = arg["hint_string"]
 
 	match hint:
 		PROPERTY_HINT_ARRAY_TYPE:
@@ -273,13 +264,13 @@ static func _argument_hint(arg :Dictionary) -> int:
 			return 0
 
 
-static func _argument_type_as_string(arg :Dictionary) -> String:
+static func _argument_type_as_string(arg: Dictionary) -> String:
 	var type := _argument_type(arg)
 	match type:
 		TYPE_NIL:
 			return ""
 		TYPE_OBJECT:
-			var clazz_name :String = arg["class_name"]
+			var clazz_name: String = arg["class_name"]
 			if not clazz_name.is_empty():
 				return clazz_name
 			return ""

--- a/addons/gdUnit4/src/core/parse/GdFunctionParameterSetResolver.gd
+++ b/addons/gdUnit4/src/core/parse/GdFunctionParameterSetResolver.gd
@@ -26,7 +26,7 @@ func _init(fd: GdFunctionDescriptor) -> void:
 
 func resolve_test_cases(script: GDScript) -> Array[GdUnitTestCase]:
 	if not is_parameterized():
-		return [GdUnitTestCase.from(script.resource_path, _fd.source_path(), _fd.line_number(), _fd.name())]
+		return [GdUnitTestCase.from(script.resource_path, _fd.source_path(), _fd.begin_line(), _fd.name())]
 	return extract_test_cases_by_reflection(script)
 
 
@@ -102,7 +102,7 @@ func extract_test_cases_by_reflection(script: GDScript) -> Array[GdUnitTestCase]
 			var parameter_set := parameter_sets[parameter_set_index]
 			_static_sets_by_index[parameter_set_index] = _is_static_parameter_set(parameter_set, property_names)
 			@warning_ignore("return_value_discarded")
-			test_cases.append(GdUnitTestCase.from(script.resource_path, _fd.source_path(), _fd.line_number(), _fd.name(), parameter_set_index, parameter_set))
+			test_cases.append(GdUnitTestCase.from(script.resource_path, _fd.source_path(), _fd.begin_line(), _fd.name(), parameter_set_index, parameter_set))
 			parameter_set_index += 1
 		return test_cases
 
@@ -128,7 +128,7 @@ func _extract_test_cases_by_reflection(source: Node, script: GDScript) -> Array[
 	for index in parameter_sets.size():
 		var parameter_set := str(parameter_sets[index])
 		@warning_ignore("return_value_discarded")
-		test_cases.append(GdUnitTestCase.from(script.resource_path, _fd.source_path(), _fd.line_number(), _fd.name(), index, parameter_set))
+		test_cases.append(GdUnitTestCase.from(script.resource_path, _fd.source_path(), _fd.begin_line(), _fd.name(), index, parameter_set))
 	return test_cases
 
 

--- a/addons/gdUnit4/src/core/parse/GdScriptParser.gd
+++ b/addons/gdUnit4/src/core/parse/GdScriptParser.gd
@@ -3,12 +3,12 @@ extends RefCounted
 
 const GdUnitTools := preload("res://addons/gdUnit4/src/core/GdUnitTools.gd")
 
-const TYPE_VOID = GdObjects.TYPE_VOID
-const TYPE_VARIANT = GdObjects.TYPE_VARIANT
-const TYPE_VARARG = GdObjects.TYPE_VARARG
-const TYPE_FUNC = GdObjects.TYPE_FUNC
-const TYPE_FUZZER = GdObjects.TYPE_FUZZER
-const TYPE_ENUM = GdObjects.TYPE_ENUM
+const TYPE_VOID := GdObjects.TYPE_VOID
+const TYPE_VARIANT := GdObjects.TYPE_VARIANT
+const TYPE_VARARG := GdObjects.TYPE_VARARG
+const TYPE_FUNC := GdObjects.TYPE_FUNC
+const TYPE_FUZZER := GdObjects.TYPE_FUZZER
+const TYPE_ENUM := GdObjects.TYPE_ENUM
 
 
 var TOKEN_NOT_MATCH := Token.new("")
@@ -16,6 +16,7 @@ var TOKEN_SPACE := SkippableToken.new(" ")
 var TOKEN_TABULATOR := SkippableToken.new("\t")
 var TOKEN_NEW_LINE := SkippableToken.new("\n")
 var TOKEN_COMMENT := SkippableToken.new("#")
+var TOKEN_ANNOTATION := SkippableToken.new("@")
 var TOKEN_CLASS_NAME := RegExToken.new("class_name", GdUnitTools.to_regex("(class_name)\\s+([\\w\\p{L}\\p{N}_]+) (extends[a-zA-Z]+:)|(class_name)\\s+([\\w\\p{L}\\p{N}_]+)"), 5)
 var TOKEN_INNER_CLASS := TokenInnerClass.new("class", GdUnitTools.to_regex("(class)\\s+(\\w\\p{L}\\p{N}_]+) (extends[a-zA-Z]+:)|(class)\\s+([\\w\\p{L}\\p{N}_]+)"), 5)
 var TOKEN_EXTENDS := RegExToken.new("extends", GdUnitTools.to_regex("extends\\s+"))
@@ -52,6 +53,7 @@ var TOKENS :Array[Token] = [
 	TOKEN_NEW_LINE,
 	TOKEN_BACKSLASH,
 	TOKEN_COMMENT,
+	TOKEN_ANNOTATION,
 	TOKEN_BRACKET_ROUND_OPEN,
 	TOKEN_BRACKET_ROUND_CLOSE,
 	TOKEN_BRACKET_SQUARE_OPEN,
@@ -683,9 +685,11 @@ func _enrich_function_descriptor(script: GDScript, fds: Array[GdFunctionDescript
 			enriched_functions[function_name] = true
 			var func_signature := extract_func_signature(rows, rowIndex)
 			var func_arguments := _parse_function_arguments(func_signature)
+			var func_begin_line := rowIndex + 1
+			var func_end_line := _parse_func_end_line(rows, func_begin_line)
 			# enrich missing default values
 			fd.enrich_arguments(func_arguments)
-			fd.enrich_file_info(script_to_scan.resource_path, rowIndex + 1)
+			fd.enrich_file_info(script_to_scan.resource_path, func_begin_line, func_end_line)
 			fd._is_coroutine = is_func_coroutine(rows, rowIndex)
 			# enrich return class name if not set
 			if fd.return_type() == TYPE_OBJECT and fd._return_class in ["", "Resource", "RefCounted"]:
@@ -694,6 +698,20 @@ func _enrich_function_descriptor(script: GDScript, fds: Array[GdFunctionDescript
 					fd._return_class = _patch_inner_class_names(var_token.plain_value(), "")
 		# if the script ihnerits we need to scan this also
 		script_to_scan = script_to_scan.get_base_script()
+
+
+func _parse_func_end_line(rows: PackedStringArray, func_row_index: int) -> int:
+	var last_non_empty := func_row_index
+	for row_index in range(func_row_index, rows.size()):
+		var row := rows[row_index]
+		if row.begins_with("#") or row.is_empty():
+			continue
+		var token := next_token(row, 0)
+		# scan until next function or annotation
+		if token in [TOKEN_ANNOTATION, TOKEN_FUNCTION_STATIC_DECLARATION, TOKEN_FUNCTION_DECLARATION]:
+			break
+		last_non_empty = row_index
+	return last_non_empty + 1
 
 
 func is_func_coroutine(rows :PackedStringArray, index :int) -> bool:

--- a/addons/gdUnit4/test/core/GdObjectsTest.gd
+++ b/addons/gdUnit4/test/core/GdObjectsTest.gd
@@ -467,12 +467,12 @@ func test_extract_class_functions() -> void:
 	var functions := GdObjects.extract_class_functions("Resource", [""])
 	for f :Dictionary in functions:
 		if f["name"] == "get_path":
-			assert_str(GdFunctionDescriptor.extract_from(f)._to_string()).is_equal("[Line:-1] func get_path() -> String:")
+			assert_str(GdFunctionDescriptor.extract_from(f)._to_string()).is_equal("[Line:(-1,-1)] func get_path() -> String:")
 
 	functions = GdObjects.extract_class_functions("CustomResourceTestClass", ["res://addons/gdUnit4/test/mocker/resources/CustomResourceTestClass.gd"])
 	for f :Dictionary in functions:
 		if f["name"] == "get_path":
-			assert_str(GdFunctionDescriptor.extract_from(f)._to_string()).is_equal("[Line:-1] func get_path() -> String:")
+			assert_str(GdFunctionDescriptor.extract_from(f)._to_string()).is_equal("[Line:(-1,-1)] func get_path() -> String:")
 
 
 func test_all_types() -> void:

--- a/addons/gdUnit4/test/core/parse/GdScriptParserTest.gd
+++ b/addons/gdUnit4/test/core/parse/GdScriptParserTest.gd
@@ -2,12 +2,12 @@ extends GdUnitTestSuite
 
 var _parser: GdScriptParser
 
-const TYPE_VOID = GdObjects.TYPE_VOID
-const TYPE_VARIANT = GdObjects.TYPE_VARIANT
-const TYPE_VARARG = GdObjects.TYPE_VARARG
-const TYPE_FUNC = GdObjects.TYPE_FUNC
-const TYPE_FUZZER = GdObjects.TYPE_FUZZER
-const TYPE_ENUM = GdObjects.TYPE_ENUM
+const TYPE_VOID := GdObjects.TYPE_VOID
+const TYPE_VARIANT := GdObjects.TYPE_VARIANT
+const TYPE_VARARG := GdObjects.TYPE_VARARG
+const TYPE_FUNC := GdObjects.TYPE_FUNC
+const TYPE_FUZZER := GdObjects.TYPE_FUZZER
+const TYPE_ENUM := GdObjects.TYPE_ENUM
 
 
 func before() -> void:
@@ -383,6 +383,7 @@ func test_parse_func_name() -> void:
 	assert_str(_parser.parse_func_name("#func foo():")).is_empty()
 	assert_str(_parser.parse_func_name("var x")).is_empty()
 
+
 func test_load_source_code_inner_class_AtmosphereData() -> void:
 	var base_class := AdvancedTestClass.new()
 	@warning_ignore("unsafe_cast")
@@ -473,21 +474,21 @@ func test_parse_func_description() -> void:
 	var fds := _parser.get_function_descriptors(script)
 
 	assert_that(fds[0])\
-		.is_equal(GdFunctionDescriptor.create("foo0", script.resource_path, 4, TYPE_STRING, [
+		.is_equal(create("foo0", script.resource_path, 4, 5, TYPE_STRING, [
 			GdFunctionArgument.new("arg1", TYPE_INT),
 			GdFunctionArgument.new("arg2", TYPE_BOOL, false)
 		]))
 
 	# static function
 	assert_that(fds[1])\
-		.is_equal(GdFunctionDescriptor.create_static("foo1", script.resource_path, 8, TYPE_STRING, [
+		.is_equal(create_static("foo1", script.resource_path, 8, 9, TYPE_STRING, [
 			GdFunctionArgument.new("arg1", TYPE_INT),
 			GdFunctionArgument.new("arg2", TYPE_BOOL, false)
 		]))
 
 	# static function without return type
 	assert_that(fds[2])\
-		.is_equal(GdFunctionDescriptor.create_static("foo2", script.resource_path, 12, GdObjects.TYPE_VARIANT, [
+		.is_equal(create_static("foo2", script.resource_path, 12, 13, GdObjects.TYPE_VARIANT, [
 			GdFunctionArgument.new("arg1", TYPE_INT),
 			GdFunctionArgument.new("arg2", TYPE_BOOL, true)
 		]))
@@ -498,8 +499,7 @@ func test_get_function_descriptors_return_type_enum() -> void:
 	var fds := _parser.get_function_descriptors(script, ["get_enum"])
 
 	assert_that(fds[0])\
-		.is_equal(GdFunctionDescriptor
-			.create("get_enum", script.resource_path, 15, GdObjects.TYPE_ENUM)
+		.is_equal(create("get_enum", script.resource_path, 15, 16, GdObjects.TYPE_ENUM, [])
 			.with_return_class("ClassWithEnumReturnTypes.TEST_ENUM")
 		)
 
@@ -509,8 +509,7 @@ func test_parse_func_description_return_type_internal_class_enum() -> void:
 	var fds := _parser.get_function_descriptors(script, ["get_inner_class_enum"])
 
 	assert_that(fds[0])\
-		.is_equal(GdFunctionDescriptor
-			.create("get_inner_class_enum", script.resource_path, 25, GdObjects.TYPE_ENUM)
+		.is_equal(create("get_inner_class_enum", script.resource_path, 25, 26, GdObjects.TYPE_ENUM, [])
 			.with_return_class("ClassWithEnumReturnTypes.InnerClass.TEST_ENUM")
 		)
 
@@ -520,8 +519,7 @@ func test_parse_func_description_return_type_external_class_enum() -> void:
 	var fds := _parser.get_function_descriptors(script, ["get_external_class_enum"])
 
 	assert_that(fds[0])\
-		.is_equal(GdFunctionDescriptor
-			.create("get_external_class_enum", script.resource_path, 20, GdObjects.TYPE_ENUM)
+		.is_equal(create("get_external_class_enum", script.resource_path, 20, 21, GdObjects.TYPE_ENUM, [])
 			.with_return_class("CustomEnums.TEST_ENUM")
 		)
 
@@ -539,17 +537,17 @@ func test_parse_class_inherits() -> void:
 	assert_bool(clazz_desccriptor.is_inner_class()).is_false()
 	assert_array(clazz_desccriptor.functions())\
 		.contains_exactly([
-			GdFunctionDescriptor.create("foo2", "res://addons/gdUnit4/test/mocker/resources/CustomClassExtendsCustomClass.gd", 6, GdObjects.TYPE_VARIANT),
-			GdFunctionDescriptor.create("bar2", "res://addons/gdUnit4/test/mocker/resources/CustomClassExtendsCustomClass.gd", 9, TYPE_STRING),
-			GdFunctionDescriptor.create("foo", "res://addons/gdUnit4/test/mocker/resources/CustomResourceTestClass.gd", 4, TYPE_STRING),
-			GdFunctionDescriptor.create("foo_void", "res://addons/gdUnit4/test/mocker/resources/CustomResourceTestClass.gd", 10, GdObjects.TYPE_VOID),
-			GdFunctionDescriptor.create("bar", "res://addons/gdUnit4/test/mocker/resources/CustomResourceTestClass.gd", 13, TYPE_STRING, [
+			create("foo2", "res://addons/gdUnit4/test/mocker/resources/CustomClassExtendsCustomClass.gd", 6, 7, GdObjects.TYPE_VARIANT),
+			create("bar2", "res://addons/gdUnit4/test/mocker/resources/CustomClassExtendsCustomClass.gd", 9, 10, TYPE_STRING),
+			create("foo", "res://addons/gdUnit4/test/mocker/resources/CustomResourceTestClass.gd", 4, 5, TYPE_STRING),
+			create("foo_void", "res://addons/gdUnit4/test/mocker/resources/CustomResourceTestClass.gd", 10, 11, GdObjects.TYPE_VOID),
+			create("bar", "res://addons/gdUnit4/test/mocker/resources/CustomResourceTestClass.gd", 13, 14, TYPE_STRING, [
 				GdFunctionArgument.new("arg1", TYPE_INT),
 				GdFunctionArgument.new("arg2", TYPE_INT, 23),
 				GdFunctionArgument.new("name", TYPE_STRING, "test"),
 			]),
 			# see https://github.com/godotengine/godot/pull/118032
-			GdFunctionDescriptor.create("foo5", "res://addons/gdUnit4/test/mocker/resources/CustomResourceTestClass.gd", 17,
+			create("foo5", "res://addons/gdUnit4/test/mocker/resources/CustomResourceTestClass.gd", 17, 18,
 				GdObjects.TYPE_VARIANT if Engine.get_version_info()["minor"] >= 7 else GdObjects.TYPE_VOID),
 		])
 
@@ -618,7 +616,7 @@ func test_parse_func_description_paramized_test() -> void:
 	""")
 	var fds := GdScriptParser.new().get_function_descriptors(script, ["test_parameterized"])
 
-	assert_that(fds[0]).is_equal(GdFunctionDescriptor.create("test_parameterized", script.resource_path, 3, GdObjects.TYPE_VARIANT, [
+	assert_that(fds[0]).is_equal(create("test_parameterized", script.resource_path, 3, 4, GdObjects.TYPE_VARIANT, [
 		GdFunctionArgument.new("a", TYPE_INT),
 		GdFunctionArgument.new("b", TYPE_INT),
 		GdFunctionArgument.new("c", TYPE_INT),
@@ -679,7 +677,7 @@ func test_parse_func_descriptor_with_fuzzers() -> void:
 	# see https://github.com/godotengine/godot/pull/118032
 	var untyped_return_type: int = GdObjects.TYPE_VARIANT if Engine.get_version_info()["minor"] >= 7 else GdObjects.TYPE_VOID
 
-	assert_that(fds[0]).is_equal(GdFunctionDescriptor.create("test_foo", script.resource_path, 12, untyped_return_type, [
+	assert_that(fds[0]).is_equal(create("test_foo", script.resource_path, 12, 17, untyped_return_type, [
 		# all fuzzer must by type TYPE_FUZZER
 		GdFunctionArgument.new("fuzzer_a", GdObjects.TYPE_FUZZER, "fuzz_a()"),
 		GdFunctionArgument.new("fuzzer_b", GdObjects.TYPE_FUZZER, "fuzz_b()"),
@@ -740,3 +738,63 @@ func test_using_class_in_variable_name() -> void:
 	var rows := script.split("\n")
 	assert_bool(_parser.is_func_coroutine(rows, 0)).is_false()
 	assert_bool(_parser.is_func_coroutine(rows, 4)).is_false()
+
+
+func test_find_end_line() -> void:
+	var source := """
+		extends RefCounted															# Line: 1
+
+
+		func test_foo1() -> void:                                                   # Line: 4
+			pass																	# Line: 5
+		func test_foo2() -> void:													# Line: 6
+			pass																	# Line: 7
+
+
+		# Single comment
+		func test_foo3() -> void:													# Line: 11
+			# comment
+
+			pass																	# Line: 14
+
+		@warning_ignore("untyped_declaration")
+		func test_with_paramset(													# Line: 17
+			values: Array,
+			expected: String,
+			_test_parameters : Array = [
+				[ ["a"], "a" ],
+				[ ["a", "very", "long", "argument"], "a very long argument" ],
+			]
+		) -> void:
+			var current := " ".join(values)
+			assert_that(current.strip_edges()).is_equal(expected)(					# Line: 26
+
+		## function doc
+		## pla ...
+		func test_end() -> void:													# Line: 30
+			pass																	# Line: 31
+		""".dedent().trim_prefix("\n")
+
+	var rows := source.split("\n")
+	# test_foo1()
+	assert_int(_parser._parse_func_end_line(rows, 4)).is_equal(5)
+	# test_foo2()
+	assert_int(_parser._parse_func_end_line(rows, 6)).is_equal(7)
+	# test_foo3()
+	assert_int(_parser._parse_func_end_line(rows, 11)).is_equal(14)
+	# test_with_paramset()
+	assert_int(_parser._parse_func_end_line(rows, 17)).is_equal(26)
+	# test_end()
+	assert_int(_parser._parse_func_end_line(rows, 30)).is_equal(31)
+
+
+static func create(func_name: String, source_path: String, begin_line: int, end_line: int, return_type: int, args: Array[GdFunctionArgument] = []) -> GdFunctionDescriptor:
+	var fd := GdFunctionDescriptor.new(func_name, false, false, false, return_type, "", args)
+	fd.enrich_file_info(source_path, begin_line, end_line)
+	return fd
+
+
+static func create_static(func_name: String, source_path: String, begin_line: int, end_line: int, return_type: int, args: Array[GdFunctionArgument]) -> GdFunctionDescriptor:
+	var fd := GdFunctionDescriptor.new(func_name, false, true, false, return_type, "", args)
+	fd.enrich_file_info(source_path, begin_line, end_line)
+	return fd

--- a/addons/gdUnit4/test/core/parse/GdScriptParsingFunctionDescriptorsTest.gd
+++ b/addons/gdUnit4/test/core/parse/GdScriptParsingFunctionDescriptorsTest.gd
@@ -16,38 +16,32 @@ func test_default_args_dictionary() -> void:
 
 	var fds := _parser.get_function_descriptors(script, [])
 	assert_that(fds[0])\
-		.is_equal(GdFunctionDescriptor
-			.create("on_dictionary_case1", script.resource_path, 5, TYPE_ARRAY, [
+		.is_equal(create("on_dictionary_case1", script.resource_path, 5, 6, TYPE_ARRAY, [
 				GdFunctionArgument.new("dict", TYPE_DICTIONARY, {}),
 			])
 		)
 	assert_that(fds[1])\
-		.is_equal(GdFunctionDescriptor
-			.create("on_dictionary_case2", script.resource_path, 9, TYPE_ARRAY, [
+		.is_equal(create("on_dictionary_case2", script.resource_path, 9, 10, TYPE_ARRAY, [
 				GdFunctionArgument.new("dict", TYPE_DICTIONARY, {}),
 			])
 		)
 	assert_that(fds[2])\
-		.is_equal(GdFunctionDescriptor
-			.create("on_dictionary_case3", script.resource_path, 13, TYPE_ARRAY, [
+		.is_equal(create("on_dictionary_case3", script.resource_path, 13, 14, TYPE_ARRAY, [
 				GdFunctionArgument.new("dict", TYPE_DICTIONARY, {}),
 			])
 		)
 	assert_that(fds[3])\
-		.is_equal(GdFunctionDescriptor
-			.create("on_dictionary_case4", script.resource_path, 17, TYPE_ARRAY, [
+		.is_equal(create("on_dictionary_case4", script.resource_path, 17, 18, TYPE_ARRAY, [
 				GdFunctionArgument.new("dict", TYPE_DICTIONARY, {"a":"value_a", "b":"value_b"}),
 			])
 		)
 	assert_that(fds[4])\
-		.is_equal(GdFunctionDescriptor
-			.create("on_dictionary_case5", script.resource_path, 21, TYPE_ARRAY, [
+		.is_equal(create("on_dictionary_case5", script.resource_path, 21, 24, TYPE_ARRAY, [
 				GdFunctionArgument.new("dict", TYPE_DICTIONARY, {"a":"value_a", "b":"value_b"}),
 			])
 		)
 	assert_that(fds[5])\
-		.is_equal(GdFunctionDescriptor
-			.create("on_dictionary_case6", script.resource_path, 27, TYPE_ARRAY, [
+		.is_equal(create("on_dictionary_case6", script.resource_path, 27, 28, TYPE_ARRAY, [
 				GdFunctionArgument.new("dict", TYPE_DICTIONARY, {"a":"value_a", "b":"value_b"}),
 			])
 		)
@@ -58,38 +52,32 @@ func test_default_args_array() -> void:
 
 	var fds := _parser.get_function_descriptors(script, [])
 	assert_that(fds[0])\
-		.is_equal(GdFunctionDescriptor
-			.create("on_array_case1", script.resource_path, 5, TYPE_ARRAY, [
+		.is_equal(create("on_array_case1", script.resource_path, 5, 6, TYPE_ARRAY, [
 				GdFunctionArgument.new("values", TYPE_ARRAY, []),
 			])
 		)
 	assert_that(fds[1])\
-		.is_equal(GdFunctionDescriptor
-			.create("on_array_case2", script.resource_path, 9, TYPE_ARRAY, [
+		.is_equal(create("on_array_case2", script.resource_path, 9, 10, TYPE_ARRAY, [
 				GdFunctionArgument.new("values", TYPE_ARRAY, []),
 			])
 		)
 	assert_that(fds[2])\
-		.is_equal(GdFunctionDescriptor
-			.create("on_array_case3", script.resource_path, 13, TYPE_ARRAY, [
+		.is_equal(create("on_array_case3", script.resource_path, 13, 14, TYPE_ARRAY, [
 				GdFunctionArgument.new("values", TYPE_ARRAY, []),
 			])
 		)
 	assert_that(fds[3])\
-		.is_equal(GdFunctionDescriptor
-			.create("on_array_case4", script.resource_path, 17, TYPE_ARRAY, [
+		.is_equal(create("on_array_case4", script.resource_path, 17, 18, TYPE_ARRAY, [
 				GdFunctionArgument.new("values", TYPE_ARRAY, [1, "3", [], {}]),
 			])
 		)
 	assert_that(fds[4])\
-		.is_equal(GdFunctionDescriptor
-			.create("on_array_case5", script.resource_path, 21, TYPE_ARRAY, [
+		.is_equal(create("on_array_case5", script.resource_path, 21, 26, TYPE_ARRAY, [
 				GdFunctionArgument.new("values", TYPE_ARRAY, [1, "3", [], {}]),
 			])
 		)
 	assert_that(fds[5])\
-		.is_equal(GdFunctionDescriptor
-			.create("on_array_case6", script.resource_path, 29, TYPE_ARRAY, [
+		.is_equal(create("on_array_case6", script.resource_path, 29, 30, TYPE_ARRAY, [
 				GdFunctionArgument.new("values", TYPE_ARRAY, [1, "3", [], {}]),
 			])
 		)
@@ -100,26 +88,22 @@ func test_default_args_callable() -> void:
 
 	var fds := _parser.get_function_descriptors(script, [])
 	assert_that(fds[0])\
-		.is_equal(GdFunctionDescriptor
-			.create("on_callable_case1", script.resource_path, 5, TYPE_CALLABLE, [
+		.is_equal(create("on_callable_case1", script.resource_path, 5, 6, TYPE_CALLABLE, [
 				GdFunctionArgument.new("cb", TYPE_CALLABLE),
 			])
 		)
 	assert_that(fds[1])\
-		.is_equal(GdFunctionDescriptor
-			.create("on_callable_case2", script.resource_path, 9, TYPE_CALLABLE, [
+		.is_equal(create("on_callable_case2", script.resource_path, 9, 10, TYPE_CALLABLE, [
 				GdFunctionArgument.new("cb", TYPE_CALLABLE, Callable()),
 			])
 		)
 	assert_that(fds[2])\
-		.is_equal(GdFunctionDescriptor
-			.create("on_callable_case3", script.resource_path, 13, TYPE_CALLABLE, [
+		.is_equal(create("on_callable_case3", script.resource_path, 13, 14, TYPE_CALLABLE, [
 				GdFunctionArgument.new("cb", TYPE_CALLABLE, Callable()),
 			])
 		)
 	assert_that(fds[3])\
-		.is_equal(GdFunctionDescriptor
-			.create("on_callable_case4", script.resource_path, 17, TYPE_CALLABLE, [
+		.is_equal(create("on_callable_case4", script.resource_path, 17, 18, TYPE_CALLABLE, [
 				GdFunctionArgument.new("cb", TYPE_CALLABLE, Callable(null, "method_foo")),
 			])
 		)
@@ -130,8 +114,7 @@ func test_default_args_variant() -> void:
 
 	var fds := _parser.get_function_descriptors(script, [])
 	assert_that(fds[0])\
-		.is_equal(GdFunctionDescriptor
-			.create("add_button", script.resource_path, 4, GdObjects.TYPE_VOID, [
+		.is_equal(create("add_button", script.resource_path, 4, 8, GdObjects.TYPE_VOID, [
 				GdFunctionArgument.new("ucids", TYPE_ARRAY, GdFunctionArgument.UNDEFINED, TYPE_INT),
 				GdFunctionArgument.new("position", TYPE_VECTOR2I),
 				GdFunctionArgument.new("size", TYPE_VECTOR2I),
@@ -151,20 +134,17 @@ func test_default_args_basic_type_int() -> void:
 
 	var fds := _parser.get_function_descriptors(script, [])
 	assert_that(fds[0])\
-		.is_equal(GdFunctionDescriptor
-			.create("on_int_case1", script.resource_path, 5, TYPE_INT, [
+		.is_equal(create("on_int_case1", script.resource_path, 5, 6, TYPE_INT, [
 				GdFunctionArgument.new("value", TYPE_INT),
 			])
 		)
 	assert_that(fds[1])\
-		.is_equal(GdFunctionDescriptor
-			.create("on_int_case2", script.resource_path, 9, TYPE_INT, [
+		.is_equal(create("on_int_case2", script.resource_path, 9, 10, TYPE_INT, [
 				GdFunctionArgument.new("value", TYPE_INT, 42),
 			])
 		)
 	assert_that(fds[2])\
-		.is_equal(GdFunctionDescriptor
-			.create("on_int_case3", script.resource_path, 13, TYPE_INT, [
+		.is_equal(create("on_int_case3", script.resource_path, 13, 14, TYPE_INT, [
 				GdFunctionArgument.new("value", TYPE_INT, 42),
 			])
 		)
@@ -175,20 +155,17 @@ func test_default_args_basic_type_float() -> void:
 
 	var fds := _parser.get_function_descriptors(script, [])
 	assert_that(fds[0])\
-		.is_equal(GdFunctionDescriptor
-			.create("on_float_case1", script.resource_path, 5, TYPE_FLOAT, [
+		.is_equal(create("on_float_case1", script.resource_path, 5, 6, TYPE_FLOAT, [
 				GdFunctionArgument.new("value", TYPE_FLOAT),
 			])
 		)
 	assert_that(fds[1])\
-		.is_equal(GdFunctionDescriptor
-			.create("on_float_case2", script.resource_path, 9, TYPE_FLOAT, [
+		.is_equal(create("on_float_case2", script.resource_path, 9, 10, TYPE_FLOAT, [
 				GdFunctionArgument.new("value", TYPE_FLOAT, 42.1),
 			])
 		)
 	assert_that(fds[2])\
-		.is_equal(GdFunctionDescriptor
-			.create("on_float_case3", script.resource_path, 13, TYPE_FLOAT, [
+		.is_equal(create("on_float_case3", script.resource_path, 13, 14, TYPE_FLOAT, [
 				GdFunctionArgument.new("value", TYPE_FLOAT, 42.1),
 			])
 		)
@@ -199,20 +176,17 @@ func test_default_args_basic_type_bool() -> void:
 
 	var fds := _parser.get_function_descriptors(script, [])
 	assert_that(fds[0])\
-		.is_equal(GdFunctionDescriptor
-			.create("on_bool_case1", script.resource_path, 5, TYPE_BOOL, [
+		.is_equal(create("on_bool_case1", script.resource_path, 5, 6, TYPE_BOOL, [
 				GdFunctionArgument.new("value", TYPE_BOOL),
 			])
 		)
 	assert_that(fds[1])\
-		.is_equal(GdFunctionDescriptor
-			.create("on_bool_case2", script.resource_path, 9, TYPE_BOOL, [
+		.is_equal(create("on_bool_case2", script.resource_path, 9, 10, TYPE_BOOL, [
 				GdFunctionArgument.new("value", TYPE_BOOL, true),
 			])
 		)
 	assert_that(fds[2])\
-		.is_equal(GdFunctionDescriptor
-			.create("on_bool_case3", script.resource_path, 13, TYPE_BOOL, [
+		.is_equal(create("on_bool_case3", script.resource_path, 13, 14, TYPE_BOOL, [
 				GdFunctionArgument.new("value", TYPE_BOOL, true),
 			])
 		)
@@ -223,20 +197,17 @@ func test_default_args_basic_type_string() -> void:
 
 	var fds := _parser.get_function_descriptors(script, [])
 	assert_that(fds[0])\
-		.is_equal(GdFunctionDescriptor
-			.create("on_string_case1", script.resource_path, 5, TYPE_STRING, [
+		.is_equal(create("on_string_case1", script.resource_path, 5, 6, TYPE_STRING, [
 				GdFunctionArgument.new("value", TYPE_STRING),
 			])
 		)
 	assert_that(fds[1])\
-		.is_equal(GdFunctionDescriptor
-			.create("on_string_case2", script.resource_path, 9, TYPE_STRING, [
+		.is_equal(create("on_string_case2", script.resource_path, 9, 10, TYPE_STRING, [
 				GdFunctionArgument.new("value", TYPE_STRING, "foo"),
 			])
 		)
 	assert_that(fds[2])\
-		.is_equal(GdFunctionDescriptor
-			.create("on_string_case3", script.resource_path, 13, TYPE_STRING, [
+		.is_equal(create("on_string_case3", script.resource_path, 13, 14, TYPE_STRING, [
 				GdFunctionArgument.new("value", TYPE_STRING, "foo"),
 			])
 		)
@@ -247,20 +218,17 @@ func test_default_args_basic_type_string_name() -> void:
 
 	var fds := _parser.get_function_descriptors(script, [])
 	assert_that(fds[0])\
-		.is_equal(GdFunctionDescriptor
-			.create("on_string_name_case1", script.resource_path, 5, TYPE_STRING_NAME, [
+		.is_equal(create("on_string_name_case1", script.resource_path, 5, 6, TYPE_STRING_NAME, [
 				GdFunctionArgument.new("value", TYPE_STRING_NAME),
 			])
 		)
 	assert_that(fds[1])\
-		.is_equal(GdFunctionDescriptor
-			.create("on_string_name_case2", script.resource_path, 9, TYPE_STRING_NAME, [
+		.is_equal(create("on_string_name_case2", script.resource_path, 9, 10, TYPE_STRING_NAME, [
 				GdFunctionArgument.new("value", TYPE_STRING_NAME, &"foo"),
 			])
 		)
 	assert_that(fds[2])\
-		.is_equal(GdFunctionDescriptor
-			.create("on_string_name_case3", script.resource_path, 13, TYPE_STRING_NAME, [
+		.is_equal(create("on_string_name_case3", script.resource_path, 13, 14, TYPE_STRING_NAME, [
 				GdFunctionArgument.new("value", TYPE_STRING_NAME, &"foo"),
 			])
 		)
@@ -271,26 +239,22 @@ func test_default_args_basic_type_node_path() -> void:
 
 	var fds := _parser.get_function_descriptors(script, [])
 	assert_that(fds[0])\
-		.is_equal(GdFunctionDescriptor
-			.create("on_node_path_case1", script.resource_path, 5, TYPE_NODE_PATH, [
+		.is_equal(create("on_node_path_case1", script.resource_path, 5, 6, TYPE_NODE_PATH, [
 				GdFunctionArgument.new("value", TYPE_NODE_PATH),
 			])
 		)
 	assert_that(fds[1])\
-		.is_equal(GdFunctionDescriptor
-			.create("on_node_path_case2", script.resource_path, 9, TYPE_NODE_PATH, [
+		.is_equal(create("on_node_path_case2", script.resource_path, 9, 10, TYPE_NODE_PATH, [
 				GdFunctionArgument.new("value", TYPE_NODE_PATH, NodePath("foo1")),
 			])
 		)
 	assert_that(fds[2])\
-		.is_equal(GdFunctionDescriptor
-			.create("on_node_path_case3", script.resource_path, 13, TYPE_NODE_PATH, [
+		.is_equal(create("on_node_path_case3", script.resource_path, 13, 14, TYPE_NODE_PATH, [
 				GdFunctionArgument.new("value", TYPE_NODE_PATH, NodePath("foo2")),
 			])
 		)
 	assert_that(fds[3])\
-		.is_equal(GdFunctionDescriptor
-			.create("on_node_path_case4", script.resource_path, 17, TYPE_NODE_PATH, [
+		.is_equal(create("on_node_path_case4", script.resource_path, 17, 18, TYPE_NODE_PATH, [
 				GdFunctionArgument.new("value", TYPE_NODE_PATH, NodePath("foo3")),
 			])
 		)
@@ -301,20 +265,17 @@ func test_default_args_basic_type_vector2() -> void:
 
 	var fds := _parser.get_function_descriptors(script, [])
 	assert_that(fds[0])\
-		.is_equal(GdFunctionDescriptor
-			.create("on_vector2_case1", script.resource_path, 5, TYPE_VECTOR2, [
+		.is_equal(create("on_vector2_case1", script.resource_path, 5, 6, TYPE_VECTOR2, [
 				GdFunctionArgument.new("value", TYPE_VECTOR2),
 			])
 		)
 	assert_that(fds[1])\
-		.is_equal(GdFunctionDescriptor
-			.create("on_vector2_case2", script.resource_path, 9, TYPE_VECTOR2, [
+		.is_equal(create("on_vector2_case2", script.resource_path, 9, 10, TYPE_VECTOR2, [
 				GdFunctionArgument.new("value", TYPE_VECTOR2, Vector2.ONE),
 			])
 		)
 	assert_that(fds[2])\
-		.is_equal(GdFunctionDescriptor
-			.create("on_vector2_case3", script.resource_path, 13, TYPE_VECTOR2, [
+		.is_equal(create("on_vector2_case3", script.resource_path, 13, 14, TYPE_VECTOR2, [
 				GdFunctionArgument.new("value", TYPE_VECTOR2, Vector2.ONE),
 			])
 		)
@@ -325,20 +286,17 @@ func test_default_args_basic_type_vector2i() -> void:
 
 	var fds := _parser.get_function_descriptors(script, [])
 	assert_that(fds[0])\
-		.is_equal(GdFunctionDescriptor
-			.create("on_vector2i_case1", script.resource_path, 5, TYPE_VECTOR2I, [
+		.is_equal(create("on_vector2i_case1", script.resource_path, 5, 6, TYPE_VECTOR2I, [
 				GdFunctionArgument.new("value", TYPE_VECTOR2I),
 			])
 		)
 	assert_that(fds[1])\
-		.is_equal(GdFunctionDescriptor
-			.create("on_vector2i_case2", script.resource_path, 9, TYPE_VECTOR2I, [
+		.is_equal(create("on_vector2i_case2", script.resource_path, 9, 10, TYPE_VECTOR2I, [
 				GdFunctionArgument.new("value", TYPE_VECTOR2I, Vector2i.ONE),
 			])
 		)
 	assert_that(fds[2])\
-		.is_equal(GdFunctionDescriptor
-			.create("on_vector2i_case3", script.resource_path, 13, TYPE_VECTOR2I, [
+		.is_equal(create("on_vector2i_case3", script.resource_path, 13, 14, TYPE_VECTOR2I, [
 				GdFunctionArgument.new("value", TYPE_VECTOR2I, Vector2i.ONE),
 			])
 		)
@@ -349,20 +307,17 @@ func test_default_args_basic_type_vector3() -> void:
 
 	var fds := _parser.get_function_descriptors(script, [])
 	assert_that(fds[0])\
-		.is_equal(GdFunctionDescriptor
-			.create("on_vector3_case1", script.resource_path, 5, TYPE_VECTOR3, [
+		.is_equal(create("on_vector3_case1", script.resource_path, 5, 6, TYPE_VECTOR3, [
 				GdFunctionArgument.new("value", TYPE_VECTOR3),
 			])
 		)
 	assert_that(fds[1])\
-		.is_equal(GdFunctionDescriptor
-			.create("on_vector3_case2", script.resource_path, 9, TYPE_VECTOR3, [
+		.is_equal(create("on_vector3_case2", script.resource_path, 9, 10, TYPE_VECTOR3, [
 				GdFunctionArgument.new("value", TYPE_VECTOR3, Vector3.ONE),
 			])
 		)
 	assert_that(fds[2])\
-		.is_equal(GdFunctionDescriptor
-			.create("on_vector3_case3", script.resource_path, 13, TYPE_VECTOR3, [
+		.is_equal(create("on_vector3_case3", script.resource_path, 13, 14, TYPE_VECTOR3, [
 				GdFunctionArgument.new("value", TYPE_VECTOR3, Vector3.ONE),
 			])
 		)
@@ -373,20 +328,17 @@ func test_default_args_basic_type_vector3i() -> void:
 
 	var fds := _parser.get_function_descriptors(script, [])
 	assert_that(fds[0])\
-		.is_equal(GdFunctionDescriptor
-			.create("on_vector3i_case1", script.resource_path, 5, TYPE_VECTOR3I, [
+		.is_equal(create("on_vector3i_case1", script.resource_path, 5, 6, TYPE_VECTOR3I, [
 				GdFunctionArgument.new("value", TYPE_VECTOR3I),
 			])
 		)
 	assert_that(fds[1])\
-		.is_equal(GdFunctionDescriptor
-			.create("on_vector3i_case2", script.resource_path, 9, TYPE_VECTOR3I, [
+		.is_equal(create("on_vector3i_case2", script.resource_path, 9, 10, TYPE_VECTOR3I, [
 				GdFunctionArgument.new("value", TYPE_VECTOR3I, Vector3i.ONE),
 			])
 		)
 	assert_that(fds[2])\
-		.is_equal(GdFunctionDescriptor
-			.create("on_vector3i_case3", script.resource_path, 13, TYPE_VECTOR3I, [
+		.is_equal(create("on_vector3i_case3", script.resource_path, 13, 14, TYPE_VECTOR3I, [
 				GdFunctionArgument.new("value", TYPE_VECTOR3I, Vector3i.ONE),
 			])
 		)
@@ -397,20 +349,17 @@ func test_default_args_basic_type_vector4() -> void:
 
 	var fds := _parser.get_function_descriptors(script, [])
 	assert_that(fds[0])\
-		.is_equal(GdFunctionDescriptor
-			.create("on_vector4_case1", script.resource_path, 5, TYPE_VECTOR4, [
+		.is_equal(create("on_vector4_case1", script.resource_path, 5, 6, TYPE_VECTOR4, [
 				GdFunctionArgument.new("value", TYPE_VECTOR4),
 			])
 		)
 	assert_that(fds[1])\
-		.is_equal(GdFunctionDescriptor
-			.create("on_vector4_case2", script.resource_path, 9, TYPE_VECTOR4, [
+		.is_equal(create("on_vector4_case2", script.resource_path, 9, 10, TYPE_VECTOR4, [
 				GdFunctionArgument.new("value", TYPE_VECTOR4, Vector4.ONE),
 			])
 		)
 	assert_that(fds[2])\
-		.is_equal(GdFunctionDescriptor
-			.create("on_vector4_case3", script.resource_path, 13, TYPE_VECTOR4, [
+		.is_equal(create("on_vector4_case3", script.resource_path, 13, 14, TYPE_VECTOR4, [
 				GdFunctionArgument.new("value", TYPE_VECTOR4, Vector4.ONE),
 			])
 		)
@@ -421,20 +370,17 @@ func test_default_args_basic_type_vector4i() -> void:
 
 	var fds := _parser.get_function_descriptors(script, [])
 	assert_that(fds[0])\
-		.is_equal(GdFunctionDescriptor
-			.create("on_vector4i_case1", script.resource_path, 5, TYPE_VECTOR4I, [
+		.is_equal(create("on_vector4i_case1", script.resource_path, 5, 6, TYPE_VECTOR4I, [
 				GdFunctionArgument.new("value", TYPE_VECTOR4I),
 			])
 		)
 	assert_that(fds[1])\
-		.is_equal(GdFunctionDescriptor
-			.create("on_vector4i_case2", script.resource_path, 9, TYPE_VECTOR4I, [
+		.is_equal(create("on_vector4i_case2", script.resource_path, 9, 10, TYPE_VECTOR4I, [
 				GdFunctionArgument.new("value", TYPE_VECTOR4I, Vector4i.ONE),
 			])
 		)
 	assert_that(fds[2])\
-		.is_equal(GdFunctionDescriptor
-			.create("on_vector4i_case3", script.resource_path, 13, TYPE_VECTOR4I, [
+		.is_equal(create("on_vector4i_case3", script.resource_path, 13, 14, TYPE_VECTOR4I, [
 				GdFunctionArgument.new("value", TYPE_VECTOR4I, Vector4i.ONE),
 			])
 		)
@@ -445,32 +391,27 @@ func test_default_args_basic_type_rect2() -> void:
 
 	var fds := _parser.get_function_descriptors(script, [])
 	assert_that(fds[0])\
-		.is_equal(GdFunctionDescriptor
-			.create("on_rect2_case1", script.resource_path, 5, TYPE_RECT2, [
+		.is_equal(create("on_rect2_case1", script.resource_path, 5, 6, TYPE_RECT2, [
 				GdFunctionArgument.new("value", TYPE_RECT2),
 			])
 		)
 	assert_that(fds[1])\
-		.is_equal(GdFunctionDescriptor
-			.create("on_rect2_case2", script.resource_path, 9, TYPE_RECT2, [
+		.is_equal(create("on_rect2_case2", script.resource_path, 9, 10, TYPE_RECT2, [
 				GdFunctionArgument.new("value", TYPE_RECT2, Rect2()),
 			])
 		)
 	assert_that(fds[2])\
-		.is_equal(GdFunctionDescriptor
-			.create("on_rect2_case3", script.resource_path, 13, TYPE_RECT2, [
+		.is_equal(create("on_rect2_case3", script.resource_path, 13, 14, TYPE_RECT2, [
 				GdFunctionArgument.new("value", TYPE_RECT2, Rect2()),
 			])
 		)
 	assert_that(fds[3])\
-		.is_equal(GdFunctionDescriptor
-			.create("on_rect2_case4", script.resource_path, 17, TYPE_RECT2, [
+		.is_equal(create("on_rect2_case4", script.resource_path, 17, 18, TYPE_RECT2, [
 				GdFunctionArgument.new("value", TYPE_RECT2, Rect2(Vector2.ONE, Vector2.ZERO)),
 			])
 		)
 	assert_that(fds[4])\
-		.is_equal(GdFunctionDescriptor
-			.create("on_rect2_case5", script.resource_path, 21, TYPE_RECT2, [
+		.is_equal(create("on_rect2_case5", script.resource_path, 21, 22, TYPE_RECT2, [
 				GdFunctionArgument.new("value", TYPE_RECT2, Rect2(Vector2(0, 1), Vector2(2, 3))),
 			])
 		)
@@ -481,26 +422,28 @@ func test_default_args_basic_type_transform2d() -> void:
 
 	var fds := _parser.get_function_descriptors(script, [])
 	assert_that(fds[0])\
-		.is_equal(GdFunctionDescriptor
-			.create("on_transform2d_case1", script.resource_path, 5, TYPE_TRANSFORM2D, [
+		.is_equal(create("on_transform2d_case1", script.resource_path, 5, 6, TYPE_TRANSFORM2D, [
 				GdFunctionArgument.new("value", TYPE_TRANSFORM2D),
 			])
 		)
 	assert_that(fds[1])\
-		.is_equal(GdFunctionDescriptor
-			.create("on_transform2d_case2", script.resource_path, 9, TYPE_TRANSFORM2D, [
+		.is_equal(create("on_transform2d_case2", script.resource_path, 9, 10, TYPE_TRANSFORM2D, [
 				GdFunctionArgument.new("value", TYPE_TRANSFORM2D, Transform2D()),
 			])
 		)
 	assert_that(fds[2])\
-		.is_equal(GdFunctionDescriptor
-			.create("on_transform2d_case3", script.resource_path, 13, TYPE_TRANSFORM2D, [
+		.is_equal(create("on_transform2d_case3", script.resource_path, 13, 14, TYPE_TRANSFORM2D, [
 				GdFunctionArgument.new("value", TYPE_TRANSFORM2D, Transform2D()),
 			])
 		)
 	assert_that(fds[3])\
-		.is_equal(GdFunctionDescriptor
-			.create("on_transform2d_case4", script.resource_path, 17, TYPE_TRANSFORM2D, [
+		.is_equal(create("on_transform2d_case4", script.resource_path, 17, 18, TYPE_TRANSFORM2D, [
 				GdFunctionArgument.new("value", TYPE_TRANSFORM2D, Transform2D(1.2, Vector2.ONE)),
 			])
 		)
+
+
+static func create(func_name: String, source_path: String, begin_line: int, end_line: int, return_type: int, args: Array[GdFunctionArgument] = []) -> GdFunctionDescriptor:
+	var fd := GdFunctionDescriptor.new(func_name, false, false, false, return_type, "", args)
+	fd.enrich_file_info(source_path, begin_line, end_line)
+	return fd

--- a/addons/gdUnit4/test/doubler/GdMockFunctionDoublerTest.gd
+++ b/addons/gdUnit4/test/doubler/GdMockFunctionDoublerTest.gd
@@ -136,7 +136,7 @@ func test_double_untyped_function_with_varargs() -> void:
 	var doubler := GdUnitMockFunctionDoubler.new()
 
 	# void emit_custom(signal_name, args__ ...) vararg const
-	var fd := GdFunctionDescriptor.new("emit_custom", 10, false, false, false, TYPE_NIL, "",
+	var fd := GdFunctionDescriptor.new("emit_custom", false, false, false, TYPE_NIL, "",
 		[GdFunctionArgument.new("signal", TYPE_SIGNAL)],
 		GdFunctionDescriptor._build_varargs(true))
 	var expected := """

--- a/addons/gdUnit4/test/doubler/GdSpyFunctionDoublerTest.gd
+++ b/addons/gdUnit4/test/doubler/GdSpyFunctionDoublerTest.gd
@@ -171,7 +171,7 @@ func test_double_return_typed_function_with_args_and_varargs() -> void:
 func test_double_return_void_function_only_varargs() -> void:
 	var doubler := GdUnitSpyFunctionDoubler.new()
 	# void bar(s...) vararg
-	var fd := GdFunctionDescriptor.new( "bar", 23, false, false, false, TYPE_NIL, "void", [], GdFunctionDescriptor._build_varargs(true))
+	var fd := GdFunctionDescriptor.new("bar", false, false, false, TYPE_NIL, "void", [], GdFunctionDescriptor._build_varargs(true))
 	var expected := """
 		func bar(...varargs_: Array) -> void:
 			var __args := [] + varargs_
@@ -206,7 +206,7 @@ func test_double_return_void_function_only_varargs() -> void:
 func test_double_return_typed_function_only_varargs() -> void:
 	var doubler := GdUnitSpyFunctionDoubler.new()
 	# String bar(s...) vararg
-	var fd := GdFunctionDescriptor.new("bar", 23, false, false, false, TYPE_STRING, "String", [], GdFunctionDescriptor._build_varargs(true))
+	var fd := GdFunctionDescriptor.new("bar", false, false, false, TYPE_STRING, "String", [], GdFunctionDescriptor._build_varargs(true))
 	var expected := """
 		func bar(...varargs_: Array) -> String:
 			var __args := [] + varargs_
@@ -241,7 +241,7 @@ func test_double_return_typed_function_only_varargs() -> void:
 func test_double_static_return_void_function_without_args() -> void:
 	var doubler := GdUnitSpyFunctionDoubler.new()
 	# void foo()
-	var fd := GdFunctionDescriptor.new("foo", 23, false, true, false, TYPE_NIL, "", [])
+	var fd := GdFunctionDescriptor.new("foo", false, true, false, TYPE_NIL, "", [])
 	var expected := """
 		static func foo() -> void:
 			var __args := []
@@ -262,7 +262,7 @@ func test_double_static_return_void_function_without_args() -> void:
 
 func test_double_static_return_void_function_with_args() -> void:
 	var doubler := GdUnitSpyFunctionDoubler.new()
-	var fd := GdFunctionDescriptor.new("foo", 23, false, true, false, TYPE_NIL, "", [
+	var fd := GdFunctionDescriptor.new("foo", false, true, false, TYPE_NIL, "", [
 		GdFunctionArgument.new("arg1", TYPE_BOOL),
 		GdFunctionArgument.new("arg2", TYPE_STRING, "default")
 	])
@@ -287,7 +287,7 @@ func test_double_static_return_void_function_with_args() -> void:
 func test_double_static_script_function_with_args_return_bool() -> void:
 	var doubler := GdUnitSpyFunctionDoubler.new()
 
-	var fd := GdFunctionDescriptor.new("foo", 23, false, true, false, TYPE_BOOL, "", [
+	var fd := GdFunctionDescriptor.new("foo", false, true, false, TYPE_BOOL, "", [
 		GdFunctionArgument.new("arg1", TYPE_BOOL),
 		GdFunctionArgument.new("arg2", TYPE_STRING, "default")
 	])


### PR DESCRIPTION
# Why
Automatic orphan node detection needs to inject code at the end of each test function.
To do this efficiently without re-parsing the script at injection time, the parser must precompute and store the function's end line alongside the start line.

# What
- Add `_end_line` field and `end_line()` accessor to `GdFunctionDescriptor`
- Rename `_line_number`/`line_number()` to `_begin_line`/`begin_line()` for clarity
- Update `enrich_file_info` to accept and store the function end line
- Add `_parse_func_end_line()` to `GdScriptParser` to locate function boundaries by indentation
- Add `TOKEN_ANNOTATION` so annotated functions parse correctly
- Move test-only `create`/`create_static` factory methods to the test file
- Various GDScript style fixes (spacing around type annotations)

Closes #1160