### PR TITLE
TASK-1274: Renaming the refactoring issue template to Improvement

### DIFF
--- a/.github/ISSUE_TEMPLATE/improvement.yml
+++ b/.github/ISSUE_TEMPLATE/improvement.yml
@@ -12,15 +12,15 @@ body:
     attributes:
       value: |
         ### Thanks for suggesting code improvements!
-        - Please search [existing refactoring issues](https://github.com/MikeSchulze/gdUnit4/issues?q=label%3Arefactoring%20is%3Aissue) to avoid duplicates
+        - Please search [existing improvement issues](https://github.com/MikeSchulze/gdUnit4/issues?q=label%3Aimprovement%20is%3Aissue) to avoid duplicates
         - Consider the impact on existing users and backward compatibility
         - Focus on improving code quality, maintainability, or performance
 
   - type: dropdown
-    id: refactoring-type
+    id: improvement-type
     attributes:
       label: Improvement Type
-      description: What type of refactoring is this?
+      description: What type of improvement is this?
       options:
         - Code cleanup/organization
         - Performance optimization
@@ -38,7 +38,7 @@ body:
     id: current-state
     attributes:
       label: Current State
-      description: What is the current implementation that needs refactoring?
+      description: What is the current implementation that needs improving?
       placeholder: |
         Describe the current code/implementation:
         - Which files, classes, or functions are affected?
@@ -58,9 +58,9 @@ body:
     id: problems-motivation
     attributes:
       label: Problems and Motivation
-      description: Why does this refactoring need to happen?
+      description: Why does this improvement need to happen?
       placeholder: |
-        Explain the motivation for this refactoring:
+        Explain the motivation for this improvement:
         - What problems does the current code have?
         - How does it impact maintainability, performance, or usability?
         - What technical debt would this address?
@@ -74,7 +74,7 @@ body:
       label: Proposed Changes
       description: What specific changes do you propose?
       placeholder: |
-        Describe the proposed refactoring:
+        Describe the proposed improvement:
         - What would the new implementation look like?
         - Which design patterns or approaches would you use?
         - How would the API change (if at all)?
@@ -121,7 +121,7 @@ body:
     id: implementation-approach
     attributes:
       label: Implementation Approach
-      description: How should this refactoring be implemented?
+      description: How should this improvement be implemented?
       placeholder: |
         Suggest an implementation approach:
         - Could this be done incrementally?

--- a/.github/ISSUE_TEMPLATE/improvement.yml
+++ b/.github/ISSUE_TEMPLATE/improvement.yml
@@ -1,9 +1,9 @@
-name: Refactoring
-description: Create a refactoring issue to improve GdUnit4 codebase
-title: "GD-XXX: Brief description of the refactoring"
-labels: ["refactoring"]
+name: Improvement
+description: Create an improvement issue to improve GdUnit4 codebase
+title: "GD-XXX: Brief description of the improvement"
+labels: ["improvement"]
 projects: ["godot-gdunit-labs/3"]
-type: refactoring
+type: improvement
 assignees:
   - MikeSchulze
 
@@ -19,7 +19,7 @@ body:
   - type: dropdown
     id: refactoring-type
     attributes:
-      label: Refactoring Type
+      label: Improvement Type
       description: What type of refactoring is this?
       options:
         - Code cleanup/organization

--- a/.github/actions/resolve-issue-template/test.sh
+++ b/.github/actions/resolve-issue-template/test.sh
@@ -62,9 +62,9 @@ run_case "task" \
   4 open 'Task' \
   '["task-category","task-description","acceptance-criteria"]'
 
-run_case "refactoring" \
-  '{"number":5,"state":"open","type":{"name":"Refactoring"},"labels":[{"name":"refactoring"}]}' \
-  5 open 'Refactoring' \
+run_case "improvement" \
+  '{"number":5,"state":"open","type":{"name":"Improvement"},"labels":[{"name":"improvement"}]}' \
+  5 open 'Improvement' \
   '["refactoring-type","current-state","problems-motivation","proposed-changes","affected-areas","backward-compatibility"]'
 
 run_case "unrecognized type" \

--- a/.github/actions/resolve-issue-template/test.sh
+++ b/.github/actions/resolve-issue-template/test.sh
@@ -65,7 +65,7 @@ run_case "task" \
 run_case "improvement" \
   '{"number":5,"state":"open","type":{"name":"Improvement"},"labels":[{"name":"improvement"}]}' \
   5 open 'Improvement' \
-  '["refactoring-type","current-state","problems-motivation","proposed-changes","affected-areas","backward-compatibility"]'
+  '["improvement-type","current-state","problems-motivation","proposed-changes","affected-areas","backward-compatibility"]'
 
 run_case "unrecognized type" \
   '{"number":6,"state":"open","type":null,"labels":[]}' \


### PR DESCRIPTION
## Why

The refactoring issue template set its custom issue type to `refactoring`, a type this repository never actually defined, so every issue filed through it ended up with no usable type at all. The automated issue triage then treated those issues as if they had skipped every template entirely and closed them outright. The repository's existing `Improvement` type already describes exactly what this template covers, enhancements to existing functionality that don't add new features or fix bugs, so retargeting the template is the correct fix rather than inventing a new type.

## What

Renames the template file, its display name, description, title prefix, label, and issue type from Refactoring to Improvement, and updates the corresponding test fixture to match.

Closes #1274