### PR TITLE
Update CI to Godot-4.7-rc2

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -19,11 +19,10 @@
       "Read(//mnt/d/development/workspace/gdUnit4/**)",
       "Skill(update-config)",
       "WebFetch(domain:docs.godotengine.org)",
+      "WebFetch(domain:godot-gdunit-labs.github.io)",
       "WebSearch",
-      "Bash(git add *)",
-      "Bash(git rm *)",
-      "Bash(git push *)",
-      "Bash(git commit -m ' *)"
+      "Bash(Get-Content *)",
+      "Bash(git fetch *)"
     ]
   },
   "hooks": {

--- a/.github/workflows/ci-pr-publish-report.yml
+++ b/.github/workflows/ci-pr-publish-report.yml
@@ -29,7 +29,7 @@ jobs:
         godot-net: ['-net', '']
         include:
           - godot-version: '4.7'
-            godot-status: 'beta5'
+            godot-status: 'rc2'
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -41,7 +41,7 @@ jobs:
         godot-net: ['.Net', '']
         include:
           - godot-version: '4.7'
-            godot-status: 'beta5'
+            godot-status: 'rc2'
 
     permissions:
       actions: write

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
   <img src="https://img.shields.io/badge/v4.6-%23478cbf?logo=godot-engine&logoColor=cyian&color=green" alt="">
   <img src="https://img.shields.io/badge/v4.6.1-%23478cbf?logo=godot-engine&logoColor=cyian&color=green" alt="">
   <img src="https://img.shields.io/badge/v4.6.2-%23478cbf?logo=godot-engine&logoColor=cyian&color=green" alt="">
-  <img src="https://img.shields.io/badge/v4.7.beta5-%23478cbf?logo=godot-engine&logoColor=cyian&color=yellow" alt="">
+  <img src="https://img.shields.io/badge/v4.7.rc2-%23478cbf?logo=godot-engine&logoColor=cyian&color=yellow" alt="">
 </p>
 
 <h1 align="center">Compatibility Overview</h1>
@@ -35,7 +35,7 @@
   </thead>
   <tbody>
     <tr>
-      <td>master (upcoming v6.2)</td><td>v4.5, v4.5.1, v4.6, v4.6.1, v4.6.2, v4.7-beta5</td>
+      <td>master (upcoming v6.2)</td><td>v4.5, v4.5.1, v4.6, v4.6.1, v4.6.2, v4.7-rc2</td>
     </tr>
     <tr>
       <td>v6.1.x</td><td>v4.5, v4.5.1, v4.6, v4.6.1, v4.6.2</td>


### PR DESCRIPTION
# Why
The new release candidate Godot-4.7-rc2 is published and we need to test against nothing is broken.

# What
Updating the CI to Godot-4.7-rc2

