### PR TITLE
GD-1269: Compare String arguments case-sensitively in mock verification

### DIFF
--- a/addons/gdUnit4/src/matchers/EqualsArgumentMatcher.gd
+++ b/addons/gdUnit4/src/matchers/EqualsArgumentMatcher.gd
@@ -11,7 +11,7 @@ func _init(current :Variant, auto_deep_check_mode := false) -> void:
 
 
 func is_match(value :Variant) -> bool:
-	var case_sensitive_check := true
+	var case_sensitive_check := false
 	return GdObjects.equals(_current, value, case_sensitive_check, compare_mode(value))
 
 

--- a/addons/gdUnit4/test/matchers/EqualsArgumentMatcherTest.gd
+++ b/addons/gdUnit4/test/matchers/EqualsArgumentMatcherTest.gd
@@ -1,0 +1,20 @@
+# GdUnit generated TestSuite
+class_name EqualsArgumentMatcherTest
+extends GdUnitTestSuite
+
+# TestSuite generated from
+const __source = 'res://addons/gdUnit4/src/matchers/EqualsArgumentMatcher.gd'
+
+
+func test_is_match() -> void:
+	var matcher := EqualsArgumentMatcher.new("foo")
+
+	assert_bool(matcher.is_match("foo")).is_true()
+	assert_bool(matcher.is_match("bar")).is_false()
+
+
+func test_is_match_string_is_case_sensitive() -> void:
+	var matcher := EqualsArgumentMatcher.new("Foo")
+
+	assert_bool(matcher.is_match("Foo")).is_true()
+	assert_bool(matcher.is_match("foo")).is_false()


### PR DESCRIPTION
# Why

`verify(mock).some_method("Foo")` passes when the only call made was `some_method("foo")`.

Verification wraps plain arguments in an `EqualsArgumentMatcher`, which passes `case_sensitive_check := true` as the
third argument of `GdObjects.equals`. That argument is named `case_sensitive`, but in the `TYPE_STRING` branch the
`true` path is `obj_a.to_lower() == obj_b.to_lower()` and the `else` path is the exact `obj_a == obj_b`. The flag means
"ignore case", not "compare case-sensitively".

`GdUnitStringAssertImpl` already passes it that way - `is_equal()` passes `false`, `is_equal_ignoring_case()` passes
`true`. The two call sites pass the same flag with opposite meanings, and the matcher is the one that went by the name.

# What

- Pass `false` in `EqualsArgumentMatcher.is_match()`, so String arguments compare exactly. `GdObjects.equals` and
  `is_equal_ignoring_case` are unchanged.
- Add `EqualsArgumentMatcherTest` - the only matcher in `src/matchers/` without a test, and the one every plain
  argument gets wrapped in.

The case-sensitivity test fails on `master` and passes with the change. The full suite on Godot 4.7.stable gives the
same result as before the change, plus the two new tests.

Closes #1269
