### PR TITLE
TASK-1246: Improve warning propagation for parameter expression errors

### DIFF
--- a/addons/gdUnit4/src/core/parameters/GdInlineParameterSetResolver.gd
+++ b/addons/gdUnit4/src/core/parameters/GdInlineParameterSetResolver.gd
@@ -20,6 +20,8 @@ func __run_expression() -> Array:
 var _parameter_sets: PackedStringArray
 var _preparsed_expressions: Array[Expression] = []
 var _bound_input_values: Array[Array] = []
+var _source_path := ""
+var _function_name := ""
 
 
 static var _native_class_mapping: Dictionary[String, Variant] = {}
@@ -29,9 +31,16 @@ static var _constant_token_regex: RegEx
 static var _script_variant_type_regex: RegEx
 
 
-func _init(parameter_sets: PackedStringArray, args: Array[GdFunctionArgument] = []) -> void:
+func _init(
+	parameter_sets: PackedStringArray,
+	args: Array[GdFunctionArgument] = [],
+	source_path: String = "",
+	function_name: String = ""
+) -> void:
 	super(args)
 	_parameter_sets = parameter_sets
+	_source_path = source_path
+	_function_name = function_name
 
 	var bound_class_names := _scan_bound_class_names(_parameter_sets)
 	for index in _parameter_sets.size():
@@ -99,28 +108,30 @@ func _preparse_parameter_set(index: int, bound_class_names: PackedStringArray) -
 
 	var expression := Expression.new()
 	if expression.parse(expression_source, input_names) != OK:
-		_print_fallback_warning(_parameter_sets[index], expression.get_error_text())
+		_print_fallback_warning(_parameter_sets[index], expression.get_error_text(), _source_path, _function_name)
 		_preparsed_expressions.append(null)
 	else:
 		_preparsed_expressions.append(expression)
 	_bound_input_values.append(input_values)
 
 
-static func _print_fallback_warning(parameter_set: String, error_text: String) -> void:
+static func _print_fallback_warning(parameter_set: String, error_text: String, source_path: String, function_name: String) -> void:
 	if parameter_set.contains("as Array"):
 		push_warning("""
 		Avoid type-casting with `as Array` in parameter sets; use the typed `Array(...)` constructor instead.
+			test: '%s' (%s)
 			expression: '%s'
 		Falling back to slower script-based resolver.
-		""".dedent() % [parameter_set])
+		""".dedent() % [function_name, source_path, parameter_set])
 		return
 
 	push_warning("""
 		Parameter expression parsing failed (error: %s).
 		Falling back to slower script-based resolver.
 		Check for unsupported syntax or missing class bindings.
+			test: '%s' (%s)
 			expression: '%s'
-		""".dedent() % [error_text, parameter_set])
+		""".dedent() % [error_text, function_name, source_path, parameter_set])
 
 
 static func _get_constant_token_regex() -> RegEx:

--- a/addons/gdUnit4/src/core/parameters/GdInlineParameterSetResolver.gd
+++ b/addons/gdUnit4/src/core/parameters/GdInlineParameterSetResolver.gd
@@ -33,9 +33,9 @@ static var _script_variant_type_regex: RegEx
 
 func _init(
 	parameter_sets: PackedStringArray,
-	args: Array[GdFunctionArgument] = [],
-	source_path: String = "",
-	function_name: String = ""
+	source_path: String,
+	function_name: String,
+	args: Array[GdFunctionArgument] = []
 ) -> void:
 	super(args)
 	_parameter_sets = parameter_sets

--- a/addons/gdUnit4/src/core/parameters/GdParameterSetResolverFactory.gd
+++ b/addons/gdUnit4/src/core/parameters/GdParameterSetResolverFactory.gd
@@ -13,7 +13,7 @@ static func create(fd: GdFunctionDescriptor, instance: Node) -> GdParameterSetRe
 	var parameter_sets := parameter_set_argument.parameter_sets()
 
 	if not parameter_sets.is_empty():
-		return GdInlineParameterSetResolver.new(parameter_sets, fd.args())
+		return GdInlineParameterSetResolver.new(parameter_sets, fd.args(), fd.source_path(), fd.name())
 
 	# A parenthesis signals a callable expression, e.g. "my_provider()".
 	var expression: String = parameter_set_argument._default_value

--- a/addons/gdUnit4/src/core/parameters/GdParameterSetResolverFactory.gd
+++ b/addons/gdUnit4/src/core/parameters/GdParameterSetResolverFactory.gd
@@ -13,7 +13,7 @@ static func create(fd: GdFunctionDescriptor, instance: Node) -> GdParameterSetRe
 	var parameter_sets := parameter_set_argument.parameter_sets()
 
 	if not parameter_sets.is_empty():
-		return GdInlineParameterSetResolver.new(parameter_sets, fd.args(), fd.source_path(), fd.name())
+		return GdInlineParameterSetResolver.new(parameter_sets, fd.source_path(), fd.name(), fd.args())
 
 	# A parenthesis signals a callable expression, e.g. "my_provider()".
 	var expression: String = parameter_set_argument._default_value

--- a/addons/gdUnit4/test/core/parameters/GdInlineParameterSetResolverTest.gd
+++ b/addons/gdUnit4/test/core/parameters/GdInlineParameterSetResolverTest.gd
@@ -179,7 +179,7 @@ func using_typed_dictionary_parameter(_items: Dictionary[String, int], _test_par
 #region get_parameters
 
 func test_get_parameters() -> void:
-	var resolver := GdInlineParameterSetResolver.new(example_parameters)
+	var resolver := GdInlineParameterSetResolver.new(example_parameters, "", "")
 
 	assert_int(resolver.get_max_index()).is_equal(9)
 
@@ -253,7 +253,7 @@ func test_get_parameters_with_constants() -> void:
 		'[Color.RED, "Color"]',
 	]
 
-	var resolver := GdInlineParameterSetResolver.new(test_parameters)
+	var resolver := GdInlineParameterSetResolver.new(test_parameters, "", "")
 
 	assert_int(resolver.get_max_index()).is_equal(3)
 
@@ -283,7 +283,7 @@ func test_get_parameters_with_constants_uses_fast_path() -> void:
 		'[Vector4.ZERO, Vector4.ONE, Vector4.INF]',
 		'[Color.RED, Color.WEB_GRAY]',
 	]
-	var resolver := GdInlineParameterSetResolver.new(test_parameters)
+	var resolver := GdInlineParameterSetResolver.new(test_parameters, "", "")
 
 	for index in resolver.get_max_index():
 		assert_object(resolver._preparsed_expressions[index]).is_not_null()
@@ -299,7 +299,7 @@ func test_get_parameters_binds_user_classes_on_fast_path() -> void:
 		'[GdUnitBoolAssert, "bool"]',
 		'[GdUnitStringAssert, "string"]',
 	]
-	var resolver := GdInlineParameterSetResolver.new(test_parameters)
+	var resolver := GdInlineParameterSetResolver.new(test_parameters, "", "")
 
 	for index in resolver.get_max_index():
 		assert_object(resolver._preparsed_expressions[index]).is_not_null()
@@ -312,7 +312,7 @@ func test_fallback_warning_includes_source_context() -> void:
 	var test_parameters := ["[Array([1, 2, 3, 1]) as Array[int], TYPE_ARRAY]"]
 
 	assert_error(func() -> void:
-		GdInlineParameterSetResolver.new(test_parameters, [], "res://foo/bar.gd", "test_broken_expression")
+		GdInlineParameterSetResolver.new(test_parameters, "res://foo/bar.gd", "test_broken_expression")
 	).is_push_warning("""
 		Avoid type-casting with `as Array` in parameter sets; use the typed `Array(...)` constructor instead.
 			test: 'test_broken_expression' (res://foo/bar.gd)
@@ -489,7 +489,7 @@ func _resolve_parameters(child_name: String) -> Array[Array]:
 
 	var parameter_set_argument := GdFunctionArgument.get_parameter_set(fd.args())
 	var parameter_sets := parameter_set_argument.parameter_sets()
-	var resolver := GdInlineParameterSetResolver.new(parameter_sets, fd.args(), fd.source_path(), fd.name())
+	var resolver := GdInlineParameterSetResolver.new(parameter_sets, fd.source_path(), fd.name(), fd.args())
 	if resolver == null:
 		return []
 	var result: Array[Array] = []
@@ -503,7 +503,7 @@ func _resolve_parameters(child_name: String) -> Array[Array]:
 
 func test_performance_single() -> void:
 	const ITERATIONS := 1000
-	var resolver := GdInlineParameterSetResolver.new(example_parameters)
+	var resolver := GdInlineParameterSetResolver.new(example_parameters, "", "")
 
 	var t1 := Time.get_ticks_usec()
 	for _i in ITERATIONS:
@@ -519,7 +519,7 @@ func test_performance_single() -> void:
 
 func test_performance_get_parameters_overall() -> void:
 	const ITERATIONS := 1000
-	var resolver := GdInlineParameterSetResolver.new(example_parameters)
+	var resolver := GdInlineParameterSetResolver.new(example_parameters, "", "")
 
 	var t1 := Time.get_ticks_usec()
 	for _i in ITERATIONS:

--- a/addons/gdUnit4/test/core/parameters/GdInlineParameterSetResolverTest.gd
+++ b/addons/gdUnit4/test/core/parameters/GdInlineParameterSetResolverTest.gd
@@ -307,6 +307,19 @@ func test_get_parameters_binds_user_classes_on_fast_path() -> void:
 	assert_array(resolver.get_parameters(self, 0)).contains_exactly(GdUnitBoolAssert, "bool", [])
 	assert_array(resolver.get_parameters(self, 1)).contains_exactly(GdUnitStringAssert, "string", [])
 
+
+func test_fallback_warning_includes_source_context() -> void:
+	var test_parameters := ["[Array([1, 2, 3, 1]) as Array[int], TYPE_ARRAY]"]
+
+	assert_error(func() -> void:
+		GdInlineParameterSetResolver.new(test_parameters, [], "res://foo/bar.gd", "test_broken_expression")
+	).is_push_warning("""
+		Avoid type-casting with `as Array` in parameter sets; use the typed `Array(...)` constructor instead.
+			test: 'test_broken_expression' (res://foo/bar.gd)
+			expression: '%s'
+		Falling back to slower script-based resolver.
+		""".dedent() % [test_parameters[0]])
+
 #endregion
 #region _resolve_parameters
 
@@ -476,7 +489,7 @@ func _resolve_parameters(child_name: String) -> Array[Array]:
 
 	var parameter_set_argument := GdFunctionArgument.get_parameter_set(fd.args())
 	var parameter_sets := parameter_set_argument.parameter_sets()
-	var resolver := GdInlineParameterSetResolver.new(parameter_sets, fd.args())
+	var resolver := GdInlineParameterSetResolver.new(parameter_sets, fd.args(), fd.source_path(), fd.name())
 	if resolver == null:
 		return []
 	var result: Array[Array] = []


### PR DESCRIPTION
## Why

When parameter expression parsing fails, `_print_fallback_warning` only printed the expression text and the parser error, with no indication of which test script or test case produced it. Locating the affected test required manually correlating the expression text against the codebase.

## What

- `GdInlineParameterSetResolver` now accepts and stores the source script path and function name
- `_print_fallback_warning` accepts these as parameters and includes them in both fallback warning messages


Closes #1246