### PR TITLE
GD-1200-2: Introduce `GdCallableParameterSetResolver` for callable-based parameterized test data

### DIFF
--- a/addons/gdUnit4/src/core/parameters/GdCallableParameterSetResolver.gd
+++ b/addons/gdUnit4/src/core/parameters/GdCallableParameterSetResolver.gd
@@ -1,0 +1,59 @@
+class_name GdCallableParameterSetResolver
+extends GdParameterSetResolver
+
+
+var _expression: String
+var _parameters: Array[Array]
+
+var _func_call_regex := RegEx.create_from_string("^(\\w+)\\((.*)\\)$")
+
+
+func _init(instance: Node, expression: String, args: Array[GdFunctionArgument] = []) -> void:
+	super(args)
+	_expression = expression
+	_parameters = _compile(instance, expression)
+
+
+func get_max_index() -> int:
+	return _parameters.size()
+
+
+func get_parameters(_instance: Node, index: int) -> Array:
+	return _parameters[index]
+
+
+func _compile(instance: Node, expression: String) -> Array[Array]:
+	var regex_result := _func_call_regex.search(expression)
+	if regex_result == null:
+		push_error("GdCallableParameterSetResolver: Cannot parse expression '%s'" % expression)
+		return []
+
+	var func_name := regex_result.get_string(1)
+	var args_str := regex_result.get_string(2).strip_edges()
+
+	if not instance.has_method(func_name):
+		push_error("GdCallableParameterSetResolver: Method '%s' not found on instance." % func_name)
+		return []
+
+	var args: Array = [] if args_str.is_empty() else _parse_arguments(args_str)
+	var parameter_set: Array = instance.callv(func_name, args)
+	if parameter_set == null:
+		return []
+
+	for parameters: Array in parameter_set:
+		_finalize_parameter_set(parameters)
+
+	# We want to use allways typed arrays
+	if not parameter_set.is_typed():
+		parameter_set = Array(parameter_set, TYPE_ARRAY, "", null)
+
+	return parameter_set
+
+
+func _parse_arguments(args_str: String) -> Array:
+	var result: Array = []
+	for raw: String in args_str.split(","):
+		var value := raw.strip_edges()
+		var converted: Variant = str_to_var(value)
+		result.append(converted if converted != null else value)
+	return result

--- a/addons/gdUnit4/test/core/parameters/GdCallableParameterSetResolverTest.gd
+++ b/addons/gdUnit4/test/core/parameters/GdCallableParameterSetResolverTest.gd
@@ -1,0 +1,210 @@
+# GdUnit generated TestSuite
+extends GdUnitTestSuite
+
+
+var _x := 42
+var _obj: Node2D
+var _color := Color.RED
+var _test_set_a := ["test_8", Color(1,1,1), Color(.1,.1,.1)]
+
+
+class TestObj:
+
+	func _init() -> void:
+		pass
+
+
+func _dynamic_parameterset(count: int) -> Array[Array]:
+	var iterations: Array[Array] = []
+	for i in range(count):
+		iterations.append(["test_%s"%i, i])
+	return iterations
+
+
+func _parameters_typed() -> Array[Array]:
+	return [
+		["test_0", auto_free(Node2D.new()), Node2D],
+		["test_1", auto_free(Node3D.new()), Node3D],
+		["test_2", auto_free(Node.new()), Node],
+		["test_3", auto_free(RefCounted.new()), RefCounted],
+	]
+
+
+func _parameters_untyped() -> Array:
+	return [
+		["test_0", auto_free(Node2D.new()), Node2D],
+		["test_1", auto_free(Node3D.new()), Node3D],
+		["test_2", auto_free(Node.new()), Node],
+		["test_3", auto_free(RefCounted.new()), RefCounted],
+	]
+
+
+func _parameters_with_references_typed() -> Array[Array]:
+	return [
+		["test_0", auto_free(Node.new()), Node],
+		["test_1", auto_free(Node3D.new()), Node3D],
+		["test_2", "abc", "String"],
+		["test_3", _x, "Integer"],
+		["test_4", _obj, Node2D],
+		["test_5", TestObj.new(), TestObj],
+		["test_6", Vector3(1,1,1), Vector2(2,2)],
+		["test_7", Color(1,1,1), _color],
+		_test_set_a
+	]
+
+
+func before() -> void:
+	_obj = auto_free(Node2D.new())
+
+
+func test_get_parameters_dynamic_created() -> void:
+	var resolver := GdCallableParameterSetResolver.new(self, "_dynamic_parameterset(4)")
+
+	# We used the function `_dynamic_parameterset(4)` to pre-build a parameter set with size 4
+	assert_int(resolver.get_max_index()).is_equal(4)
+
+	# We test here a parameter resolver for a test function signature like
+	# `func test_foo(arg1, arg2, _test_parameters := _dynamic_parameterset(5) -> void:`
+	# The result of `get_parameters` must match the function signature
+	# - first arg is extracted from the orignal _test_parameters using the `_dynamic_parameterset()` function
+	# - second arg is extracted from the orignal _test_parameters using the `_dynamic_parameterset()` function
+	# - third argument is a empty placeholder to replace the defaults of `_test_parameters` argument
+	#   to avoid reinitalization of the complete parameter set
+	assert_array(resolver.get_parameters(self, 0)) \
+		.has_size(3) \
+		.contains_exactly("test_0", 0, [])
+	assert_array(resolver.get_parameters(self, 1)) \
+		.has_size(3) \
+		.contains_exactly("test_1", 1, [])
+	assert_array(resolver.get_parameters(self, 2)) \
+		.has_size(3) \
+		.contains_exactly("test_2", 2, [])
+	assert_array(resolver.get_parameters(self, 3)) \
+		.has_size(3) \
+		.contains_exactly("test_3", 3, [])
+
+
+func test_get_parameters_typed_static_created() -> void:
+	var resolver := GdCallableParameterSetResolver.new(self, "_parameters_typed()")
+
+	# We used the function `_parameters_typed()` that builds a parameter set with size 4
+	assert_int(resolver.get_max_index()).is_equal(4)
+
+	# We test here a parameter resolver for a test function signature like
+	# `func test_foo(arg1, arg2, _test_parameters := _parameters_typed() -> void:`
+	# The result of `get_parameters` must match the function signature
+	# - first arg is extracted from the orignal _test_parameters using the `_parameters_typed()` function
+	# - second arg is extracted from the orignal _test_parameters using the `_parameters_typed()` function
+	# - third argument is a empty placeholder to replace the defaults of `_test_parameters` argument
+	#   to avoid reinitalization of the complete parameter set
+	var parameters := resolver.get_parameters(self, 0)
+	assert_array(parameters).has_size(4)
+	assert_str(parameters[0]).is_equal("test_0")
+	assert_object(parameters[1]).is_instanceof(Node2D).is_valid()
+	assert_object(parameters[2]).is_equal(Node2D)
+	assert_object(parameters[3]).is_equal([])
+
+	parameters = resolver.get_parameters(self, 1)
+	assert_array(parameters).has_size(4)
+	assert_str(parameters[0]).is_equal("test_1")
+	assert_object(parameters[1]).is_instanceof(Node3D).is_valid()
+	assert_object(parameters[2]).is_equal(Node3D)
+	assert_object(parameters[3]).is_equal([])
+
+	parameters = resolver.get_parameters(self, 2)
+	assert_array(parameters).has_size(4)
+	assert_str(parameters[0]).is_equal("test_2")
+	assert_object(parameters[1]).is_instanceof(Node).is_valid()
+	assert_object(parameters[2]).is_equal(Node)
+	assert_object(parameters[3]).is_equal([])
+
+	parameters = resolver.get_parameters(self, 3)
+	assert_array(parameters).has_size(4)
+	assert_str(parameters[0]).is_equal("test_3")
+	assert_object(parameters[1]).is_instanceof(RefCounted).is_valid()
+	assert_object(parameters[2]).is_equal(RefCounted)
+	assert_object(parameters[3]).is_equal([])
+
+
+func test_get_parameters_untyped() -> void:
+	var resolver := GdCallableParameterSetResolver.new(self, "_parameters_untyped()")
+
+	# We used the function `_parameters_typed()` that builds a parameter set with size 4
+	assert_int(resolver.get_max_index()).is_equal(4)
+
+	# We test here a parameter resolver for a test function signature like
+	# `func test_foo(arg1, arg2, _test_parameters := _parameters_typed() -> void:`
+	# The result of `get_parameters` must match the function signature
+	# - first arg is extracted from the orignal _test_parameters using the `_parameters_typed()` function
+	# - second arg is extracted from the orignal _test_parameters using the `_parameters_typed()` function
+	# - third argument is a empty placeholder to replace the defaults of `_test_parameters` argument
+	#   to avoid reinitalization of the complete parameter set
+	var parameters := resolver.get_parameters(self, 0)
+	assert_array(parameters).has_size(4)
+	assert_str(parameters[0]).is_equal("test_0")
+	assert_object(parameters[1]).is_instanceof(Node2D).is_valid()
+	assert_object(parameters[2]).is_equal(Node2D)
+	assert_object(parameters[3]).is_equal([])
+
+	parameters = resolver.get_parameters(self, 1)
+	assert_array(parameters).has_size(4)
+	assert_str(parameters[0]).is_equal("test_1")
+	assert_object(parameters[1]).is_instanceof(Node3D).is_valid()
+	assert_object(parameters[2]).is_equal(Node3D)
+	assert_object(parameters[3]).is_equal([])
+
+	parameters = resolver.get_parameters(self, 2)
+	assert_array(parameters).has_size(4)
+	assert_str(parameters[0]).is_equal("test_2")
+	assert_object(parameters[1]).is_instanceof(Node).is_valid()
+	assert_object(parameters[2]).is_equal(Node)
+	assert_object(parameters[3]).is_equal([])
+
+	parameters = resolver.get_parameters(self, 3)
+	assert_array(parameters).has_size(4)
+	assert_str(parameters[0]).is_equal("test_3")
+	assert_object(parameters[1]).is_instanceof(RefCounted).is_valid()
+	assert_object(parameters[2]).is_equal(RefCounted)
+
+
+func test_get_parameters_dynamic_referenced() -> void:
+	var resolver := GdCallableParameterSetResolver.new(self, "_parameters_with_references_typed()")
+
+	# We used the function `_parameters_with_references_typed()` that builds a parameter set with size 9
+	assert_int(resolver.get_max_index()).is_equal(9)
+
+#region performance
+
+func test_performance_single() -> void:
+	const ITERATIONS := 1000
+	var resolver := GdCallableParameterSetResolver.new(self, "_dynamic_parameterset(5)")
+
+	var t1 := Time.get_ticks_usec()
+	for _i in ITERATIONS:
+		resolver.get_parameters(self, 0)
+	var elapsed_time := Time.get_ticks_usec() - t1
+
+	@warning_ignore_start("integer_division")
+	prints("--- GdCallableParameterSetResolver:single performance (%d iterations) ---" % ITERATIONS)
+	prints("	%8d µs  (%d µs/iteration)" % [elapsed_time, elapsed_time / ITERATIONS])
+	assert_int(elapsed_time/ITERATIONS).is_less(5)
+	@warning_ignore_restore("integer_division")
+
+
+func test_performance_get_parameters_overall() -> void:
+	const ITERATIONS := 1000
+	var resolver := GdCallableParameterSetResolver.new(self, "_dynamic_parameterset(5)")
+
+	var t1 := Time.get_ticks_usec()
+	for _i in ITERATIONS:
+		for index in resolver.get_max_index():
+			resolver.get_parameters(self, index)
+	var elapsed_time := Time.get_ticks_usec() - t1
+
+	@warning_ignore_start("integer_division")
+	prints("--- GdCallableParameterSetResolver:overall performance (%d iterations) ---" % ITERATIONS)
+	prints("	%8d µs  (%d µs/iteration)" % [elapsed_time, elapsed_time / ITERATIONS])
+	assert_int(elapsed_time/ITERATIONS).is_less(10)
+	@warning_ignore_restore("integer_division")
+
+#endregion


### PR DESCRIPTION
## Why

Part 2 of #1200. Depends on GD-1200-1 (`GdParameterSetResolver` base class).

Parameterized tests can supply their data via a callable expression such as `_test_parameters := _build_data()` or `_test_parameters := _build_data(5)`. The old resolver infrastructure had no dedicated strategy for this source kind and handled it through a single monolithic class that mixed callable, property, and inline resolution.

## What

Introduces `GdCallableParameterSetResolver`, a concrete `GdParameterSetResolver` subclass that resolves parameter sets from a callable expression string:

- Parses the expression with a regex to extract the method name and optional argument list.
- Calls the method on the test suite instance at construction time, caching the full parameter set.
- `get_parameters(instance, index)` returns the cached row for the given iteration index.
- `get_max_index()` returns the number of cached rows.
- Arguments in the expression string are parsed via `str_to_var`, falling back to raw strings for non-GDScript-literal values.