### PR TITLE
GD-1240: Support built-in constant parsing in inline parameter sets

### DIFF
--- a/addons/gdUnit4/src/core/parameters/GdBuiltinConstants.gd
+++ b/addons/gdUnit4/src/core/parameters/GdBuiltinConstants.gd
@@ -1,0 +1,50 @@
+class_name GdBuiltinConstants
+extends RefCounted
+
+
+## Built-in Variant types that expose named constants via static member access (e.g. `Vector2.ONE`,
+## `Color.RED`). This gate is what keeps resolution silent: only tokens whose type is listed here are
+## compiled, so arbitrary `Identifier.UPPER` matches (enum refs, text) never reach the parser.
+## New builtin types are rare, so this list changes far less often than the constants themselves.
+const CONSTANT_BEARING_TYPES: PackedStringArray = [
+	"Vector2", "Vector2i",
+	"Vector3", "Vector3i",
+	"Vector4", "Vector4i",
+	"Color",
+	"Basis", "Quaternion", "Plane",
+	"Transform2D", "Transform3D", "Projection",
+]
+
+const _RESOLVE_SCRIPT_TEMPLATE := """
+extends RefCounted
+
+func value() -> Variant:
+	return %s
+"""
+
+static var _resolved_values: Dictionary[String, Variant] = {}
+static var _unresolvable_tokens: Dictionary[String, bool] = {}
+
+
+## Resolves a dotted constant token (e.g. `Vector2.ONE`) to its runtime value, compiling it once and
+## caching the result process-wide. Returns true when the token is a known constant of a supported
+## builtin type; its value is then available via [method value_of].
+static func is_known_constant(type_name: String, token: String) -> bool:
+	if _resolved_values.has(token):
+		return true
+	if _unresolvable_tokens.has(token) or not CONSTANT_BEARING_TYPES.has(type_name):
+		return false
+
+	var script := GDScript.new()
+	script.source_code = _RESOLVE_SCRIPT_TEMPLATE % token
+	if script.reload() != OK:
+		_unresolvable_tokens[token] = true
+		return false
+
+	@warning_ignore("unsafe_method_access")
+	_resolved_values[token] = script.new().call("value")
+	return true
+
+
+static func value_of(token: String) -> Variant:
+	return _resolved_values[token]

--- a/addons/gdUnit4/src/core/parameters/GdInlineParameterSetResolver.gd
+++ b/addons/gdUnit4/src/core/parameters/GdInlineParameterSetResolver.gd
@@ -17,67 +17,98 @@ func __run_expression() -> Array:
 
 """
 
-var _expression: Expression
 var _parameter_sets: PackedStringArray
-var _used_input_types: Array[PackedStringArray] = []
+var _preparsed_expressions: Array[Expression] = []
+var _bound_input_values: Array[Array] = []
 
 
-## Lazily built map from Godot class name to a live instance, used by
-## [GdInlineParameterSetResolver] to resolve class-name tokens inside inline expressions.
 static var _global_class_type_mapping: Dictionary[String, Variant] = {}
+static var _constant_token_regex: RegEx
 
 
 func _init(parameter_sets: PackedStringArray, args: Array[GdFunctionArgument] = []) -> void:
 	super(args)
-	_expression = Expression.new()
 	_parameter_sets = parameter_sets
 
-	# Scan for used types
-	for index in _used_input_types.resize(_parameter_sets.size()):
-		_used_input_types[index] = PackedStringArray()
-
-	for clazz_name: String in _get_class_type_mapping().keys():
-		for parameter_set_index in _parameter_sets.size():
-			var paramater_set := _parameter_sets[parameter_set_index]
-			if paramater_set.contains(clazz_name):
-				_used_input_types[parameter_set_index].append(clazz_name)
+	var bound_class_names := _scan_bound_class_names(_parameter_sets)
+	for index in _parameter_sets.size():
+		_preparse_parameter_set(index, bound_class_names[index])
 
 
 func get_max_index() -> int:
-	return _used_input_types.size()
+	return _parameter_sets.size()
 
 
 func get_parameters(instance: Node, index: int) -> Array:
-	var mapping := _get_class_type_mapping()
-	var input_values: Array = []
+	var expression := _preparsed_expressions[index]
+	if expression == null:
+		return _run_expression_via_script(instance, _parameter_sets[index])
 
-	for clazz_name in _used_input_types[index]:
-		input_values.append(mapping[clazz_name])
-
-	var expression := _parameter_sets[index]
-	var parse_error := _expression.parse(expression, _used_input_types[index])
-	if parse_error != OK:
-		# TODO provide better error reporting
-		prints("""
-			Warning: Fallback to slower parameter resolving!
-				GdInlineParameterSetResolver: parsing error: %s
-				'%s'
-				error: %s
-			""".dedent() % [error_string(parse_error), expression, _expression.get_error_text()])
-		return _run_expression_via_script(instance, expression)
-
-	var parameters: Variant = _expression.execute(input_values, instance, false)
-	if _expression.has_execute_failed():
-		# TODO provide better error reporting
-		prints("Expression execute error:", _expression.get_error_text())
-		return _run_expression_via_script(instance, expression)
+	var parameters: Variant = expression.execute(_bound_input_values[index], instance, false)
+	if expression.has_execute_failed():
+		prints("Expression execute error:", expression.get_error_text())
+		return _run_expression_via_script(instance, _parameter_sets[index])
 	if not parameters is Array:
-		# The expression may reference a class const or property not accessible via Object.get();
-		# fall back to a GDScript that extends the test class so it can resolve such identifiers.
-		return _run_expression_via_script(instance, expression)
+		return _run_expression_via_script(instance, _parameter_sets[index])
 
 	@warning_ignore("unsafe_call_argument")
 	return _finalize_parameter_set(parameters)
+
+
+static func _scan_bound_class_names(parameter_sets: PackedStringArray) -> Array[PackedStringArray]:
+	var bound_class_names: Array[PackedStringArray] = []
+	for index in bound_class_names.resize(parameter_sets.size()):
+		bound_class_names[index] = PackedStringArray()
+
+	for clazz_name: String in _get_class_type_mapping().keys():
+		for index in parameter_sets.size():
+			if parameter_sets[index].contains(clazz_name):
+				bound_class_names[index].append(clazz_name)
+	return bound_class_names
+
+
+func _preparse_parameter_set(index: int, bound_class_names: PackedStringArray) -> void:
+	var mapping := _get_class_type_mapping()
+	var input_names := bound_class_names
+	var input_values: Array = []
+	for clazz_name in bound_class_names:
+		input_values.append(mapping[clazz_name])
+
+	var expression_source := _parameter_sets[index]
+	for regex_match in _get_constant_token_regex().search_all(expression_source):
+		var token := regex_match.get_string(0)
+		var type_name := regex_match.get_string(1)
+		var alias := token.replace(".", "__")
+		if bound_class_names.has(type_name) or input_names.has(alias):
+			continue
+		if GdBuiltinConstants.is_known_constant(type_name, token):
+			input_names.append(alias)
+			input_values.append(GdBuiltinConstants.value_of(token))
+			expression_source = expression_source.replace(token, alias)
+
+	var expression := Expression.new()
+	if expression.parse(expression_source, input_names) != OK:
+		_print_fallback_warning(_parameter_sets[index], expression.get_error_text())
+		_preparsed_expressions.append(null)
+	else:
+		_preparsed_expressions.append(expression)
+	_bound_input_values.append(input_values)
+
+
+static func _print_fallback_warning(parameter_set: String, error_text: String) -> void:
+	prints("""
+		Warning: Fallback to slower parameter resolving!
+			GdInlineParameterSetResolver: parsing error:
+			'%s'
+			error: %s
+		""".dedent() % [parameter_set, error_text])
+
+
+static func _get_constant_token_regex() -> RegEx:
+	if _constant_token_regex == null:
+		_constant_token_regex = RegEx.new()
+		_constant_token_regex.compile("([A-Za-z_][A-Za-z0-9_]*)\\.([A-Z][A-Z0-9_]*)\\b")
+	return _constant_token_regex
 
 
 # This is a fallback option to run the expression by kind of reflection

--- a/addons/gdUnit4/test/core/parameters/GdBuiltinConstantsTest.gd
+++ b/addons/gdUnit4/test/core/parameters/GdBuiltinConstantsTest.gd
@@ -1,0 +1,29 @@
+# GdUnit generated TestSuite
+extends GdUnitTestSuite
+
+
+#region is_known_constant
+func test_is_known_constant_resolves_vector_constants() -> void:
+	assert_bool(GdBuiltinConstants.is_known_constant("Vector2", "Vector2.ONE")).is_true()
+	assert_bool(GdBuiltinConstants.is_known_constant("Vector3", "Vector3.INF")).is_true()
+	assert_bool(GdBuiltinConstants.is_known_constant("Vector4i", "Vector4i.MAX")).is_true()
+
+
+func test_is_known_constant_resolves_color_constants_without_manual_mapping() -> void:
+	assert_bool(GdBuiltinConstants.is_known_constant("Color", "Color.RED")).is_true()
+	assert_bool(GdBuiltinConstants.is_known_constant("Color", "Color.WEB_GRAY")).is_true()
+
+
+func test_is_known_constant_rejects_unsupported_type() -> void:
+	assert_bool(GdBuiltinConstants.is_known_constant("String", "String.NOPE")).is_false()
+	assert_bool(GdBuiltinConstants.is_known_constant("Foo", "Foo.BAR")).is_false()
+#endregion
+
+#region value_of
+func test_value_of_returns_resolved_value() -> void:
+	assert_bool(GdBuiltinConstants.is_known_constant("Vector2", "Vector2.ONE")).is_true()
+	assert_object(GdBuiltinConstants.value_of("Vector2.ONE")).is_equal(Vector2.ONE)
+
+	assert_bool(GdBuiltinConstants.is_known_constant("Color", "Color.RED")).is_true()
+	assert_object(GdBuiltinConstants.value_of("Color.RED")).is_equal(Color.RED)
+#endregion

--- a/addons/gdUnit4/test/core/parameters/GdInlineParameterSetResolverTest.gd
+++ b/addons/gdUnit4/test/core/parameters/GdInlineParameterSetResolverTest.gd
@@ -240,6 +240,24 @@ func test_get_parameters_with_constants() -> void:
 	assert_str(parameters[1]).is_equal("Color")
 	assert_object(parameters[2]).is_equal([])
 
+
+func test_get_parameters_with_constants_uses_fast_path() -> void:
+	var test_parameters := [
+		'[Vector2.ZERO, Vector2.ONE, Vector2.DOWN, Vector2.INF]',
+		'[Vector3.ZERO, Vector3.ONE, Vector3.DOWN, Vector3.INF]',
+		'[Vector4.ZERO, Vector4.ONE, Vector4.INF]',
+		'[Color.RED, Color.WEB_GRAY]',
+	]
+	var resolver := GdInlineParameterSetResolver.new(test_parameters)
+
+	for index in resolver.get_max_index():
+		assert_object(resolver._preparsed_expressions[index]).is_not_null()
+
+	assert_array(resolver.get_parameters(self, 0)).contains_exactly(Vector2.ZERO, Vector2.ONE, Vector2.DOWN, Vector2.INF, [])
+	assert_array(resolver.get_parameters(self, 1)).contains_exactly(Vector3.ZERO, Vector3.ONE, Vector3.DOWN, Vector3.INF, [])
+	assert_array(resolver.get_parameters(self, 2)).contains_exactly(Vector4.ZERO, Vector4.ONE, Vector4.INF, [])
+	assert_array(resolver.get_parameters(self, 3)).contains_exactly(Color.RED, Color.WEB_GRAY, [])
+
 #endregion
 #region _resolve_parameters
 


### PR DESCRIPTION
## Why

Parameterized tests that use built-in type constants such as `Vector2.ONE` or `Color.RED` in their inline parameter arrays could not be evaluated by the fast inline resolver, because Godot's `Expression` parser only accepts constructor calls like `Vector2(...)` and rejects static member access. Every affected parameter set silently fell back to the slower script-based resolver and printed a `Warning: Fallback to slower parameter resolving!` message to the Godot console for each test case.

## What

Dotted constant tokens are now rewritten into bound identifiers and their values resolved at runtime, so they evaluate on the fast inline path with no fallback and no console warnings. Values are resolved by compiling a throwaway script once per unique token and caching the result process-wide, which means newly added engine constants are supported automatically without a hand-maintained table. A small allowlist of constant-bearing built-in types gates resolution so arbitrary tokens never reach the parser and cannot produce parser noise, and each expression is pre-parsed once during construction to keep the hot `get_parameters` path free of re-parsing. The new resolution logic lives in a dedicated `GdBuiltinConstants` helper with its own test suite.

Closes #1240