### PR TITLE
TASK-1217: Update CI execution matrix from Godot 4.7-rc2 to stable Godot 4.7

### DIFF
--- a/.github/workflows/ci-pr-publish-report.yml
+++ b/.github/workflows/ci-pr-publish-report.yml
@@ -24,12 +24,12 @@ jobs:
       fail-fast: false
       max-parallel: 10
       matrix:
-        godot-version: ['4.5', '4.5.1', '4.6', '4.6.1', '4.6.2']
+        godot-version: ['4.5', '4.5.1', '4.6', '4.6.1', '4.6.2', '4.7']
         godot-status: ['stable']
         godot-net: ['-net', '']
-        include:
-          - godot-version: '4.7'
-            godot-status: 'rc2'
+        # include:
+        #   - godot-version: '4.7'
+        #     godot-status: 'rc2'
 
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -36,12 +36,12 @@ jobs:
       max-parallel: 10
       matrix:
         # If changes are made here, they must be transferred to `.github\workflows\ci-pr-publish-report.yml`
-        godot-version: ['4.5', '4.5.1', '4.6', '4.6.1', '4.6.2']
+        godot-version: ['4.5', '4.5.1', '4.6', '4.6.1', '4.6.2', '4.7']
         godot-status: ['stable']
         godot-net: ['.Net', '']
-        include:
-          - godot-version: '4.7'
-            godot-status: 'rc2'
+        # include:
+        #   - godot-version: '4.7'
+        #     godot-status: 'rc2'
 
     permissions:
       actions: write

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
   <img src="https://img.shields.io/badge/v4.6-%23478cbf?logo=godot-engine&logoColor=cyian&color=green" alt="">
   <img src="https://img.shields.io/badge/v4.6.1-%23478cbf?logo=godot-engine&logoColor=cyian&color=green" alt="">
   <img src="https://img.shields.io/badge/v4.6.2-%23478cbf?logo=godot-engine&logoColor=cyian&color=green" alt="">
-  <img src="https://img.shields.io/badge/v4.7.rc2-%23478cbf?logo=godot-engine&logoColor=cyian&color=yellow" alt="">
+  <img src="https://img.shields.io/badge/v4.7-%23478cbf?logo=godot-engine&logoColor=cyian&color=green" alt="">
 </p>
 
 <h1 align="center">Compatibility Overview</h1>
@@ -34,7 +34,7 @@
   </thead>
   <tbody>
     <tr>
-      <td>master (upcoming v6.2)</td><td>v4.5, v4.5.1, v4.6, v4.6.1, v4.6.2, v4.7-rc2</td>
+      <td>master (upcoming v6.2)</td><td>v4.5, v4.5.1, v4.6, v4.6.1, v4.6.2, v4.7</td>
     </tr>
     <tr>
       <td>v6.1.x</td><td>v4.5, v4.5.1, v4.6, v4.6.1, v4.6.2</td>


### PR DESCRIPTION
## Why
Godot 4.7 has now been officially released as stable, so the CI matrix and compatibility documentation should test against and advertise the stable release rather than the release candidate.

## What
- Moved Godot 4.7 into the main stable version list of the CI test matrix and the report publishing workflow, commenting out the now-unused release-candidate include entries in both files for easy reference.
- Updated the README badges and compatibility table to list v4.7 as stable instead of v4.7-rc2.

Closes #1217