### PR TITLE
GD-1199: Use `GdParameterSetResolverFactory` in test discoverer to correctly count dynamic parameterized test cases

### DIFF
--- a/addons/gdUnit4/src/core/discovery/GdUnitTestDiscoverer.gd
+++ b/addons/gdUnit4/src/core/discovery/GdUnitTestDiscoverer.gd
@@ -129,8 +129,51 @@ static func discover_tests_from_gd_script(script: GDScript) -> Array[GdUnitTestC
 			test_names.append(method["name"])
 	if test_names.is_empty():
 		return []
+
+	var source: Node = script.new()
 	var fds := GdScriptParser.new().get_function_descriptors(script, test_names)
-	return GdFunctionParameterSetResolver.new(fds).discover_tests(script)
+	var test_cases: Array[GdUnitTestCase] = []
+	for fd in fds:
+		if fd.is_parameterized():
+			test_cases.append_array(discover_parameterised_tests(source, fd))
+		else:
+			test_cases.append(GdUnitTestCase.from(script.resource_path, fd.source_path(), fd.begin_line(), fd.name()))
+	source.free()
+
+	return test_cases
+
+
+static func discover_parameterised_tests(source: Node, fd: GdFunctionDescriptor) -> Array[GdUnitTestCase]:
+	var fa := GdFunctionArgument.get_parameter_set(fd.args())
+	var parameter_expressions := fa.parameter_sets()
+	var count := parameter_expressions.size()
+
+	# The parameter set is not static we need to preload it to get the amount of test sets
+	if count == 0:
+		var resolver := GdParameterSetResolverFactory.create(fd, source)
+		if resolver == null:
+			return []
+		count = resolver.get_max_index()
+		for i in count:
+			var params := resolver.get_parameters(source, i)
+			# Strip trailing EMPTY_SET added by the resolver; stringify for display name
+			parameter_expressions.append(str(params.slice(0, params.size() - 1)))
+
+	var test_cases: Array[GdUnitTestCase] = []
+	for parameter_index in count:
+		var parameter_expression := parameter_expressions[parameter_index]
+
+		@warning_ignore("return_value_discarded")
+		test_cases.append(
+			GdUnitTestCase.from(
+				fd.source_path(),
+				fd.source_path(),
+				fd.begin_line(),
+				fd.name(),
+				parameter_index,
+				parameter_expression)
+			)
+	return test_cases
 
 
 static func scan_all_test_directories(root: String) -> PackedStringArray:

--- a/addons/gdUnit4/test/core/discovery/GdUnitTestDiscovererTest.gd
+++ b/addons/gdUnit4/test/core/discovery/GdUnitTestDiscovererTest.gd
@@ -151,3 +151,99 @@ func test_scan_all_test_directories() -> void:
 
 	# Test when test_root_folder is set to something which doesn't exist
 	assert_array(GdUnitTestDiscoverer.scan_all_test_directories("notest")).is_empty()
+
+
+func test_discover_tests_with_fuzzers() -> void:
+	# Setup
+	var script: GDScript = load("res://addons/gdUnit4/test/core/parse/resources/TestSuiteWithFuzzers.gd")
+
+	# Act
+	var tests := GdUnitTestDiscoverer.discover_tests_from_gd_script(script)
+
+	# Verify
+	assert_array(tests)\
+		.extractv(
+			extr("suite_name"),
+			extr("test_name"),
+			extr("source_file"),
+			extr("line_number"),
+			extr("attribute_index"))\
+		.contains_exactly(
+			tuple("TestSuiteWithFuzzers", "test_do_skip_as_first_param", script.resource_path, 4, -1),
+			tuple("TestSuiteWithFuzzers", "test_do_skip_in_middle", script.resource_path, 11, -1),
+			tuple("TestSuiteWithFuzzers", "test_do_skip_as_last_param", script.resource_path, 18, -1),
+		)
+
+
+func test_discover_tests_with_static_parameterset() -> void:
+	# Setup
+	var script: GDScript = load("res://addons/gdUnit4/test/core/parse/resources/TestSuiteWithStaticParameterSet.gd")
+
+	# Act
+	var tests := GdUnitTestDiscoverer.discover_tests_from_gd_script(script)
+
+	# Verify
+	assert_array(tests)\
+		.extractv(
+			extr("suite_name"),
+			extr("test_name"),
+			extr("source_file"),
+			extr("line_number"),
+			extr("attribute_index"))\
+		.contains_exactly(
+			tuple("TestSuiteWithStaticParameterSet", "test_parameterized_bool_value", script.resource_path, 20, 0),
+			tuple("TestSuiteWithStaticParameterSet", "test_parameterized_bool_value", script.resource_path, 20, 1),
+			tuple("TestSuiteWithStaticParameterSet", "test_parameterized_int_values", script.resource_path, 27, 0),
+			tuple("TestSuiteWithStaticParameterSet", "test_parameterized_int_values", script.resource_path, 27, 1),
+			tuple("TestSuiteWithStaticParameterSet", "test_parameterized_int_values", script.resource_path, 27, 2),
+			tuple("TestSuiteWithStaticParameterSet", "test_parameterized_float_values", script.resource_path, 35, 0),
+			tuple("TestSuiteWithStaticParameterSet", "test_parameterized_float_values", script.resource_path, 35, 1),
+			tuple("TestSuiteWithStaticParameterSet", "test_parameterized_float_values", script.resource_path, 35, 2),
+			tuple("TestSuiteWithStaticParameterSet", "test_parameterized_string_values", script.resource_path, 42, 0),
+			tuple("TestSuiteWithStaticParameterSet", "test_parameterized_string_values", script.resource_path, 42, 1),
+			tuple("TestSuiteWithStaticParameterSet", "test_parameterized_string_values", script.resource_path, 42, 2),
+			tuple("TestSuiteWithStaticParameterSet", "test_parameterized_Vector2_values", script.resource_path, 50, 0),
+			tuple("TestSuiteWithStaticParameterSet", "test_parameterized_Vector2_values", script.resource_path, 50, 1),
+			tuple("TestSuiteWithStaticParameterSet", "test_parameterized_Vector2_values", script.resource_path, 50, 2),
+			tuple("TestSuiteWithStaticParameterSet", "test_with_instance_parameters", script.resource_path, 58, 0),
+			tuple("TestSuiteWithStaticParameterSet", "test_with_instance_parameters", script.resource_path, 58, 1),
+			tuple("TestSuiteWithStaticParameterSet", "test_with_instance_parameters", script.resource_path, 58, 2),
+			tuple("TestSuiteWithStaticParameterSet", "test_with_instance_parameters", script.resource_path, 58, 3),
+			tuple("TestSuiteWithStaticParameterSet", "test_with_instance_parameters", script.resource_path, 58, 4),
+		)
+
+
+func test_discover_tests_with_dynamic_parameterset() -> void:
+	# Setup
+	var script: GDScript = load("res://addons/gdUnit4/test/core/parse/resources/TestSuiteWithDynamicParameterSet.gd")
+
+	# Act
+	var tests := GdUnitTestDiscoverer.discover_tests_from_gd_script(script)
+
+	# Verify
+	assert_array(tests)\
+		.extractv(
+			extr("suite_name"),
+			extr("test_name"),
+			extr("source_file"),
+			extr("line_number"),
+			extr("attribute_index"))\
+		.contains_exactly(
+			# test_with_dynamic_parameters_typed_array
+			tuple("TestSuiteWithDynamicParameterSet", "test_with_dynamic_parameters_typed_array", script.resource_path, 25, 0),
+			tuple("TestSuiteWithDynamicParameterSet", "test_with_dynamic_parameters_typed_array", script.resource_path, 25, 1),
+			# test_with_dynamic_parameters_untyped_array
+			tuple("TestSuiteWithDynamicParameterSet", "test_with_dynamic_parameters_untyped_array", script.resource_path, 29, 0),
+			tuple("TestSuiteWithDynamicParameterSet", "test_with_dynamic_parameters_untyped_array", script.resource_path, 29, 1),
+			# test_with_dynamic_parameterset
+			tuple("TestSuiteWithDynamicParameterSet", "test_with_dynamic_parameterset", script.resource_path, 33, 0),
+			tuple("TestSuiteWithDynamicParameterSet", "test_with_dynamic_parameterset", script.resource_path, 33, 1),
+			tuple("TestSuiteWithDynamicParameterSet", "test_with_dynamic_parameterset", script.resource_path, 33, 2),
+			tuple("TestSuiteWithDynamicParameterSet", "test_with_dynamic_parameterset", script.resource_path, 33, 3),
+			tuple("TestSuiteWithDynamicParameterSet", "test_with_dynamic_parameterset", script.resource_path, 33, 4),
+			tuple("TestSuiteWithDynamicParameterSet", "test_with_dynamic_parameterset", script.resource_path, 33, 5),
+			tuple("TestSuiteWithDynamicParameterSet", "test_with_dynamic_parameterset", script.resource_path, 33, 6),
+			tuple("TestSuiteWithDynamicParameterSet", "test_with_dynamic_parameterset", script.resource_path, 33, 7),
+			tuple("TestSuiteWithDynamicParameterSet", "test_with_dynamic_parameterset", script.resource_path, 33, 8),
+			tuple("TestSuiteWithDynamicParameterSet", "test_with_dynamic_parameterset", script.resource_path, 33, 9),
+		)

--- a/addons/gdUnit4/test/core/parse/resources/TestSuiteWithDynamicParameterSet.gd
+++ b/addons/gdUnit4/test/core/parse/resources/TestSuiteWithDynamicParameterSet.gd
@@ -1,0 +1,34 @@
+extends GdUnitTestSuite
+
+
+func _test_parameters_untyped() -> Array:
+	return [
+		["test_a", auto_free(Node2D.new()), Node2D],
+		["test_b", auto_free(Node3D.new()), Node3D],
+	]
+
+
+func _test_parameters_typed() -> Array[Array]:
+	return [
+		["test_a", auto_free(Node2D.new()), Node2D],
+		["test_b", auto_free(Node3D.new()), Node3D],
+	]
+
+
+func _dynamic_parameterset(count: int) -> Array[Array]:
+	var iterations: Array[Array] = []
+	for i in range(count):
+		iterations.append(["name_%s"%i, i, i])
+	return iterations
+
+
+func test_with_dynamic_parameters_typed_array(_name: String, _value: Variant, _expected: Variant, _test_parameters := _test_parameters_typed()) -> void:
+	pass
+
+
+func test_with_dynamic_parameters_untyped_array(_name: String, _value: Variant, _expected: Variant, _test_parameters := _test_parameters_untyped()) -> void:
+	pass
+
+
+func test_with_dynamic_parameterset(_name: String, _value: Variant, _expected: Variant, _test_parameters := _dynamic_parameterset(10)) -> void:
+	pass

--- a/addons/gdUnit4/test/core/parse/resources/TestSuiteWithStaticParameterSet.gd
+++ b/addons/gdUnit4/test/core/parse/resources/TestSuiteWithStaticParameterSet.gd
@@ -1,5 +1,20 @@
 extends GdUnitTestSuite
 
+var _test_node_before: Node
+var _test_node_before_test: Node
+
+
+func before() -> void:
+	_test_node_before = auto_free(SubViewport.new())
+	_test_node_before_test = auto_free(SubViewport.new())
+
+
+class TestObj extends RefCounted:
+	var _value: String
+
+	func _init(value: String) -> void:
+		_value = value
+
 
 @warning_ignore("unused_parameter")
 func test_parameterized_bool_value(a: int, expected: bool, _test_parameters := [
@@ -23,7 +38,6 @@ func test_parameterized_float_values(a: float, b: float, expected: float, _test_
 	[3.3, 2.2, 5.5] ]) -> void:
 	pass
 
-
 @warning_ignore("unused_parameter")
 func test_parameterized_string_values(a: String, b: String, expected: String, _test_parameters := [
 	["2.2", "2.2", "2.22.2"],
@@ -37,4 +51,15 @@ func test_parameterized_Vector2_values(a: Vector2, b: Vector2, expected: Vector2
 	[Vector2.ONE, Vector2.ONE, Vector2(2, 2)],
 	[Vector2.LEFT, Vector2.RIGHT, Vector2.ZERO],
 	[Vector2.ZERO, Vector2.LEFT, Vector2.LEFT] ]) -> void:
+	pass
+
+
+@warning_ignore("unused_parameter")
+func test_with_instance_parameters(name_: String, value: Variant, expected: Variant, _test_parameters := [
+	["test_a", auto_free(Node2D.new()), Node2D],
+	["test_b", auto_free(Node3D.new()), Node3D],
+	["test_c", _test_node_before, SubViewport],
+	["test_d", _test_node_before_test, SubViewport],
+	["test_e", TestObj.new("abc"), TestObj]
+]) -> void:
 	pass

--- a/addons/gdUnit4/test/core/runners/GdUnitTestCIRunnerTest.gd
+++ b/addons/gdUnit4/test/core/runners/GdUnitTestCIRunnerTest.gd
@@ -9,7 +9,10 @@ func test_discover_tests_on_path() -> void:
 	runner.add_test_suite("res://addons/gdUnit4/test/core/discovery/resources/")
 
 	var tests := runner.discover_tests()
-	assert_array(tests).has_size(12)
+	if GdUnit4CSharpApiLoader.is_api_loaded():
+		assert_array(tests).has_size(14)
+	else:
+		assert_array(tests).has_size(12)
 
 
 func test_discover_tests_on_file() -> void:


### PR DESCRIPTION
## Why

When the test discoverer scans a test suite it must register one `GdUnitTestCase` entry per expected iteration before execution begins. For parameterized tests backed by an inline array this count is trivially available from the AST. For callable-based and property-based sources the actual array is only produced when the method or property is evaluated on a live instance of the test suite class.

The discoverer previously had no way to evaluate these dynamic sources, so it fell back to a count of one regardless of how many parameter sets the source would actually produce. Tests backed by callable or property sources were therefore either silently under-counted or shown as a single test when multiple iterations were expected.

Closes #1199

> **Note:** This PR targets the `GD-1200` branch. It will be retargeted to `master` once that branch is merged.

## What

- `GdUnitTestDiscoverer` now instantiates the test suite script and calls `GdParameterSetResolverFactory.create()` to obtain the correct resolver for each parameterized test function, then queries the resolver for the actual parameter count.
- Adds test cases covering callable-based and property-based parameter sources to `GdUnitTestDiscovererTest`.
- Adds `TestSuiteWithDynamicParameterSet` as a test-resource fixture with callable and property parameter sources, alongside `TestSuiteWithStaticParameterSet` which already existed for inline sources.
- Adds a `_.gdignore` marker so that the resource fixtures under `test/core/parse/resources/` are not themselves treated as test suites by the runner.