### PR TITLE
GD-1234: Fix `spy()` and `mock()` crash on field initializer calls

### DIFF
--- a/addons/gdUnit4/src/mocking/GdUnitMockImpl.gd
+++ b/addons/gdUnit4/src/mocking/GdUnitMockImpl.gd
@@ -48,11 +48,16 @@ func _notification(what: int) -> void:
 
 
 static func __get_verifier() -> GdUnitObjectInteractionsVerifier:
+	# not yet initialized, happens when a base class field initializer calls an overridden
+	# function before the mock's `__init()` had a chance to run `__init_doubler()`
+	if not Engine.has_meta(__INSTANCE_ID):
+		return null
 	return Engine.get_meta(__INSTANCE_ID).__verifier_instance
 
 
 static func __is_prepare_return_value() -> bool:
-	return __doubler_state().is_prepare_return
+	var doubler_state := __doubler_state()
+	return doubler_state != null and doubler_state.is_prepare_return
 
 
 static func __sort_by_argument_matcher(__left_args: Array, __right_args: Array) -> bool:
@@ -124,6 +129,9 @@ static func __return_mock_value(__func_name: String, __func_args: Array, __defau
 
 static func __is_do_not_call_real_func(__func_name: String, __func_args := []) -> bool:
 	var doubler_state := __doubler_state()
+	# not yet initialized, fall back to calling the real function
+	if doubler_state == null:
+		return false
 	var __is_call_real_func: bool = doubler_state.working_mode == GdUnitMock.CALL_REAL_FUNC  and not doubler_state.excluded_methods.has(__func_name)
 	# do not call real funcions for mocked functions
 	if __is_call_real_func and doubler_state.return_values.has(__func_name):

--- a/addons/gdUnit4/src/spy/GdUnitSpyImpl.gd
+++ b/addons/gdUnit4/src/spy/GdUnitSpyImpl.gd
@@ -38,6 +38,10 @@ func _notification(what: int) -> void:
 
 
 static func __get_verifier() -> GdUnitObjectInteractionsVerifier:
+	# not yet initialized, happens when a base class field initializer calls an overridden
+	# function before the spy's `_init()` had a chance to run `__init_doubler()`
+	if not Engine.has_meta(__INSTANCE_ID):
+		return null
 	return Engine.get_meta(__INSTANCE_ID).__verifier_instance
 
 

--- a/addons/gdUnit4/test/mocker/GdUnitMockerTest.gd
+++ b/addons/gdUnit4/test/mocker/GdUnitMockerTest.gd
@@ -120,6 +120,14 @@ func test_mock_Node() -> void:
 	assert_that(mocked_node.get_child_count()).is_equal(24)
 
 
+func test_mock_class_with_field_initializer_calling_overridden_method() -> void:
+	# GD-1234: field initializer calls a method before `__init()` runs.
+	var m: FieldInitCallTestClass = mock(FieldInitCallTestClass)
+
+	assert_that(m).is_not_null()
+	assert_str(m.greeting).is_equal("hello from the real function")
+
+
 func test_mock_source_with_class_name_by_resource_path() -> void:
 	var resource_path_ := 'res://addons/gdUnit4/test/mocker/resources/GD-256/world.gd'
 	var m: Variant = mock(resource_path_)

--- a/addons/gdUnit4/test/mocker/resources/FieldInitCallTestClass.gd
+++ b/addons/gdUnit4/test/mocker/resources/FieldInitCallTestClass.gd
@@ -1,0 +1,8 @@
+class_name FieldInitCallTestClass
+extends Node
+
+var greeting: String = build_greeting()
+
+
+func build_greeting() -> String:
+	return "hello from the real function"

--- a/addons/gdUnit4/test/spy/GdUnitSpyTest.gd
+++ b/addons/gdUnit4/test/spy/GdUnitSpyTest.gd
@@ -881,5 +881,14 @@ func test_doc_argument_matchers_example() -> void:
 #endregion
 
 
+func test_spy_class_with_field_initializer_calling_overridden_method() -> void:
+	# GD-1234: field initializer calls a method before `__init()` runs.
+	var instance: FieldInitCallTestClass = auto_free(FieldInitCallTestClass.new())
+	var spy_instance: FieldInitCallTestClass = spy(instance)
+
+	assert_that(spy_instance).is_not_null()
+	assert_str(spy_instance.greeting).is_equal("hello from the real function")
+
+
 func _load(resource_path: String) -> GDScript:
 	return load(resource_path)


### PR DESCRIPTION
## Why
GdUnit4's spy and mock doublers generate a subclass that overrides the target class's methods to route them through the verifier and mock-state machinery, but Godot runs a class's field initializers as part of object construction, before the doubled subclass's own `_init()`/`__init()` body gets a chance to register that instance's doubler state, so when a doubled class has a field initializer that calls one of its own methods, the overridden method fires before the verifier or mock state exists and crashes trying to read it.

## What
Guard the generated doubler's verifier and mock-state lookups so they return null or false instead of crashing when the per-instance doubler state has not been registered yet, letting calls made during this construction window fall through to the real method body the same way an un-doubled instance would behave, and add regression tests reproducing the reported crash for both spy and mock.

Closes #1234