### PR TITLE
GD-1157: `_do_skip` causes 'Method/function failed' if first parameter.

### DIFF
--- a/addons/gdUnit4/src/core/GdUnitTestSuiteScanner.gd
+++ b/addons/gdUnit4/src/core/GdUnitTestSuiteScanner.gd
@@ -167,15 +167,24 @@ func load_suite(script: GDScript, tests: Array[GdUnitTestCase]) -> GdUnitTestSui
 
 func _build_test_attribute(script: GDScript, fd: GdFunctionDescriptor) -> TestCaseAttribute:
 	var collected_unknown_aruments := PackedStringArray()
+	var seen_config_arguments := PackedStringArray()
 	var attribute := TestCaseAttribute.new()
 
 	# Collect test attributes
 	for arg: GdFunctionArgument in fd.args():
 		if arg.type() == GdObjects.TYPE_FUZZER:
+			if not seen_config_arguments.is_empty():
+				attribute.is_skipped = true
+				attribute.skip_reason = (
+					"Fuzzer argument '%s' must be declared before the test config argument(s) %s."
+					% [arg.name(), seen_config_arguments])
+				return attribute
 			attribute.fuzzers.append(arg)
 		else:
 			# We allow underscore as prefix to prevent unused argument warnings
-			match arg.name().trim_prefix("_"):
+			var arg_name := arg.name().trim_prefix("_")
+			seen_config_arguments.append(arg_name)
+			match arg_name:
 				ARGUMENT_TIMEOUT:
 					attribute.timeout = type_convert(arg.default(), TYPE_INT)
 				ARGUMENT_SKIP:

--- a/addons/gdUnit4/test/core/GdUnitTestSuiteScannerTest.gd
+++ b/addons/gdUnit4/test/core/GdUnitTestSuiteScannerTest.gd
@@ -303,6 +303,18 @@ func test_resolve_test_suite_path_with_src_folders() -> void:
 	assert_str(GdUnitTestSuiteScanner.resolve_test_suite_path("res://project/folder/MyClass.gd", "/")).is_equal("res://project/folder/MyClassTest.gd")
 
 
+func test_build_test_attribute_rejects_fuzzer_after_config_argument() -> void:
+	var source_path := "res://addons/gdUnit4/test/core/resources/testsuites/TestSuiteWithFuzzerAfterConfigArg.gd"
+	var script: GDScript = load(source_path)
+	var fd: GdFunctionDescriptor = GdScriptParser.new().get_function_descriptors(script, ["test_fuzzer_after_do_skip"]).front()
+
+	var attribute := GdUnitTestSuiteScanner.new()._build_test_attribute(script, fd)
+
+	assert_bool(attribute.is_skipped).is_true()
+	assert_str(attribute.skip_reason).is_equal(
+		"Fuzzer argument 'fuzzer_value' must be declared before the test config argument(s) [\"do_skip\"].")
+
+
 func test_scan_test_suite_exclude_non_test_suites() -> void:
 	var scanner :GdUnitTestSuiteScanner = GdUnitTestSuiteScanner.new()
 	var test_suites := scanner.scan("res://addons/gdUnit4/test/core/resources/scan_testsuite_inheritance/plugin/")

--- a/addons/gdUnit4/test/core/resources/testsuites/TestSuiteWithFuzzerAfterConfigArg.gd
+++ b/addons/gdUnit4/test/core/resources/testsuites/TestSuiteWithFuzzerAfterConfigArg.gd
@@ -1,0 +1,10 @@
+extends GdUnitTestSuite
+
+
+func test_fuzzer_after_do_skip(
+	_do_skip := false,
+	fuzzer_value := Fuzzers.rangei(0, 10),
+	_fuzzer_iterations := 2
+) -> void:
+	var value: int = fuzzer_value.next_value()
+	assert_int(value).is_between(0, 10)


### PR DESCRIPTION
## Why

Test functions call fuzzer arguments positionally via `callv()`, which only works if fuzzers are declared before config arguments like `_do_skip`. When a fuzzer comes after one, it binds to the wrong parameter slot and crashes with a cryptic `Method/function failed` error instead of running or failing clearly.

## What

`GdUnitTestSuiteScanner` now detects this ordering and skips the test with a clear reason instead of crashing at runtime.

Closes #1157