### PR TITLE
DOC-1178: Fixing broken link in `GdUnit4 C# Test Setup` documentation

### DIFF
--- a/documentation/doc/_csharp_project_setup/csharp-setup.md
+++ b/documentation/doc/_csharp_project_setup/csharp-setup.md
@@ -107,7 +107,7 @@ The output should indicate that the project is built successfully.
 
 ### Running C# Tests inside the Godot Editor
 
-How to [run test]({{site.baseurl}}/testing/run-tests/)
+How to [run test]({{site.baseurl}}/first_steps/run-tests/#how-to-run-test)
 
 ## Using External C# Editor
 


### PR DESCRIPTION
# Why
Under `GdUnit4 C# Test Setup`  [Running C# Tests inside the Godot Editor](https://godot-gdunit-labs.github.io/gdUnit4/latest/csharp_project_setup/csharp-setup/#running-c-tests-inside-the-godot-editor) the link 'Run test' is broken

# What
- fixed the corrupted link
