### PR TITLE
GD-1198: Guard `auto_free()` against null execution context during suite initialization

### DIFF
--- a/addons/gdUnit4/src/GdUnitTestSuite.gd
+++ b/addons/gdUnit4/src/GdUnitTestSuite.gd
@@ -99,7 +99,13 @@ func error_as_string(error_number: int) -> String:
 func auto_free(obj: Variant) -> Variant:
 	var execution_context := GdUnitThreadManager.get_current_context().get_execution_context()
 
-	assert(execution_context != null, "INTERNAL ERROR: The current execution_context is null! Please report this as bug.")
+	# If the execution context is null, we are not in the execution call stack, so we mark the object as “queued free.”
+	if execution_context == null:
+		if obj is Node:
+			@warning_ignore("unsafe_method_access")
+			obj.queue_free()
+		return obj
+
 	return execution_context.register_auto_free(obj)
 
 

--- a/addons/gdUnit4/src/core/execution/GdUnitTestSuiteExecutor.gd
+++ b/addons/gdUnit4/src/core/execution/GdUnitTestSuiteExecutor.gd
@@ -41,6 +41,7 @@ func run_and_wait(tests: Array[GdUnitTestCase]) -> void:
 		var script := GdUnitTestSuiteScanner.load_with_disabled_warnings(suite_path)
 		if script.get_class() == "GDScript":
 			var context := GdUnitExecutionContext.new(suite_path)
+			GdUnitThreadManager.get_current_context().set_execution_context(context)
 			var test_suite := scanner.load_suite(script as GDScript, suite_tests)
 			context.test_suite = test_suite
 			(Engine.get_main_loop() as SceneTree).root.add_child(test_suite)


### PR DESCRIPTION
## Why

`GdUnitTestSuite.auto_free()` contained a hard assertion that the current execution context is non-null. The execution context was registered only after suite loading completed, but test suite nodes are constructed and added to the scene tree before that point. Any call to `auto_free()` from a class-level variable initialiser (e.g. `var _node := auto_free(Node.new())`) hit the unguarded assertion and crashed the engine instead of running the test.

A second related problem: the execution context was being registered after the suite was already loaded, so even the corrected null guard could not fall back to the context for early calls.

Closes #1198

## What

- `auto_free()` now checks for a null execution context and gracefully degrades: it queues the object for free (if it is a `Node`) and returns it, rather than asserting.
- `GdUnitTestSuiteExecutor` now registers the execution context on the thread manager before calling `scanner.load_suite()`, so the context is available for any code that runs during suite construction.