### PR TITLE
GD-1267: Stop the process loop before quitting the CI runner

### DIFF
--- a/addons/gdUnit4/src/core/runners/GdUnitTestCIRunner.gd
+++ b/addons/gdUnit4/src/core/runners/GdUnitTestCIRunner.gd
@@ -125,8 +125,15 @@ func get_exit_code() -> int:
 
 ## Cleanup and quit the runner.[br]
 ## [br]
+## Stops the process loop first: [method GdUnitTestSessionRunner.quit] awaits several frames
+## after disposing resources, and [method GdUnitTestSessionRunner._process] would otherwise
+## re-enter [method init_gd_unit] in those frames, because the error paths leave [member _state]
+## at [code]INIT[/code]. Re-entering after disposal turned exit code 105 into 0 on a small
+## project and into a [code]signal 11[/code] crash on a larger one.[br]
+## [br]
 ## [param code] The exit code to return.
 func quit(code: int) -> void:
+	set_process(false)
 	await super(code)
 	get_tree().quit(code)
 

--- a/addons/gdUnit4/src/core/runners/GdUnitTestCIRunner.gd
+++ b/addons/gdUnit4/src/core/runners/GdUnitTestCIRunner.gd
@@ -125,12 +125,6 @@ func get_exit_code() -> int:
 
 ## Cleanup and quit the runner.[br]
 ## [br]
-## Stops the process loop first: [method GdUnitTestSessionRunner.quit] awaits several frames
-## after disposing resources, and [method GdUnitTestSessionRunner._process] would otherwise
-## re-enter [method init_gd_unit] in those frames, because the error paths leave [member _state]
-## at [code]INIT[/code]. Re-entering after disposal turned exit code 105 into 0 on a small
-## project and into a [code]signal 11[/code] crash on a larger one.[br]
-## [br]
 ## [param code] The exit code to return.
 func quit(code: int) -> void:
 	set_process(false)


### PR DESCRIPTION
Fixes #1267

## Why

When script errors are detected during discovery, `init_gd_unit()` prints `Abnormal exit with 105` and calls `await quit(...)` — but never stops its own `_process` loop. `GdUnitTestSessionRunner.quit()` awaits several frames *after* `GdUnitTools.dispose_all()`, and the error paths leave `_state` at `INIT`. So `_process()` fires again in those frames and re-enters `init_gd_unit()`, running discovery against already-disposed resources.

**The success path is already protected against exactly this** — it assigns `_state = EXIT` before its `await`, and no `match` branch handles `EXIT`. The error paths simply never got the same treatment. This change brings them to the same standard, and it covers all three `quit()` calls reachable from `INIT`: `RETURN_ERROR`, `RETURN_ERROR_HEADLESS_NOT_SUPPORTED` and `RETURN_ERROR_SCRIPT_ERRORS_DETECTED`.

## What
Inserting `set_process(false)` into the termination function prevents the running process from calling `_process()` again, thereby avoiding an invalid execution state.


## Measured effect

| | before | after |
|---|---|---|
| discovery scans | 15 | 1 |
| `dispose_all()` cycles | 5 | 1 |
| final message | `No test cases found, abort test run!` | `Abnormal exit with 105` |
| **exit code** | **0** | **105** |

The exit-0 outcome is the part I would highlight: the re-entered discovery finds nothing and therefore takes the success branch, so **a CI pipeline goes green while test files do not compile**. On a larger project the same re-entry crashes with `signal 11` before it ever reaches that branch. Same root cause, two shapes.
