### PR TITLE
GD-1269: mock/spy verification matches String arguments case-insensitively

### DIFF
--- a/addons/gdUnit4/src/asserts/GdUnitArrayAssertImpl.gd
+++ b/addons/gdUnit4/src/asserts/GdUnitArrayAssertImpl.gd
@@ -71,7 +71,7 @@ func _toPackedStringArray(value: Variant) -> PackedStringArray:
 	return PackedStringArray([str(value)])
 
 
-func _array_equals_div(current: Variant, expected: Variant, case_sensitive: bool = false) -> Array:
+func _array_equals_div(current: Variant, expected: Variant, case_sensitive: bool = true) -> Array:
 	var current_value := _toPackedStringArray(current)
 	var expected_value := _toPackedStringArray(expected)
 	var index_report := Array()
@@ -102,7 +102,7 @@ func _array_div(compare_mode: GdObjects.COMPARE_MODE, left: Array[Variant], righ
 		var c: Variant = left[index_c]
 		for index_e in right.size():
 			var e: Variant = right[index_e]
-			if GdObjects.equals(c, e, false, compare_mode):
+			if GdObjects.equals(c, e, true, compare_mode):
 				GdArrayTools.erase_value(not_expect, e)
 				GdArrayTools.erase_value(not_found, c)
 				break
@@ -136,10 +136,10 @@ func _contains_exactly(expected: Array, compare_mode: GdObjects.COMPARE_MODE) ->
 	if current_value == null:
 		return report_error(GdAssertMessages.error_arr_contains_exactly(null, expected_value, [], expected_value, compare_mode))
 	# has same content in same order
-	if _is_equal(current_value, expected_value, false, compare_mode):
+	if _is_equal(current_value, expected_value, true, compare_mode):
 		return report_success()
 	# check has same elements but in different order
-	if _is_equals_sorted(current_value, expected_value, false, compare_mode):
+	if _is_equals_sorted(current_value, expected_value, true, compare_mode):
 		return report_error(GdAssertMessages.error_arr_contains_exactly(current_value, expected_value, [], [], compare_mode))
 	# find the difference
 	@warning_ignore("unsafe_cast")
@@ -230,7 +230,7 @@ func is_equal_ignoring_case(...expected: Array) -> GdUnitArrayAssert:
 		@warning_ignore("unsafe_cast")
 		return report_error(GdAssertMessages.error_equal(null, GdArrayTools.as_string(expected_value)))
 
-	if not _is_equal(current_value, expected_value, true):
+	if not _is_equal(current_value, expected_value, false):
 		@warning_ignore("unsafe_cast")
 		var diff := _array_equals_div(current_value, expected_value, true)
 		var expected_as_list := GdArrayTools.as_string(diff[0])
@@ -257,7 +257,7 @@ func is_not_equal_ignoring_case(...expected: Array) -> GdUnitArrayAssert:
 	if not _validate_value_type(expected_value):
 		return report_error("ERROR: expected value: <%s>\n is not a Array Type!" % GdObjects.typeof_as_string(expected_value))
 
-	if _is_equal(current_value, expected_value, true):
+	if _is_equal(current_value, expected_value, false):
 		@warning_ignore("unsafe_cast")
 		var c := GdArrayTools.as_string(current_value as Array)
 		@warning_ignore("unsafe_cast")
@@ -394,7 +394,7 @@ func _extract_variadic_value(values: Variant) -> Variant:
 func _is_equal(
 	left: Variant,
 	right: Variant,
-	case_sensitive := false,
+	case_sensitive := true,
 	compare_mode := GdObjects.COMPARE_MODE.PARAMETER_DEEP_TEST) -> bool:
 
 	@warning_ignore("unsafe_cast")
@@ -409,7 +409,7 @@ func _is_equal(
 func _is_equals_sorted(
 	left: Variant,
 	right: Variant,
-	case_sensitive := false,
+	case_sensitive := true,
 	compare_mode := GdObjects.COMPARE_MODE.PARAMETER_DEEP_TEST) -> bool:
 
 	@warning_ignore("unsafe_cast")

--- a/addons/gdUnit4/src/asserts/GdUnitDictionaryAssertImpl.gd
+++ b/addons/gdUnit4/src/asserts/GdUnitDictionaryAssertImpl.gd
@@ -147,7 +147,7 @@ func _contains_key_value(key :Variant, value :Variant, compare_mode :GdObjects.C
 	var keys_not_found :Array = expected.filter(_filter_by_key.bind(dict_current.keys(), compare_mode))
 	if not keys_not_found.is_empty():
 		return report_error(GdAssertMessages.error_contains_keys(dict_current.keys() as Array, expected, keys_not_found, compare_mode))
-	if not GdObjects.equals(dict_current[key], value, false, compare_mode):
+	if not GdObjects.equals(dict_current[key], value, true, compare_mode):
 		return report_error(GdAssertMessages.error_contains_key_value(key, value, dict_current[key], compare_mode))
 	return report_success()
 
@@ -190,7 +190,7 @@ func not_contains_same_keys(...expected: Array) -> GdUnitDictionaryAssert:
 
 func _filter_by_key(element :Variant, values :Array, compare_mode :GdObjects.COMPARE_MODE, is_not :bool = false) -> bool:
 	for key :Variant in values:
-		if GdObjects.equals(key, element, false, compare_mode):
+		if GdObjects.equals(key, element, true, compare_mode):
 			return is_not
 	return !is_not
 

--- a/addons/gdUnit4/src/asserts/GdUnitStringAssertImpl.gd
+++ b/addons/gdUnit4/src/asserts/GdUnitStringAssertImpl.gd
@@ -60,20 +60,20 @@ func is_not_null() -> GdUnitStringAssert:
 
 
 func is_equal(expected: Variant) -> GdUnitStringAssert:
-	return _is_equal(expected, false, GdAssertMessages.error_equal)
+	return _is_equal(expected, true, GdAssertMessages.error_equal)
 
 
 func is_equal_ignoring_case(expected: Variant) -> GdUnitStringAssert:
-	return _is_equal(expected, true, GdAssertMessages.error_equal_ignoring_case)
+	return _is_equal(expected, false, GdAssertMessages.error_equal_ignoring_case)
 
 
 @warning_ignore_start("unsafe_call_argument")
-func _is_equal(expected: Variant, ignore_case: bool, message_cb: Callable) -> GdUnitStringAssert:
+func _is_equal(expected: Variant, case_sensitive: bool, message_cb: Callable) -> GdUnitStringAssert:
 	var current: Variant = current_value()
 	if current == null:
 		return report_error(message_cb.call(current, expected))
 	var cur_value := str(current)
-	if not GdObjects.equals(cur_value, expected, ignore_case):
+	if not GdObjects.equals(cur_value, expected, case_sensitive):
 		var exp_value := str(expected)
 		if contains_bbcode(cur_value):
 			# mask user bbcode
@@ -95,7 +95,7 @@ func is_not_equal(expected: Variant) -> GdUnitStringAssert:
 
 func is_not_equal_ignoring_case(expected :Variant) -> GdUnitStringAssert:
 	var current :Variant = current_value()
-	if GdObjects.equals(current, expected, true):
+	if GdObjects.equals(current, expected, false):
 		return report_error(GdAssertMessages.error_not_equal(current, expected))
 	return report_success()
 

--- a/addons/gdUnit4/src/core/GdObjects.gd
+++ b/addons/gdUnit4/src/core/GdObjects.gd
@@ -199,11 +199,11 @@ static func obj2dict(obj: Object, hashed_objects := Dictionary()) -> Dictionary:
 	return {"%s" % clazz_name : dict}
 
 
-static func equals(obj_a :Variant, obj_b :Variant, case_sensitive :bool = false, compare_mode :COMPARE_MODE = COMPARE_MODE.PARAMETER_DEEP_TEST) -> bool:
+static func equals(obj_a: Variant, obj_b: Variant, case_sensitive: bool = true, compare_mode: COMPARE_MODE = COMPARE_MODE.PARAMETER_DEEP_TEST) -> bool:
 	return _equals(obj_a, obj_b, case_sensitive, compare_mode, [], 0)
 
 
-static func equals_sorted(obj_a: Array[Variant], obj_b: Array[Variant], case_sensitive: bool = false, compare_mode: COMPARE_MODE = COMPARE_MODE.PARAMETER_DEEP_TEST) -> bool:
+static func equals_sorted(obj_a: Array[Variant], obj_b: Array[Variant], case_sensitive: bool = true, compare_mode: COMPARE_MODE = COMPARE_MODE.PARAMETER_DEEP_TEST) -> bool:
 	var a: Array[Variant] = obj_a.duplicate()
 	var b: Array[Variant] = obj_b.duplicate()
 	a.sort()
@@ -211,7 +211,7 @@ static func equals_sorted(obj_a: Array[Variant], obj_b: Array[Variant], case_sen
 	return equals(a, b, case_sensitive, compare_mode)
 
 
-static func _equals(obj_a :Variant, obj_b :Variant, case_sensitive :bool, compare_mode :COMPARE_MODE, deep_stack :Array, stack_depth :int ) -> bool:
+static func _equals(obj_a: Variant, obj_b: Variant, case_sensitive: bool, compare_mode: COMPARE_MODE, deep_stack: Array, stack_depth: int ) -> bool:
 	var type_a := typeof(obj_a)
 	var type_b := typeof(obj_b)
 	if stack_depth > 32:
@@ -286,10 +286,10 @@ static func _equals(obj_a :Variant, obj_b :Variant, case_sensitive :bool, compar
 
 		TYPE_STRING:
 			if case_sensitive:
+				return obj_a == obj_b
+			else:
 				@warning_ignore("unsafe_method_access")
 				return obj_a.to_lower() == obj_b.to_lower()
-			else:
-				return obj_a == obj_b
 	return obj_a == obj_b
 
 

--- a/addons/gdUnit4/test/core/GdObjectsTest.gd
+++ b/addons/gdUnit4/test/core/GdObjectsTest.gd
@@ -29,6 +29,12 @@ func test_equals_string() -> void:
 	assert_bool(GdObjects.equals(d, Vector3.ONE)).is_false()
 
 
+func test_equals_string_case_insensitive() -> void:
+	assert_bool(GdObjects.equals("abc", "abC", false)).is_true()
+	assert_bool(GdObjects.equals("abc", "ABC", false)).is_true()
+	assert_bool(GdObjects.equals("abc", "abd", false)).is_false()
+
+
 func test_equals_stringname() -> void:
 	assert_bool(GdObjects.equals("",  &"")).is_true()
 	assert_bool(GdObjects.equals("abc", &"abc")).is_true()

--- a/addons/gdUnit4/test/mocker/GdUnitMockerTest.gd
+++ b/addons/gdUnit4/test/mocker/GdUnitMockerTest.gd
@@ -855,6 +855,28 @@ func test_verify_fail() -> void:
 		.has_message(expected_error)
 
 
+func test_verify_string_argument_mach_case_sensitive() -> void:
+	var mocked_node: Variant = mock(Node)
+
+	# Act
+	mocked_node.set_name("foo")
+
+	# Verify it fails by checking the arguments case sensitive
+	var expected_error := """
+		Expecting interaction on:
+			'set_name(Foo :String)'	1 time's
+		But found interactions on:
+			'set_name(foo :String)'	1 time's""" \
+		.dedent().trim_prefix("\n").replace("\r", "")
+	assert_failure(func() -> void: verify(mocked_node).set_name("Foo")) \
+		.is_failed() \
+		.has_message(expected_error)
+
+	# Finally we verify by using the correct lowercase argument
+	verify(mocked_node).set_name("foo")
+	verify_no_more_interactions(mocked_node)
+
+
 func test_verify_func_interaction_wiht_PoolStringArray() -> void:
 	var mocked: Variant = mock(ClassWithPoolStringArrayFunc)
 


### PR DESCRIPTION
## Why
`GdObjects._equals` had its `case_sensitive` branches inverted for `TYPE_STRING`, so `EqualsArgumentMatcher.is_match` requested an exact match but got a case-insensitive one instead, letting `verify(mock).some_method("Foo")` pass for a call made with `some_method("foo")`.

## What
Fixed the inverted branch in `GdObjects._equals`, and updated the assertion call sites in `GdUnitStringAssertImpl`, `GdUnitArrayAssertImpl`, and `GdUnitDictionaryAssertImpl` that had been passing values tuned to the old, inverted default so their existing behavior is preserved. Added regression tests reproducing the original issue

Closes #1269