### PR TITLE
GD-1265: Add Godot 4.8-dev2 to the CI execution matrix

### DIFF
--- a/.github/workflows/ci-dev.yml
+++ b/.github/workflows/ci-dev.yml
@@ -22,7 +22,7 @@ jobs:
       fail-fast: false
       max-parallel: 10
       matrix:
-        godot-version: ['4.5', '4.5.1', '4.5.2', '4.6', '4.6.1', '4.6.2', '4.6.3', '4.7']
+        godot-version: ['4.5', '4.5.1', '4.5.2', '4.6', '4.6.1', '4.6.2', '4.6.3', '4.7', '4.7.1']
         godot-status: ['stable']
         godot-net: ['.Net', '']
 

--- a/.github/workflows/ci-pr-publish-report.yml
+++ b/.github/workflows/ci-pr-publish-report.yml
@@ -24,12 +24,12 @@ jobs:
       fail-fast: false
       max-parallel: 10
       matrix:
-        godot-version: ['4.5', '4.5.1', '4.5.2', '4.6', '4.6.1', '4.6.2', '4.6.3', '4.7']
+        godot-version: ['4.5', '4.5.1', '4.5.2', '4.6', '4.6.1', '4.6.2', '4.6.3', '4.7', '4.7.1']
         godot-status: ['stable']
         godot-net: ['-net', '']
         include:
-          - godot-version: '4.7.1'
-            godot-status: 'rc1'
+          - godot-version: '4.8'
+            godot-status: 'dev2'
 
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -36,12 +36,12 @@ jobs:
       max-parallel: 10
       matrix:
         # If changes are made here, they must be transferred to `.github\workflows\ci-pr-publish-report.yml`
-        godot-version: ['4.5', '4.5.1', '4.5.2', '4.6', '4.6.1', '4.6.2', '4.6.3', '4.7']
+        godot-version: ['4.5', '4.5.1', '4.5.2', '4.6', '4.6.1', '4.6.2', '4.6.3', '4.7', '4.7.1']
         godot-status: ['stable']
         godot-net: ['.Net', '']
         include:
-          - godot-version: '4.7.1'
-            godot-status: 'rc1'
+          - godot-version: '4.8'
+            godot-status: 'dev2'
 
     permissions:
       actions: write


### PR DESCRIPTION
## Why

Godot 4.8-dev2 was released, and the pull-request CI matrix must track new prereleases so regressions surface early, following the same rolling-replacement pattern used for previous dev, beta, and rc snapshots. Godot 4.7.1 has since shipped stable, so it moves out of the prerelease slot and into the regular stable version list.

## What

- Replace the prerelease matrix entry in `ci-pr.yml` and `ci-pr-publish-report.yml` from `4.7.1-rc1` to `4.8-dev2`.
- Add `4.7.1` to the stable version list in `ci-dev.yml`, `ci-pr.yml`, and `ci-pr-publish-report.yml`.

Closes #1265