### PR TITLE
GD-1200: Introduce `GdParameterSetResolverFactory` to select resolver by expression type

### DIFF
--- a/addons/gdUnit4/src/core/parameters/GdInlineParameterSetResolver.gd
+++ b/addons/gdUnit4/src/core/parameters/GdInlineParameterSetResolver.gd
@@ -21,6 +21,9 @@ var _expression: Expression
 var _parameter_sets: PackedStringArray
 var _used_input_types: Array[PackedStringArray] = []
 
+
+## Lazily built map from Godot class name to a live instance, used by
+## [GdInlineParameterSetResolver] to resolve class-name tokens inside inline expressions.
 static var _global_class_type_mapping: Dictionary[String, Variant] = {}
 
 
@@ -102,12 +105,16 @@ func _run_expression_via_script(instance: Node, expression: String) -> Array:
 	return _finalize_parameter_set(parameters)
 
 
+## Returns the shared class-name-to-instance map, building it once on first access.
 static func _get_class_type_mapping() -> Dictionary[String, Variant]:
 	if _global_class_type_mapping.is_empty():
 		_global_class_type_mapping = _build_class_type_mapping()
 	return _global_class_type_mapping
 
 
+## Builds the class-name-to-instance map by generating and executing a GDScript that
+## returns a dictionary literal — the only way to obtain live class references from
+## [ClassDB] names, since GDScript has no eval or direct class-by-name lookup.
 static func _build_class_type_mapping() -> Dictionary[String, Variant]:
 	var source := """
 		extends RefCounted

--- a/addons/gdUnit4/src/core/parameters/GdParameterSetResolverFactory.gd
+++ b/addons/gdUnit4/src/core/parameters/GdParameterSetResolverFactory.gd
@@ -1,7 +1,11 @@
+## Factory that selects and constructs the correct [GdParameterSetResolver] for a
+## parameterized test function based on how the [code]_test_parameters[/code] default
+## value is expressed: inline array literals, a callable, or a property reference.
 class_name GdParameterSetResolverFactory
 extends RefCounted
 
 
+## Returns the appropriate resolver for [param fd], or null when the function is not parameterized.
 static func create(fd: GdFunctionDescriptor, instance: Node) -> GdParameterSetResolver:
 	if not fd.is_parameterized():
 		return null

--- a/addons/gdUnit4/src/core/parameters/GdParameterSetResolverFactory.gd
+++ b/addons/gdUnit4/src/core/parameters/GdParameterSetResolverFactory.gd
@@ -1,0 +1,18 @@
+class_name GdParameterSetResolverFactory
+extends RefCounted
+
+
+static func create(fd: GdFunctionDescriptor, instance: Node) -> GdParameterSetResolver:
+	if not fd.is_parameterized():
+		return null
+	var parameter_set_argument := GdFunctionArgument.get_parameter_set(fd.args())
+	var parameter_sets := parameter_set_argument.parameter_sets()
+
+	if not parameter_sets.is_empty():
+		return GdInlineParameterSetResolver.new(parameter_sets, fd.args())
+
+	# A parenthesis signals a callable expression, e.g. "my_provider()".
+	var expression: String = parameter_set_argument._default_value
+	if expression.contains("("):
+		return GdCallableParameterSetResolver.new(instance, expression, fd.args())
+	return GdPropertyParameterSetResolver.new(instance, expression, fd.args())

--- a/addons/gdUnit4/test/core/parameters/GdParameterSetResolverFactoryTest.gd
+++ b/addons/gdUnit4/test/core/parameters/GdParameterSetResolverFactoryTest.gd
@@ -1,0 +1,59 @@
+extends GdUnitTestSuite
+
+var _test_properties := [
+	["test_a"],
+	["test_b"],
+	["test_c"]
+]
+
+
+func _static_parameters(_a: int, _b: int, _test_parameters := [[1, 2], [3, 4]]) -> void:
+	pass
+
+
+func _callable_parameters(_a: int, _b: int, _test_parameters := _build_params()) -> void:
+	pass
+
+
+func _properties_parameters(_a: int, _b: int, _test_parameters := _test_properties) -> void:
+	pass
+
+
+func _no_parameters(_a: int, _b: int) -> void:
+	pass
+
+
+func _build_params() -> Array[Array]:
+	return [[1, 2], [3, 4]]
+
+
+func _descriptor(func_name: String) -> GdFunctionDescriptor:
+	var script: GDScript = get_script()
+	return GdScriptParser.new().get_function_descriptors(script, [func_name]).front()
+
+
+#region create
+
+func test_create_returns_null_for_non_parameterized() -> void:
+	var resolver := GdParameterSetResolverFactory.create(_descriptor("_no_parameters"), self)
+	assert_that(resolver).is_null()
+
+
+func test_create_returns_inline_resolver() -> void:
+	var resolver := GdParameterSetResolverFactory.create(_descriptor("_static_parameters"), self)
+	assert_object(resolver).is_instanceof(GdInlineParameterSetResolver)
+	assert_int(resolver.get_max_index()).is_equal(2)
+
+
+func test_create_returns_callable_resolver() -> void:
+	var resolver := GdParameterSetResolverFactory.create(_descriptor("_callable_parameters"), self)
+	assert_object(resolver).is_instanceof(GdCallableParameterSetResolver)
+	assert_int(resolver.get_max_index()).is_equal(2)
+
+
+func test_create_returns_property_resolver() -> void:
+	var resolver := GdParameterSetResolverFactory.create(_descriptor("_properties_parameters"), self)
+	assert_object(resolver).is_instanceof(GdPropertyParameterSetResolver)
+	assert_int(resolver.get_max_index()).is_equal(3)
+
+#endregion

--- a/addons/gdUnit4/test/core/parameters/GdParameterSetValidationTest.gd
+++ b/addons/gdUnit4/test/core/parameters/GdParameterSetValidationTest.gd
@@ -1,0 +1,95 @@
+extends GdUnitTestSuite
+
+
+const GdUnitTools := preload("res://addons/gdUnit4/src/core/GdUnitTools.gd")
+
+
+func test_validate_parameter_set() -> void:
+	var test_suite: GdUnitTestSuite = auto_free(
+		GdUnitTestResourceLoader.load_test_suite(
+			"res://addons/gdUnit4/test/core/resources/testsuites/TestSuiteInvalidParameterizedTests.gd"
+		)
+	)
+
+	assert_is_not_skipped(test_suite, "test_no_parameters")
+	assert_is_not_skipped(test_suite, "test_parameterized_success", 0)
+	assert_is_not_skipped(test_suite, "test_parameterized_success", 1)
+	assert_is_not_skipped(test_suite, "test_parameterized_success", 2)
+	assert_is_not_skipped(test_suite, "test_parameterized_failed", 0)
+	assert_is_not_skipped(test_suite, "test_parameterized_failed", 1)
+	assert_is_not_skipped(test_suite, "test_parameterized_failed", 2)
+	assert_is_skipped(test_suite, "test_parameterized_to_less_args", 0).is_equal(
+		"""
+			The test data set at index (0) does not match the expected test parameters:
+				test function: func test...(a: int,b: int,expected: int)
+				test input values: [1, 2, 3, 6]
+		""".dedent()
+	)
+	assert_is_skipped(test_suite, "test_parameterized_to_less_args", 1).is_equal(
+		"""
+			The test data set at index (1) does not match the expected test parameters:
+				test function: func test...(a: int,b: int,expected: int)
+				test input values: [3, 4, 5, 11]
+		""".dedent()
+	)
+	assert_is_skipped(test_suite, "test_parameterized_to_many_args", 0).is_equal(
+		"""
+			The test data set at index (0) does not match the expected test parameters:
+				test function: func test...(a: int,b: int,c: int,d: int,expected: int)
+				test input values: [1, 2, 3, 6]
+		""".dedent()
+	)
+	# test_parameterized_invalid_struct
+	assert_is_not_skipped(test_suite, "test_parameterized_invalid_struct", 0)
+	assert_is_skipped(test_suite, "test_parameterized_invalid_struct", 1).is_equal(
+		"""
+			The test data set at index (1) does not match the expected test parameters:
+				test function: func test...(a: int,b: int,expected: int)
+				test input values: ["foo"]
+		""".dedent()
+	)
+	assert_is_not_skipped(test_suite, "test_parameterized_invalid_struct", 2)
+	# test_parameterized_invalid_args
+	assert_is_not_skipped(test_suite, "test_parameterized_invalid_args", 0)
+	assert_is_skipped(test_suite, "test_parameterized_invalid_args", 1).is_equal(
+		"""
+			The test data value does not match the expected input type!
+				input value: '4', <String>
+				expected parameter: b: int
+		""".dedent()
+	)
+	assert_is_not_skipped(test_suite, "test_parameterized_invalid_args", 2)
+	# test_with_extern_const_parameter_set
+	assert_is_not_skipped(test_suite, "test_with_extern_const_parameter_set", 0)
+	assert_is_not_skipped(test_suite, "test_with_extern_const_parameter_set", 1)
+
+
+func assert_is_not_skipped(test_suite: GdUnitTestSuite, test_case: String, index := -1) -> void:
+	var test := simulate_test_execution_with_parameter_validation(test_suite, test_case, index)
+	assert_bool(test.is_skipped()).is_false()
+
+
+func assert_is_skipped(test_suite: GdUnitTestSuite, test_case: String, index := -1) -> GdUnitStringAssert:
+	var test := simulate_test_execution_with_parameter_validation(test_suite, test_case, index)
+	assert_bool(test.is_skipped()).is_true()
+	return assert_str(GdUnitTools.richtext_normalize(test.skip_info()))
+
+
+func simulate_test_execution_with_parameter_validation(test_suite: GdUnitTestSuite, test_case_name: String, index := -1) -> _TestCase:
+	var test: _TestCase = GdUnitTools.find_test_case(test_suite, test_case_name, index)
+	if test == null or not test.is_parameterized():
+		return test
+	var attribute_index := test._test_case.attribute_index
+	var script: GDScript = test_suite.get_script()
+	var fds := GdScriptParser.new().get_function_descriptors(script, [test_case_name])
+	if fds.is_empty():
+		return test
+	var fd: GdFunctionDescriptor = fds.front()
+	var resolver := GdParameterSetResolverFactory.create(fd, test_suite)
+	if resolver == null:
+		return test
+	var parameter_set := resolver.get_parameters(test_suite, attribute_index)
+	var result := resolver.validate(parameter_set, attribute_index)
+	if result.is_error():
+		test.do_skip(true, result.error_message())
+	return test

--- a/addons/gdUnit4/test/core/resources/testsuites/TestSuiteInvalidParameterizedTests.gd
+++ b/addons/gdUnit4/test/core/resources/testsuites/TestSuiteInvalidParameterizedTests.gd
@@ -1,0 +1,65 @@
+class_name TestSuiteInvalidParameterizedTests
+extends GdUnitTestSuite
+
+func test_no_parameters() -> void:
+	assert_that(true).is_equal(true)
+
+@warning_ignore('unused_parameter')
+func test_parameterized_success(a: int, b :int, c :int, expected :int, test_parameters := [
+	[1, 2, 3, 6],
+	[3, 4, 5, 12],
+	[6, 7, 8, 21] ]) -> void:
+
+	assert_that(a+b+c).is_equal(expected)
+
+@warning_ignore('unused_parameter')
+func test_parameterized_failed(a: int, b :int, c :int, expected :int, test_parameters := [
+	[1, 2, 3, 6],
+	[3, 4, 5, 11],
+	[6, 7, 8, 21] ]) -> void:
+
+	assert_that(a+b+c).is_equal(expected)
+
+@warning_ignore('unused_parameter')
+func test_parameterized_to_less_args(a: int, b :int, expected :int, test_parameters := [
+	[1, 2, 3, 6],
+	[3, 4, 5, 11],
+	[6, 7, 8, 21] ]) -> void:
+	pass
+
+@warning_ignore('unused_parameter')
+func test_parameterized_to_many_args(a: int, b :int, c :int, d :int, expected :int, test_parameters := [
+	[1, 2, 3, 6],
+	[3, 4, 5, 11],
+	[6, 7, 8, 21] ]) -> void:
+	pass
+
+@warning_ignore('unused_parameter')
+func test_parameterized_to_less_args_at_index_1(a: int, b :int, expected :int, test_parameters := [
+	[1, 2, 6],
+	[3, 4, 5, 11],
+	[6, 7, 21] ]) -> void:
+	pass
+
+@warning_ignore('unused_parameter')
+func test_parameterized_invalid_struct(a: int, b :int, expected :int, test_parameters := [
+	[1, 2, 6],
+	["foo"],
+	[6, 7, 21] ]) -> void:
+	pass
+
+@warning_ignore('unused_parameter')
+func test_parameterized_invalid_args(a: int, b :int, expected :int, test_parameters := [
+	[1, 2, 6],
+	[3, "4", 11],
+	[6, 7, 21] ]) -> void:
+	pass
+
+
+const _data1 := ["aa"]
+const _data2 := ["bb"]
+
+
+@warning_ignore('unused_parameter')
+func test_with_extern_const_parameter_set(value: String, _test_parameters := [_data1, _data2]) -> void:
+	pass


### PR DESCRIPTION
## Why

Part 5 of #1200. Depends on GD-1200-4 (`GdInlineParameterSetResolver`).

Parameterized tests can express their data as inline array literals, callable expressions, or property references. The resolver infrastructure has no single entry point that inspects the default-value expression and selects the appropriate resolver, so every call site must implement that selection logic itself.

## What

Introduces `GdParameterSetResolverFactory` with a single `create(fd, instance)` static method that returns the correct `GdParameterSetResolver` subclass based on whether the `_test_parameters` default-value expression contains inline array literals, a callable invocation, or a property reference. Adds `GdParameterSetValidationTest` to verify that type-mismatch and count-mismatch parameter data sets are correctly marked as skipped at execution time.

Closes #1200