### PR TITLE
GD-1158: Optimize parameterized test discovery with shared resolver

### DIFF
--- a/addons/gdUnit4/src/core/discovery/GdUnitTestCase.gd
+++ b/addons/gdUnit4/src/core/discovery/GdUnitTestCase.gd
@@ -84,7 +84,14 @@ static func to_dict(test: GdUnitTestCase) -> Dictionary:
 	}
 
 
-static func from(_suite_resource_path: String, _source_file: String, _line_number: int, _test_name: String, _attribute_index := -1, _test_parameters := "") -> GdUnitTestCase:
+static func from(
+	_suite_resource_path: String,
+	_source_file: String,
+	_line_number: int,
+	_test_name: String,
+	_attribute_index := -1,
+	_test_parameters := "") -> GdUnitTestCase:
+
 	if(_source_file == null or _source_file.is_empty()):
 		prints(_test_name)
 
@@ -122,4 +129,6 @@ func _build_fully_qualified_name(_resource_path: String) -> void:
 		fully_qualified_name = "%s.%s" % [name_space, test_name]
 	else:
 		fully_qualified_name = "%s.%s.%s" % [name_space, test_name, display_name]
-	assert(fully_qualified_name != null and not fully_qualified_name.is_empty(), "Precondition: The parameter 'fully_qualified_name' can't be resolved")
+	assert(
+		fully_qualified_name != null and not fully_qualified_name.is_empty(),
+		"Precondition: The parameter 'fully_qualified_name' can't be resolved")

--- a/addons/gdUnit4/src/core/discovery/GdUnitTestDiscoverer.gd
+++ b/addons/gdUnit4/src/core/discovery/GdUnitTestDiscoverer.gd
@@ -105,35 +105,32 @@ static func console_log(message: String, on_console := false) -> void:
 		GdUnitSignals.instance().gdunit_message.emit(message)
 
 
-static func filter_tests(method: Dictionary) -> bool:
-	var method_name: String = method["name"]
-	return method_name.begins_with("test_")
-
-
 static func default_discover_sink(test_case: GdUnitTestCase) -> void:
 	GdUnitTestDiscoverSink.discover(test_case)
 
 
 static func discover_tests(source_script: Script, discover_sink := default_discover_sink) -> void:
 	if source_script is GDScript:
-		var test_names := source_script.get_script_method_list()\
-			.filter(filter_tests)\
-			.map(func(method: Dictionary) -> String: return method["name"])
-		# no tests discovered?
-		if test_names.is_empty():
-			return
-
-		var parser := GdScriptParser.new()
-		var fds := parser.get_function_descriptors(source_script as GDScript, test_names)
-		for fd in fds:
-			var resolver := GdFunctionParameterSetResolver.new(fd)
-			for test_case in resolver.resolve_test_cases(source_script as GDScript):
-				discover_sink.call(test_case)
+		for test_case in discover_tests_from_gd_script(source_script as GDScript):
+			discover_sink.call(test_case)
 	elif source_script.get_class() == "CSharpScript":
 		if not GdUnit4CSharpApiLoader.is_api_loaded():
 			return
 		for test_case in GdUnit4CSharpApiLoader.discover_tests(source_script):
 			discover_sink.call(test_case)
+
+
+static func discover_tests_from_gd_script(script: GDScript) -> Array[GdUnitTestCase]:
+	# Filter by test case only
+	var test_names: Array[String] = []
+	for method: Dictionary in script.get_script_method_list():
+		@warning_ignore("unsafe_method_access")
+		if method["name"].begins_with("test_"):
+			test_names.append(method["name"])
+	if test_names.is_empty():
+		return []
+	var fds := GdScriptParser.new().get_function_descriptors(script, test_names)
+	return GdFunctionParameterSetResolver.new(fds).discover_tests(script)
 
 
 static func scan_all_test_directories(root: String) -> PackedStringArray:

--- a/addons/gdUnit4/src/core/parse/GdFunctionParameterSetResolver.gd
+++ b/addons/gdUnit4/src/core/parse/GdFunctionParameterSetResolver.gd
@@ -1,7 +1,7 @@
 class_name GdFunctionParameterSetResolver
 extends RefCounted
 
-const CLASS_TEMPLATE = """
+const CLASS_TEMPLATE := """
 class_name _ParameterExtractor extends '${clazz_path}'
 
 func __extract_test_parameters() -> Array:
@@ -9,42 +9,39 @@ func __extract_test_parameters() -> Array:
 
 """
 
-const EXCLUDE_PROPERTIES_TO_COPY = [
+const EXCLUDE_PROPERTIES_TO_COPY := [
 	"script",
 	"type",
 	"Node",
 	"_import_path"]
 
 
-var _fd: GdFunctionDescriptor
+var _function_descriptors: Array[GdFunctionDescriptor]
 var _static_sets_by_index := {}
 var _is_static := true
 
-func _init(fd: GdFunctionDescriptor) -> void:
-	_fd = fd
+
+func _init(function_descriptors: Array[GdFunctionDescriptor]) -> void:
+	_function_descriptors = function_descriptors
 
 
-func resolve_test_cases(script: GDScript) -> Array[GdUnitTestCase]:
-	if not is_parameterized():
-		return [GdUnitTestCase.from(script.resource_path, _fd.source_path(), _fd.begin_line(), _fd.name())]
-	return extract_test_cases_by_reflection(script)
+func discover_tests(script: GDScript) -> Array[GdUnitTestCase]:
+	var source: Node = script.new()
+	source.queue_free()
 
+	var test_cases: Array[GdUnitTestCase] = []
+	for fd in _function_descriptors:
+		if fd.is_parameterized():
+			test_cases.append_array(extract_test_cases_by_reflection(source, fd))
+		else:
+			test_cases.append(GdUnitTestCase.from(script.resource_path, fd.source_path(), fd.begin_line(), fd.name()))
 
-func is_parameterized() -> bool:
-	return _fd.is_parameterized()
-
-
-func is_parameter_sets_static() -> bool:
-	return _is_static
-
-
-func is_parameter_set_static(index: int) -> bool:
-	return _is_static and _static_sets_by_index.get(index, false)
+	return test_cases
 
 
 # validates the given arguments are complete and matches to required input fields of the test function
-func validate(input_value_set: Array) -> String:
-	var input_arguments := _fd.args()
+func validate(input_value_set: Array, fd: GdFunctionDescriptor) -> String:
+	var input_arguments := fd.args()
 	# check given parameter set with test case arguments
 	var expected_arg_count := input_arguments.size() - 1
 	for input_values :Variant in input_value_set:
@@ -53,12 +50,18 @@ func validate(input_value_set: Array) -> String:
 			var arr_values: Array = input_values
 			var current_arg_count := arr_values.size()
 			if current_arg_count != expected_arg_count:
-				return "\n	The parameter set at index [%d] does not match the expected input parameters!\n	The test case requires [%d] input parameters, but the set contains [%d]" % [parameter_set_index, expected_arg_count, current_arg_count]
+				return """
+					The parameter set at index [%d] does not match the expected input parameters!
+					The test case requires [%d] input parameters, but the set contains [%d]
+					""".dedent() % [parameter_set_index, expected_arg_count, current_arg_count]
 			var error := validate_parameter_types(input_arguments, arr_values, parameter_set_index)
 			if not error.is_empty():
 				return error
 		else:
-			return "\n	The parameter set at index [%d] does not match the expected input parameters!\n	Expecting an array of input values." % parameter_set_index
+			return """
+				The parameter set at index [%d] does not match the expected input parameters!
+				Expecting an array of input values.
+				""".dedent() % parameter_set_index
 	return ""
 
 
@@ -69,7 +72,7 @@ static func validate_parameter_types(input_arguments: Array, input_values: Array
 		if input_param.is_parameter_set():
 			continue
 		var input_param_type := input_param.type()
-		var input_value :Variant = input_values[i]
+		var input_value: Variant = input_values[i]
 		var input_value_type := typeof(input_value)
 		# input parameter is not typed or is Variant we skip the type test
 		if input_param_type == TYPE_NIL or input_param_type == GdObjects.TYPE_VARIANT:
@@ -81,30 +84,37 @@ static func validate_parameter_types(input_arguments: Array, input_values: Array
 		if input_param_type == TYPE_OBJECT and input_value_type == TYPE_NIL:
 			continue
 		if input_param_type != input_value_type:
-			return "\n	The parameter set at index [%d] does not match the expected input parameters!\n	The value '%s' does not match the required input parameter <%s>." % [parameter_set_index, input_value, input_param]
+			return (
+				"\n\tThe parameter set at index [%d] does not match the expected input parameters!"
+				+ "\n\tThe value '%s' does not match the required input parameter <%s>."
+			) % [parameter_set_index, input_value, input_param]
 	return ""
 
 
-func extract_test_cases_by_reflection(script: GDScript) -> Array[GdUnitTestCase]:
-	var source: Node = script.new()
-	source.queue_free()
-
-	var fa := GdFunctionArgument.get_parameter_set(_fd.args())
+func extract_test_cases_by_reflection(source: Node, fd: GdFunctionDescriptor) -> Array[GdUnitTestCase]:
+	var fa := GdFunctionArgument.get_parameter_set(fd.args())
 	var parameter_sets := fa.parameter_sets()
 	# if no parameter set detected we need to resolve it by using reflection
 	if parameter_sets.size() == 0:
 		_is_static = false
-		return _extract_test_cases_by_reflection(source, script)
-	else:
-		var test_cases: Array[GdUnitTestCase] = []
-		var property_names := _extract_property_names(source)
-		for parameter_set_index in parameter_sets.size():
-			var parameter_set := parameter_sets[parameter_set_index]
-			_static_sets_by_index[parameter_set_index] = _is_static_parameter_set(parameter_set, property_names)
-			@warning_ignore("return_value_discarded")
-			test_cases.append(GdUnitTestCase.from(script.resource_path, _fd.source_path(), _fd.begin_line(), _fd.name(), parameter_set_index, parameter_set))
-			parameter_set_index += 1
-		return test_cases
+		return _extract_test_cases_by_reflection(source, fd)
+	var test_cases: Array[GdUnitTestCase] = []
+	var property_names := _extract_property_names(source)
+	for parameter_set_index in parameter_sets.size():
+		var parameter_set := parameter_sets[parameter_set_index]
+		_static_sets_by_index[parameter_set_index] = _is_static_parameter_set(parameter_set, property_names)
+		@warning_ignore("return_value_discarded")
+		test_cases.append(
+			GdUnitTestCase.from(
+				fd.source_path(),
+				fd.source_path(),
+				fd.begin_line(),
+				fd.name(),
+				parameter_set_index,
+				parameter_set)
+			)
+		parameter_set_index += 1
+	return test_cases
 
 
 func _extract_property_names(source: Node) -> PackedStringArray:
@@ -122,21 +132,22 @@ func _is_static_parameter_set(parameters :String, property_names :PackedStringAr
 	return true
 
 
-func _extract_test_cases_by_reflection(source: Node, script: GDScript) -> Array[GdUnitTestCase]:
-	var parameter_sets := load_parameter_sets(source)
+func _extract_test_cases_by_reflection(source: Node, fd: GdFunctionDescriptor) -> Array[GdUnitTestCase]:
+	var parameter_sets := load_parameter_sets(source, fd)
 	var test_cases: Array[GdUnitTestCase] = []
 	for index in parameter_sets.size():
 		var parameter_set := str(parameter_sets[index])
+		var script: GDScript = source.get_script()
 		@warning_ignore("return_value_discarded")
-		test_cases.append(GdUnitTestCase.from(script.resource_path, _fd.source_path(), _fd.begin_line(), _fd.name(), index, parameter_set))
+		test_cases.append(GdUnitTestCase.from(script.resource_path, fd.source_path(), fd.begin_line(), fd.name(), index, parameter_set))
 	return test_cases
 
 
 # extracts the arguments from the given test case, using kind of reflection solution
 # to restore the parameters from a string representation to real instance type
-func load_parameter_sets(source: Node) -> Array:
+func load_parameter_sets(source: Node, fd: GdFunctionDescriptor) -> Array:
 	var source_script: GDScript = source.get_script()
-	var parameter_arg := GdFunctionArgument.get_parameter_set(_fd.args())
+	var parameter_arg := GdFunctionArgument.get_parameter_set(fd.args())
 	var source_code := CLASS_TEMPLATE \
 		.replace("${clazz_path}", source_script.resource_path) \
 		.replace("${test_params}", parameter_arg.value_as_string())
@@ -154,7 +165,7 @@ func load_parameter_sets(source: Node) -> Array:
 	GdFunctionParameterSetResolver.copy_properties(source, instance)
 	instance.queue_free()
 	var parameter_sets: Array = instance.call("__extract_test_parameters")
-	return fixure_typed_parameters(parameter_sets, _fd.args())
+	return fixure_typed_parameters(parameter_sets, fd.args())
 
 
 func fixure_typed_parameters(parameter_sets: Array, arg_descriptors: Array[GdFunctionArgument]) -> Array:

--- a/addons/gdUnit4/test/core/parse/GdFunctionParameterSetResolverTest.gd
+++ b/addons/gdUnit4/test/core/parse/GdFunctionParameterSetResolverTest.gd
@@ -1,0 +1,51 @@
+# GdUnit generated TestSuite
+extends GdUnitTestSuite
+
+
+func test_discover_tests_with_fuzzers() -> void:
+	# Setup
+	var script: GDScript = load("res://addons/gdUnit4/test/core/parse/resources/TestSuiteWithFuzzers.gd")
+
+	# Act
+	var tests := GdUnitTestDiscoverer.discover_tests_from_gd_script(script)
+
+	# Verify
+	assert_array(tests)\
+		.extractv(
+			extr("suite_name"),
+			extr("test_name"),
+			extr("source_file"),
+			extr("line_number"),
+			extr("attribute_index"))\
+		.contains_exactly(
+			tuple("TestSuiteWithFuzzers", "test_do_skip_as_first_param", script.resource_path, 4, -1),
+			tuple("TestSuiteWithFuzzers", "test_do_skip_in_middle", script.resource_path, 11, -1),
+			tuple("TestSuiteWithFuzzers", "test_do_skip_as_last_param", script.resource_path, 18, -1),
+		)
+
+
+func test_discover_tests_with_static_parameterset() -> void:
+	# Setup
+	var script: GDScript = load("res://addons/gdUnit4/test/core/parse/resources/TestSuiteWithStaticParameterSet.gd")
+
+	# Act
+	var tests := GdUnitTestDiscoverer.discover_tests_from_gd_script(script)
+
+	# Verify
+	assert_array(tests)\
+		.extractv(
+			extr("suite_name"),
+			extr("test_name"),
+			extr("source_file"),
+			extr("line_number"),
+			extr("attribute_index"))\
+		.contains(
+			tuple("TestSuiteWithStaticParameterSet", "test_parameterized_bool_value", script.resource_path, 5, 0),
+			tuple("TestSuiteWithStaticParameterSet", "test_parameterized_bool_value", script.resource_path, 5, 1),
+			tuple("TestSuiteWithStaticParameterSet", "test_parameterized_int_values", script.resource_path, 12, 0),
+			tuple("TestSuiteWithStaticParameterSet", "test_parameterized_int_values", script.resource_path, 12, 1),
+			tuple("TestSuiteWithStaticParameterSet", "test_parameterized_int_values", script.resource_path, 12, 2),
+			tuple("TestSuiteWithStaticParameterSet", "test_parameterized_float_values", script.resource_path, 20, 0),
+			tuple("TestSuiteWithStaticParameterSet", "test_parameterized_float_values", script.resource_path, 20, 1),
+			tuple("TestSuiteWithStaticParameterSet", "test_parameterized_float_values", script.resource_path, 20, 2),
+		)

--- a/addons/gdUnit4/test/core/parse/GdScriptParsingFunctionDescriptorsTest.gd
+++ b/addons/gdUnit4/test/core/parse/GdScriptParsingFunctionDescriptorsTest.gd
@@ -443,6 +443,33 @@ func test_default_args_basic_type_transform2d() -> void:
 		)
 
 
+func test_parse_fuzz_do_skip_param_GD_1157() -> void:
+	var script: GDScript = load("res://addons/gdUnit4/test/core/resources/testsuites/TestSuiteFuzzedDoSkipParamTest.gd")
+
+	var fds := _parser.get_function_descriptors(script, [])
+	assert_that(fds[0])\
+		.is_equal(create("test_do_skip_as_first_param", script.resource_path, 6, 10, GdObjects.TYPE_VOID, [
+				GdFunctionArgument.new("_do_skip", TYPE_BOOL, false),
+				GdFunctionArgument.new("_fuzzer", GdObjects.TYPE_FUZZER, "Fuzzers.rangei(0, 10)"),
+				GdFunctionArgument.new("_fuzzer_iterations", TYPE_INT, 3),
+			])
+		)
+	assert_that(fds[1])\
+		.is_equal(create("test_do_skip_in_middle", script.resource_path, 13, 17, GdObjects.TYPE_VOID, [
+				GdFunctionArgument.new("_fuzzer_a", GdObjects.TYPE_FUZZER, "Fuzzers.rangei(0, 10)"),
+				GdFunctionArgument.new("_do_skip", TYPE_BOOL, false),
+				GdFunctionArgument.new("_fuzzer_iterations", TYPE_INT, 3),
+			])
+		)
+	assert_that(fds[2])\
+		.is_equal(create("test_do_skip_as_last_param", script.resource_path, 20, 24, GdObjects.TYPE_VOID, [
+				GdFunctionArgument.new("_fuzzer", GdObjects.TYPE_FUZZER, "Fuzzers.rangei(0, 10)"),
+				GdFunctionArgument.new("_fuzzer_iterations", TYPE_INT, 3),
+				GdFunctionArgument.new("_do_skip", TYPE_BOOL, false),
+			])
+		)
+
+
 static func create(func_name: String, source_path: String, begin_line: int, end_line: int, return_type: int, args: Array[GdFunctionArgument] = []) -> GdFunctionDescriptor:
 	var fd := GdFunctionDescriptor.new(func_name, false, false, false, return_type, "", args)
 	fd.enrich_file_info(source_path, begin_line, end_line)

--- a/addons/gdUnit4/test/core/parse/resources/TestSuiteWithFuzzers.gd
+++ b/addons/gdUnit4/test/core/parse/resources/TestSuiteWithFuzzers.gd
@@ -1,0 +1,22 @@
+extends GdUnitTestSuite
+
+
+func test_do_skip_as_first_param(
+	_do_skip := false,
+	_fuzzer := Fuzzers.rangei(0, 10),
+	_fuzzer_iterations := 3) -> void:
+	pass
+
+
+func test_do_skip_in_middle(
+		_fuzzer_a := Fuzzers.rangei(0, 10),
+		_do_skip := false,
+		_fuzzer_iterations := 3) -> void:
+	pass
+
+
+func test_do_skip_as_last_param(
+	_fuzzer := Fuzzers.rangei(0, 10),
+	_fuzzer_iterations := 3,
+	_do_skip := false) -> void:
+	pass

--- a/addons/gdUnit4/test/core/parse/resources/TestSuiteWithStaticParameterSet.gd
+++ b/addons/gdUnit4/test/core/parse/resources/TestSuiteWithStaticParameterSet.gd
@@ -1,0 +1,40 @@
+extends GdUnitTestSuite
+
+
+@warning_ignore("unused_parameter")
+func test_parameterized_bool_value(a: int, expected: bool, _test_parameters := [
+	[0, false],
+	[1, true]]) -> void:
+	pass
+
+
+@warning_ignore("unused_parameter")
+func test_parameterized_int_values(a: int, b: int, c: int, expected: int, _test_parameters := [
+	[1, 2, 3, 6],
+	[3, 4, 5, 12],
+	[6, 7, 8, 21] ]) -> void:
+	pass
+
+
+@warning_ignore("unused_parameter")
+func test_parameterized_float_values(a: float, b: float, expected: float, _test_parameters := [
+	[2.2, 2.2, 4.4],
+	[2.2, 2.3, 4.5],
+	[3.3, 2.2, 5.5] ]) -> void:
+	pass
+
+
+@warning_ignore("unused_parameter")
+func test_parameterized_string_values(a: String, b: String, expected: String, _test_parameters := [
+	["2.2", "2.2", "2.22.2"],
+	["foo", "bar", "foobar"],
+	["a", "b", "ab"] ]) -> void:
+	pass
+
+
+@warning_ignore("unused_parameter")
+func test_parameterized_Vector2_values(a: Vector2, b: Vector2, expected: Vector2, _test_parameters := [
+	[Vector2.ONE, Vector2.ONE, Vector2(2, 2)],
+	[Vector2.LEFT, Vector2.RIGHT, Vector2.ZERO],
+	[Vector2.ZERO, Vector2.LEFT, Vector2.LEFT] ]) -> void:
+	pass


### PR DESCRIPTION
# Why
During test discovery, `GdFunctionParameterSetResolver` was instantiated once per function descriptor, causing `script.new()` to be called N times for N parameterized functions in the same suite. The single-descriptor API forced callers to loop externally and prevented any cross-function optimization. This PR is the first step toward resolving the parameterized test performance regression reported in #1158.

# What
- `GdFunctionParameterSetResolver` now accepts all function descriptors at once and resolves them in a single `discover_tests()` call, reducing `script.new()` from N to 1 per suite
- `GdUnitTestDiscoverer` gains a dedicated `discover_tests_from_gd_script()` entry point, keeping method filtering and descriptor parsing in one place
- Deprecated single-descriptor methods removed, new test coverage added in `GdFunctionParameterSetResolverTest.gd`

Closes #1158