### PR TITLE
TASK-1242: Lazily bind script global classes in the inline parameter resolver

### DIFF
--- a/addons/gdUnit4/src/core/parameters/GdInlineParameterSetResolver.gd
+++ b/addons/gdUnit4/src/core/parameters/GdInlineParameterSetResolver.gd
@@ -23,6 +23,8 @@ var _bound_input_values: Array[Array] = []
 
 
 static var _global_class_type_mapping: Dictionary[String, Variant] = {}
+static var _global_class_path_index: Dictionary[String, String] = {}
+static var _resolved_global_classes: Dictionary[String, Variant] = {}
 static var _constant_token_regex: RegEx
 
 
@@ -60,19 +62,21 @@ static func _scan_bound_class_names(parameter_sets: PackedStringArray) -> Array[
 	for index in bound_class_names.resize(parameter_sets.size()):
 		bound_class_names[index] = PackedStringArray()
 
-	for clazz_name: String in _get_class_type_mapping().keys():
+	var candidate_names := PackedStringArray()
+	candidate_names.append_array(_get_class_type_mapping().keys())
+	candidate_names.append_array(_get_global_class_paths().keys())
+	for clazz_name: String in candidate_names:
 		for index in parameter_sets.size():
-			if parameter_sets[index].contains(clazz_name):
+			if parameter_sets[index].contains(clazz_name) and not bound_class_names[index].has(clazz_name):
 				bound_class_names[index].append(clazz_name)
 	return bound_class_names
 
 
 func _preparse_parameter_set(index: int, bound_class_names: PackedStringArray) -> void:
-	var mapping := _get_class_type_mapping()
 	var input_names := bound_class_names
 	var input_values: Array = []
 	for clazz_name in bound_class_names:
-		input_values.append(mapping[clazz_name])
+		input_values.append(_class_value_of(clazz_name))
 
 	var expression_source := _parameter_sets[index]
 	for regex_match in _get_constant_token_regex().search_all(expression_source):
@@ -141,6 +145,28 @@ static func _get_class_type_mapping() -> Dictionary[String, Variant]:
 	if _global_class_type_mapping.is_empty():
 		_global_class_type_mapping = _build_class_type_mapping()
 	return _global_class_type_mapping
+
+
+static func _class_value_of(clazz_name: String) -> Variant:
+	var native_classes := _get_class_type_mapping()
+	if native_classes.has(clazz_name):
+		return native_classes[clazz_name]
+	return _lazily_loaded_global_class(clazz_name)
+
+
+static func _lazily_loaded_global_class(clazz_name: String) -> Variant:
+	if not _resolved_global_classes.has(clazz_name):
+		_resolved_global_classes[clazz_name] = load(_get_global_class_paths()[clazz_name])
+	return _resolved_global_classes[clazz_name]
+
+
+static func _get_global_class_paths() -> Dictionary[String, String]:
+	if _global_class_path_index.is_empty():
+		for entry in ProjectSettings.get_global_class_list():
+			if entry["language"] == &"GDScript":
+				var clazz_name: String = entry["class"]
+				_global_class_path_index[clazz_name] = entry["path"]
+	return _global_class_path_index
 
 
 ## Builds the class-name-to-instance map by generating and executing a GDScript that

--- a/addons/gdUnit4/src/core/parameters/GdInlineParameterSetResolver.gd
+++ b/addons/gdUnit4/src/core/parameters/GdInlineParameterSetResolver.gd
@@ -22,9 +22,9 @@ var _preparsed_expressions: Array[Expression] = []
 var _bound_input_values: Array[Array] = []
 
 
-static var _global_class_type_mapping: Dictionary[String, Variant] = {}
-static var _global_class_path_index: Dictionary[String, String] = {}
-static var _resolved_global_classes: Dictionary[String, Variant] = {}
+static var _native_class_mapping: Dictionary[String, Variant] = {}
+static var _user_class_paths: Dictionary[String, String] = {}
+static var _resolved_user_classes: Dictionary[String, Variant] = {}
 static var _constant_token_regex: RegEx
 
 
@@ -63,8 +63,8 @@ static func _scan_bound_class_names(parameter_sets: PackedStringArray) -> Array[
 		bound_class_names[index] = PackedStringArray()
 
 	var candidate_names := PackedStringArray()
-	candidate_names.append_array(_get_class_type_mapping().keys())
-	candidate_names.append_array(_get_global_class_paths().keys())
+	candidate_names.append_array(_get_native_class_mapping().keys())
+	candidate_names.append_array(_get_user_class_paths().keys())
 	for clazz_name: String in candidate_names:
 		for index in parameter_sets.size():
 			if parameter_sets[index].contains(clazz_name) and not bound_class_names[index].has(clazz_name):
@@ -141,38 +141,38 @@ func _run_expression_via_script(instance: Node, expression: String) -> Array:
 
 
 ## Returns the shared class-name-to-instance map, building it once on first access.
-static func _get_class_type_mapping() -> Dictionary[String, Variant]:
-	if _global_class_type_mapping.is_empty():
-		_global_class_type_mapping = _build_class_type_mapping()
-	return _global_class_type_mapping
+static func _get_native_class_mapping() -> Dictionary[String, Variant]:
+	if _native_class_mapping.is_empty():
+		_native_class_mapping = _build_native_class_mapping()
+	return _native_class_mapping
 
 
 static func _class_value_of(clazz_name: String) -> Variant:
-	var native_classes := _get_class_type_mapping()
+	var native_classes := _get_native_class_mapping()
 	if native_classes.has(clazz_name):
 		return native_classes[clazz_name]
-	return _lazily_loaded_global_class(clazz_name)
+	return _lazily_loaded_user_class(clazz_name)
 
 
-static func _lazily_loaded_global_class(clazz_name: String) -> Variant:
-	if not _resolved_global_classes.has(clazz_name):
-		_resolved_global_classes[clazz_name] = load(_get_global_class_paths()[clazz_name])
-	return _resolved_global_classes[clazz_name]
+static func _lazily_loaded_user_class(clazz_name: String) -> Variant:
+	if not _resolved_user_classes.has(clazz_name):
+		_resolved_user_classes[clazz_name] = load(_get_user_class_paths()[clazz_name])
+	return _resolved_user_classes[clazz_name]
 
 
-static func _get_global_class_paths() -> Dictionary[String, String]:
-	if _global_class_path_index.is_empty():
+static func _get_user_class_paths() -> Dictionary[String, String]:
+	if _user_class_paths.is_empty():
 		for entry in ProjectSettings.get_global_class_list():
 			if entry["language"] == &"GDScript":
 				var clazz_name: String = entry["class"]
-				_global_class_path_index[clazz_name] = entry["path"]
-	return _global_class_path_index
+				_user_class_paths[clazz_name] = entry["path"]
+	return _user_class_paths
 
 
 ## Builds the class-name-to-instance map by generating and executing a GDScript that
 ## returns a dictionary literal — the only way to obtain live class references from
 ## [ClassDB] names, since GDScript has no eval or direct class-by-name lookup.
-static func _build_class_type_mapping() -> Dictionary[String, Variant]:
+static func _build_native_class_mapping() -> Dictionary[String, Variant]:
 	var source := """
 		extends RefCounted
 

--- a/addons/gdUnit4/test/core/parameters/GdInlineParameterSetResolverTest.gd
+++ b/addons/gdUnit4/test/core/parameters/GdInlineParameterSetResolverTest.gd
@@ -258,6 +258,20 @@ func test_get_parameters_with_constants_uses_fast_path() -> void:
 	assert_array(resolver.get_parameters(self, 2)).contains_exactly(Vector4.ZERO, Vector4.ONE, Vector4.INF, [])
 	assert_array(resolver.get_parameters(self, 3)).contains_exactly(Color.RED, Color.WEB_GRAY, [])
 
+
+func test_get_parameters_binds_script_global_classes_on_fast_path() -> void:
+	var test_parameters := [
+		'[GdUnitBoolAssert, "bool"]',
+		'[GdUnitStringAssert, "string"]',
+	]
+	var resolver := GdInlineParameterSetResolver.new(test_parameters)
+
+	for index in resolver.get_max_index():
+		assert_object(resolver._preparsed_expressions[index]).is_not_null()
+
+	assert_array(resolver.get_parameters(self, 0)).contains_exactly(GdUnitBoolAssert, "bool", [])
+	assert_array(resolver.get_parameters(self, 1)).contains_exactly(GdUnitStringAssert, "string", [])
+
 #endregion
 #region _resolve_parameters
 

--- a/addons/gdUnit4/test/core/parameters/GdInlineParameterSetResolverTest.gd
+++ b/addons/gdUnit4/test/core/parameters/GdInlineParameterSetResolverTest.gd
@@ -451,17 +451,16 @@ func test_performance_get_parameters_overall() -> void:
 #endregion
 
 
-#region _get_class_type_mapping
+#region _get_native_class_mapping
 
-func test_get_class_type_mapping() -> void:
+func test_get_native_class_mapping() -> void:
 	var expected_count := 0
 	for clazz_name in ClassDB.get_class_list():
 		if ClassDB.class_get_api_type(clazz_name) != 0 or not ClassDB.can_instantiate(clazz_name):
 			continue
 		expected_count += 1
 
-	assert_dict(GdInlineParameterSetResolver._get_class_type_mapping()).has_size(expected_count)
-	# Second call returns the same cached mapping without rebuilding
-	assert_dict(GdInlineParameterSetResolver._get_class_type_mapping()).has_size(expected_count)
+	assert_dict(GdInlineParameterSetResolver._get_native_class_mapping()).has_size(expected_count)
+	assert_dict(GdInlineParameterSetResolver._get_native_class_mapping()).has_size(expected_count)
 
 #endregion

--- a/addons/gdUnit4/test/core/parameters/GdInlineParameterSetResolverTest.gd
+++ b/addons/gdUnit4/test/core/parameters/GdInlineParameterSetResolverTest.gd
@@ -259,7 +259,7 @@ func test_get_parameters_with_constants_uses_fast_path() -> void:
 	assert_array(resolver.get_parameters(self, 3)).contains_exactly(Color.RED, Color.WEB_GRAY, [])
 
 
-func test_get_parameters_binds_script_global_classes_on_fast_path() -> void:
+func test_get_parameters_binds_user_classes_on_fast_path() -> void:
 	var test_parameters := [
 		'[GdUnitBoolAssert, "bool"]',
 		'[GdUnitStringAssert, "string"]',


### PR DESCRIPTION
## Why

Parameter sets that use a script global class as a value could not be evaluated on the fast inline path, because only native classes were bound. They fell back to the slower resolver and printed console noise for every affected test case.

## What

Script global classes are now bound too, so these parameter sets resolve on the fast inline path without fallback or console output. Global classes are looked up lazily and cached, and only when actually referenced, so construction stays fast and the parameter retrieval path is unchanged.

Closes #1242