### PR TITLE
TASK-1227: Update CI execution matrix to Godot 4.7.1-rc1

### DIFF
--- a/.github/workflows/ci-pr-publish-report.yml
+++ b/.github/workflows/ci-pr-publish-report.yml
@@ -27,9 +27,9 @@ jobs:
         godot-version: ['4.5', '4.5.1', '4.5.2', '4.6', '4.6.1', '4.6.2', '4.7']
         godot-status: ['stable']
         godot-net: ['-net', '']
-        # include:
-        #   - godot-version: '4.7'
-        #     godot-status: 'rc2'
+        include:
+          - godot-version: '4.7.1'
+            godot-status: 'rc1'
 
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -39,9 +39,9 @@ jobs:
         godot-version: ['4.5', '4.5.1', '4.5.2', '4.6', '4.6.1', '4.6.2', '4.7']
         godot-status: ['stable']
         godot-net: ['.Net', '']
-        # include:
-        #   - godot-version: '4.7'
-        #     godot-status: 'rc2'
+        include:
+          - godot-version: '4.7.1'
+            godot-status: 'rc1'
 
     permissions:
       actions: write

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@
   <img src="https://img.shields.io/badge/v4.6.1-%23478cbf?logo=godot-engine&logoColor=cyian&color=green" alt="">
   <img src="https://img.shields.io/badge/v4.6.2-%23478cbf?logo=godot-engine&logoColor=cyian&color=green" alt="">
   <img src="https://img.shields.io/badge/v4.7-%23478cbf?logo=godot-engine&logoColor=cyian&color=green" alt="">
+  <img src="https://img.shields.io/badge/v4.7.1.rc1-%23478cbf?logo=godot-engine&logoColor=cyian&color=yellow" alt="">
 </p>
 
 <h1 align="center">Compatibility Overview</h1>
@@ -35,7 +36,7 @@
   </thead>
   <tbody>
     <tr>
-      <td>master (upcoming v6.2)</td><td>v4.5, v4.5.1, v4.5.2, v4.6, v4.6.1, v4.6.2, v4.7</td>
+      <td>master (upcoming v6.2)</td><td>v4.5, v4.5.1, v4.5.2, v4.6, v4.6.1, v4.6.2, v4.7, v4.7.1-rc1</td>
     </tr>
     <tr>
       <td>v6.1.x</td><td>v4.5, v4.5.1, v4.5.2, v4.6, v4.6.1, v4.6.2</td>


### PR DESCRIPTION
## Why

Godot published the first release candidate on the 4.7.1 line, and the prerelease slot in the CI matrix is still parked on the 4.7 release candidate that already went stable, so upcoming patch regressions would go unnoticed.

## What

Reactivates the prerelease include entry in both pull request workflows and points it at 4.7.1 with status rc1, and updates the README with a yellow prerelease badge and the matching compatibility table entry.

Closes #1227
