### PR TITLE
TASK-1220: Add Godot 4.5.2 to the CI execution matrix

### DIFF
--- a/.github/workflows/ci-dev.yml
+++ b/.github/workflows/ci-dev.yml
@@ -22,7 +22,7 @@ jobs:
       fail-fast: false
       max-parallel: 10
       matrix:
-        godot-version: ['4.5', '4.5.1', '4.6', '4.6.1', '4.6.2']
+        godot-version: ['4.5', '4.5.1', '4.5.2', '4.6', '4.6.1', '4.6.2']
         godot-status: ['stable']
         godot-net: ['.Net', '']
 

--- a/.github/workflows/ci-pr-publish-report.yml
+++ b/.github/workflows/ci-pr-publish-report.yml
@@ -24,7 +24,7 @@ jobs:
       fail-fast: false
       max-parallel: 10
       matrix:
-        godot-version: ['4.5', '4.5.1', '4.6', '4.6.1', '4.6.2', '4.7']
+        godot-version: ['4.5', '4.5.1', '4.5.2', '4.6', '4.6.1', '4.6.2', '4.7']
         godot-status: ['stable']
         godot-net: ['-net', '']
         # include:

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -36,7 +36,7 @@ jobs:
       max-parallel: 10
       matrix:
         # If changes are made here, they must be transferred to `.github\workflows\ci-pr-publish-report.yml`
-        godot-version: ['4.5', '4.5.1', '4.6', '4.6.1', '4.6.2', '4.7']
+        godot-version: ['4.5', '4.5.1', '4.5.2', '4.6', '4.6.1', '4.6.2', '4.7']
         godot-status: ['stable']
         godot-net: ['.Net', '']
         # include:

--- a/README.md
+++ b/README.md
@@ -38,10 +38,10 @@
       <td>master (upcoming v6.2)</td><td>v4.5, v4.5.1, v4.5.2, v4.6, v4.6.1, v4.6.2, v4.7</td>
     </tr>
     <tr>
-      <td>v6.1.x</td><td>v4.5, v4.5.1, v4.6, v4.6.1, v4.6.2</td>
+      <td>v6.1.x</td><td>v4.5, v4.5.1, v4.5.2, v4.6, v4.6.1, v4.6.2</td>
     </tr>
     <tr>
-      <td>v6.0.x+</td><td>v4.5, v4.5.1</td>
+      <td>v6.0.x+</td><td>v4.5, v4.5.1, v4.5.2</td>
     </tr>
     <tr>
       <td>v5.x+</td><td>v4.3, v4.4, v4.4.1</td>

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
   <img src="https://img.shields.io/badge/v4.4-%23478cbf?logo=godot-engine&logoColor=cyian&color=green" alt="">
   <img src="https://img.shields.io/badge/v4.4.1-%23478cbf?logo=godot-engine&logoColor=cyian&color=green" alt="">
   <img src="https://img.shields.io/badge/v4.5-%23478cbf?logo=godot-engine&logoColor=cyian&color=green" alt="">
+  <img src="https://img.shields.io/badge/v4.5.2-%23478cbf?logo=godot-engine&logoColor=cyian&color=green" alt="">
   <img src="https://img.shields.io/badge/v4.6-%23478cbf?logo=godot-engine&logoColor=cyian&color=green" alt="">
   <img src="https://img.shields.io/badge/v4.6.1-%23478cbf?logo=godot-engine&logoColor=cyian&color=green" alt="">
   <img src="https://img.shields.io/badge/v4.6.2-%23478cbf?logo=godot-engine&logoColor=cyian&color=green" alt="">
@@ -34,7 +35,7 @@
   </thead>
   <tbody>
     <tr>
-      <td>master (upcoming v6.2)</td><td>v4.5, v4.5.1, v4.6, v4.6.1, v4.6.2, v4.7</td>
+      <td>master (upcoming v6.2)</td><td>v4.5, v4.5.1, v4.5.2, v4.6, v4.6.1, v4.6.2, v4.7</td>
     </tr>
     <tr>
       <td>v6.1.x</td><td>v4.5, v4.5.1, v4.6, v4.6.1, v4.6.2</td>


### PR DESCRIPTION
## Why
Godot 4.5.2 is a stable maintenance release on the 4.5 line that was never added to the CI matrix, an existing gap unrelated to any recent release rather than something newly announced.

## What
- Added 4.5.2 to the stable version list of the CI test matrix, the report publishing workflow, and the dev-branch workflow, inserted in ascending order alongside the existing entries.
- Updated the README badges and compatibility table to include v4.5.2.

Closes #1220