### PR TITLE
DOC-1230: Fix misleading auto-freeing description and broken examples in the spy documentation

### DIFF
--- a/addons/gdUnit4/test/spy/GdUnitSpyTest.gd
+++ b/addons/gdUnit4/test/spy/GdUnitSpyTest.gd
@@ -1,4 +1,4 @@
-class_name GdUnitSpyTest
+class_name GdUnitSpyTest  # gdlint: ignore=max-public-methods
 extends GdUnitTestSuite
 
 
@@ -775,6 +775,110 @@ func test_spy_with_enum_in_constructor() -> void:
 	# test
 	@warning_ignore("unsafe_method_access")
 	verify(s, 1).set_value(ClassWithEnumConstructor.MyEnumValue.ONE)
+
+
+#region documented examples
+# The following tests verify the examples of the spy documentation page
+# documentation/doc/_advanced_testing/spy.md
+const TestClass := preload("res://addons/gdUnit4/test/spy/resources/DocExampleTestClass.gd")  # gdlint: ignore=class-definitions-order
+
+
+func test_doc_verify_example() -> void:
+	var spyed_instance: TestClass = spy(auto_free(TestClass.new()))
+
+	# Verify we have no interactions currently on this instance
+	verify_no_interactions(spyed_instance)
+
+	# Call with different arguments
+	spyed_instance.set_value(0) # 1 time
+	spyed_instance.set_value(100) # 1 time
+	spyed_instance.set_value(100) # 2 times
+
+	# Verify how often we called the function with different arguments
+	@warning_ignore("unsafe_method_access")
+	verify(spyed_instance, 1).set_value(0) # in sum one time with 0
+	@warning_ignore("unsafe_method_access")
+	verify(spyed_instance, 2).set_value(100) # in sum two times with 100
+
+	# Verify will fail because we expect the function `set_value(100)` to be called 3 times but it was only called 2 times
+	@warning_ignore("unsafe_method_access")
+	assert_failure(func() -> void: verify(spyed_instance, 3).set_value(100)).is_failed()
+
+
+func test_doc_verify_no_interactions_example() -> void:
+	var spyed_instance: TestClass = spy(auto_free(TestClass.new()))
+
+	# Test that we have no initial interactions on this spy
+	verify_no_interactions(spyed_instance)
+
+	# Interact by calling `message()`
+	spyed_instance.message()
+
+	# Now this verification will fail because we have interacted on this spy by calling `message`
+	assert_failure(func() -> void: verify_no_interactions(spyed_instance)).is_failed()
+
+
+func test_doc_verify_no_more_interactions_example() -> void:
+	var spyed_instance: TestClass = spy(auto_free(TestClass.new()))
+
+	# Interact on two functions
+	spyed_instance.message()
+	spyed_instance.set_value(42)
+
+	# Verify that the spy interacts as expected
+	@warning_ignore("unsafe_method_access")
+	verify(spyed_instance).message()
+	@warning_ignore("unsafe_method_access")
+	verify(spyed_instance).set_value(42)
+
+	# Check that there are no further interactions with the spy
+	verify_no_more_interactions(spyed_instance)
+
+	# Simulate an unexpected interaction by calling `set_value` with a not yet verified argument
+	spyed_instance.set_value(100)
+
+	# Verify that there are no further interactions with the spy
+	# and that the previous unexpected interaction is detected (the test will fail here)
+	assert_failure(func() -> void: verify_no_more_interactions(spyed_instance)).is_failed()
+
+
+func test_doc_reset_example() -> void:
+	var spyed_instance: TestClass = spy(auto_free(TestClass.new()))
+
+	# First, we test by interacting with two functions
+	spyed_instance.message()
+	spyed_instance.set_value(42)
+
+	# Verify if the interactions were recorded; at this point, two interactions are recorded
+	@warning_ignore("unsafe_method_access")
+	verify(spyed_instance).message()
+	@warning_ignore("unsafe_method_access")
+	verify(spyed_instance).set_value(42)
+
+	# Now, we want to test a different scenario and we need to reset the current recorded interactions
+	reset(spyed_instance)
+	# Verify that the previously recorded interactions have been removed
+	verify_no_more_interactions(spyed_instance)
+
+	# Continue testing
+	spyed_instance.set_value(100)
+	@warning_ignore("unsafe_method_access")
+	verify(spyed_instance).set_value(100)
+	verify_no_more_interactions(spyed_instance)
+
+
+func test_doc_argument_matchers_example() -> void:
+	var spyed_instance: TestClass = spy(auto_free(TestClass.new()))
+
+	# Call the function with different arguments
+	spyed_instance.set_value(0) # Called 1 time
+	spyed_instance.set_value(100) # Called 1 time
+	spyed_instance.set_value(100) # Called 2 times
+
+	# Verify that the function was called with any integer value 3 times
+	@warning_ignore("unsafe_method_access")
+	verify(spyed_instance, 3).set_value(any_int())
+#endregion
 
 
 func _load(resource_path: String) -> GDScript:

--- a/addons/gdUnit4/test/spy/GdUnitSpyTest.gd
+++ b/addons/gdUnit4/test/spy/GdUnitSpyTest.gd
@@ -741,8 +741,8 @@ func test_spy_ready_called_once() -> void:
 
 
 func test_spy_on_object_is_registered_for_auto_free() -> void:
-	var instance :Node = Node.new()
-	var spy_node :Variant = spy(instance)
+	var instance: Node = Node.new()
+	var spy_node: Variant = spy(instance)
 
 	# check the returned spy is a new instance and is registered for auto freeing
 	assert_bool(GdUnitMemoryObserver.is_marked_auto_free(spy_node)).is_true()
@@ -756,8 +756,8 @@ func test_spy_on_object_is_registered_for_auto_free() -> void:
 
 func test_spy_on_scene_instance_is_registered_for_auto_free() -> void:
 	var resource: PackedScene = load("res://addons/gdUnit4/test/spy/resources/TestSceneWithProperties.tscn")
-	var instance :Node2D = resource.instantiate()
-	var spy_scene :Variant = spy(instance)
+	var instance: Node2D = resource.instantiate()
+	var spy_scene: Variant = spy(instance)
 
 	# check in contrast to spy on an object, the spy on a scene instance is not a new instance,
 	# the script is exchanged on the original scene instance

--- a/addons/gdUnit4/test/spy/GdUnitSpyTest.gd
+++ b/addons/gdUnit4/test/spy/GdUnitSpyTest.gd
@@ -740,6 +740,32 @@ func test_spy_ready_called_once() -> void:
 	verify(spy_node, 1).only_one_time_call()
 
 
+func test_spy_on_object_is_registered_for_auto_free() -> void:
+	var instance :Node = Node.new()
+	var spy_node :Variant = spy(instance)
+
+	# check the returned spy is a new instance and is registered for auto freeing
+	assert_bool(GdUnitMemoryObserver.is_marked_auto_free(spy_node)).is_true()
+	# check the original instance is NOT registered for auto freeing, it remains under the ownership of the caller
+	assert_bool(GdUnitMemoryObserver.is_marked_auto_free(instance)).is_false()
+
+	# finally register the original instance for freeing after the test to avoid an orphan node
+	@warning_ignore("return_value_discarded")
+	auto_free(instance)
+
+
+func test_spy_on_scene_instance_is_registered_for_auto_free() -> void:
+	var resource: PackedScene = load("res://addons/gdUnit4/test/spy/resources/TestSceneWithProperties.tscn")
+	var instance :Node2D = resource.instantiate()
+	var spy_scene :Variant = spy(instance)
+
+	# check in contrast to spy on an object, the spy on a scene instance is not a new instance,
+	# the script is exchanged on the original scene instance
+	assert_object(spy_scene).is_same(instance)
+	# check the original scene instance is registered for auto freeing, no manual `auto_free` is needed
+	assert_bool(GdUnitMemoryObserver.is_marked_auto_free(instance)).is_true()
+
+
 func test_spy_with_enum_in_constructor() -> void:
 	# this test uses a class with an enum in the constructor
 	var unit := ClassWithEnumConstructor.new(ClassWithEnumConstructor.MyEnumValue.TWO, [])

--- a/addons/gdUnit4/test/spy/resources/DocExampleTestClass.gd
+++ b/addons/gdUnit4/test/spy/resources/DocExampleTestClass.gd
@@ -1,0 +1,13 @@
+# The class 'TestClass' used by the examples of the spy documentation page
+# documentation/doc/_advanced_testing/spy.md
+extends Node
+
+var _value: int
+
+
+func message() -> String:
+	return "a message"
+
+
+func set_value(value: int) -> void:
+	_value = value

--- a/documentation/doc/_advanced_testing/spy.md
+++ b/documentation/doc/_advanced_testing/spy.md
@@ -32,12 +32,30 @@ overwriting core functions is no longer supported, so there is no way to spy on 
 %}
 
 To spy on an object, simply use **spy(\<instance\>)**. The spy returned by **spy(\<instance\>)** is automatically registered for auto-freeing,
-so you don't need to free the spy manually. However, when spying on a plain object, the original instance you pass in is a separate object
-and remains under your ownership — wrap it in **auto_free()** to have it released after the test. When spying on a scene, the spy is the
-scene instance itself and is auto-freed, so no additional **auto_free()** is required.
+so you don't need to free the spy manually. The ownership of the original instance you pass in depends on whether you spy on an object or a scene.
+
+### Spy on an object
+
+The spy is created as a new instance, the original object you pass in is not touched and remains under your ownership.
+Wrap it in **auto_free()** to have it released after the test.
 
 ```gd
-var spy:= spy(auto_free(Node.new()))
+# The returned spy is auto-freed, the original instance is released by auto_free()
+var spy_node := spy(auto_free(Node.new()))
+```
+
+### Spy on a scene
+
+The spy is not a new instance, the script is exchanged on the scene instance itself. The spied scene is auto-freed,
+so no additional **auto_free()** is required. You can spy on a scene by its resource path or on an already instantiated scene.
+
+```gd
+# Spy on a scene by the resource path, the returned spy is the scene instance and is auto-freed
+var spy_scene := spy("res://my_scene.tscn")
+
+# Spy on an already instantiated scene, the instance itself becomes the spy and is auto-freed
+var scene: Node = load("res://my_scene.tscn").instantiate()
+var spy_on_instance := spy(scene)
 ```
 
 Here a small example to use the spy on a instance of the class 'TestClass':

--- a/documentation/doc/_advanced_testing/spy.md
+++ b/documentation/doc/_advanced_testing/spy.md
@@ -64,9 +64,18 @@ Here a small example to use the spy on a instance of the class 'TestClass':
 class_name TestClass
 extends Node
 
-    func message() -> String:
-        return "a message"
+var _value: int
 
+
+func message() -> String:
+    return "a message"
+
+
+func set_value(value: int) -> void:
+    _value = value
+```
+
+```gd
 func test_spy() -> void:
     var instance: TestClass = auto_free(TestClass.new())
 
@@ -84,6 +93,10 @@ func test_spy() -> void:
 
 A spy keeps track of all function calls and their arguments. Use the **verify()** method on the spy to verify that certain behavior happened at least once
 or an exact number of times. This way, you can check if a particular function was called and how many times it was called.
+
+{% include advice.html
+content="Since spying on core functions is not supported, all following examples use the class <b>TestClass</b> defined above."
+%}
 
 |Function |Description |
 |---|---|
@@ -105,22 +118,22 @@ verify(<spy>, <times>).function(<args>)
 Here's an example:
 
 ```gd
-var spyed_node: Node = spy(auto_free(Node.new()))
+var spyed_instance: TestClass = spy(auto_free(TestClass.new()))
 
 # Verify we have no interactions currently on this instance
-verify_no_interactions(spyed_node)
+verify_no_interactions(spyed_instance)
 
 # Call with different arguments
-spyed_node.set_process(false) # 1 times
-spyed_node.set_process(true) # 1 times
-spyed_node.set_process(true) # 2 times
+spyed_instance.set_value(0) # 1 time
+spyed_instance.set_value(100) # 1 time
+spyed_instance.set_value(100) # 2 times
 
-# Verify how often we called the function with different argument 
-verify(spyed_node, 1).set_process(false)# in sum one time with false
-verify(spyed_node, 2).set_process(true) # in sum two times with true
+# Verify how often we called the function with different arguments
+verify(spyed_instance, 1).set_value(0) # in sum one time with 0
+verify(spyed_instance, 2).set_value(100) # in sum two times with 100
 
-# Verify will fail because we expect the function `set_process(true)` to be called 3 times but it was only called 2 times
-verify(spyed_node, 3).set_process(true)
+# Verify will fail because we expect the function `set_value(100)` to be called 3 times but it was only called 2 times
+verify(spyed_instance, 3).set_value(100)
 ```
 
 ### verify_no_interactions
@@ -134,22 +147,23 @@ verify_no_interactions(<spy>)
 Here's an example:
 
 ```gd
-var spyed_node: Node = spy(auto_free(Node.new()))
+var spyed_instance: TestClass = spy(auto_free(TestClass.new()))
 
 # Test that we have no initial interactions on this spy
-verify_no_interactions(spyed_node)
+verify_no_interactions(spyed_instance)
 
-# Interact by calling `get_name()`
-spyed_node.get_name()
+# Interact by calling `message()`
+spyed_instance.message()
 
-# Now this verification will fail because we have interacted on this spy by calling `get_name`
-verify_no_interactions(spyed_node)
+# Now this verification will fail because we have interacted on this spy by calling `message`
+verify_no_interactions(spyed_instance)
 ```
 
 ### verify_no_more_interactions
 
 The **verify_no_more_interactions()** method verifies that all interactions on the spy have been verified.
-If the spy has recorded more interactions than you verified with **verify()**, an error is reported.
+An interaction is identified by the function and its arguments, if the spy has recorded a function and argument combination
+that you have not verified with **verify()**, an error is reported.
 
 ```gd
 verify_no_more_interactions(<spy>)
@@ -158,25 +172,25 @@ verify_no_more_interactions(<spy>)
 Here's an example:
 
 ```gd
-var spyed_node: Node = spy(auto_free(Node.new()))
+var spyed_instance: TestClass = spy(auto_free(TestClass.new()))
 
-# Interact on two functions 
-spyed_node.is_a_parent_of(null)
-spyed_node.set_process(false)
+# Interact on two functions
+spyed_instance.message()
+spyed_instance.set_value(42)
 
 # Verify that the spy interacts as expected
-verify(spyed_node).is_a_parent_of(null)
-verify(spyed_node).set_process(false)
+verify(spyed_instance).message()
+verify(spyed_instance).set_value(42)
 
 # Check that there are no further interactions with the spy
-verify_no_more_interactions(spyed_node)
+verify_no_more_interactions(spyed_instance)
 
-# Simulate an unexpected interaction with `set_process`
-spyed_node.set_process(false)
+# Simulate an unexpected interaction by calling `set_value` with a not yet verified argument
+spyed_instance.set_value(100)
 
 # Verify that there are no further interactions with the spy
 # and that the previous unexpected interaction is detected (the test will fail here)
-verify_no_more_interactions(spyed_node)
+verify_no_more_interactions(spyed_instance)
 ```
 
 ### reset
@@ -191,25 +205,25 @@ reset(<spy>)
 Here's an example:
 
 ```gd
-var spyed_node: Node = spy(auto_free(Node.new()))
+var spyed_instance: TestClass = spy(auto_free(TestClass.new()))
 
-# First, we test by interacting with two functions 
-spyed_node.is_a_parent_of(null)
-spyed_node.set_process(false)
+# First, we test by interacting with two functions
+spyed_instance.message()
+spyed_instance.set_value(42)
 
 # Verify if the interactions were recorded; at this point, two interactions are recorded
-verify(spyed_node).is_a_parent_of(null)
-verify(spyed_node).set_process(false)
+verify(spyed_instance).message()
+verify(spyed_instance).set_value(42)
 
 # Now, we want to test a different scenario and we need to reset the current recorded interactions
-reset(spyed_node)
+reset(spyed_instance)
 # Verify that the previously recorded interactions have been removed
-verify_no_more_interactions(spyed_node)
+verify_no_more_interactions(spyed_instance)
 
 # Continue testing
-spyed_node.set_process(true)
-verify(spyed_node).set_process(true)
-verify_no_more_interactions(spyed_node)
+spyed_instance.set_value(100)
+verify(spyed_instance).set_value(100)
+verify_no_more_interactions(spyed_instance)
 ```
 
 ---
@@ -219,19 +233,19 @@ verify_no_more_interactions(spyed_node)
 Argument matchers allow you to simplify the verification of function calls by verifying function arguments based on their type or class.
 This is particularly useful when working with spys because you can use argument matchers to verify function calls without specifying the exact argument values.
 
-For example, instead of verifying that a function was called with a specific boolean argument value, you can use the **any_bool()** argument matcher
-to verify that the function was called with any boolean value. Here's an example:
+For example, instead of verifying that a function was called with a specific integer argument value, you can use the **any_int()** argument matcher
+to verify that the function was called with any integer value. Here's an example:
 
 ```gd
-var spyed_node: Node = spy(auto_free(Node.new()))
+var spyed_instance: TestClass = spy(auto_free(TestClass.new()))
 
 # Call the function with different arguments
-spyed_node.set_process(false) # Called 1 time
-spyed_node.set_process(true) # Called 1 time
-spyed_node.set_process(true) # Called 2 times
+spyed_instance.set_value(0) # Called 1 time
+spyed_instance.set_value(100) # Called 1 time
+spyed_instance.set_value(100) # Called 2 times
 
-# Verify that the function was called with any boolean value 3 times
-verify(spyed_node, 3).set_process(any_bool())
+# Verify that the function was called with any integer value 3 times
+verify(spyed_instance, 3).set_value(any_int())
 ```
 
 For more details on how to use argument matchers, please see the [Argument Matchers]({{site.baseurl}}/advanced_testing/argument_matchers) section.

--- a/documentation/doc/_advanced_testing/spy.md
+++ b/documentation/doc/_advanced_testing/spy.md
@@ -31,7 +31,10 @@ content="Spy on core functions are not possible since Godot has improved the GDS
 overwriting core functions is no longer supported, so there is no way to spy on core functions anymore."
 %}
 
-To spy on an object, simply use **spy(\<instance\>)**. A spied instance is marked for auto-freeing, so you don't need to free it manually.
+To spy on an object, simply use **spy(\<instance\>)**. The spy returned by **spy(\<instance\>)** is automatically registered for auto-freeing,
+so you don't need to free the spy manually. However, when spying on a plain object, the original instance you pass in is a separate object
+and remains under your ownership — wrap it in **auto_free()** to have it released after the test. When spying on a scene, the spy is the
+scene instance itself and is auto-freed, so no additional **auto_free()** is required.
 
 ```gd
 var spy:= spy(auto_free(Node.new()))
@@ -84,7 +87,7 @@ verify(<spy>, <times>).function(<args>)
 Here's an example:
 
 ```gd
-var spyed_node :Node = spy(Node.new())
+var spyed_node :Node = spy(auto_free(Node.new()))
 
 # Verify we have no interactions currently on this instance
 verify_no_interactions(spyed_node)
@@ -113,7 +116,7 @@ verify_no_interactions(<spy>)
 Here's an example:
 
 ```gd
-var spyed_node := spy(Node.new()) as Node
+var spyed_node := spy(auto_free(Node.new())) as Node
 
 # Test that we have no initial interactions on this spy
 verify_no_interactions(spyed_node)
@@ -137,7 +140,7 @@ verify_no_more_interactions(<spy>)
 Here's an example:
 
 ```gd
-var spyed_node := spy(Node.new()) as Node
+var spyed_node := spy(auto_free(Node.new())) as Node
 
 # Interact on two functions 
 spyed_node.is_a_parent_of(null)
@@ -170,7 +173,7 @@ reset(<spy>)
 Here's an example:
 
 ```gd
-var spyed_node :Node = spy(Node.new())
+var spyed_node :Node = spy(auto_free(Node.new()))
 
 # First, we test by interacting with two functions 
 spyed_node.is_a_parent_of(null)
@@ -202,7 +205,7 @@ For example, instead of verifying that a function was called with a specific boo
 to verify that the function was called with any boolean value. Here's an example:
 
 ```gd
-var spyed_node :Node = spy(Node.new())
+var spyed_node :Node = spy(auto_free(Node.new()))
 
 # Call the function with different arguments
 spyed_node.set_process(false) # Called 1 time

--- a/documentation/doc/_advanced_testing/spy.md
+++ b/documentation/doc/_advanced_testing/spy.md
@@ -41,7 +41,7 @@ Wrap it in **auto_free()** to have it released after the test.
 
 ```gd
 # The returned spy is auto-freed, the original instance is released by auto_free()
-var spy_node := spy(auto_free(Node.new()))
+var spy_node: Node = spy(auto_free(Node.new()))
 ```
 
 ### Spy on a scene
@@ -51,11 +51,11 @@ so no additional **auto_free()** is required. You can spy on a scene by its reso
 
 ```gd
 # Spy on a scene by the resource path, the returned spy is the scene instance and is auto-freed
-var spy_scene := spy("res://my_scene.tscn")
+var spy_scene: Node = spy("res://my_scene.tscn")
 
 # Spy on an already instantiated scene, the instance itself becomes the spy and is auto-freed
 var scene: Node = load("res://my_scene.tscn").instantiate()
-var spy_on_instance := spy(scene)
+var spy_on_instance: Node = spy(scene)
 ```
 
 Here a small example to use the spy on a instance of the class 'TestClass':
@@ -67,17 +67,17 @@ extends Node
     func message() -> String:
         return "a message"
 
-func test_spy():
-    var instance = auto_free(TestClass.new())
+func test_spy() -> void:
+    var instance: TestClass = auto_free(TestClass.new())
 
     # Build a spy on the instance
-    var spy = spy(instance)
+    var spy_instance: TestClass = spy(instance)
 
     # Call function `message` on the spy to track the interaction
-    spy.message()
+    spy_instance.message()
 
     # Verify the function 'message' is called one times
-    verify(spy, 1).message()
+    verify(spy_instance, 1).message()
 ```
 
 ## Verification of Function Calls
@@ -134,7 +134,7 @@ verify_no_interactions(<spy>)
 Here's an example:
 
 ```gd
-var spyed_node := spy(auto_free(Node.new())) as Node
+var spyed_node: Node = spy(auto_free(Node.new()))
 
 # Test that we have no initial interactions on this spy
 verify_no_interactions(spyed_node)
@@ -158,7 +158,7 @@ verify_no_more_interactions(<spy>)
 Here's an example:
 
 ```gd
-var spyed_node := spy(auto_free(Node.new())) as Node
+var spyed_node: Node = spy(auto_free(Node.new()))
 
 # Interact on two functions 
 spyed_node.is_a_parent_of(null)

--- a/documentation/doc/_advanced_testing/spy.md
+++ b/documentation/doc/_advanced_testing/spy.md
@@ -105,7 +105,7 @@ verify(<spy>, <times>).function(<args>)
 Here's an example:
 
 ```gd
-var spyed_node :Node = spy(auto_free(Node.new()))
+var spyed_node: Node = spy(auto_free(Node.new()))
 
 # Verify we have no interactions currently on this instance
 verify_no_interactions(spyed_node)
@@ -191,7 +191,7 @@ reset(<spy>)
 Here's an example:
 
 ```gd
-var spyed_node :Node = spy(auto_free(Node.new()))
+var spyed_node: Node = spy(auto_free(Node.new()))
 
 # First, we test by interacting with two functions 
 spyed_node.is_a_parent_of(null)
@@ -223,7 +223,7 @@ For example, instead of verifying that a function was called with a specific boo
 to verify that the function was called with any boolean value. Here's an example:
 
 ```gd
-var spyed_node :Node = spy(auto_free(Node.new()))
+var spyed_node: Node = spy(auto_free(Node.new()))
 
 # Call the function with different arguments
 spyed_node.set_process(false) # Called 1 time


### PR DESCRIPTION
## Why

A user reported the spying documentation as contradictory, the "How to use a Spy" section says a spied instance is marked for auto-freeing and doesn't need to be freed manually, while the example right below wraps the instance in `auto_free()`. Verifying the page against the actual implementation showed that the paragraph is misleading rather than the example being wrong, and it also uncovered that the verification examples on the page were broken, they still used the Godot 3 API `is_a_parent_of()`, they spied on core functions which is not supported, and one example claimed a failure detection that the framework does not actually perform.

## What

- Reworded the auto-freeing paragraph and split the introduction into two simple examples, spying on an object where the original instance stays under the caller's ownership and must be wrapped in `auto_free()`, and spying on a scene where the scene instance itself becomes the spy and is auto-freed.
- Rebuilt all verification examples on top of the small custom class defined on the page, since spying on core functions is not supported and calls through statically typed variables bypass the spy without recording any interaction, the previous examples never worked in Godot 4. This also removes the leftover Godot 3 API `is_a_parent_of()`.
- Corrected the description of the unverified interaction detection, an interaction is identified by its function and argument combination, so repeating an already verified call is not reported, and the example now triggers the documented failure with a not yet verified argument.
- Unified all examples to explicitly typed variable declarations with the official style guide spacing.
- Added test coverage for the auto-freeing ownership contract of both the object and the scene case, and a dedicated "documented examples" test section that executes every example from the page to keep the documentation verifiable.

Closes #1230
