### PR TITLE
GD-1193: Fix false orphan detection firing before `after_test` cleanup

### DIFF
--- a/addons/gdUnit4/src/core/execution/GdUnitExecutionContext.gd
+++ b/addons/gdUnit4/src/core/execution/GdUnitExecutionContext.gd
@@ -86,6 +86,10 @@ func dispose_sub_contexts() -> void:
 	_sub_context.clear()
 
 
+func last_sub_context() -> GdUnitExecutionContext:
+	return null if _sub_context.is_empty() else _sub_context[-1]
+
+
 func terminate() -> void:
 	if test_case:
 		test_case.do_terminate()

--- a/addons/gdUnit4/src/core/execution/stages/GdUnitTestCaseAfterStage.gd
+++ b/addons/gdUnit4/src/core/execution/stages/GdUnitTestCaseAfterStage.gd
@@ -4,6 +4,12 @@ class_name GdUnitTestCaseAfterStage
 extends IGdUnitExecutionStage
 
 
+## The test-case scoped context (the one the test body executed in), gc'ed right after
+## `after_test()` runs and before the parent's own orphan snapshot, so cleanup performed by
+## `after_test()` is accounted for and test-case-scoped `auto_free()` objects don't leak into
+## the parent context's orphan count.
+var test_case_context: GdUnitExecutionContext = null
+
 var _call_stage: bool
 
 
@@ -17,6 +23,10 @@ func _execute(context: GdUnitExecutionContext) -> void:
 	if _call_stage:
 		@warning_ignore("redundant_await")
 		await test_suite.after_test()
+
+	if test_case_context != null:
+		await test_case_context.gc(GdUnitExecutionContext.GC_ORPHANS_CHECK.TEST_CASE)
+		test_case_context = null
 
 	await context.gc(GdUnitExecutionContext.GC_ORPHANS_CHECK.TEST_HOOK_AFTER)
 	context.error_monitor_stop()

--- a/addons/gdUnit4/src/core/execution/stages/GdUnitTestCaseAfterStage.gd
+++ b/addons/gdUnit4/src/core/execution/stages/GdUnitTestCaseAfterStage.gd
@@ -4,12 +4,6 @@ class_name GdUnitTestCaseAfterStage
 extends IGdUnitExecutionStage
 
 
-## The test-case scoped context (the one the test body executed in), gc'ed right after
-## `after_test()` runs and before the parent's own orphan snapshot, so cleanup performed by
-## `after_test()` is accounted for and test-case-scoped `auto_free()` objects don't leak into
-## the parent context's orphan count.
-var test_case_context: GdUnitExecutionContext = null
-
 var _call_stage: bool
 
 
@@ -24,9 +18,9 @@ func _execute(context: GdUnitExecutionContext) -> void:
 		@warning_ignore("redundant_await")
 		await test_suite.after_test()
 
+	var test_case_context := context.last_sub_context()
 	if test_case_context != null:
 		await test_case_context.gc(GdUnitExecutionContext.GC_ORPHANS_CHECK.TEST_CASE)
-		test_case_context = null
 
 	await context.gc(GdUnitExecutionContext.GC_ORPHANS_CHECK.TEST_HOOK_AFTER)
 	context.error_monitor_stop()

--- a/addons/gdUnit4/src/core/execution/stages/single/GdUnitTestCaseSingleExecutionStage.gd
+++ b/addons/gdUnit4/src/core/execution/stages/single/GdUnitTestCaseSingleExecutionStage.gd
@@ -13,9 +13,14 @@ func _execute(context :GdUnitExecutionContext) -> void:
 	while context.retry_execution():
 		var test_context := GdUnitExecutionContext.of(context)
 		await _stage_before.execute(test_context)
+		var test_case_context: GdUnitExecutionContext = null
 		if not test_context.is_skipped():
-			await _stage_test.execute(GdUnitExecutionContext.of(test_context))
+			test_case_context = GdUnitExecutionContext.of(test_context)
+			await _stage_test.execute(test_case_context)
 		await _stage_after.execute(test_context)
+		# collect test-case level orphans only after `after_test()` has run so its cleanup is accounted for
+		if test_case_context != null:
+			await test_case_context.gc(GdUnitExecutionContext.GC_ORPHANS_CHECK.TEST_CASE)
 		if test_context.is_success() or test_context.is_skipped() or test_context.is_interupted():
 			break
 

--- a/addons/gdUnit4/src/core/execution/stages/single/GdUnitTestCaseSingleExecutionStage.gd
+++ b/addons/gdUnit4/src/core/execution/stages/single/GdUnitTestCaseSingleExecutionStage.gd
@@ -4,7 +4,7 @@ extends IGdUnitExecutionStage
 
 
 var _stage_before :IGdUnitExecutionStage = GdUnitTestCaseBeforeStage.new()
-var _stage_after := GdUnitTestCaseAfterStage.new()
+var _stage_after :IGdUnitExecutionStage = GdUnitTestCaseAfterStage.new()
 var _stage_test :IGdUnitExecutionStage = GdUnitTestCaseSingleTestStage.new()
 
 
@@ -13,12 +13,8 @@ func _execute(context :GdUnitExecutionContext) -> void:
 	while context.retry_execution():
 		var test_context := GdUnitExecutionContext.of(context)
 		await _stage_before.execute(test_context)
-		var test_case_context: GdUnitExecutionContext = null
 		if not test_context.is_skipped():
-			test_case_context = GdUnitExecutionContext.of(test_context)
-			await _stage_test.execute(test_case_context)
-		# gc'ed inside the after-stage, right after `after_test()` and before the parent's own orphan snapshot
-		_stage_after.test_case_context = test_case_context
+			await _stage_test.execute(GdUnitExecutionContext.of(test_context))
 		await _stage_after.execute(test_context)
 		if test_context.is_success() or test_context.is_skipped() or test_context.is_interupted():
 			break

--- a/addons/gdUnit4/src/core/execution/stages/single/GdUnitTestCaseSingleExecutionStage.gd
+++ b/addons/gdUnit4/src/core/execution/stages/single/GdUnitTestCaseSingleExecutionStage.gd
@@ -4,7 +4,7 @@ extends IGdUnitExecutionStage
 
 
 var _stage_before :IGdUnitExecutionStage = GdUnitTestCaseBeforeStage.new()
-var _stage_after :IGdUnitExecutionStage = GdUnitTestCaseAfterStage.new()
+var _stage_after := GdUnitTestCaseAfterStage.new()
 var _stage_test :IGdUnitExecutionStage = GdUnitTestCaseSingleTestStage.new()
 
 
@@ -17,10 +17,9 @@ func _execute(context :GdUnitExecutionContext) -> void:
 		if not test_context.is_skipped():
 			test_case_context = GdUnitExecutionContext.of(test_context)
 			await _stage_test.execute(test_case_context)
+		# gc'ed inside the after-stage, right after `after_test()` and before the parent's own orphan snapshot
+		_stage_after.test_case_context = test_case_context
 		await _stage_after.execute(test_context)
-		# collect test-case level orphans only after `after_test()` has run so its cleanup is accounted for
-		if test_case_context != null:
-			await test_case_context.gc(GdUnitExecutionContext.GC_ORPHANS_CHECK.TEST_CASE)
 		if test_context.is_success() or test_context.is_skipped() or test_context.is_interupted():
 			break
 

--- a/addons/gdUnit4/src/core/execution/stages/single/GdUnitTestCaseSingleTestStage.gd
+++ b/addons/gdUnit4/src/core/execution/stages/single/GdUnitTestCaseSingleTestStage.gd
@@ -8,4 +8,3 @@ extends IGdUnitExecutionStage
 ##  -> test_case() [br]
 func _execute(context: GdUnitExecutionContext) -> void:
 	await context.test_case.execute()
-	await context.gc(GdUnitExecutionContext.GC_ORPHANS_CHECK.TEST_CASE)

--- a/addons/gdUnit4/test/ui/parts/GdUnitInspectorTreeMainPanelTest.gd
+++ b/addons/gdUnit4/test/ui/parts/GdUnitInspectorTreeMainPanelTest.gd
@@ -225,11 +225,6 @@ func test_select_next_failure() -> void:
 	_inspector._on_select_next_item_by_state(FAILED)
 	assert_str(_inspector._tree.get_selected().get_text(0)).is_equal("test_ad")
 
-	# TODO fix the invalid orphan detection, this is actually only a hot fix!
-	_inspector.free()
-	# Give the engine time to queue_free marked objects
-	await await_idle_frame()
-
 
 func test_select_previous_failure() -> void:
 	# test initial nothing is selected
@@ -264,12 +259,6 @@ func test_select_previous_failure() -> void:
 	assert_str(_inspector._tree.get_selected().get_text(0)).is_equal("test_ce")
 	_inspector._on_select_previous_item_by_state(FAILED)
 	assert_str(_inspector._tree.get_selected().get_text(0)).is_equal("test_cc")
-
-	# TODO fix the invalid orphan detection, this is actually only a hot fix!
-	_inspector.free()
-	# Give the engine time to queue_free marked objects
-	await await_idle_frame()
-
 
 
 func test_select_next_flaky() -> void:


### PR DESCRIPTION
## Why
The test-case orphan check ran right after the test body and before `after_test()` had a chance to free nodes, so tests that clean up correctly in `after_test` were flagged with false orphan warnings. Two tests in the inspector panel suite carried a fragile manual `free()` + `await_idle_frame()` hot-fix in the test body to work around this.

## What
Moves the test-case gc to run after `after_test()` completes but before the parent context's own orphan snapshot, matching the ordering the fuzzed test path already used. Removes the two hot-fix workarounds in the inspector panel test suite since they're no longer needed.

Closes #1193