### PR TITLE
TASK-1226: Add Godot 4.7 to the `ci-dev.yml` execution matrix

### DIFF
--- a/.github/workflows/ci-dev.yml
+++ b/.github/workflows/ci-dev.yml
@@ -22,7 +22,7 @@ jobs:
       fail-fast: false
       max-parallel: 10
       matrix:
-        godot-version: ['4.5', '4.5.1', '4.5.2', '4.6', '4.6.1', '4.6.2']
+        godot-version: ['4.5', '4.5.1', '4.5.2', '4.6', '4.6.1', '4.6.2', '4.7']
         godot-status: ['stable']
         godot-net: ['.Net', '']
 


### PR DESCRIPTION
## Why

Godot 4.7 went stable and the pull request workflows already test against it, but the dev workflow that validates pushes to master was left behind on the 4.6 line.

## What

Extends the stable version matrix of the dev workflow with the 4.7 entry so master is verified against the newest stable Godot release.

Closes #1226
