### PR TITLE
GD-1200-4: Introduce `GdInlineParameterSetResolver` for inline array literal parameterized test resolution

### DIFF
--- a/addons/gdUnit4/src/core/parameters/GdInlineParameterSetResolver.gd
+++ b/addons/gdUnit4/src/core/parameters/GdInlineParameterSetResolver.gd
@@ -1,0 +1,150 @@
+class_name GdInlineParameterSetResolver
+extends GdParameterSetResolver
+
+
+const EXCLUDE_PROPERTIES_TO_COPY := [
+	"script",
+	"type",
+	"Node",
+	"_import_path"]
+
+
+const EXPRESSION_TEMPLATE := """
+extends '${clazz_path}'
+
+func __run_expression() -> Array:
+	return ${test_params}
+
+"""
+
+var _expression: Expression
+var _parameter_sets: PackedStringArray
+var _used_input_types: Array[PackedStringArray] = []
+
+static var _global_class_type_mapping: Dictionary[String, Variant] = {}
+
+
+func _init(parameter_sets: PackedStringArray, args: Array[GdFunctionArgument] = []) -> void:
+	super(args)
+	_expression = Expression.new()
+	_parameter_sets = parameter_sets
+
+	# Scan for used types
+	for index in _used_input_types.resize(_parameter_sets.size()):
+		_used_input_types[index] = PackedStringArray()
+
+	for clazz_name: String in _get_class_type_mapping().keys():
+		for parameter_set_index in _parameter_sets.size():
+			var paramater_set := _parameter_sets[parameter_set_index]
+			if paramater_set.contains(clazz_name):
+				_used_input_types[parameter_set_index].append(clazz_name)
+
+
+func get_max_index() -> int:
+	return _used_input_types.size()
+
+
+func get_parameters(instance: Node, index: int) -> Array:
+	var mapping := _get_class_type_mapping()
+	var input_values: Array = []
+
+	for clazz_name in _used_input_types[index]:
+		input_values.append(mapping[clazz_name])
+
+	var expression := _parameter_sets[index]
+	var parse_error := _expression.parse(expression, _used_input_types[index])
+	if parse_error != OK:
+		# TODO provide better error reporting
+		prints("""
+			Warning: Fallback to slower parameter resolving!
+				GdInlineParameterSetResolver: parsing error: %s
+				'%s'
+				error: %s
+			""".dedent() % [error_string(parse_error), expression, _expression.get_error_text()])
+		return _run_expression_via_script(instance, expression)
+
+	var parameters: Variant = _expression.execute(input_values, instance, false)
+	if _expression.has_execute_failed():
+		# TODO provide better error reporting
+		prints("Expression execute error:", _expression.get_error_text())
+		return _run_expression_via_script(instance, expression)
+	if not parameters is Array:
+		# The expression may reference a class const or property not accessible via Object.get();
+		# fall back to a GDScript that extends the test class so it can resolve such identifiers.
+		return _run_expression_via_script(instance, expression)
+
+	@warning_ignore("unsafe_call_argument")
+	return _finalize_parameter_set(parameters)
+
+
+# This is a fallback option to run the expression by kind of reflection
+func _run_expression_via_script(instance: Node, expression: String) -> Array:
+	var source_script: GDScript = instance.get_script()
+	var script := GDScript.new()
+	script.source_code = EXPRESSION_TEMPLATE \
+		.replace("${clazz_path}", source_script.resource_path) \
+		.replace("${test_params}", expression)
+	var debug := false
+	if debug == true:
+		# enable these lines only for debugging
+		script.resource_path = GdUnitFileAccess.create_temp_dir("parameter_extract") + "/%sExpression.gd" % source_script.resource_path.get_file()
+		DirAccess.remove_absolute(script.resource_path)
+		ResourceSaver.save(script, script.resource_path)
+	var result := script.reload()
+	if result != OK:
+		prints("Extracting test parameters failed! Script loading error: %s" % error_string(result))
+		return []
+
+	var expression_runner: Node = script.new()
+	copy_properties(instance, expression_runner)
+	var parameters: Array = expression_runner.call("__run_expression")
+	expression_runner.free()
+	return _finalize_parameter_set(parameters)
+
+
+static func _get_class_type_mapping() -> Dictionary[String, Variant]:
+	if _global_class_type_mapping.is_empty():
+		_global_class_type_mapping = _build_class_type_mapping()
+	return _global_class_type_mapping
+
+
+static func _build_class_type_mapping() -> Dictionary[String, Variant]:
+	var source := """
+		extends RefCounted
+
+		func get_class_type_mappings() -> Dictionary[String, Variant]:
+			return {
+		""".dedent()
+
+	for clazz_name in ClassDB.get_class_list():
+		if ClassDB.class_get_api_type(clazz_name) != 0 or not ClassDB.can_instantiate(clazz_name):
+			continue
+		if clazz_name.is_valid_identifier():
+			source += '\t\t"%s": %s,\n' % [clazz_name, clazz_name]
+	source += "\t}"
+
+	var script := GDScript.new()
+	script.source_code = source
+	var err := script.reload()
+	if err != OK:
+		prints("Failed to build class:type mappings: %s" % error_string(err))
+		return {}
+
+	@warning_ignore("unsafe_method_access")
+	return script.new().get_class_type_mappings()
+
+
+static func copy_properties(source: Object, dest: Object) -> void:
+	for property in source.get_property_list():
+		var property_name :String = property["name"]
+		var property_value :Variant = source.get(property_name)
+		if EXCLUDE_PROPERTIES_TO_COPY.has(property_name):
+			continue
+		#if dest.get(property_name) == null:
+		#	prints("|%s|" % property_name, source.get(property_name))
+
+		# check for invalid name property
+		if property_name == "name" and property_value == "":
+			dest.set(property_name, "<empty>");
+			continue
+		dest.set(property_name, property_value)

--- a/addons/gdUnit4/test/core/parameters/GdInlineParameterSetResolverTest.gd
+++ b/addons/gdUnit4/test/core/parameters/GdInlineParameterSetResolverTest.gd
@@ -1,0 +1,435 @@
+# GdUnit generated TestSuite
+extends GdUnitTestSuite
+
+
+const DATA1 := ["aa"]
+const DATA2 := ["bb"]
+
+
+var example_parameters := [
+	'[auto_free(Node.new()), Node]',
+	'[auto_free(Node3D.new()), Node3D]',
+	'["abc", "String"]',
+	'[_x, "Integer"]',
+	'[_obj, Node2D]',
+	'[TestObj.new(), TestObj]',
+	'[Vector3(1,1,1), Vector2(2,2)]',
+	'[Color(1,1,1), _color]',
+	'_test_set_a]'
+	]
+
+class TestObj:
+
+	func _init() -> void:
+		pass
+
+
+class TestObjNamed extends RefCounted:
+	var _value: String
+
+	func _init(value: String) -> void:
+		_value = value
+
+	func _to_string() -> String:
+		return _value
+
+
+@warning_ignore_start("unused_private_class_variable")
+var _x := 42
+var _obj: Node2D
+var _color := Color.RED
+var _test_set_a := [Color(1,1,1), Color(.1,.1,.1)]
+var _test_param1 := 10
+var _test_param2 := 20
+@warning_ignore_restore("unused_private_class_variable")
+
+func before() -> void:
+	_obj = auto_free(Node2D.new())
+	_test_param1 = 11
+
+
+#region test data
+func before_test() -> void:
+	_test_param2 = 22
+
+
+func build_param(value: float) -> Vector3:
+	return Vector3(value, value, value)
+
+
+func using_parameters_static_int_values(_a: int, _b: int, _test_parameters := [
+	[1, 2], [3, 4]
+	]) -> void:
+	pass
+
+
+func using_parameters_function_values(_a: Vector3, _b: Vector3, _test_parameters := [
+	[build_param(1), build_param(3)],
+	[Vector3.BACK, Vector3.UP]
+	]) -> void:
+	pass
+
+
+func using_parameters_static_vector2_values(_a: Vector2, _b: Vector2, _test_parameters := [
+	[Vector2.ZERO, Vector2.ONE], [Vector2(1.1, 3.2), Vector2.DOWN]
+	]) -> void:
+	pass
+
+
+func using_parameters_static_object_values(_a: Object, _b: Object, _test_parameters := [
+	[Resource.new(), Resource.new()],
+	[Resource.new(), null]
+	]) -> void:
+	pass
+
+
+func using_parameters_static_custom_object_values(_a: Object, _b: Object, _expected: String, _test_parameters := [
+	[TestObjNamed.new("abc"), TestObjNamed.new("def"), "abcdef"]
+	]) -> void:
+	pass
+
+
+func using_parameters_static_values(_a: int, _b: int, _test_parameters := [
+	[1, 10],
+	[2, 20]
+	]) -> void:
+	pass
+
+
+func using_parameters_with_properties(_a: int, _b: int, _test_parameters := [
+	[1, _test_param1],
+	[2, _test_param2],
+	[3, 30]
+	]) -> void:
+	pass
+
+
+func using_parameters_with_const_values(_value: String, _test_parameters := [DATA1, DATA2]) -> void:
+	pass
+
+
+func using_parameters_with_comments(_a: int, _b: int, _c: String, _expected: int, _test_parameters := [
+	# before data set
+	[1, 2, '3', 6], # after data set
+	# between data sets
+	[3, 4, '5', 11],
+	[6, 7, 'string #ABCD', 21], # dataset with [comment] sign
+	[6, 7, "string #ABCD", 21] # dataset with "comment" sign
+	#eof
+]) -> void:
+	pass
+
+
+func using_typed_array_parameter(_items: Array[int], _test_parameters := [
+	[[42, 99]],
+	[[1, 2, 3]],
+	]) -> void:
+	pass
+
+
+func using_typed_key_dictionary_parameter(_items: Dictionary[String, Variant], _test_parameters := [
+	[{"foo" : 10}],
+	[{"bar" : 20}],
+	]) -> void:
+	pass
+
+
+func using_typed_dictionary_parameter(_items: Dictionary[String, int], _test_parameters := [
+	[{"foo" : 10}],
+	[{"bar" : 20}],
+	]) -> void:
+	pass
+#endregion
+
+#region get_parameters
+
+func test_get_parameters() -> void:
+	var resolver := GdInlineParameterSetResolver.new(example_parameters)
+
+	assert_int(resolver.get_max_index()).is_equal(9)
+
+	# We test here a parameter resolver for a test function signature like
+	# `func test_foo(arg1, arg2, _test_parameters := [[a,b],[a,b]) -> void:`
+	# The result of `get_parameters` must match the function signature
+	# - first arg is extracted from the orignal _test_parameters array
+	# - second arg is extracted from the orignal _test_parameters array
+	# - third argument is a empty placeholder to replace the defaults of `_test_parameters` argument
+	#   to avoid reinitalization of the complete parameter set
+
+	var parameters := resolver.get_parameters(self, 0)
+	assert_array(parameters).has_size(3)
+	assert_object(parameters[0]).is_instanceof(Node).is_valid()
+	assert_object(parameters[1]).is_equal(Node)
+	assert_object(parameters[2]).is_equal([])
+
+	parameters = resolver.get_parameters(self, 1)
+	assert_array(parameters).has_size(3)
+	assert_object(parameters[0]).is_instanceof(Node3D).is_valid()
+	assert_object(parameters[1]).is_equal(Node3D)
+	assert_object(parameters[2]).is_equal([])
+
+	parameters = resolver.get_parameters(self, 2)
+	assert_array(parameters).has_size(3)
+	assert_str(parameters[0]).is_equal("abc")
+	assert_str(parameters[1]).is_equal("String")
+	assert_object(parameters[2]).is_equal([])
+
+	parameters = resolver.get_parameters(self, 3)
+	assert_array(parameters).has_size(3)
+	assert_int(parameters[0]).is_equal(_x)
+	assert_str(parameters[1]).is_equal("Integer")
+	assert_object(parameters[2]).is_equal([])
+
+	parameters = resolver.get_parameters(self, 4)
+	assert_array(parameters).has_size(3)
+	assert_object(parameters[0]).is_equal(_obj).is_valid()
+	assert_object(parameters[1]).is_equal(Node2D)
+	assert_object(parameters[2]).is_equal([])
+
+	parameters = resolver.get_parameters(self, 5)
+	assert_array(parameters).has_size(3)
+	assert_object(parameters[0]).is_instanceof(TestObj).is_valid()
+	assert_object(parameters[1]).is_equal(TestObj)
+	assert_object(parameters[2]).is_equal([])
+
+	parameters = resolver.get_parameters(self, 6)
+	assert_array(parameters).has_size(3)
+	assert_object(parameters[0]).is_equal(Vector3(1,1,1))
+	assert_object(parameters[1]).is_equal(Vector2(2,2))
+	assert_object(parameters[2]).is_equal([])
+
+	parameters = resolver.get_parameters(self, 7)
+	assert_array(parameters).has_size(3)
+	assert_object(parameters[0]).is_equal(Color(1,1,1))
+	assert_object(parameters[1]).is_equal(_color)
+	assert_object(parameters[2]).is_equal([])
+
+	parameters = resolver.get_parameters(self, 8)
+	assert_array(parameters).has_size(3)
+	assert_object(parameters[0]).is_equal(_test_set_a[0])
+	assert_object(parameters[1]).is_equal(_test_set_a[1])
+	assert_object(parameters[2]).is_equal(_test_set_a[2])
+
+
+func test_get_parameters_with_constants() -> void:
+	var test_parameters := [
+		'[Vector2.ONE, "Vector2"]',
+		'[Vector3.ZERO, "Vector3"]',
+		'[Color.RED, "Color"]',
+	]
+
+	var resolver := GdInlineParameterSetResolver.new(test_parameters)
+
+	assert_int(resolver.get_max_index()).is_equal(3)
+
+	var parameters := resolver.get_parameters(self, 0)
+	assert_array(parameters).has_size(3)
+	assert_object(parameters[0]).is_equal(Vector2.ONE)
+	assert_str(parameters[1]).is_equal("Vector2")
+	assert_object(parameters[2]).is_equal([])
+
+	parameters = resolver.get_parameters(self, 1)
+	assert_array(parameters).has_size(3)
+	assert_object(parameters[0]).is_equal(Vector3.ZERO)
+	assert_str(parameters[1]).is_equal("Vector3")
+	assert_object(parameters[2]).is_equal([])
+
+	parameters = resolver.get_parameters(self, 2)
+	assert_array(parameters).has_size(3)
+	assert_object(parameters[0]).is_equal(Color.RED)
+	assert_str(parameters[1]).is_equal("Color")
+	assert_object(parameters[2]).is_equal([])
+
+#endregion
+#region _resolve_parameters
+
+func test_resolve_parameters_with_different_types() -> void:
+	assert_array(_resolve_parameters("using_parameters_static_int_values")) \
+		.is_equal([[1, 2, []], [3, 4, []]])
+
+	assert_array(_resolve_parameters("using_parameters_static_vector2_values")) \
+		.is_equal([[Vector2.ZERO, Vector2.ONE, []], [Vector2(1.1, 3.2), Vector2.DOWN, []]])
+
+	assert_array(_resolve_parameters("using_parameters_static_object_values")) \
+		.is_equal([[Resource.new(), Resource.new(), []], [Resource.new(), null, []]])
+
+	assert_array(_resolve_parameters("using_parameters_function_values")) \
+		.is_equal([[Vector3(1, 1, 1), Vector3(3, 3, 3), []], [Vector3.BACK, Vector3.UP, []]])
+
+	assert_array(_resolve_parameters("using_parameters_static_custom_object_values")) \
+		.is_equal([[TestObjNamed.new("abc"), TestObjNamed.new("def"), "abcdef", []]])
+
+
+func test_resolve_parameters_with_static_values() -> void:
+	var params := _resolve_parameters("using_parameters_static_values")
+	assert_that(params).is_not_null()
+	assert_array(params) \
+		.is_equal([
+			[1, 10, []],
+			[2, 20, []]
+		])
+
+
+func test_resolve_parameters_with_properties() -> void:
+	var params := _resolve_parameters("using_parameters_with_properties")
+	assert_that(params).is_not_null()
+	assert_array(params) \
+		.is_equal([
+			# the value `_test_param1` is changed from 10 to 11 on `before` stage
+			[1, 11, []],
+			# the value `_test_param2` is changed from 20 to 22 on `test_before` stage
+			[2, 22, []],
+			# the value is static initial `30`
+			[3, 30, []]])
+
+
+func test_resolve_parameters_with_comments() -> void:
+	var params := _resolve_parameters("using_parameters_with_comments")
+	assert_that(params).is_not_null()
+	assert_array(params) \
+		.is_equal([
+			[1, 2, '3', 6, []],
+			[3, 4, '5', 11, []],
+			[6, 7, 'string #ABCD', 21, []],
+			[6, 7, "string #ABCD", 21, []]])
+
+
+func test_resolve_parameters_with_typed_array() -> void:
+	var params := _resolve_parameters("using_typed_array_parameter")
+
+	assert_array(params).contains_exactly(
+		[[42, 99], []],
+		[[1, 2, 3], []]
+	)
+
+	var first: Array = params[0][0]
+	assert_bool(first.is_typed()).is_true()
+	assert_int(first.get_typed_builtin()).is_equal(TYPE_INT)
+
+	var second: Array = params[1][0]
+	assert_bool(second.is_typed()).is_true()
+	assert_int(second.get_typed_builtin()).is_equal(TYPE_INT)
+
+
+# TODO needs to be enabled when typed dictionary support is implemented
+func test_resolve_parameters_with_typed_key_dictionary(_do_skip := true, _skip_reason  := "typed dictionary not support") -> void:
+	var params := _resolve_parameters("using_typed_key_dictionary_parameter")
+
+	assert_dict(params).is_equal(
+		[
+			[{"foo" : 10}, []],
+			[{"bar" : 20}, []],
+		]
+	)
+
+	var first: Dictionary = params[0][0]
+	assert_bool(first.is_typed()).is_true()
+	assert_int(first.get_typed_key_builtin()).is_equal(TYPE_STRING)
+	assert_int(first.get_typed_value_builtin()).is_equal(TYPE_NIL)
+
+	var second: Dictionary = params[1][0]
+	assert_bool(second.is_typed()).is_true()
+	assert_int(second.get_typed_key_builtin()).is_equal(TYPE_STRING)
+	assert_int(second.get_typed_value_builtin()).is_equal(TYPE_NIL)
+
+
+# TODO needs to be enabled when typed dictionary support is implemented
+func test_resolve_parameters_with_typed_dictionary(_do_skip := true, _skip_reason  := "typed dictionary not support") -> void:
+	var params := _resolve_parameters("using_typed_dictionary_parameter")
+
+	assert_dict(params).is_equal(
+		[
+			[{"foo" : 10}, []],
+			[{"bar" : 20}, []],
+		]
+	)
+
+	var first: Dictionary = params[0][0]
+	assert_bool(first.is_typed()).is_true()
+	assert_int(first.get_typed_key_builtin()).is_equal(TYPE_STRING)
+	assert_int(first.get_typed_value_builtin()).is_equal(TYPE_INT)
+
+	var second: Dictionary = params[1][0]
+	assert_bool(second.is_typed()).is_true()
+	assert_int(second.get_typed_key_builtin()).is_equal(TYPE_STRING)
+	assert_int(second.get_typed_value_builtin()).is_equal(TYPE_INT)
+
+
+func test_resolve_parameters_with_const_values() -> void:
+	var params := _resolve_parameters("using_parameters_with_const_values")
+	assert_that(params).is_not_null()
+	assert_array(params) \
+		.is_equal([
+			["aa", []],
+			["bb", []]
+			])
+
+
+func _resolve_parameters(child_name: String) -> Array[Array]:
+	var script: GDScript = self.get_script()
+	var function_descriptors := GdScriptParser.new().get_function_descriptors(script, [child_name])
+	var fd: GdFunctionDescriptor = function_descriptors.front()
+
+	var parameter_set_argument := GdFunctionArgument.get_parameter_set(fd.args())
+	var parameter_sets := parameter_set_argument.parameter_sets()
+	var resolver := GdInlineParameterSetResolver.new(parameter_sets, fd.args())
+	if resolver == null:
+		return []
+	var result: Array[Array] = []
+	for i in resolver.get_max_index():
+		result.append(resolver.get_parameters(self, i))
+	return result
+#endregion
+
+
+#region performance
+
+func test_performance_single() -> void:
+	const ITERATIONS := 1000
+	var resolver := GdInlineParameterSetResolver.new(example_parameters)
+
+	var t1 := Time.get_ticks_usec()
+	for _i in ITERATIONS:
+		resolver.get_parameters(self, 0)
+	var elapsed_time := Time.get_ticks_usec() - t1
+
+	@warning_ignore_start("integer_division")
+	prints("--- GdInlineParameterSetResolver:single performance (%d iterations) ---" % ITERATIONS)
+	prints("	%8d µs  (%d µs/iteration)" % [elapsed_time, elapsed_time / ITERATIONS])
+	assert_int(elapsed_time/ITERATIONS).is_less(20)
+	@warning_ignore_restore("integer_division")
+
+
+func test_performance_get_parameters_overall() -> void:
+	const ITERATIONS := 1000
+	var resolver := GdInlineParameterSetResolver.new(example_parameters)
+
+	var t1 := Time.get_ticks_usec()
+	for _i in ITERATIONS:
+		for index in resolver.get_max_index():
+			resolver.get_parameters(self, index)
+	var elapsed_time := Time.get_ticks_usec() - t1
+
+	@warning_ignore_start("integer_division")
+	prints("--- GdInlineParameterSetResolver:overall performance (%d iterations) ---" % ITERATIONS)
+	prints("	%8d µs  (%d µs/iteration)" % [elapsed_time, elapsed_time / ITERATIONS])
+	assert_int(elapsed_time/ITERATIONS).is_less(60)
+	@warning_ignore_restore("integer_division")
+
+#endregion
+
+
+#region _get_class_type_mapping
+
+func test_get_class_type_mapping() -> void:
+	var expected_count := 0
+	for clazz_name in ClassDB.get_class_list():
+		if ClassDB.class_get_api_type(clazz_name) != 0 or not ClassDB.can_instantiate(clazz_name):
+			continue
+		expected_count += 1
+
+	assert_dict(GdInlineParameterSetResolver._get_class_type_mapping()).has_size(expected_count)
+	# Second call returns the same cached mapping without rebuilding
+	assert_dict(GdInlineParameterSetResolver._get_class_type_mapping()).has_size(expected_count)
+
+#endregion


### PR DESCRIPTION
## Why

Part 4 of #1200. Depends on GD-1200-3 (`GdPropertyParameterSetResolver`).

Parameterized tests can express their data as inline array literals directly in the function signature. The resolver infrastructure has no dedicated strategy for this source kind.

## What

Introduces `GdInlineParameterSetResolver`, a concrete `GdParameterSetResolver` subclass that resolves inline array literal parameter sets by evaluating each expression string against a lazily cached Godot class-name-to-instance mapping, with a generated GDScript fallback for expressions referencing class-level identifiers.

Closes #1200