### PR TITLE
TAKS-1160 Add GdUnitOrphanDetectionInjector

### DIFF
--- a/addons/gdUnit4/src/core/GdUnitTestSuiteScanner.gd
+++ b/addons/gdUnit4/src/core/GdUnitTestSuiteScanner.gd
@@ -133,10 +133,6 @@ func _load_is_test_suite(resource_path: String) -> Script:
 
 
 func load_suite(script: GDScript, tests: Array[GdUnitTestCase]) -> GdUnitTestSuite:
-	var test_suite: GdUnitTestSuite = script.new()
-	var first_test: GdUnitTestCase = tests.front()
-	test_suite.set_name(first_test.suite_name)
-
 	# We need to group first all parameterized tests together to load the parameter set once
 	var grouped_by_test := GdArrayTools.group_by(tests, func(test: GdUnitTestCase) -> String:
 		return test.test_name
@@ -145,6 +141,12 @@ func load_suite(script: GDScript, tests: Array[GdUnitTestCase]) -> GdUnitTestSui
 	var test_names: PackedStringArray = grouped_by_test.keys()
 	test_names.append("before")
 	var function_descriptors := _script_parser.get_function_descriptors(script, test_names)
+
+	#GdUnitOrphanDetectionInjector.intercept(script, function_descriptors)
+
+	var test_suite: GdUnitTestSuite = script.new()
+	var first_test: GdUnitTestCase = tests.front()
+	test_suite.set_name(first_test.suite_name)
 
 	# Convert to test
 	for fd in function_descriptors:

--- a/addons/gdUnit4/src/core/execution/GdUnitTestSuiteExecutor.gd
+++ b/addons/gdUnit4/src/core/execution/GdUnitTestSuiteExecutor.gd
@@ -45,6 +45,7 @@ func run_and_wait(tests: Array[GdUnitTestCase]) -> void:
 			context.test_suite = test_suite
 			(Engine.get_main_loop() as SceneTree).root.add_child(test_suite)
 			await _executeStage.execute(context)
+			GdUnitOrphanDetectionInjector.cleanup()
 			context.dispose()
 		else:
 			await GdUnit4CSharpApiLoader.execute(suite_tests)

--- a/addons/gdUnit4/src/monitor/GdUnitOrphanDetectionInjector.gd
+++ b/addons/gdUnit4/src/monitor/GdUnitOrphanDetectionInjector.gd
@@ -1,0 +1,99 @@
+## Patches GDScript test suite source code to inject orphan node detection calls
+## at the end of each test_ function, eliminating the need for manual calls.
+class_name GdUnitOrphanDetectionInjector
+extends RefCounted
+
+
+## The code block injected at the end of each test_ function body.
+const INJECT_CODE := "\n"\
+	+ "	# Injected collect orphan details\n" \
+	+ "	await get_tree().process_frame\n" \
+	+ "	collect_orphan_node_details()"
+
+## Number of lines INJECT_CODE adds per injection; used to compute and undo line shifts.
+static var _injection_line_count := INJECT_CODE.split("\n").size()
+
+## Maps resource_path -> sorted Array[int] of patched line indices where each injection block starts.
+## Used by resolve_original_line to map patched line numbers back to original source line numbers.
+static var _injection_positions: Dictionary[String, Array] = {}
+
+
+## Patches the given GDScript by injecting orphan detection calls at the end of each test_ function.
+static func intercept(script: GDScript, function_descriptors: Array[GdFunctionDescriptor] = []) -> void:
+	if function_descriptors.is_empty():
+		return
+
+	var source := GdScriptParser.to_unix_format(script.source_code)
+	var positions: Array[int] = []
+	var patched := _inject_from_descriptors(source, function_descriptors, positions)
+	if patched == source:
+		return
+
+	_injection_positions[script.resource_path] = positions
+	script.source_code = patched
+	script.reload()
+
+
+## Clears all recorded injection positions; call after a test suite finishes.
+static func cleanup() -> void:
+	_injection_positions.clear()
+
+
+## Converts a patched source line number back to the original source line number.
+## Returns patched_line unchanged when the script was not intercepted.
+static func resolve_original_line(resource_path: String, patched_line: int) -> int:
+	if not _injection_positions.has(resource_path):
+		return patched_line
+
+	return _resolve_line(_injection_positions[resource_path], patched_line)
+
+
+## Injects INJECT_CODE after each test_ function body and records the patched line indices
+## of each injection start into injection_positions.
+static func _inject_from_descriptors(
+	source: String,
+	function_descriptors: Array[GdFunctionDescriptor],
+	injection_positions: Array[int] = []
+) -> String:
+	if function_descriptors.is_empty():
+		return source
+
+	# Sort descending so functions are processed bottom-to-top.
+	# Each insert() shifts all following line indices; starting from the end of the file
+	# ensures that earlier functions' end_line values remain valid when we reach them.
+	function_descriptors.sort_custom(func(a: GdFunctionDescriptor, b: GdFunctionDescriptor) -> bool:
+		return a.end_line() > b.end_line()
+	)
+	var lines := Array(source.split("\n"))
+	var end_lines: Array[int] = []
+	for fd: GdFunctionDescriptor in function_descriptors:
+		var func_lines := PackedStringArray(lines.slice(fd.begin_line(), fd.end_line()))
+		if _has_orphan_collect_call(func_lines):
+			continue
+		lines.insert(fd.end_line(), INJECT_CODE)
+		end_lines.append(fd.end_line())
+	if end_lines.is_empty():
+		return source
+	end_lines.sort()
+	for i: int in end_lines.size():
+		injection_positions.append(end_lines[i] + 1 + i * _injection_line_count)
+	return "\n".join(lines)
+
+
+## Subtracts the cumulative injection offset from patched_line to recover the original line index.
+static func _resolve_line(positions: Array[int], patched_line: int) -> int:
+	var offset := 0
+	for pos in positions:
+		if pos <= patched_line:
+			offset += _injection_line_count
+		else:
+			break
+	return patched_line - offset
+
+
+## Returns true when func_lines already contains a collect_orphan_node_details call.
+static func _has_orphan_collect_call(func_lines: PackedStringArray) -> bool:
+	for line: String in func_lines:
+		if line.contains("collect_orphan_node_details"):
+			return true
+	return false

--- a/addons/gdUnit4/test/monitor/GdUnitOrphanDetectionInjectorTest.gd
+++ b/addons/gdUnit4/test/monitor/GdUnitOrphanDetectionInjectorTest.gd
@@ -1,0 +1,56 @@
+class_name GdUnitOrphanDetectionInjectorTest
+extends GdUnitTestSuite
+
+
+const EXAMPLE_SCRIPT_PATH := "res://addons/gdUnit4/test/resources/monitor/TestsWithOrphanNodes.gd"
+
+
+func before() -> void:
+	ProjectSettings.set_setting(GdUnitSettings.REPORT_ORPHANS, true)
+
+
+func after() -> void:
+	GdUnitOrphanDetectionInjector.cleanup()
+
+
+func _collect_test_function_descriptors(script: GDScript) -> Array[GdFunctionDescriptor]:
+	var test_names: PackedStringArray = []
+	for function: Dictionary in script.get_script_method_list():
+		var func_name: String = function["name"]
+		if func_name.begins_with("test_"):
+			test_names.append(func_name)
+	return GdScriptParser.new().get_function_descriptors(script, test_names)
+
+
+func test_intercept() -> void:
+	var source_script: GDScript = load(EXAMPLE_SCRIPT_PATH)
+	var source_code := source_script.source_code
+	GdUnitOrphanDetectionInjector.intercept(source_script, _collect_test_function_descriptors(source_script))
+
+	# Verify the patched source matches the expected output
+	var patched_code := source_script.source_code
+	var expected_source_code := FileAccess.get_file_as_string("res://addons/gdUnit4/test/resources/monitor/TestsWithOrphanNodesPatched.gd")
+	assert_str(patched_code).is_equal(expected_source_code)
+
+	var original_lines := source_code.split("\n")
+	var patched_lines := patched_code.split("\n")
+
+	var patched_row_index := 0
+
+	# Verify the `resolve_original_line` maps patched line number to original source line number
+	while patched_row_index < patched_lines.size():
+		var patched_source_row := patched_lines[patched_row_index]
+		# Skip injected code
+		if patched_source_row.contains("# Injected collect orphan details"):
+			patched_row_index += GdUnitOrphanDetectionInjector._injection_line_count
+			continue
+
+		var orig_line_num := GdUnitOrphanDetectionInjector.resolve_original_line(EXAMPLE_SCRIPT_PATH, patched_row_index)
+		var original_source_row := original_lines[orig_line_num]
+		assert_str(patched_source_row).is_equal(original_source_row)
+		if is_failure():
+			return
+		patched_row_index += 1
+
+	# Verify that a script which was not intercepted returns the line number unchanged
+	assert_int(GdUnitOrphanDetectionInjector.resolve_original_line("res://unknown.gd", 42)).is_equal(42)

--- a/addons/gdUnit4/test/resources/monitor/TestsWithOrphanNodes.gd
+++ b/addons/gdUnit4/test/resources/monitor/TestsWithOrphanNodes.gd
@@ -1,0 +1,62 @@
+extends GdUnitTestSuite
+
+@warning_ignore_start("unused_private_class_variable")
+var _member_node1 := T2.new() # produces an orphan Node2D
+
+
+func test_one_orphans_nodes() -> void:
+	var _func_ref2 := RefCounted.new() # is refcounted and never orphan
+	var _func_obj2 := Object.new() # produces an orphan Object
+	var _func_node2 := Node3D.new() # produces an orphan Node3D
+
+
+func test_one_orphans_nodes_skip_inject() -> void:
+	var _func_ref2 := RefCounted.new() # is refcounted and never orphan
+	var _func_obj2 := Object.new() # produces an orphan Object
+	var _func_node2 := Node3D.new() # produces an orphan Node3D
+
+	collect_orphan_node_details()
+
+
+# Results in four orphan nodes related to local valze t2
+func test_four_orphan_nodes() -> void:
+	var _func_node3 := Node3D.new() # produces an orphan Node3D
+	var t2 := T2.new()
+
+	add_child(t2)
+
+
+## Loads a sceen via `scene_runner` (auto_free) but it contains orphan nodes
+func test_with_scene_orphans() -> void:
+
+	# run scene with orphan nodes
+	var runner := scene_runner("res://addons/gdUnit4/test/core/execution/resources/OrphanScene.tscn")
+
+	@warning_ignore("redundant_await")
+	await runner.simulate_frames(10)
+
+
+## Loads a sceen and do not freeing
+func test_load_scene_orphans() -> void:
+	# run scene with orphan nodes
+	var _scene: Node2D = preload("res://addons/gdUnit4/test/core/execution/resources/OrphanScene.tscn").instantiate()
+
+
+## Shold not detect any orphan becuase the node is auto freed
+func test_no_orphans_auto_free() -> void:
+	var func_node2: Node3D = auto_free(Node3D.new())
+
+	assert_object(func_node2).is_not_null()
+
+
+## This test has no orphans
+func test_no_orphans() -> void:
+	assert_bool(true).is_true()
+
+
+## using parameterized test with orphans
+@warning_ignore("unused_parameter")
+func test_parameterized_with_orphans(index: int, obj: Object, test_parameters := [
+	[0, RefCounted.new()],
+	[1, Node2D.new()]]) -> void:
+	assert_that(obj).is_not_null()

--- a/addons/gdUnit4/test/resources/monitor/TestsWithOrphanNodesPatched.gd
+++ b/addons/gdUnit4/test/resources/monitor/TestsWithOrphanNodesPatched.gd
@@ -1,0 +1,90 @@
+extends GdUnitTestSuite
+
+@warning_ignore_start("unused_private_class_variable")
+var _member_node1 := T2.new() # produces an orphan Node2D
+
+
+func test_one_orphans_nodes() -> void:
+	var _func_ref2 := RefCounted.new() # is refcounted and never orphan
+	var _func_obj2 := Object.new() # produces an orphan Object
+	var _func_node2 := Node3D.new() # produces an orphan Node3D
+
+	# Injected collect orphan details
+	await get_tree().process_frame
+	collect_orphan_node_details()
+
+
+func test_one_orphans_nodes_skip_inject() -> void:
+	var _func_ref2 := RefCounted.new() # is refcounted and never orphan
+	var _func_obj2 := Object.new() # produces an orphan Object
+	var _func_node2 := Node3D.new() # produces an orphan Node3D
+
+	collect_orphan_node_details()
+
+
+# Results in four orphan nodes related to local valze t2
+func test_four_orphan_nodes() -> void:
+	var _func_node3 := Node3D.new() # produces an orphan Node3D
+	var t2 := T2.new()
+
+	add_child(t2)
+
+	# Injected collect orphan details
+	await get_tree().process_frame
+	collect_orphan_node_details()
+
+
+## Loads a sceen via `scene_runner` (auto_free) but it contains orphan nodes
+func test_with_scene_orphans() -> void:
+
+	# run scene with orphan nodes
+	var runner := scene_runner("res://addons/gdUnit4/test/core/execution/resources/OrphanScene.tscn")
+
+	@warning_ignore("redundant_await")
+	await runner.simulate_frames(10)
+
+	# Injected collect orphan details
+	await get_tree().process_frame
+	collect_orphan_node_details()
+
+
+## Loads a sceen and do not freeing
+func test_load_scene_orphans() -> void:
+	# run scene with orphan nodes
+	var _scene: Node2D = preload("res://addons/gdUnit4/test/core/execution/resources/OrphanScene.tscn").instantiate()
+
+	# Injected collect orphan details
+	await get_tree().process_frame
+	collect_orphan_node_details()
+
+
+## Shold not detect any orphan becuase the node is auto freed
+func test_no_orphans_auto_free() -> void:
+	var func_node2: Node3D = auto_free(Node3D.new())
+
+	assert_object(func_node2).is_not_null()
+
+	# Injected collect orphan details
+	await get_tree().process_frame
+	collect_orphan_node_details()
+
+
+## This test has no orphans
+func test_no_orphans() -> void:
+	assert_bool(true).is_true()
+
+	# Injected collect orphan details
+	await get_tree().process_frame
+	collect_orphan_node_details()
+
+
+## using parameterized test with orphans
+@warning_ignore("unused_parameter")
+func test_parameterized_with_orphans(index: int, obj: Object, test_parameters := [
+	[0, RefCounted.new()],
+	[1, Node2D.new()]]) -> void:
+	assert_that(obj).is_not_null()
+
+	# Injected collect orphan details
+	await get_tree().process_frame
+	collect_orphan_node_details()


### PR DESCRIPTION
## Prototyping - STOPPED

I've put this on hold for now, as integrating the code introduces many complications that aren't easily resolved and adds too much complexity, making the test execution unstable.
Since the original test code is enriched with injected code, the original line numbers shift, which is still relatively easy to handle. However, this causes problems in debug mode because breakpoints become invalid—the debugger has no idea about the injected code, so debugging breaks down. 